### PR TITLE
Harden Kuramoto IO parsing, export contract, and test coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,9 +411,11 @@ The **Kuramoto simulation engine** (`core/kuramoto/`) implements the canonical c
 It integrates the Kuramoto ODE using 4th-order Runge-Kutta:
 
 ```
-dθᵢ/dt = ωᵢ + (K/N) · Σⱼ sin(θⱼ − θᵢ)       # global (all-to-all) coupling
+dθᵢ/dt = ωᵢ + (K/N) · Σⱼ≠ᵢ sin(θⱼ − θᵢ)      # global (all-to-all) coupling
 dθᵢ/dt = ωᵢ + K · Σⱼ Aᵢⱼ sin(θⱼ − θᵢ)        # explicit weighted adjacency (diagonal ignored)
 ```
+
+For exact no-self-coupling semantics, the implementation enforces a zero diagonal in both modes; equivalently, the global sum is over `j != i`.
 
 The **order parameter** R(t) ∈ [0, 1] measures instantaneous synchronisation:
 - R ≈ 0 → oscillators are fully desynchronised
@@ -494,11 +496,12 @@ tp-kuramoto simulate --N 50 --edge-list-file graph_edges.json --export summary -
 | `steps` | int ≥ 1 | 1000 | Number of integration steps |
 | `adjacency` | array(N,N) \| None | None | Weighted coupling matrix (`K` is a global scale). Diagonal is ignored |
 | `theta0` | array(N) \| None | None | Initial phases (rad). Drawn from U(0, 2π) if omitted |
-| `seed` | int \| None | None | RNG seed for reproducible random draws |
+| `seed` | int \| None | None | RNG seed for reproducible random draws when `omega`/`theta0` are omitted |
 
 ### Outputs
 
 CLI JSON exports include a stable `schema_version` field (`1` for this contract).
+`schema_version` increments only when the JSON payload contract changes incompatibly.
 
 `--export summary` returns only:
 - `schema_version`
@@ -509,6 +512,8 @@ CLI JSON exports include a stable `schema_version` field (`1` for this contract)
 - `order_parameter`
 - `time`
 - `phases`
+
+When `--quiet` and `--output` are both used, stdout and file payloads are byte-equivalent JSON serializations of the same object.
 
 | Field | Shape | Description |
 |-------|-------|-------------|

--- a/core/kuramoto/cli.py
+++ b/core/kuramoto/cli.py
@@ -26,6 +26,10 @@ def cli() -> None:
     Coupling semantics:
       - Global topology (no adjacency input): K/N on all off-diagonal pairs.
       - Explicit adjacency topology: K scales the provided adjacency weights A_ij.
+
+    Seed semantics:
+      - Explicit --omega bypasses RNG for natural frequencies.
+      - Explicit --theta0 bypasses RNG for initial phases.
     """
 
 

--- a/core/kuramoto/io.py
+++ b/core/kuramoto/io.py
@@ -19,9 +19,16 @@ SCHEMA_VERSION = 1
 
 def parse_float_list(raw: str, *, option_name: str) -> NDArray[np.float64]:
     """Parse a comma-separated vector and reject empty/non-finite values."""
-    values = [chunk.strip() for chunk in raw.split(",") if chunk.strip()]
-    if not values:
+    chunks = raw.split(",")
+    if not chunks:
         raise ValueError(f"{option_name} must contain at least one numeric value.")
+    if any(not chunk.strip() for chunk in chunks):
+        raise ValueError(
+            f"{option_name} contains an empty entry. "
+            f"Use a strict comma-separated list such as '0.1,0.2,0.3'."
+        )
+
+    values = [chunk.strip() for chunk in chunks]
 
     try:
         vector = np.array([float(v) for v in values], dtype=np.float64)
@@ -39,6 +46,8 @@ def _load_json(path: Path) -> Any:
         return json.loads(path.read_text(encoding="utf-8"))
     except json.JSONDecodeError as exc:
         raise ValueError(f"Malformed JSON in {path}: {exc.msg}.") from exc
+    except OSError as exc:
+        raise ValueError(f"Failed to read JSON file {path}: {exc}.") from exc
 
 
 def load_adjacency_matrix(path: Path) -> NDArray[np.float64]:
@@ -47,9 +56,12 @@ def load_adjacency_matrix(path: Path) -> NDArray[np.float64]:
     if suffix == ".json":
         matrix = np.asarray(_load_json(path), dtype=np.float64)
     elif suffix in {".csv", ".txt"}:
-        matrix = np.loadtxt(path, delimiter=",", dtype=np.float64)
+        try:
+            matrix = np.loadtxt(path, delimiter=",", dtype=np.float64)
+        except ValueError as exc:
+            raise ValueError(f"Malformed delimited adjacency matrix in {path}: {exc}.") from exc
     elif suffix == ".npy":
-        matrix = np.load(path)
+        matrix = np.load(path, allow_pickle=False)
     else:
         raise ValueError(
             f"Unsupported adjacency file extension '{suffix}'. "
@@ -78,6 +90,7 @@ def load_edge_list(path: Path, n_oscillators: int) -> NDArray[np.float64]:
         raise ValueError("Edge-list JSON must contain an 'edges' array.")
 
     adj = np.zeros((n_oscillators, n_oscillators), dtype=np.float64)
+    seen_edges: set[tuple[int, int]] = set()
 
     for idx, edge in enumerate(edges):
         if not isinstance(edge, dict):
@@ -95,6 +108,9 @@ def load_edge_list(path: Path, n_oscillators: int) -> NDArray[np.float64]:
             raise ValueError(f"Edge ({source}, {target}) out of range for N={n_oscillators}.")
         if not np.isfinite(weight):
             raise ValueError(f"Edge ({source}, {target}) has non-finite weight.")
+        if (source, target) in seen_edges:
+            raise ValueError(f"Duplicate edge ({source}, {target}) is not allowed.")
+        seen_edges.add((source, target))
 
         adj[source, target] = weight
 
@@ -111,6 +127,20 @@ def export_payload(
     phases: NDArray[np.float64],
 ) -> dict[str, Any]:
     """Build deterministic JSON-safe payload for stdout and file export."""
+    if not np.isfinite(order_parameter).all() or not np.isfinite(time).all() or not np.isfinite(phases).all():
+        raise ValueError("Export payload requires finite trajectories.")
+    expected_steps = len(time)
+    if len(order_parameter) != expected_steps:
+        raise ValueError(
+            "Export payload shape mismatch: "
+            f"order_parameter has length {len(order_parameter)}, expected {expected_steps}."
+        )
+    if phases.ndim != 2 or phases.shape[0] != expected_steps:
+        raise ValueError(
+            "Export payload shape mismatch: "
+            f"phases has shape {phases.shape}, expected ({expected_steps}, N)."
+        )
+
     payload: dict[str, Any] = {
         "schema_version": SCHEMA_VERSION,
         "summary": summary,

--- a/tests/unit/core/test_kuramoto_cli.py
+++ b/tests/unit/core/test_kuramoto_cli.py
@@ -21,6 +21,9 @@ def test_cli_quiet_summary_mode_contract() -> None:
         "summary": payload["summary"],
         "config": payload["config"],
     }
+    assert "order_parameter" not in payload
+    assert "time" not in payload
+    assert "phases" not in payload
 
 
 def test_cli_full_export_file_round_trip() -> None:
@@ -113,6 +116,16 @@ def test_cli_bad_omega_and_theta0_fail() -> None:
     assert "contains non-finite" in theta_result.output
 
 
+def test_cli_rejects_empty_list_entries_for_omega_and_theta0() -> None:
+    runner = CliRunner()
+    omega_result = runner.invoke(cli, ["simulate", "--omega", "1.0,,2.0"])
+    theta_result = runner.invoke(cli, ["simulate", "--theta0", "0.0, ,1.0"])
+    assert omega_result.exit_code != 0
+    assert theta_result.exit_code != 0
+    assert "contains an empty entry" in omega_result.output
+    assert "contains an empty entry" in theta_result.output
+
+
 def test_cli_adjacency_file_shape_mismatch_fails() -> None:
     runner = CliRunner()
     with runner.isolated_filesystem():
@@ -153,3 +166,34 @@ def test_cli_edge_list_malformed_schema_and_weight_failures() -> None:
         assert "must contain an 'edges' array" in schema_result.output
         assert weight_result.exit_code != 0
         assert "non-finite weight" in weight_result.output
+
+
+def test_cli_edge_list_duplicate_edges_fail() -> None:
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        with open("dup_edges.json", "w", encoding="utf-8") as handle:
+            json.dump(
+                {
+                    "edges": [
+                        {"source": 0, "target": 1, "weight": 0.3},
+                        {"source": 0, "target": 1, "weight": 0.7},
+                    ]
+                },
+                handle,
+            )
+        result = runner.invoke(
+            cli,
+            ["simulate", "--N", "2", "--edge-list-file", "dup_edges.json", "--quiet"],
+        )
+        assert result.exit_code != 0
+        assert "Duplicate edge" in result.output
+
+
+def test_cli_adjacency_file_malformed_json_fails() -> None:
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        with open("bad.json", "w", encoding="utf-8") as handle:
+            handle.write('{"not": "valid"')
+        result = runner.invoke(cli, ["simulate", "--N", "2", "--adjacency-file", "bad.json", "--quiet"])
+        assert result.exit_code != 0
+        assert "Malformed JSON" in result.output

--- a/tests/unit/core/test_kuramoto_engine.py
+++ b/tests/unit/core/test_kuramoto_engine.py
@@ -93,9 +93,10 @@ class TestDeterminism:
     def test_explicit_omega_alone_ignores_seed(self) -> None:
         N = 5
         omega = np.linspace(-0.5, 0.5, N)
-        a = run_simulation(KuramotoConfig(N=N, K=1.0, dt=0.01, steps=20, seed=1, omega=omega))
-        b = run_simulation(KuramotoConfig(N=N, K=1.0, dt=0.01, steps=20, seed=9, omega=omega))
-        np.testing.assert_array_equal(a.order_parameter, b.order_parameter)
+        engine_a = KuramotoEngine(KuramotoConfig(N=N, K=1.0, dt=0.01, steps=20, seed=1, omega=omega))
+        engine_b = KuramotoEngine(KuramotoConfig(N=N, K=1.0, dt=0.01, steps=20, seed=9, omega=omega))
+        np.testing.assert_array_equal(engine_a._omega, engine_b._omega)
+        assert not np.array_equal(engine_a._theta0, engine_b._theta0)
 
     def test_explicit_theta0_alone_ignores_seed(self) -> None:
         N = 5
@@ -127,6 +128,8 @@ class TestValidation:
             KuramotoConfig(N=3, K=1.0, dt=0.01, steps=10, theta0=np.array([0.0, np.inf, 1.0]))
         with pytest.raises(ValueError, match="adjacency"):
             KuramotoConfig(N=4, K=1.0, dt=0.01, steps=10, adjacency=np.ones((3, 3)))
+        with pytest.raises(ValueError, match="adjacency"):
+            KuramotoConfig(N=3, K=1.0, dt=0.01, steps=10, adjacency=np.array([[0.0, 1.0, np.nan]] * 3))
 
     def test_seed_and_coupling_validation(self) -> None:
         with pytest.raises(ValueError, match="seed"):
@@ -235,6 +238,12 @@ class TestSummaryAndHelpers:
             KuramotoResult(phases=phases[:-1], order_parameter=order, time=time, config=default_cfg)
         with pytest.raises(ValueError, match="order_parameter"):
             KuramotoResult(phases=phases, order_parameter=order[:-1], time=time, config=default_cfg)
+        with pytest.raises(ValueError, match="time"):
+            KuramotoResult(phases=phases, order_parameter=order, time=time[:-1], config=default_cfg)
+        phases_bad = phases.copy()
+        phases_bad[0, 0] = np.nan
+        with pytest.raises(ValueError, match="non-finite"):
+            KuramotoResult(phases=phases_bad, order_parameter=order, time=time, config=default_cfg)
 
     def test_order_parameter_helper(self) -> None:
         assert _order_parameter(np.zeros(20)) == pytest.approx(1.0)


### PR DESCRIPTION
### Motivation
- Strengthen CLI/topology input failure semantics and make JSON export a sharp public contract so consumers cannot receive malformed or ambiguous payloads.
- Make seed/coupling semantics explicit in docs and CLI help to match engine implementation (no-self-coupling, K scaling, and explicit-array seed scope).
- Restore and extend unit-test contours around IO edge-cases (malformed input, duplicate edges, empty list entries) that were previously underspecified.

### Description
- `core/kuramoto/io.py`: enforce strict comma-list parsing in `parse_float_list` (reject empty chunks), add JSON read `OSError` handling, tighten CSV/TXT parsing errors, use `np.load(..., allow_pickle=False)` for `.npy`, reject duplicate edges in `load_edge_list`, and add shape/finiteness checks in `export_payload` before serialization.
- `core/kuramoto/cli.py`: clarified seed semantics in CLI docstring so explicit `--omega`/`--theta0` behavior is unambiguous.
- `README.md`: clarified mathematical coupling formulas to explicitly show the `j != i` summation, documented no-self-coupling enforcement, clarified `schema_version` semantics, seed scope, and stdout/file parity guarantee for `--quiet` + `--output`.
- `tests/unit/core/test_kuramoto_cli.py`: added tests for summary payload excluding trajectories, empty-entry parsing failures for `--omega`/`--theta0`, duplicate edge-list rejection, and malformed JSON adjacency handling; preserved full-export round-trip checks.
- `tests/unit/core/test_kuramoto_engine.py`: corrected deterministic-seed semantics test for explicit `omega`, added adjacency non-finite validation, and strengthened `KuramotoResult` validation tests for `time` shape and non-finite trajectory detection.

### Testing
- Attempted targeted pytest runs: `pytest -q tests/unit/core/test_kuramoto_engine.py` and `pytest -q tests/unit/core/test_kuramoto_cli.py` but both were blocked in this environment due to interpreter/dependency mismatch (repo requires Python 3.11+ and installed 3.11 interpreter lacks project deps such as `numpy`); therefore full test-suite could not be executed here (FAILED due to environment).
- Executed focused runtime smoke checks using `CliRunner` in an ad-hoc Python invocation which passed: summary-mode keys validated and full-mode stdout/file JSON parity validated (script invoked `tp-kuramoto simulate` via `cli` and compared payload and file round-trip, PASS).
- Executed direct unit probes for IO helpers (calling `parse_float_list`, `load_edge_list`, `load_adjacency_matrix`) in an interactive Python snippet; these produced the expected precise errors for empty entries, duplicate edges, and malformed CSV (PASS).
- Performed syntax/compile sanity check with `python -m compileall core/kuramoto tests/unit/core/test_kuramoto_engine.py tests/unit/core/test_kuramoto_cli.py` which completed without syntax errors (PASS).

Notes: full `pytest` evidence must be produced in CI or a developer environment provisioned with Python 3.11/3.12 and pinned project dependencies; the local container used here could not run full test suites for environmental reasons.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfb0e7dc388324b57aba1b7204a139)