### PR TITLE
Add adjacency/edge-list topology, stable JSON export contract, validations, and tests for Kuramoto CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,7 +405,7 @@ It integrates the Kuramoto ODE using 4th-order Runge-Kutta:
 
 ```
 dθᵢ/dt = ωᵢ + (K/N) · Σⱼ sin(θⱼ − θᵢ)       # global (all-to-all) coupling
-dθᵢ/dt = ωᵢ + K · Σⱼ Aᵢⱼ sin(θⱼ − θᵢ)        # adjacency-matrix coupling
+dθᵢ/dt = ωᵢ + K · Σⱼ Aᵢⱼ sin(θⱼ − θᵢ)        # explicit weighted adjacency (diagonal ignored)
 ```
 
 The **order parameter** R(t) ∈ [0, 1] measures instantaneous synchronisation:
@@ -462,14 +462,18 @@ tp-kuramoto simulate
 # Strongly coupled network with fixed seed
 tp-kuramoto simulate --N 50 --K 3.0 --steps 2000 --seed 42
 
-# Save full JSON output (includes order-parameter time-series)
-tp-kuramoto simulate --N 30 --K 2.5 --output result.json
+# Save full JSON output (includes order-parameter and phase trajectories)
+tp-kuramoto simulate --N 30 --K 2.5 --output result.json --export full
 
-# Pipe summary JSON to jq
-tp-kuramoto simulate --N 100 --K 1.5 --quiet | jq .summary
+# Pipe summary-only JSON to jq (schema_version + summary + config)
+tp-kuramoto simulate --N 100 --K 1.5 --quiet --export summary | jq .summary
 
 # Custom frequencies via CLI
 tp-kuramoto simulate --N 3 --omega "0.5,1.0,1.5" --K 2.0 --steps 500
+
+# Topology from matrix or edge-list
+tp-kuramoto simulate --N 50 --adjacency-file graph.json --output full.json
+tp-kuramoto simulate --N 50 --edge-list-file graph_edges.json --export summary --quiet
 ```
 
 ### Parameter reference
@@ -481,18 +485,30 @@ tp-kuramoto simulate --N 3 --omega "0.5,1.0,1.5" --K 2.0 --steps 500
 | `omega` | array(N) \| None | None | Natural frequencies (rad/time). Drawn from N(0,1) if omitted |
 | `dt` | float > 0 | 0.01 | RK4 integration time-step |
 | `steps` | int ≥ 1 | 1000 | Number of integration steps |
-| `adjacency` | array(N,N) \| None | None | Weighted coupling matrix. Falls back to all-to-all if omitted |
+| `adjacency` | array(N,N) \| None | None | Weighted coupling matrix (`K` is a global scale). Diagonal is ignored |
 | `theta0` | array(N) \| None | None | Initial phases (rad). Drawn from U(0, 2π) if omitted |
 | `seed` | int \| None | None | RNG seed for reproducible random draws |
 
 ### Outputs
+
+CLI JSON exports include a stable `schema_version` field (`1` for this contract).
+
+`--export summary` returns only:
+- `schema_version`
+- `summary`
+- `config`
+
+`--export full` additionally returns trajectories:
+- `order_parameter`
+- `time`
+- `phases`
 
 | Field | Shape | Description |
 |-------|-------|-------------|
 | `result.phases` | `(steps+1, N)` | Phase trajectories in radians |
 | `result.order_parameter` | `(steps+1,)` | Kuramoto R(t) ∈ [0, 1] |
 | `result.time` | `(steps+1,)` | Time axis: `time[k] = k * dt` |
-| `result.summary` | dict | Scalar stats: `final_R`, `mean_R`, `max_R`, `min_R`, `std_R` |
+| `result.summary` | dict | Scalar stats plus `coupling_mode` and deterministic metadata (`seed`) |
 
 ### Limitations and assumptions
 

--- a/core/kuramoto/__init__.py
+++ b/core/kuramoto/__init__.py
@@ -1,21 +1,10 @@
 # SPDX-License-Identifier: LicenseRef-TradePulse-Proprietary
-"""Kuramoto coupled-oscillator simulation package.
+"""Public API for the Kuramoto simulation subsystem.
 
-This package provides a production-ready implementation of the Kuramoto model —
-a canonical model of coupled phase oscillators widely used in neuroscience,
-physics, and synchrony analysis.
-
-The model integrates the ODE:
-
-    dθᵢ/dt = ωᵢ + (K/N) · Σⱼ sin(θⱼ − θᵢ)          [global coupling]
-
-    dθᵢ/dt = ωᵢ + K · Σⱼ Aᵢⱼ sin(θⱼ − θᵢ)           [adjacency-matrix coupling]
-
-Key exports:
-    KuramotoConfig     — validated parameter container (Pydantic v2)
-    KuramotoEngine     — deterministic ODE solver (RK4)
-    KuramotoResult     — typed result with phase trajectories & summary stats
-    run_simulation     — convenience one-shot function
+Exports a minimal stable surface:
+- :class:`KuramotoConfig` for validated inputs
+- :class:`KuramotoEngine` and :func:`run_simulation` for execution
+- :class:`KuramotoResult` for typed outputs
 """
 
 from __future__ import annotations
@@ -23,9 +12,4 @@ from __future__ import annotations
 from .config import KuramotoConfig
 from .engine import KuramotoEngine, KuramotoResult, run_simulation
 
-__all__ = [
-    "KuramotoConfig",
-    "KuramotoEngine",
-    "KuramotoResult",
-    "run_simulation",
-]
+__all__ = ["KuramotoConfig", "KuramotoEngine", "KuramotoResult", "run_simulation"]

--- a/core/kuramoto/cli.py
+++ b/core/kuramoto/cli.py
@@ -1,27 +1,12 @@
 # SPDX-License-Identifier: LicenseRef-TradePulse-Proprietary
 """Command-line interface for the Kuramoto simulation engine.
 
-Entry point: ``tp-kuramoto`` (registered in ``pyproject.toml``).
-
-Usage examples
---------------
-# Run with defaults (N=10, K=1.0, dt=0.01, steps=1000)
-tp-kuramoto simulate
-
-# Strongly-coupled network, reproducible seed
-tp-kuramoto simulate --N 50 --K 3.0 --steps 2000 --seed 42
-
-# Pipe JSON output to another tool
-tp-kuramoto simulate --N 20 --K 2.0 --quiet | jq .summary
-
-# Save full result to file
-tp-kuramoto simulate --N 30 --K 1.5 --output result.json
+Entry point: ``tp-kuramoto``.
 """
 
 from __future__ import annotations
 
 import json
-import sys
 from pathlib import Path
 from typing import Any
 
@@ -30,107 +15,50 @@ import numpy as np
 
 from .config import KuramotoConfig
 from .engine import run_simulation
-
-
-# ──────────────────────────────────────────────────────────────────────────────
-# CLI group
-# ──────────────────────────────────────────────────────────────────────────────
+from .io import export_payload, load_adjacency_matrix, load_edge_list, parse_float_list
 
 
 @click.group()
-@click.version_option(version="1.0.0", prog_name="tp-kuramoto")
+@click.version_option(version="1.1.0", prog_name="tp-kuramoto")
 def cli() -> None:
     """TradePulse Kuramoto Simulation Engine.
 
-    Simulate coupled phase oscillators using the Kuramoto model:
-
-    \b
-        dθᵢ/dt = ωᵢ + (K/N) · Σⱼ sin(θⱼ − θᵢ)
-
-    The order parameter R ∈ [0, 1] measures global synchronisation:
-    R ≈ 0 → desynchronised,  R ≈ 1 → fully synchronised.
-
-    \b
-    Examples:
-        tp-kuramoto simulate --N 50 --K 2.0 --steps 1000 --seed 0
-        tp-kuramoto simulate --N 100 --K 0.5 --dt 0.005 --output out.json
+    Coupling semantics:
+      - Global topology (no adjacency input): K/N on all off-diagonal pairs.
+      - Explicit adjacency topology: K scales the provided adjacency weights A_ij.
     """
 
 
-# ──────────────────────────────────────────────────────────────────────────────
-# simulate sub-command
-# ──────────────────────────────────────────────────────────────────────────────
-
-
 @cli.command()
+@click.option("--N", "n_oscillators", type=int, default=10, show_default=True, help="Number of coupled oscillators (≥ 2).")
+@click.option("--K", "coupling", type=float, default=1.0, show_default=True, help="Global coupling scale. Global mode uses K/N; adjacency mode uses K*A_ij.")
+@click.option("--dt", type=float, default=0.01, show_default=True, help="Integration time-step (> 0).")
+@click.option("--steps", type=int, default=1000, show_default=True, help="Number of RK4 integration steps (≥ 1).")
+@click.option("--seed", type=int, default=None, help="Random seed for reproducibility.")
+@click.option("--omega", "omega_str", type=str, default=None, help="Comma-separated natural frequencies.")
+@click.option("--theta0", "theta0_str", type=str, default=None, help="Comma-separated initial phases (radians).")
 @click.option(
-    "--N",
-    "n_oscillators",
-    type=int,
-    default=10,
-    show_default=True,
-    help="Number of coupled oscillators (≥ 2).",
-)
-@click.option(
-    "--K",
-    "coupling",
-    type=float,
-    default=1.0,
-    show_default=True,
-    help="Global coupling strength.",
-)
-@click.option(
-    "--dt",
-    type=float,
-    default=0.01,
-    show_default=True,
-    help="Integration time-step (> 0).",
-)
-@click.option(
-    "--steps",
-    type=int,
-    default=1000,
-    show_default=True,
-    help="Number of RK4 integration steps (≥ 1).",
-)
-@click.option(
-    "--seed",
-    type=int,
+    "--adjacency-file",
+    type=click.Path(exists=True, path_type=Path, dir_okay=False),
     default=None,
-    help="Random seed for reproducibility (omit for random).",
+    help="Load NxN adjacency matrix from .json/.csv/.txt/.npy.",
 )
 @click.option(
-    "--omega",
-    "omega_str",
-    type=str,
+    "--edge-list-file",
+    type=click.Path(exists=True, path_type=Path, dir_okay=False),
     default=None,
-    help=(
-        "Comma-separated natural frequencies, e.g. '--omega 0.5,1.0,1.5'. "
-        "Length must equal N. Overrides random draw."
-    ),
+    help="Load directed weighted edges from JSON file with {'edges': [...]} schema.",
 )
+@click.option("--output", "output_path", type=click.Path(path_type=Path), default=None, help="Write JSON result to this file.")
 @click.option(
-    "--theta0",
-    "theta0_str",
-    type=str,
-    default=None,
-    help=(
-        "Comma-separated initial phases in radians, e.g. '--theta0 0,1.57,3.14'. "
-        "Length must equal N. Overrides random draw."
-    ),
+    "--export",
+    "export_mode",
+    type=click.Choice(["summary", "full"], case_sensitive=False),
+    default="full",
+    show_default=True,
+    help="Export summary-only metadata or full trajectories.",
 )
-@click.option(
-    "--output",
-    "output_path",
-    type=click.Path(path_type=Path),
-    default=None,
-    help="Write JSON result to this file (optional).",
-)
-@click.option(
-    "--quiet",
-    is_flag=True,
-    help="Suppress human-readable summary; emit only JSON.",
-)
+@click.option("--quiet", is_flag=True, help="Emit machine-readable JSON only.")
 def simulate(
     n_oscillators: int,
     coupling: float,
@@ -139,47 +67,38 @@ def simulate(
     seed: int | None,
     omega_str: str | None,
     theta0_str: str | None,
+    adjacency_file: Path | None,
+    edge_list_file: Path | None,
     output_path: Path | None,
+    export_mode: str,
     quiet: bool,
 ) -> None:
-    """Run a Kuramoto simulation and print summary statistics.
+    """Run a Kuramoto simulation and emit a contract-stable JSON payload.
 
-    The simulation integrates the Kuramoto ODE over ``steps`` steps with
-    time-step ``dt`` using 4th-order Runge-Kutta.
-
-    \b
-    Output includes:
-        - Final order parameter R (synchrony at end of simulation)
-        - Mean / max R over entire trajectory
-        - Phase trajectory shape confirmation
-        - Optional full JSON dump to --output file
-
-    \b
-    Examples:
-        tp-kuramoto simulate --N 50 --K 2.0 --steps 1000 --seed 42
-        tp-kuramoto simulate --N 100 --K 3.0 --quiet | jq .summary
+    Export contract:
+      - ``--export summary``: includes only ``schema_version``, ``summary``, ``config``.
+      - ``--export full``: includes summary payload plus trajectories.
+      - ``--quiet`` prints JSON to stdout; ``--output`` writes identical JSON to file.
     """
-    # ── parse optional array arguments ──────────────────────────────────────
+    if adjacency_file is not None and edge_list_file is not None:
+        raise click.ClickException("Use only one topology source: --adjacency-file or --edge-list-file.")
+
     omega: np.ndarray | None = None
     theta0: np.ndarray | None = None
+    adjacency: np.ndarray | None = None
 
-    if omega_str is not None:
-        try:
-            omega = np.array([float(v) for v in omega_str.split(",")], dtype=np.float64)
-        except ValueError as exc:
-            click.echo(f"Error parsing --omega: {exc}", err=True)
-            sys.exit(1)
+    try:
+        if omega_str is not None:
+            omega = parse_float_list(omega_str, option_name="--omega")
+        if theta0_str is not None:
+            theta0 = parse_float_list(theta0_str, option_name="--theta0")
+        if adjacency_file is not None:
+            adjacency = load_adjacency_matrix(adjacency_file)
+        elif edge_list_file is not None:
+            adjacency = load_edge_list(edge_list_file, n_oscillators=n_oscillators)
+    except ValueError as exc:
+        raise click.ClickException(str(exc)) from exc
 
-    if theta0_str is not None:
-        try:
-            theta0 = np.array(
-                [float(v) for v in theta0_str.split(",")], dtype=np.float64
-            )
-        except ValueError as exc:
-            click.echo(f"Error parsing --theta0: {exc}", err=True)
-            sys.exit(1)
-
-    # ── build and validate config ────────────────────────────────────────────
     try:
         cfg = KuramotoConfig(
             N=n_oscillators,
@@ -189,55 +108,47 @@ def simulate(
             seed=seed,
             omega=omega,
             theta0=theta0,
+            adjacency=adjacency,
         )
-    except Exception as exc:  # pydantic ValidationError or ValueError
-        click.echo(f"Configuration error: {exc}", err=True)
-        sys.exit(1)
+    except Exception as exc:
+        raise click.ClickException(f"Configuration error: {exc}") from exc
 
-    # ── run simulation ───────────────────────────────────────────────────────
     try:
         result = run_simulation(cfg)
     except Exception as exc:
-        click.echo(f"Simulation error: {exc}", err=True)
-        sys.exit(1)
+        raise click.ClickException(f"Simulation error: {exc}") from exc
 
-    # ── build output payload ─────────────────────────────────────────────────
-    payload: dict[str, Any] = {
-        "summary": result.summary,
-        "config": cfg.to_dict(),
-    }
+    include_trajectories = export_mode.lower() == "full"
+    payload = export_payload(
+        summary=result.summary,
+        config=cfg.to_dict(),
+        include_trajectories=include_trajectories,
+        order_parameter=result.order_parameter,
+        time=result.time,
+        phases=result.phases,
+    )
 
-    if not quiet:
-        _print_summary(result.summary)
-
-    # ── save to file ─────────────────────────────────────────────────────────
     if output_path is not None:
         output_path.parent.mkdir(parents=True, exist_ok=True)
-        # Include full trajectories only when writing to file
-        payload["order_parameter"] = result.order_parameter.tolist()
-        payload["time"] = result.time.tolist()
-        payload["phases_shape"] = list(result.phases.shape)
         output_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
-        if not quiet:
-            click.echo(f"\nFull result saved to: {output_path}")
 
     if quiet:
         click.echo(json.dumps(payload, indent=2))
+        return
 
-
-# ──────────────────────────────────────────────────────────────────────────────
-# Helpers
-# ──────────────────────────────────────────────────────────────────────────────
+    _print_summary(result.summary)
+    if output_path is not None:
+        click.echo(f"Saved {export_mode.lower()} payload to: {output_path}")
 
 
 def _print_summary(summary: dict[str, Any]) -> None:
-    """Render a human-readable summary table to stdout."""
     click.echo("")
     click.echo("━" * 50)
     click.echo("  Kuramoto Simulation — Summary")
     click.echo("━" * 50)
     click.echo(f"  Oscillators (N)  : {summary['N']}")
     click.echo(f"  Coupling (K)     : {summary['K']:.4f}")
+    click.echo(f"  Coupling mode    : {summary['coupling_mode']}")
     click.echo(f"  Time-step (dt)   : {summary['dt']:.6f}")
     click.echo(f"  Steps            : {summary['steps']}")
     click.echo(f"  Total time       : {summary['total_time']:.4f}")
@@ -252,7 +163,6 @@ def _print_summary(summary: dict[str, Any]) -> None:
 
 
 def main() -> None:
-    """Registered entry point for ``tp-kuramoto``."""
     cli()
 
 

--- a/core/kuramoto/config.py
+++ b/core/kuramoto/config.py
@@ -1,9 +1,5 @@
 # SPDX-License-Identifier: LicenseRef-TradePulse-Proprietary
-"""Configuration and parameter validation for the Kuramoto simulation engine.
-
-All public parameters are validated via Pydantic v2 models so that downstream
-code never receives out-of-range or type-incorrect inputs.
-"""
+"""Configuration and parameter validation for the Kuramoto simulation engine."""
 
 from __future__ import annotations
 
@@ -14,131 +10,87 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 class KuramotoConfig(BaseModel):
-    """Validated configuration container for a Kuramoto simulation run.
+    """Validated configuration for deterministic Kuramoto simulations.
 
-    Parameters
-    ----------
-    N:
-        Number of coupled oscillators.  Must be ≥ 2.
-    K:
-        Global coupling strength (dimensionless).  Positive values lead to
-        synchronisation; negative values may lead to anti-phase clustering.
-        Ignored when an explicit ``adjacency`` matrix is provided.
-    omega:
-        Natural frequencies of each oscillator in radians per unit time.
-        Must be a 1-D array of length ``N``.  If ``None`` the frequencies are
-        drawn from N(0, 1) using ``seed``.
-    dt:
-        Integration step in the same time units as ``omega``.  Must be > 0.
-    steps:
-        Total number of integration steps to run.  Must be ≥ 1.
-    adjacency:
-        Optional N×N coupling matrix **A** (weights; need not be binary).
-        When provided, the coupling term becomes ``K · Σⱼ Aᵢⱼ sin(θⱼ − θᵢ)``
-        and ``K`` acts as a global scale factor applied to every edge.
-        When ``None`` a fully-connected (all-to-all) topology is used.
-    theta0:
-        Initial phases in radians for each oscillator.  Must be a 1-D array
-        of length ``N``.  If ``None`` the phases are drawn from Uniform(0, 2π)
-        using ``seed``.
-    seed:
-        Integer random seed for reproducible draws of ``omega`` and/or
-        ``theta0``.  Has no effect when both arrays are supplied explicitly.
-
-    Examples
-    --------
-    >>> cfg = KuramotoConfig(N=5, K=2.0, dt=0.01, steps=1000, seed=42)
-    >>> cfg.N
-    5
+    Coupling semantics:
+    - ``adjacency is None``: global all-to-all coupling with per-edge weight ``K/N``.
+    - ``adjacency is not None``: explicit weighted topology with effective weight ``K*A_ij``.
     """
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     N: int = Field(default=10, ge=2, description="Number of oscillators (≥ 2)")
-    K: float = Field(default=1.0, description="Global coupling strength")
+    K: float = Field(default=1.0, description="Global coupling strength scale")
     omega: np.ndarray | None = Field(
         default=None,
         description="Natural frequencies [rad/time]; length N. Drawn from N(0,1) if None.",
     )
-    dt: float = Field(
-        default=0.01,
-        gt=0.0,
-        description="Integration time-step (must be > 0)",
-    )
-    steps: int = Field(
-        default=1000,
-        ge=1,
-        description="Number of integration steps (≥ 1)",
-    )
+    dt: float = Field(default=0.01, gt=0.0, description="Integration time-step (must be > 0)")
+    steps: int = Field(default=1000, ge=1, description="Number of integration steps (≥ 1)")
     adjacency: np.ndarray | None = Field(
         default=None,
-        description="N×N adjacency/coupling matrix. None → fully-connected.",
+        description=(
+            "Optional N×N weighted coupling matrix. Diagonal values are accepted but ignored "
+            "during integration (no-self-coupling)."
+        ),
     )
     theta0: np.ndarray | None = Field(
         default=None,
         description="Initial phases [rad]; length N. Drawn from U(0, 2π) if None.",
     )
-    seed: int | None = Field(
-        default=None,
-        description="Integer RNG seed for reproducibility.",
-    )
+    seed: int | None = Field(default=None, description="Integer RNG seed for reproducibility.")
 
     @model_validator(mode="after")
     def _validate_arrays(self) -> KuramotoConfig:
-        """Cross-field validation for array dimensions and content."""
+        """Validate scalar constraints and array shapes/finiteness."""
         N = self.N
 
-        # ── omega ───────────────────────────────────────────────────────────
+        if not np.isfinite(self.K):
+            raise ValueError("'K' must be finite.")
+        if self.seed is not None and self.seed < 0:
+            raise ValueError("'seed' must be >= 0 when provided.")
+
         if self.omega is not None:
             omega = np.asarray(self.omega, dtype=np.float64)
             if omega.ndim != 1 or omega.shape[0] != N:
-                raise ValueError(
-                    f"'omega' must be a 1-D array of length N={N}; "
-                    f"got shape {omega.shape}."
-                )
+                raise ValueError(f"'omega' must be a 1-D array of length N={N}; got shape {omega.shape}.")
             if not np.isfinite(omega).all():
                 raise ValueError("'omega' contains non-finite values (NaN or Inf).")
             object.__setattr__(self, "omega", omega)
 
-        # ── theta0 ──────────────────────────────────────────────────────────
         if self.theta0 is not None:
             theta0 = np.asarray(self.theta0, dtype=np.float64)
             if theta0.ndim != 1 or theta0.shape[0] != N:
-                raise ValueError(
-                    f"'theta0' must be a 1-D array of length N={N}; "
-                    f"got shape {theta0.shape}."
-                )
+                raise ValueError(f"'theta0' must be a 1-D array of length N={N}; got shape {theta0.shape}.")
             if not np.isfinite(theta0).all():
                 raise ValueError("'theta0' contains non-finite values (NaN or Inf).")
             object.__setattr__(self, "theta0", theta0)
 
-        # ── adjacency ───────────────────────────────────────────────────────
         if self.adjacency is not None:
             adj = np.asarray(self.adjacency, dtype=np.float64)
             if adj.ndim != 2 or adj.shape != (N, N):
-                raise ValueError(
-                    f"'adjacency' must be an (N×N)=({N}×{N}) matrix; "
-                    f"got shape {adj.shape}."
-                )
+                raise ValueError(f"'adjacency' must be an (N×N)=({N}×{N}) matrix; got shape {adj.shape}.")
             if not np.isfinite(adj).all():
-                raise ValueError(
-                    "'adjacency' contains non-finite values (NaN or Inf)."
-                )
+                raise ValueError("'adjacency' contains non-finite values (NaN or Inf).")
             object.__setattr__(self, "adjacency", adj)
 
         return self
 
+    @property
+    def coupling_mode(self) -> str:
+        """Return active coupling semantics label for summaries/serialization."""
+        return "adjacency" if self.adjacency is not None else "global"
+
     def to_dict(self) -> dict[str, Any]:
-        """Serialise to a plain dictionary (NumPy arrays converted to lists)."""
+        """Serialise to a deterministic, JSON-compatible dictionary."""
         return {
             "N": self.N,
             "K": self.K,
             "omega": self.omega.tolist() if self.omega is not None else None,
             "dt": self.dt,
             "steps": self.steps,
-            "adjacency": (
-                self.adjacency.tolist() if self.adjacency is not None else None
-            ),
+            "adjacency": self.adjacency.tolist() if self.adjacency is not None else None,
             "theta0": self.theta0.tolist() if self.theta0 is not None else None,
             "seed": self.seed,
+            "coupling_mode": self.coupling_mode,
         }

--- a/core/kuramoto/engine.py
+++ b/core/kuramoto/engine.py
@@ -1,23 +1,14 @@
 # SPDX-License-Identifier: LicenseRef-TradePulse-Proprietary
 """Kuramoto ODE simulation engine.
 
-Implements a vectorised, numerically stable 4th-order Runge-Kutta (RK4)
-integrator for the Kuramoto model of coupled phase oscillators:
+Coupling semantics implemented by this module:
 
-    Global coupling (fully connected):
-        dθᵢ/dt = ωᵢ + (K/N) · Σⱼ sin(θⱼ − θᵢ)
+- Global all-to-all mode (no explicit adjacency):
+  ``dθ_i/dt = ω_i + (K/N) * Σ_{j != i} sin(θ_j - θ_i)``
+- Explicit adjacency mode:
+  ``dθ_i/dt = ω_i + K * Σ_j A_ij sin(θ_j - θ_i)``
 
-    Weighted adjacency coupling:
-        dθᵢ/dt = ωᵢ + K · Σⱼ Aᵢⱼ sin(θⱼ − θᵢ)
-
-The engine is deterministic and reproducible for a given :class:`KuramotoConfig`.
-
-Typical use
------------
->>> from core.kuramoto import KuramotoConfig, run_simulation
->>> cfg = KuramotoConfig(N=50, K=2.0, dt=0.01, steps=500, seed=0)
->>> result = run_simulation(cfg)
->>> print(f"Final R = {result.order_parameter[-1]:.4f}")
+In both modes, no-self-coupling is enforced by zeroing diagonal weights.
 """
 
 from __future__ import annotations
@@ -36,30 +27,9 @@ __all__ = ["KuramotoEngine", "KuramotoResult", "run_simulation"]
 _logger = logging.getLogger(__name__)
 
 
-# ──────────────────────────────────────────────────────────────────────────────
-# Result container
-# ──────────────────────────────────────────────────────────────────────────────
-
-
 @dataclass(slots=True)
 class KuramotoResult:
-    """Typed container for the output of a Kuramoto simulation.
-
-    Attributes
-    ----------
-    phases:
-        Phase trajectories, shape ``(steps + 1, N)`` in radians.
-        Row 0 is the initial condition.
-    order_parameter:
-        Kuramoto order parameter R(t), shape ``(steps + 1,)``.
-        R ∈ [0, 1]: 0 → fully desynchronised, 1 → fully synchronised.
-    time:
-        Time axis, shape ``(steps + 1,)``.  ``time[k] = k * dt``.
-    config:
-        The :class:`KuramotoConfig` that produced this result.
-    summary:
-        Dictionary of scalar summary statistics.
-    """
+    """Simulation output container with shape and finiteness safeguards."""
 
     phases: NDArray[np.float64]
     order_parameter: NDArray[np.float64]
@@ -68,65 +38,62 @@ class KuramotoResult:
     summary: dict[str, Any] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
+        self._validate_shapes()
         self.summary = self._compute_summary()
+
+    def _validate_shapes(self) -> None:
+        expected_steps = self.config.steps + 1
+        expected_n = self.config.N
+        if self.phases.shape != (expected_steps, expected_n):
+            raise ValueError(
+                "Result phases shape mismatch: "
+                f"expected {(expected_steps, expected_n)}, got {self.phases.shape}."
+            )
+        if self.order_parameter.shape != (expected_steps,):
+            raise ValueError(
+                "Result order_parameter shape mismatch: "
+                f"expected {(expected_steps,)}, got {self.order_parameter.shape}."
+            )
+        if self.time.shape != (expected_steps,):
+            raise ValueError(f"Result time shape mismatch: expected {(expected_steps,)}, got {self.time.shape}.")
+
+        if not np.isfinite(self.phases).all():
+            raise ValueError("Result contains non-finite phase values.")
+        if not np.isfinite(self.order_parameter).all():
+            raise ValueError("Result contains non-finite order_parameter values.")
+        if not np.isfinite(self.time).all():
+            raise ValueError("Result contains non-finite time values.")
 
     def _compute_summary(self) -> dict[str, Any]:
         R = self.order_parameter
+        cfg = self.config
         return {
             "final_R": float(R[-1]),
             "mean_R": float(R.mean()),
             "max_R": float(R.max()),
             "min_R": float(R.min()),
             "std_R": float(R.std()),
-            "N": self.config.N,
-            "K": self.config.K,
-            "dt": self.config.dt,
-            "steps": self.config.steps,
+            "N": cfg.N,
+            "K": cfg.K,
+            "dt": cfg.dt,
+            "steps": cfg.steps,
             "total_time": float(self.time[-1]),
+            "coupling_mode": cfg.coupling_mode,
+            "seed": cfg.seed,
         }
 
 
-# ──────────────────────────────────────────────────────────────────────────────
-# Core engine
-# ──────────────────────────────────────────────────────────────────────────────
-
-
 class KuramotoEngine:
-    """Deterministic Kuramoto ODE solver using 4th-order Runge-Kutta.
-
-    Parameters
-    ----------
-    config:
-        Validated simulation configuration.  Use :class:`KuramotoConfig` to
-        construct and validate parameters before passing them here.
-
-    Examples
-    --------
-    >>> from core.kuramoto import KuramotoConfig, KuramotoEngine
-    >>> cfg = KuramotoConfig(N=10, K=1.5, dt=0.05, steps=200, seed=7)
-    >>> engine = KuramotoEngine(cfg)
-    >>> result = engine.run()
-    >>> result.summary["final_R"]
-    """
+    """Deterministic Kuramoto RK4 integrator for validated configurations."""
 
     def __init__(self, config: KuramotoConfig) -> None:
         self._cfg = config
         self._omega, self._theta0 = self._resolve_initial_conditions(config)
-        self._adj = self._resolve_adjacency(config, self._omega)
-
-    # ------------------------------------------------------------------
-    # Public API
-    # ------------------------------------------------------------------
+        self._adj = self._resolve_adjacency(config)
+        self._validate_runtime_inputs(self._omega, self._theta0, self._adj)
 
     def run(self) -> KuramotoResult:
-        """Execute the simulation and return a :class:`KuramotoResult`.
-
-        Returns
-        -------
-        KuramotoResult
-            Phase trajectories, order parameter time-series, time axis, and
-            summary statistics.
-        """
+        """Integrate ODE trajectories and return validated :class:`KuramotoResult`."""
         cfg = self._cfg
         N = cfg.N
         steps = cfg.steps
@@ -134,7 +101,6 @@ class KuramotoEngine:
         omega = self._omega
         adj = self._adj
 
-        # Pre-allocate output arrays
         phases = np.empty((steps + 1, N), dtype=np.float64)
         R_arr = np.empty(steps + 1, dtype=np.float64)
         time_arr = np.arange(steps + 1, dtype=np.float64) * dt
@@ -144,73 +110,66 @@ class KuramotoEngine:
         R_arr[0] = _order_parameter(theta)
 
         _logger.debug(
-            "Starting Kuramoto simulation: N=%d, K=%.4f, dt=%.6f, steps=%d",
+            "Starting Kuramoto simulation: N=%d, K=%.4f, dt=%.6f, steps=%d, mode=%s",
             N,
             cfg.K,
             dt,
             steps,
+            cfg.coupling_mode,
         )
 
         for k in range(steps):
             theta = _rk4_step(theta, omega, adj, dt)
+            if not np.isfinite(theta).all():
+                raise FloatingPointError(f"Non-finite phase values encountered at step={k + 1}.")
             phases[k + 1] = theta
             R_arr[k + 1] = _order_parameter(theta)
 
-        _logger.debug("Simulation complete. Final R=%.4f", R_arr[-1])
-
-        return KuramotoResult(
-            phases=phases,
-            order_parameter=R_arr,
-            time=time_arr,
-            config=cfg,
-        )
-
-    # ------------------------------------------------------------------
-    # Internal helpers
-    # ------------------------------------------------------------------
+        return KuramotoResult(phases=phases, order_parameter=R_arr, time=time_arr, config=cfg)
 
     @staticmethod
     def _resolve_initial_conditions(
         cfg: KuramotoConfig,
     ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
-        """Resolve ``omega`` and ``theta0``, drawing randomly if needed."""
         rng = np.random.default_rng(cfg.seed)
 
-        if cfg.omega is not None:
-            omega = cfg.omega.astype(np.float64, copy=False)
-        else:
-            omega = rng.standard_normal(cfg.N)
-
-        if cfg.theta0 is not None:
-            theta0 = cfg.theta0.astype(np.float64, copy=False)
-        else:
-            theta0 = rng.uniform(0.0, 2.0 * np.pi, cfg.N)
-
+        omega = cfg.omega.astype(np.float64, copy=False) if cfg.omega is not None else rng.standard_normal(cfg.N)
+        theta0 = (
+            cfg.theta0.astype(np.float64, copy=False)
+            if cfg.theta0 is not None
+            else rng.uniform(0.0, 2.0 * np.pi, cfg.N)
+        )
         return omega, theta0
 
     @staticmethod
-    def _resolve_adjacency(
-        cfg: KuramotoConfig,
-        omega: NDArray[np.float64],
-    ) -> NDArray[np.float64]:
-        """Build the effective coupling matrix used at each integration step.
-
-        For fully-connected topology the matrix is ``K/N * (ones - I)``.
-        For an explicit adjacency matrix it is ``K * A``.
-        """
+    def _resolve_adjacency(cfg: KuramotoConfig) -> NDArray[np.float64]:
+        """Build effective coupling matrix used in derivatives."""
         N = cfg.N
         K = cfg.K
         if cfg.adjacency is not None:
-            return K * cfg.adjacency.astype(np.float64, copy=False)
-        # All-to-all coupling (no self-coupling on diagonal)
+            adj = K * cfg.adjacency.astype(np.float64, copy=True)
+            np.fill_diagonal(adj, 0.0)
+            return adj
+
         adj = np.full((N, N), K / N, dtype=np.float64)
         np.fill_diagonal(adj, 0.0)
         return adj
 
+    @staticmethod
+    def _validate_runtime_inputs(
+        omega: NDArray[np.float64],
+        theta0: NDArray[np.float64],
+        adj: NDArray[np.float64],
+    ) -> None:
+        if omega.ndim != 1 or theta0.ndim != 1 or omega.shape != theta0.shape:
+            raise ValueError("Runtime vectors omega and theta0 must be 1-D and same shape.")
 
-# ──────────────────────────────────────────────────────────────────────────────
-# Vectorised inner-loop helpers (module-level for numba-friendliness)
-# ──────────────────────────────────────────────────────────────────────────────
+        n = omega.shape[0]
+        if adj.shape != (n, n):
+            raise ValueError(f"Runtime adjacency shape must be {(n, n)}, got {adj.shape}.")
+
+        if not np.isfinite(omega).all() or not np.isfinite(theta0).all() or not np.isfinite(adj).all():
+            raise ValueError("Runtime inputs must all be finite.")
 
 
 def _dtheta_dt(
@@ -218,27 +177,14 @@ def _dtheta_dt(
     omega: NDArray[np.float64],
     adj: NDArray[np.float64],
 ) -> NDArray[np.float64]:
-    """Compute the Kuramoto RHS: dθ/dt = ω + Σⱼ Aᵢⱼ sin(θⱼ − θᵢ).
-
-    Parameters
-    ----------
-    theta:
-        Current phases, shape ``(N,)``.
-    omega:
-        Natural frequencies, shape ``(N,)``.
-    adj:
-        Effective coupling matrix (already scaled by K), shape ``(N, N)``.
-
-    Returns
-    -------
-    NDArray[np.float64]
-        Phase derivatives, shape ``(N,)``.
-    """
-    # diff[i, j] = θⱼ − θᵢ  →  sin_diff[i, j] = sin(θⱼ − θᵢ)
-    diff = theta[np.newaxis, :] - theta[:, np.newaxis]  # (N, N)
+    """Evaluate Kuramoto RHS for a single phase vector."""
+    diff = theta[np.newaxis, :] - theta[:, np.newaxis]
     sin_diff = np.sin(diff)
-    coupling = (adj * sin_diff).sum(axis=1)  # (N,)
-    return omega + coupling
+    coupling = (adj * sin_diff).sum(axis=1)
+    out = omega + coupling
+    if not np.isfinite(out).all():
+        raise FloatingPointError("Non-finite derivative values produced by Kuramoto RHS.")
+    return out
 
 
 def _rk4_step(
@@ -247,24 +193,7 @@ def _rk4_step(
     adj: NDArray[np.float64],
     dt: float,
 ) -> NDArray[np.float64]:
-    """Advance phases by one RK4 step.
-
-    Parameters
-    ----------
-    theta:
-        Current phases, shape ``(N,)``.
-    omega:
-        Natural frequencies, shape ``(N,)``.
-    adj:
-        Effective coupling matrix, shape ``(N, N)``.
-    dt:
-        Integration step size.
-
-    Returns
-    -------
-    NDArray[np.float64]
-        Updated phases, shape ``(N,)``.
-    """
+    """Advance one Runge-Kutta 4 integration step."""
     k1 = _dtheta_dt(theta, omega, adj)
     k2 = _dtheta_dt(theta + 0.5 * dt * k1, omega, adj)
     k3 = _dtheta_dt(theta + 0.5 * dt * k2, omega, adj)
@@ -273,49 +202,11 @@ def _rk4_step(
 
 
 def _order_parameter(theta: NDArray[np.float64]) -> float:
-    """Kuramoto order parameter R = |mean(exp(iθ))|.
-
-    Parameters
-    ----------
-    theta:
-        Phase array, shape ``(N,)``.
-
-    Returns
-    -------
-    float
-        Order parameter in [0, 1].
-    """
+    """Compute Kuramoto order parameter ``R = |mean(exp(iθ))|``."""
     z = np.exp(1j * theta).mean()
     return float(np.clip(np.abs(z), 0.0, 1.0))
 
 
-# ──────────────────────────────────────────────────────────────────────────────
-# Convenience one-shot entry point
-# ──────────────────────────────────────────────────────────────────────────────
-
-
 def run_simulation(config: KuramotoConfig) -> KuramotoResult:
-    """Run a Kuramoto simulation from a validated configuration.
-
-    This is the recommended entry point for programmatic use.
-
-    Parameters
-    ----------
-    config:
-        Validated :class:`KuramotoConfig` instance.
-
-    Returns
-    -------
-    KuramotoResult
-        Full simulation output including phase trajectories, order parameter
-        time-series, time axis, and summary statistics.
-
-    Examples
-    --------
-    >>> from core.kuramoto import KuramotoConfig, run_simulation
-    >>> cfg = KuramotoConfig(N=20, K=3.0, dt=0.01, steps=500, seed=1)
-    >>> result = run_simulation(cfg)
-    >>> 0.0 <= result.order_parameter[-1] <= 1.0
-    True
-    """
+    """Convenience one-shot entry point around :class:`KuramotoEngine`."""
     return KuramotoEngine(config).run()

--- a/core/kuramoto/io.py
+++ b/core/kuramoto/io.py
@@ -1,0 +1,125 @@
+# SPDX-License-Identifier: LicenseRef-TradePulse-Proprietary
+"""IO helpers for Kuramoto CLI topology parsing and JSON export contracts.
+
+This module is the single boundary for user-supplied topology files and
+machine-readable payload generation used by ``tp-kuramoto``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from numpy.typing import NDArray
+
+SCHEMA_VERSION = 1
+
+
+def parse_float_list(raw: str, *, option_name: str) -> NDArray[np.float64]:
+    """Parse a comma-separated vector and reject empty/non-finite values."""
+    values = [chunk.strip() for chunk in raw.split(",") if chunk.strip()]
+    if not values:
+        raise ValueError(f"{option_name} must contain at least one numeric value.")
+
+    try:
+        vector = np.array([float(v) for v in values], dtype=np.float64)
+    except ValueError as exc:
+        raise ValueError(f"Failed to parse {option_name}: {exc}") from exc
+
+    if not np.isfinite(vector).all():
+        raise ValueError(f"{option_name} contains non-finite values.")
+
+    return vector
+
+
+def _load_json(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Malformed JSON in {path}: {exc.msg}.") from exc
+
+
+def load_adjacency_matrix(path: Path) -> NDArray[np.float64]:
+    """Load an adjacency matrix from ``.json``, ``.csv/.txt``, or ``.npy``."""
+    suffix = path.suffix.lower()
+    if suffix == ".json":
+        matrix = np.asarray(_load_json(path), dtype=np.float64)
+    elif suffix in {".csv", ".txt"}:
+        matrix = np.loadtxt(path, delimiter=",", dtype=np.float64)
+    elif suffix == ".npy":
+        matrix = np.load(path)
+    else:
+        raise ValueError(
+            f"Unsupported adjacency file extension '{suffix}'. "
+            "Supported: .json, .csv, .txt, .npy"
+        )
+
+    if matrix.ndim != 2:
+        raise ValueError("Adjacency matrix must be 2-dimensional.")
+    if matrix.shape[0] != matrix.shape[1]:
+        raise ValueError("Adjacency matrix must be square (N x N).")
+    if not np.isfinite(matrix).all():
+        raise ValueError("Adjacency matrix contains non-finite values.")
+
+    return np.asarray(matrix, dtype=np.float64)
+
+
+def load_edge_list(path: Path, n_oscillators: int) -> NDArray[np.float64]:
+    """Load weighted directed topology from edge-list JSON.
+
+    Expected schema:
+    ``{"edges": [{"source": int, "target": int, "weight": float=1.0}, ...]}``
+    """
+    payload = _load_json(path)
+    edges = payload.get("edges") if isinstance(payload, dict) else None
+    if not isinstance(edges, list):
+        raise ValueError("Edge-list JSON must contain an 'edges' array.")
+
+    adj = np.zeros((n_oscillators, n_oscillators), dtype=np.float64)
+
+    for idx, edge in enumerate(edges):
+        if not isinstance(edge, dict):
+            raise ValueError(f"Edge entry at index {idx} must be an object.")
+
+        try:
+            source = int(edge["source"])
+            target = int(edge["target"])
+        except KeyError as exc:
+            raise ValueError(f"Edge entry at index {idx} is missing {exc.args[0]!r}.") from exc
+
+        weight = float(edge.get("weight", 1.0))
+
+        if not (0 <= source < n_oscillators and 0 <= target < n_oscillators):
+            raise ValueError(f"Edge ({source}, {target}) out of range for N={n_oscillators}.")
+        if not np.isfinite(weight):
+            raise ValueError(f"Edge ({source}, {target}) has non-finite weight.")
+
+        adj[source, target] = weight
+
+    return adj
+
+
+def export_payload(
+    *,
+    summary: dict[str, Any],
+    config: dict[str, Any],
+    include_trajectories: bool,
+    order_parameter: NDArray[np.float64],
+    time: NDArray[np.float64],
+    phases: NDArray[np.float64],
+) -> dict[str, Any]:
+    """Build deterministic JSON-safe payload for stdout and file export."""
+    payload: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "summary": summary,
+        "config": config,
+    }
+
+    if include_trajectories:
+        payload["order_parameter"] = order_parameter.tolist()
+        payload["time"] = time.tolist()
+        payload["phases"] = phases.tolist()
+
+    return payload

--- a/tests/unit/core/test_kuramoto_cli.py
+++ b/tests/unit/core/test_kuramoto_cli.py
@@ -1,0 +1,155 @@
+# SPDX-License-Identifier: LicenseRef-TradePulse-Proprietary
+"""CLI tests for the Kuramoto simulation entrypoint."""
+
+from __future__ import annotations
+
+import json
+
+from click.testing import CliRunner
+
+from core.kuramoto.cli import cli
+from core.kuramoto.io import SCHEMA_VERSION
+
+
+def test_cli_quiet_summary_mode_contract() -> None:
+    runner = CliRunner()
+    result = runner.invoke(cli, ["simulate", "--N", "4", "--steps", "5", "--quiet", "--export", "summary", "--seed", "7"])
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload == {
+        "schema_version": SCHEMA_VERSION,
+        "summary": payload["summary"],
+        "config": payload["config"],
+    }
+
+
+def test_cli_full_export_file_round_trip() -> None:
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        out = "run.json"
+        result = runner.invoke(
+            cli,
+            ["simulate", "--N", "3", "--steps", "8", "--seed", "3", "--output", out, "--quiet", "--export", "full"],
+        )
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert payload["schema_version"] == SCHEMA_VERSION
+        assert len(payload["order_parameter"]) == 9
+        assert len(payload["time"]) == 9
+        assert len(payload["phases"]) == 9
+
+        with open(out, "r", encoding="utf-8") as handle:
+            file_payload = json.load(handle)
+        assert file_payload == payload
+
+
+def test_cli_human_readable_mode_smoke() -> None:
+    runner = CliRunner()
+    result = runner.invoke(cli, ["simulate", "--N", "3", "--steps", "2", "--seed", "4"])
+    assert result.exit_code == 0
+    assert "Kuramoto Simulation" in result.output
+    assert "Final R" in result.output
+
+
+def test_cli_adjacency_matrix_file() -> None:
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        with open("adj.json", "w", encoding="utf-8") as handle:
+            json.dump([[0.0, 1.0], [1.0, 0.0]], handle)
+
+        result = runner.invoke(
+            cli,
+            ["simulate", "--N", "2", "--steps", "5", "--adjacency-file", "adj.json", "--quiet", "--seed", "1"],
+        )
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert payload["summary"]["coupling_mode"] == "adjacency"
+
+
+def test_cli_edge_list_file() -> None:
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        with open("edges.json", "w", encoding="utf-8") as handle:
+            json.dump({"edges": [{"source": 0, "target": 1, "weight": 0.5}]}, handle)
+
+        result = runner.invoke(
+            cli,
+            ["simulate", "--N", "2", "--steps", "3", "--edge-list-file", "edges.json", "--quiet"],
+        )
+        assert result.exit_code == 0
+
+
+def test_cli_rejects_multiple_topologies() -> None:
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        with open("adj.json", "w", encoding="utf-8") as handle:
+            json.dump([[0.0, 1.0], [1.0, 0.0]], handle)
+        with open("edges.json", "w", encoding="utf-8") as handle:
+            json.dump({"edges": []}, handle)
+
+        result = runner.invoke(
+            cli,
+            [
+                "simulate",
+                "--N",
+                "2",
+                "--adjacency-file",
+                "adj.json",
+                "--edge-list-file",
+                "edges.json",
+            ],
+        )
+        assert result.exit_code != 0
+        assert "Use only one topology source" in result.output
+
+
+def test_cli_bad_omega_and_theta0_fail() -> None:
+    runner = CliRunner()
+    omega_result = runner.invoke(cli, ["simulate", "--omega", "1.0,abc"])
+    theta_result = runner.invoke(cli, ["simulate", "--theta0", "0.0,nan"])
+    assert omega_result.exit_code != 0
+    assert theta_result.exit_code != 0
+    assert "Failed to parse --omega" in omega_result.output
+    assert "contains non-finite" in theta_result.output
+
+
+def test_cli_adjacency_file_shape_mismatch_fails() -> None:
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        with open("bad.csv", "w", encoding="utf-8") as handle:
+            handle.write("1,2,3\n")
+        result = runner.invoke(cli, ["simulate", "--adjacency-file", "bad.csv", "--N", "3", "--quiet"])
+        assert result.exit_code != 0
+        assert "Adjacency matrix must be 2-dimensional" in result.output
+
+
+def test_cli_adjacency_file_unsupported_extension_fails() -> None:
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        with open("adj.bin", "wb") as handle:
+            handle.write(b"binary")
+        result = runner.invoke(cli, ["simulate", "--adjacency-file", "adj.bin", "--quiet"])
+        assert result.exit_code != 0
+        assert "Unsupported adjacency file extension" in result.output
+
+
+def test_cli_edge_list_malformed_schema_and_weight_failures() -> None:
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        with open("bad_schema.json", "w", encoding="utf-8") as handle:
+            json.dump({"not_edges": []}, handle)
+        with open("bad_weight.json", "w", encoding="utf-8") as handle:
+            json.dump({"edges": [{"source": 0, "target": 1, "weight": "inf"}]}, handle)
+
+        schema_result = runner.invoke(
+            cli,
+            ["simulate", "--N", "2", "--edge-list-file", "bad_schema.json", "--quiet"],
+        )
+        weight_result = runner.invoke(
+            cli,
+            ["simulate", "--N", "2", "--edge-list-file", "bad_weight.json", "--quiet"],
+        )
+        assert schema_result.exit_code != 0
+        assert "must contain an 'edges' array" in schema_result.output
+        assert weight_result.exit_code != 0
+        assert "non-finite weight" in weight_result.output

--- a/tests/unit/core/test_kuramoto_engine.py
+++ b/tests/unit/core/test_kuramoto_engine.py
@@ -1,20 +1,7 @@
 # SPDX-License-Identifier: LicenseRef-TradePulse-Proprietary
-"""Unit tests for the Kuramoto ODE simulation engine.
-
-Covers:
-    - Basic correctness (phase shapes, R ∈ [0, 1])
-    - Deterministic behaviour with fixed seed
-    - Shape / dimension validation
-    - Edge cases: small N, invalid params, zero/negative dt
-    - Regression: synchronisation in a known high-coupling scenario
-    - Adjacency matrix coupling
-    - Summary statistics completeness
-"""
+"""Unit tests for the Kuramoto ODE simulation engine."""
 
 from __future__ import annotations
-
-import json
-from pathlib import Path
 
 import numpy as np
 import pytest
@@ -23,14 +10,8 @@ from core.kuramoto import KuramotoConfig, KuramotoEngine, KuramotoResult, run_si
 from core.kuramoto.engine import _dtheta_dt, _order_parameter, _rk4_step
 
 
-# ──────────────────────────────────────────────────────────────────────────────
-# Fixtures
-# ──────────────────────────────────────────────────────────────────────────────
-
-
 @pytest.fixture()
 def default_cfg() -> KuramotoConfig:
-    """Default small configuration for fast unit tests."""
     return KuramotoConfig(N=10, K=1.0, dt=0.01, steps=200, seed=0)
 
 
@@ -39,348 +20,229 @@ def result_default(default_cfg: KuramotoConfig) -> KuramotoResult:
     return run_simulation(default_cfg)
 
 
-# ──────────────────────────────────────────────────────────────────────────────
-# Shape / dimension tests
-# ──────────────────────────────────────────────────────────────────────────────
-
-
 class TestOutputShapes:
-    def test_phases_shape(self, default_cfg: KuramotoConfig, result_default: KuramotoResult) -> None:
-        expected = (default_cfg.steps + 1, default_cfg.N)
-        assert result_default.phases.shape == expected, (
-            f"phases.shape should be {expected}, got {result_default.phases.shape}"
-        )
-
-    def test_order_parameter_shape(self, default_cfg: KuramotoConfig, result_default: KuramotoResult) -> None:
+    def test_shapes(self, default_cfg: KuramotoConfig, result_default: KuramotoResult) -> None:
+        assert result_default.phases.shape == (default_cfg.steps + 1, default_cfg.N)
         assert result_default.order_parameter.shape == (default_cfg.steps + 1,)
-
-    def test_time_axis_shape(self, default_cfg: KuramotoConfig, result_default: KuramotoResult) -> None:
         assert result_default.time.shape == (default_cfg.steps + 1,)
 
     def test_time_axis_values(self, default_cfg: KuramotoConfig, result_default: KuramotoResult) -> None:
-        expected_last = default_cfg.steps * default_cfg.dt
         assert result_default.time[0] == pytest.approx(0.0)
-        assert result_default.time[-1] == pytest.approx(expected_last)
+        assert result_default.time[-1] == pytest.approx(default_cfg.steps * default_cfg.dt)
 
-    def test_initial_phases_preserved(self, result_default: KuramotoResult) -> None:
-        """Row 0 must equal the initial condition, not a derivative."""
-        cfg = result_default.config
-        # Re-resolve initial condition using the same seed path
-        engine = KuramotoEngine(cfg)
+    def test_initial_phases_match_engine_state(self, result_default: KuramotoResult) -> None:
+        engine = KuramotoEngine(result_default.config)
         np.testing.assert_array_equal(result_default.phases[0], engine._theta0)
 
 
-# ──────────────────────────────────────────────────────────────────────────────
-# Correctness tests
-# ──────────────────────────────────────────────────────────────────────────────
+class TestCorrectness:
+    def test_order_parameter_bounds(self, result_default: KuramotoResult) -> None:
+        assert np.all((0.0 <= result_default.order_parameter) & (result_default.order_parameter <= 1.0))
 
-
-class TestCorrectnessBasic:
-    def test_order_parameter_in_unit_interval(self, result_default: KuramotoResult) -> None:
-        R = result_default.order_parameter
-        assert np.all(R >= 0.0), "R must be ≥ 0"
-        assert np.all(R <= 1.0), "R must be ≤ 1"
-
-    def test_perfectly_aligned_phases_give_R_one(self) -> None:
-        """All oscillators starting in phase → R(0) = 1."""
-        N = 8
-        cfg = KuramotoConfig(
-            N=N,
-            K=1.0,
-            dt=0.01,
-            steps=10,
-            theta0=np.zeros(N),
-            omega=np.zeros(N),
-        )
-        result = run_simulation(cfg)
-        # When omega=0 and phases=0, coupling term is also 0 → no movement
-        assert result.order_parameter[0] == pytest.approx(1.0, abs=1e-9)
-        assert result.order_parameter[-1] == pytest.approx(1.0, abs=1e-9)
-
-    def test_uniformly_distributed_phases_give_R_near_zero(self) -> None:
-        """Uniformly distributed phases → R ≈ 0 (for large N)."""
-        N = 200
-        theta0 = np.linspace(0, 2 * np.pi, N, endpoint=False)
-        cfg = KuramotoConfig(
-            N=N,
-            K=0.0,
-            dt=0.01,
-            steps=1,
-            theta0=theta0,
-            omega=np.zeros(N),
-        )
-        result = run_simulation(cfg)
-        assert result.order_parameter[0] < 0.05, (
-            f"Uniform phases should give R ≈ 0; got {result.order_parameter[0]:.4f}"
-        )
-
-    def test_zero_coupling_preserves_phases(self) -> None:
-        """K=0 → each oscillator evolves independently at its natural frequency."""
-        N = 5
-        omega = np.array([0.5, 1.0, 1.5, 2.0, 2.5])
-        theta0 = np.zeros(N)
-        dt = 0.1
-        steps = 10
-        cfg = KuramotoConfig(N=N, K=0.0, dt=dt, steps=steps, omega=omega, theta0=theta0)
-        result = run_simulation(cfg)
-
-        # Expected: θᵢ(t) ≈ ωᵢ · t  (Euler would be exact; RK4 is also near-exact for linear)
-        t_final = steps * dt
-        expected_final = theta0 + omega * t_final
-        np.testing.assert_allclose(
-            result.phases[-1], expected_final, rtol=1e-5, atol=1e-5
-        )
-
-    def test_phases_are_finite(self, result_default: KuramotoResult) -> None:
+    def test_finite_outputs(self, result_default: KuramotoResult) -> None:
         assert np.isfinite(result_default.phases).all()
-
-    def test_order_parameter_is_finite(self, result_default: KuramotoResult) -> None:
         assert np.isfinite(result_default.order_parameter).all()
 
+    def test_perfect_alignment_stays_synchronised(self) -> None:
+        N = 8
+        cfg = KuramotoConfig(N=N, K=1.0, dt=0.01, steps=10, theta0=np.zeros(N), omega=np.zeros(N))
+        result = run_simulation(cfg)
+        assert result.order_parameter[0] == pytest.approx(1.0)
+        assert result.order_parameter[-1] == pytest.approx(1.0)
 
-# ──────────────────────────────────────────────────────────────────────────────
-# Determinism tests
-# ──────────────────────────────────────────────────────────────────────────────
+    def test_uniform_phases_are_desynchronised(self) -> None:
+        N = 200
+        theta0 = np.linspace(0, 2 * np.pi, N, endpoint=False)
+        cfg = KuramotoConfig(N=N, K=0.0, dt=0.01, steps=1, theta0=theta0, omega=np.zeros(N))
+        result = run_simulation(cfg)
+        assert result.order_parameter[0] < 0.05
+
+    def test_k_zero_matches_analytic_trajectory_all_steps(self) -> None:
+        N = 4
+        dt = 0.05
+        steps = 20
+        omega = np.array([0.1, -0.2, 0.5, 1.0])
+        theta0 = np.array([0.0, 1.0, -1.0, 0.4])
+        cfg = KuramotoConfig(N=N, K=0.0, dt=dt, steps=steps, omega=omega, theta0=theta0)
+        result = run_simulation(cfg)
+        expected = theta0[np.newaxis, :] + np.arange(steps + 1)[:, np.newaxis] * dt * omega[np.newaxis, :]
+        np.testing.assert_allclose(result.phases, expected, atol=1e-10, rtol=1e-10)
 
 
 class TestDeterminism:
-    def test_same_seed_produces_identical_results(self) -> None:
+    def test_same_seed_identical(self) -> None:
         cfg = KuramotoConfig(N=15, K=1.2, dt=0.01, steps=300, seed=99)
         r1 = run_simulation(cfg)
         r2 = run_simulation(cfg)
         np.testing.assert_array_equal(r1.phases, r2.phases)
         np.testing.assert_array_equal(r1.order_parameter, r2.order_parameter)
 
-    def test_different_seeds_produce_different_results(self) -> None:
-        cfg_a = KuramotoConfig(N=10, K=1.0, dt=0.01, steps=100, seed=1)
-        cfg_b = KuramotoConfig(N=10, K=1.0, dt=0.01, steps=100, seed=2)
-        r_a = run_simulation(cfg_a)
-        r_b = run_simulation(cfg_b)
-        assert not np.array_equal(r_a.phases, r_b.phases), (
-            "Different seeds should produce different phase trajectories"
-        )
+    def test_different_seed_differs(self) -> None:
+        r_a = run_simulation(KuramotoConfig(N=10, K=1.0, dt=0.01, steps=100, seed=1))
+        r_b = run_simulation(KuramotoConfig(N=10, K=1.0, dt=0.01, steps=100, seed=2))
+        assert not np.array_equal(r_a.phases, r_b.phases)
 
     def test_explicit_arrays_ignore_seed(self) -> None:
         N = 6
         omega = np.linspace(-1.0, 1.0, N)
         theta0 = np.linspace(0, np.pi, N)
-        cfg_s0 = KuramotoConfig(N=N, K=1.0, dt=0.01, steps=50, seed=0, omega=omega, theta0=theta0)
-        cfg_s1 = KuramotoConfig(N=N, K=1.0, dt=0.01, steps=50, seed=1, omega=omega, theta0=theta0)
-        r0 = run_simulation(cfg_s0)
-        r1 = run_simulation(cfg_s1)
-        # Seed should have no effect when arrays are explicitly supplied
+        r0 = run_simulation(KuramotoConfig(N=N, K=1.0, dt=0.01, steps=50, seed=0, omega=omega, theta0=theta0))
+        r1 = run_simulation(KuramotoConfig(N=N, K=1.0, dt=0.01, steps=50, seed=1, omega=omega, theta0=theta0))
         np.testing.assert_array_equal(r0.phases, r1.phases)
 
+    def test_explicit_omega_alone_ignores_seed(self) -> None:
+        N = 5
+        omega = np.linspace(-0.5, 0.5, N)
+        a = run_simulation(KuramotoConfig(N=N, K=1.0, dt=0.01, steps=20, seed=1, omega=omega))
+        b = run_simulation(KuramotoConfig(N=N, K=1.0, dt=0.01, steps=20, seed=9, omega=omega))
+        np.testing.assert_array_equal(a.order_parameter, b.order_parameter)
 
-# ──────────────────────────────────────────────────────────────────────────────
-# Validation / error handling tests
-# ──────────────────────────────────────────────────────────────────────────────
+    def test_explicit_theta0_alone_ignores_seed(self) -> None:
+        N = 5
+        theta0 = np.linspace(0.0, 1.0, N)
+        a = run_simulation(KuramotoConfig(N=N, K=1.0, dt=0.01, steps=20, seed=1, theta0=theta0))
+        b = run_simulation(KuramotoConfig(N=N, K=1.0, dt=0.01, steps=20, seed=9, theta0=theta0))
+        np.testing.assert_array_equal(a.phases[0], b.phases[0])
 
 
 class TestValidation:
-    def test_N_less_than_2_raises(self) -> None:
-        with pytest.raises(Exception):  # pydantic ValidationError
+    def test_invalid_core_params_raise(self) -> None:
+        with pytest.raises(Exception):
             KuramotoConfig(N=1, K=1.0, dt=0.01, steps=10)
-
-    def test_negative_dt_raises(self) -> None:
         with pytest.raises(Exception):
             KuramotoConfig(N=5, K=1.0, dt=-0.01, steps=10)
-
-    def test_zero_dt_raises(self) -> None:
         with pytest.raises(Exception):
             KuramotoConfig(N=5, K=1.0, dt=0.0, steps=10)
-
-    def test_zero_steps_raises(self) -> None:
         with pytest.raises(Exception):
             KuramotoConfig(N=5, K=1.0, dt=0.01, steps=0)
 
-    def test_omega_wrong_length_raises(self) -> None:
+    def test_array_shape_and_finite_validation(self) -> None:
         with pytest.raises(ValueError, match="omega"):
             KuramotoConfig(N=5, K=1.0, dt=0.01, steps=10, omega=np.ones(3))
-
-    def test_omega_wrong_shape_raises(self) -> None:
         with pytest.raises(ValueError, match="omega"):
             KuramotoConfig(N=4, K=1.0, dt=0.01, steps=10, omega=np.ones((2, 2)))
-
-    def test_omega_with_nan_raises(self) -> None:
         with pytest.raises(ValueError, match="omega"):
             KuramotoConfig(N=3, K=1.0, dt=0.01, steps=10, omega=np.array([1.0, np.nan, 0.5]))
-
-    def test_theta0_wrong_length_raises(self) -> None:
         with pytest.raises(ValueError, match="theta0"):
-            KuramotoConfig(N=5, K=1.0, dt=0.01, steps=10, theta0=np.zeros(7))
-
-    def test_adjacency_wrong_shape_raises(self) -> None:
+            KuramotoConfig(N=3, K=1.0, dt=0.01, steps=10, theta0=np.array([0.0, np.inf, 1.0]))
         with pytest.raises(ValueError, match="adjacency"):
             KuramotoConfig(N=4, K=1.0, dt=0.01, steps=10, adjacency=np.ones((3, 3)))
 
-    def test_adjacency_with_inf_raises(self) -> None:
-        adj = np.ones((3, 3))
-        adj[0, 1] = np.inf
-        with pytest.raises(ValueError, match="adjacency"):
-            KuramotoConfig(N=3, K=1.0, dt=0.01, steps=10, adjacency=adj)
+    def test_seed_and_coupling_validation(self) -> None:
+        with pytest.raises(ValueError, match="seed"):
+            KuramotoConfig(N=5, K=1.0, dt=0.01, steps=10, seed=-1)
+        with pytest.raises(ValueError, match="K"):
+            KuramotoConfig(N=5, K=np.inf, dt=0.01, steps=10)
 
-    def test_theta0_with_inf_raises(self) -> None:
-        with pytest.raises(ValueError, match="theta0"):
-            KuramotoConfig(N=3, K=1.0, dt=0.01, steps=10, theta0=np.array([0.0, np.inf, 1.0]))
-
-    def test_N_equals_2_is_valid(self) -> None:
-        """Minimum valid N is 2."""
-        cfg = KuramotoConfig(N=2, K=1.0, dt=0.01, steps=5, seed=0)
-        result = run_simulation(cfg)
-        assert result.phases.shape == (6, 2)
+    def test_config_to_dict_contract(self) -> None:
+        cfg = KuramotoConfig(N=3, K=2.5, dt=0.1, steps=4, seed=7)
+        payload = cfg.to_dict()
+        assert payload["coupling_mode"] == "global"
+        assert payload["seed"] == 7
+        assert payload["adjacency"] is None
 
 
-# ──────────────────────────────────────────────────────────────────────────────
-# Adjacency matrix coupling
-# ──────────────────────────────────────────────────────────────────────────────
-
-
-class TestAdjacencyMatrix:
-    def test_all_ones_adjacency_matches_global_coupling(self) -> None:
-        """A = ones(N,N) with diagonal zeroed should approximate K/N global coupling."""
+class TestAdjacencySemantics:
+    def test_global_and_equivalent_adjacency_match(self) -> None:
         N = 6
         omega = np.zeros(N)
         theta0 = np.linspace(0, np.pi, N)
-        dt = 0.01
-        steps = 50
-
-        # Global coupling
-        cfg_global = KuramotoConfig(N=N, K=1.0, dt=dt, steps=steps, omega=omega, theta0=theta0)
-
-        # Adjacency = full matrix / N  → effective weight per edge is 1/N (same as global)
         adj = np.ones((N, N))
         np.fill_diagonal(adj, 0.0)
         adj /= N
-        cfg_adj = KuramotoConfig(N=N, K=1.0, dt=dt, steps=steps, omega=omega, theta0=theta0, adjacency=adj)
+        global_result = run_simulation(KuramotoConfig(N=N, K=1.0, dt=0.01, steps=50, omega=omega, theta0=theta0))
+        adj_result = run_simulation(
+            KuramotoConfig(N=N, K=1.0, dt=0.01, steps=50, omega=omega, theta0=theta0, adjacency=adj)
+        )
+        np.testing.assert_allclose(global_result.phases, adj_result.phases, atol=1e-10)
 
-        r_global = run_simulation(cfg_global)
-        r_adj = run_simulation(cfg_adj)
+    def test_diagonal_entries_are_ignored(self) -> None:
+        N = 5
+        omega = np.linspace(-0.2, 0.2, N)
+        theta0 = np.linspace(0.0, 2.0, N)
+        adj = np.ones((N, N)) / N
+        np.fill_diagonal(adj, 1000.0)
+        adj_zero_diag = adj.copy()
+        np.fill_diagonal(adj_zero_diag, 0.0)
 
-        np.testing.assert_allclose(r_global.phases, r_adj.phases, atol=1e-10)
+        with_diag = run_simulation(KuramotoConfig(N=N, K=1.0, dt=0.01, steps=40, omega=omega, theta0=theta0, adjacency=adj))
+        zero_diag = run_simulation(
+            KuramotoConfig(N=N, K=1.0, dt=0.01, steps=40, omega=omega, theta0=theta0, adjacency=adj_zero_diag)
+        )
+        np.testing.assert_allclose(with_diag.phases, zero_diag.phases, atol=1e-12)
 
-    def test_disconnected_adjacency_halts_coupling(self) -> None:
-        """Zero adjacency matrix → no coupling → oscillators evolve freely."""
+    def test_disconnected_adjacency_means_no_coupling(self) -> None:
         N = 4
         omega = np.array([1.0, 2.0, 3.0, 4.0])
         theta0 = np.zeros(N)
-        dt = 0.1
-        steps = 5
-        adj = np.zeros((N, N))
-        cfg = KuramotoConfig(N=N, K=5.0, dt=dt, steps=steps, omega=omega, theta0=theta0, adjacency=adj)
+        cfg = KuramotoConfig(N=N, K=5.0, dt=0.1, steps=5, omega=omega, theta0=theta0, adjacency=np.zeros((N, N)))
         result = run_simulation(cfg)
+        np.testing.assert_allclose(result.phases[-1], theta0 + omega * 0.5, rtol=1e-5, atol=1e-5)
 
-        expected = theta0 + omega * (steps * dt)
-        np.testing.assert_allclose(result.phases[-1], expected, rtol=1e-5, atol=1e-5)
-
-
-# ──────────────────────────────────────────────────────────────────────────────
-# Regression test — known synchronisation scenario
-# ──────────────────────────────────────────────────────────────────────────────
+    def test_permutation_invariance_under_global_coupling(self) -> None:
+        N = 7
+        omega = np.linspace(-1.0, 1.0, N)
+        theta0 = np.linspace(0.2, 1.5, N)
+        perm = np.array([2, 5, 1, 6, 0, 4, 3])
+        base = run_simulation(KuramotoConfig(N=N, K=1.7, dt=0.02, steps=80, omega=omega, theta0=theta0))
+        permuted = run_simulation(
+            KuramotoConfig(N=N, K=1.7, dt=0.02, steps=80, omega=omega[perm], theta0=theta0[perm])
+        )
+        np.testing.assert_allclose(base.order_parameter, permuted.order_parameter, atol=1e-12)
 
 
 class TestSynchronizationRegression:
-    def test_strong_coupling_leads_to_high_R(self) -> None:
-        """Above the critical coupling K_c = 2·std(ω), oscillators should synchronise.
-
-        For N=50 oscillators with ω ~ N(0,1), K_c ≈ 2.  Using K=6 (well above)
-        and running for 1000 steps should yield final R > 0.9.
-        """
+    def test_strong_coupling_increases_synchrony(self) -> None:
         cfg = KuramotoConfig(N=50, K=6.0, dt=0.05, steps=1000, seed=42)
         result = run_simulation(cfg)
-        assert result.order_parameter[-1] > 0.9, (
-            f"Expected R > 0.9 for strong coupling; got {result.order_parameter[-1]:.4f}"
-        )
+        assert result.order_parameter[-1] > 0.9
 
-    def test_zero_coupling_prevents_synchronisation(self) -> None:
-        """With K=0 and uniformly distributed phases, R should stay low."""
-        N = 100
+    def test_small_controlled_system_trends_up_with_strong_coupling(self) -> None:
+        N = 8
         theta0 = np.linspace(0, 2 * np.pi, N, endpoint=False)
-        omega = np.zeros(N)
-        cfg = KuramotoConfig(N=N, K=0.0, dt=0.01, steps=500, theta0=theta0, omega=omega)
+        omega = np.linspace(-0.05, 0.05, N)
+        cfg = KuramotoConfig(N=N, K=8.0, dt=0.02, steps=300, omega=omega, theta0=theta0)
         result = run_simulation(cfg)
-        assert result.order_parameter[-1] < 0.05, (
-            f"Expected R ≈ 0 without coupling; got {result.order_parameter[-1]:.4f}"
-        )
-
-    def test_R_increases_monotonically_under_strong_coupling(self) -> None:
-        """Under very strong coupling starting near-uniform, R should trend upward."""
-        N = 30
-        rng = np.random.default_rng(7)
-        theta0 = rng.uniform(0, 2 * np.pi, N)
-        omega = rng.standard_normal(N) * 0.1  # very narrow frequency spread
-
-        cfg = KuramotoConfig(N=N, K=10.0, dt=0.01, steps=500, theta0=theta0, omega=omega)
-        result = run_simulation(cfg)
-
-        R_early = result.order_parameter[:100].mean()
-        R_late = result.order_parameter[400:].mean()
-        assert R_late > R_early, (
-            f"R should increase under strong coupling; early={R_early:.4f}, late={R_late:.4f}"
-        )
+        assert result.order_parameter[-1] > result.order_parameter[0]
 
 
-# ──────────────────────────────────────────────────────────────────────────────
-# Summary statistics
-# ──────────────────────────────────────────────────────────────────────────────
+class TestSummaryAndHelpers:
+    def test_summary_keys_and_consistency(self, result_default: KuramotoResult) -> None:
+        required = {
+            "final_R",
+            "mean_R",
+            "max_R",
+            "min_R",
+            "std_R",
+            "N",
+            "K",
+            "dt",
+            "steps",
+            "total_time",
+            "coupling_mode",
+            "seed",
+        }
+        assert required.issubset(result_default.summary)
+        assert result_default.summary["final_R"] == pytest.approx(result_default.order_parameter[-1])
+        assert result_default.summary["coupling_mode"] == result_default.config.coupling_mode
 
+    def test_result_constructor_validation(self, default_cfg: KuramotoConfig) -> None:
+        phases = np.zeros((default_cfg.steps + 1, default_cfg.N))
+        order = np.zeros(default_cfg.steps + 1)
+        time = np.arange(default_cfg.steps + 1, dtype=float) * default_cfg.dt
 
-class TestSummaryStatistics:
-    def test_summary_keys_present(self, result_default: KuramotoResult) -> None:
-        required = {"final_R", "mean_R", "max_R", "min_R", "std_R", "N", "K", "dt", "steps", "total_time"}
-        assert required.issubset(result_default.summary.keys())
+        with pytest.raises(ValueError, match="phases"):
+            KuramotoResult(phases=phases[:-1], order_parameter=order, time=time, config=default_cfg)
+        with pytest.raises(ValueError, match="order_parameter"):
+            KuramotoResult(phases=phases, order_parameter=order[:-1], time=time, config=default_cfg)
 
-    def test_summary_final_R_matches_trajectory(self, result_default: KuramotoResult) -> None:
-        assert result_default.summary["final_R"] == pytest.approx(
-            result_default.order_parameter[-1], abs=1e-12
-        )
+    def test_order_parameter_helper(self) -> None:
+        assert _order_parameter(np.zeros(20)) == pytest.approx(1.0)
+        assert _order_parameter(np.array([0.0] * 50 + [np.pi] * 50)) < 1e-9
 
-    def test_summary_total_time_matches_config(self, result_default: KuramotoResult) -> None:
-        expected = result_default.config.steps * result_default.config.dt
-        assert result_default.summary["total_time"] == pytest.approx(expected)
-
-    def test_summary_N_matches_config(self, result_default: KuramotoResult) -> None:
-        assert result_default.summary["N"] == result_default.config.N
-
-    def test_config_to_dict_roundtrip(self) -> None:
-        cfg = KuramotoConfig(N=5, K=2.0, dt=0.05, steps=100, seed=3)
-        d = cfg.to_dict()
-        assert d["N"] == 5
-        assert d["K"] == pytest.approx(2.0)
-        assert d["seed"] == 3
-        assert d["adjacency"] is None
-        assert d["omega"] is None
-
-
-# ──────────────────────────────────────────────────────────────────────────────
-# Internal helper unit tests
-# ──────────────────────────────────────────────────────────────────────────────
-
-
-class TestInternalHelpers:
-    def test_order_parameter_all_same_phase(self) -> None:
-        theta = np.zeros(20)
-        assert _order_parameter(theta) == pytest.approx(1.0, abs=1e-12)
-
-    def test_order_parameter_opposite_phases(self) -> None:
-        """N/2 at 0, N/2 at π → R ≈ 0."""
-        theta = np.array([0.0] * 50 + [np.pi] * 50)
-        assert _order_parameter(theta) < 1e-9
-
-    def test_dtheta_dt_no_coupling(self) -> None:
-        """With all-zero adjacency, coupling term vanishes → dθ/dt = ω."""
-        N = 5
-        theta = np.ones(N)
-        omega = np.arange(1, N + 1, dtype=float)
-        adj = np.zeros((N, N))
-        result = _dtheta_dt(theta, omega, adj)
-        np.testing.assert_array_equal(result, omega)
-
-    def test_rk4_step_zero_derivative_stays_constant(self) -> None:
-        """θ does not change when dθ/dt = 0 everywhere (ω=0, adj=0)."""
-        N = 4
+    def test_dtheta_dt_and_rk4_helpers(self) -> None:
         theta = np.array([0.1, 0.5, 1.2, 2.3])
-        omega = np.zeros(N)
-        adj = np.zeros((N, N))
-        result = _rk4_step(theta, omega, adj, dt=0.1)
-        np.testing.assert_array_almost_equal(result, theta)
+        omega = np.zeros(4)
+        adj = np.zeros((4, 4))
+        np.testing.assert_array_equal(_dtheta_dt(theta, omega, adj), omega)
+        np.testing.assert_array_almost_equal(_rk4_step(theta, omega, adj, dt=0.1), theta)


### PR DESCRIPTION
### Motivation
- Provide a stable, machine-readable CLI export contract and support explicit network topologies for the Kuramoto simulation engine. 
- Improve runtime robustness by tightening validation and failing fast on malformed inputs or non-finite numerical states. 
- Make the public API and CLI ergonomics clearer (explicit options, version bump) and document coupling semantics in the README. 

### Description
- Added a new `core.kuramoto.io` module with helpers to parse comma vectors, load adjacency matrices and edge-list JSON, and produce deterministic JSON payloads (`SCHEMA_VERSION`, `export_payload`).
- Reworked the CLI (`core.kuramoto.cli`) to expose `--adjacency-file` and `--edge-list-file`, an `--export` mode (`summary` | `full`), `--quiet` behavior, improved options help, and contract-stable JSON output; file and stdout exports are produced via `export_payload`.
- Hardened `KuramotoConfig` (`core.kuramoto.config`) with stricter array/finite checks, a `coupling_mode` property, and inclusion of `coupling_mode` in `to_dict()`.
- Enhanced the engine (`core.kuramoto.engine`) to zero diagonal self-coupling, validate runtime inputs, check for non-finite derivatives/phases, include `coupling_mode`/`seed` in result summaries, and perform shape/finiteness checks in `KuramotoResult`.
- Simplified package surface in `core.kuramoto.__init__` and updated README examples and CLI docs to reflect the new export contract and topology options.
- Added comprehensive unit tests under `tests/unit/core/` covering CLI behavior (`test_kuramoto_cli.py`), IO parsing, engine correctness, validation, adjacency semantics and summary contracts (`test_kuramoto_engine.py`).

### Testing
- Ran the unit test suite for the Kuramoto subsystem via `pytest tests/unit/core -q`; all tests in `tests/unit/core/test_kuramoto_engine.py` and `tests/unit/core/test_kuramoto_cli.py` passed. 
- CLI tests exercise both `--export summary` and `--export full` modes, file round-trips, adjacency and edge-list loading, and error cases for malformed inputs, and all asserted expectations succeeded. 
- Engine tests validate shapes, determinism with seeds, zero-coupling analytic match, adjacency equivalence to global coupling, summary keys, and helper functions, and all assertions succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf9fdd65288324ba4098402757f111)