### PR TITLE
Pin Python toolchain, verify pip/pytest, and enforce Node 24 runtime in CI workflows

### DIFF
--- a/.github/actions/setup-geosync/action.yml
+++ b/.github/actions/setup-geosync/action.yml
@@ -41,7 +41,7 @@ runs:
       id: venv-cache
       with:
         path: .venv
-        key: ${{ inputs.cache-prefix }}-${{ runner.os }}-py${{ inputs.python-version }}-${{ hashFiles('requirements*.lock', 'constraints/security.txt') }}
+        key: ${{ inputs.cache-prefix }}-${{ runner.os }}-py${{ inputs.python-version }}-${{ hashFiles('requirements*.lock', 'constraints/security.txt', '.github/actions/setup-geosync/action.yml') }}
         restore-keys: |
           ${{ inputs.cache-prefix }}-${{ runner.os }}-py${{ inputs.python-version }}-
           
@@ -54,8 +54,37 @@ runs:
       if: steps.venv-cache.outputs.cache-hit != 'true'
       shell: bash
       run: |
-        .venv/bin/python -m pip install --upgrade pip setuptools wheel
+        .venv/bin/python -m pip install pip==25.0.1 setuptools==75.8.0 wheel==0.45.1
         .venv/bin/python -m pip install -c constraints/security.txt -r requirements.lock
         if [ "${{ inputs.install-dev }}" = "true" ]; then
           .venv/bin/python -m pip install -c constraints/security.txt -r requirements-dev.lock
         fi
+
+    - name: Verify pinned pip and pytest versions
+      shell: bash
+      run: |
+        .venv/bin/python - <<'PY'
+        from pathlib import Path
+        import importlib.metadata as metadata
+
+        expected_pip = "25.0.1"
+        pip_version = metadata.version("pip")
+        if pip_version != expected_pip:
+            raise SystemExit(f"pip version mismatch: {pip_version} != {expected_pip}")
+
+        if "${{ inputs.install-dev }}" == "true":
+            expected_pytest = None
+            for line in Path("requirements-dev.lock").read_text(encoding="utf-8").splitlines():
+                if line.startswith("pytest=="):
+                    expected_pytest = line.split("==", 1)[1].strip()
+                    break
+            if expected_pytest is None:
+                raise SystemExit("pytest pin not found in requirements-dev.lock")
+            pytest_version = metadata.version("pytest")
+            if pytest_version != expected_pytest:
+                raise SystemExit(
+                    f"pytest version mismatch: {pytest_version} != {expected_pytest}"
+                )
+            print(f"pytest pinned: {pytest_version}")
+        print(f"pip pinned: {pip_version}")
+        PY

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -10,3 +10,13 @@ Only these workflows are active:
    - Scheduled/manual deep security scans.
 
 If a proposed workflow does not define a distinct decision boundary, do not add it.
+
+## Runtime hardening note
+
+All canonical workflows opt into GitHub's Node.js 24 runtime for JavaScript-based actions via:
+
+`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'`
+
+Frontend workflows also pin `actions/setup-node` to `node-version: '24'` to avoid mixed runtime drift.
+
+Python environment setup enforces pinned toolchain versions for `pip` and `pytest` (from `requirements-dev.lock`) to keep CI reproducible.

--- a/.github/workflows/main-validation.yml
+++ b/.github/workflows/main-validation.yml
@@ -8,6 +8,9 @@ on:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 concurrency:
   group: main-validation-${{ github.ref }}
   cancel-in-progress: false
@@ -75,7 +78,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: npm
           cache-dependency-path: apps/web/package-lock.json
 

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -9,6 +9,9 @@ permissions:
   contents: read
   pull-requests: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 concurrency:
   group: pr-gate-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
@@ -189,7 +192,7 @@ jobs:
         if: steps.changes.outputs.frontend_changed == 'true'
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: npm
           cache-dependency-path: apps/web/package-lock.json
 

--- a/.github/workflows/security-deep.yml
+++ b/.github/workflows/security-deep.yml
@@ -9,6 +9,9 @@ permissions:
   contents: read
   security-events: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 concurrency:
   group: security-deep-${{ github.ref }}
   cancel-in-progress: false


### PR DESCRIPTION
### Motivation

- Increase CI reproducibility by pinning Python tooling versions and ensuring the virtualenv cache invalidates when the action itself changes.
- Harden JavaScript-based actions by forcing Node.js 24 runtime to avoid mixed runtime drift.
- Provide an explicit verification step to catch accidental toolchain drift between the pinned constraints and the installed packages.

### Description

- Updated `/.github/actions/setup-geosync/action.yml` to include the action file in the cache key and to pin `pip`, `setuptools`, and `wheel` to specific versions via `pip==25.0.1 setuptools==75.8.0 wheel==0.45.1` instead of an ``--upgrade`` step. 
- Added a verification step in the composite action that asserts the installed `pip` matches the pinned version and, when `install-dev` is true, reads `requirements-dev.lock` to verify the installed `pytest` version matches the lockfile.
- Updated repository workflow docs in `/.github/workflows/README.md` to mention the Node 24 runtime and the Python pinning policy.
- Set `env: FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'` in `pr-gate.yml`, `main-validation.yml`, and `security-deep.yml` and upgraded pinned `actions/setup-node` usage from `node-version: '20'` to `node-version: '24'` in workflow jobs that run frontend steps.

### Testing

- No automated tests were executed as part of this PR; changes are CI configuration and will be exercised by the repository workflows on their next runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d1228cef9c83249e65b5f6450ea76f)