### PR TITLE
Enforce CI Python toolchain pins and migrate GitHub Actions to Node.js 24

### DIFF
--- a/.github/actions/setup-geosync/action.yml
+++ b/.github/actions/setup-geosync/action.yml
@@ -35,13 +35,14 @@ runs:
           requirements.lock
           requirements-dev.lock
           constraints/security.txt
+          .github/config/python-bootstrap.lock
           
     - name: Cache Python virtual environment
       uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       id: venv-cache
       with:
         path: .venv
-        key: ${{ inputs.cache-prefix }}-${{ runner.os }}-py${{ inputs.python-version }}-${{ hashFiles('requirements*.lock', 'constraints/security.txt') }}
+        key: ${{ inputs.cache-prefix }}-${{ runner.os }}-py${{ inputs.python-version }}-${{ hashFiles('requirements*.lock', 'constraints/security.txt', '.github/config/python-bootstrap.lock', '.github/scripts/verify_toolchain_contract.py', '.github/actions/setup-geosync/action.yml') }}
         restore-keys: |
           ${{ inputs.cache-prefix }}-${{ runner.os }}-py${{ inputs.python-version }}-
           
@@ -54,8 +55,17 @@ runs:
       if: steps.venv-cache.outputs.cache-hit != 'true'
       shell: bash
       run: |
-        .venv/bin/python -m pip install --upgrade pip setuptools wheel
+        .venv/bin/python -m pip install -r .github/config/python-bootstrap.lock
         .venv/bin/python -m pip install -c constraints/security.txt -r requirements.lock
         if [ "${{ inputs.install-dev }}" = "true" ]; then
           .venv/bin/python -m pip install -c constraints/security.txt -r requirements-dev.lock
         fi
+
+    - name: Verify toolchain contract
+      shell: bash
+      run: |
+        verify_flags=()
+        if "${{ inputs.install-dev }}" == "true":
+          verify_flags+=(--require-pytest)
+        fi
+        .venv/bin/python .github/scripts/verify_toolchain_contract.py "${verify_flags[@]}"

--- a/.github/config/python-bootstrap.lock
+++ b/.github/config/python-bootstrap.lock
@@ -1,0 +1,3 @@
+pip==25.0.1
+setuptools==75.8.0
+wheel==0.45.1

--- a/.github/scripts/verify_toolchain_contract.py
+++ b/.github/scripts/verify_toolchain_contract.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Validate CI toolchain package versions against lock contracts."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.metadata as metadata
+from pathlib import Path
+
+
+def _parse_pins(lock_path: Path) -> dict[str, str]:
+    pins: dict[str, str] = {}
+    for raw_line in lock_path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "==" not in line:
+            continue
+        name, version = line.split("==", 1)
+        pins[name.strip()] = version.strip()
+    return pins
+
+
+def _read_pytest_pin(dev_lock_path: Path) -> str:
+    for raw_line in dev_lock_path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if line.startswith("pytest=="):
+            return line.split("==", 1)[1].strip()
+    raise SystemExit(f"pytest pin not found in {dev_lock_path}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--bootstrap-lock",
+        default=".github/config/python-bootstrap.lock",
+        help="Path to pinned bootstrap packages lockfile.",
+    )
+    parser.add_argument(
+        "--dev-lock",
+        default="requirements-dev.lock",
+        help="Path to dev lockfile used for pytest pin.",
+    )
+    parser.add_argument(
+        "--require-pytest",
+        action="store_true",
+        help="Fail if installed pytest does not match requirements-dev.lock pin.",
+    )
+    args = parser.parse_args()
+
+    bootstrap_pins = _parse_pins(Path(args.bootstrap_lock))
+    if not bootstrap_pins:
+        raise SystemExit(f"No pinned entries found in {args.bootstrap_lock}")
+
+    for package, expected in sorted(bootstrap_pins.items()):
+        installed = metadata.version(package)
+        if installed != expected:
+            raise SystemExit(f"{package} version mismatch: {installed} != {expected}")
+        print(f"{package} pinned: {installed}")
+
+    if args.require_pytest:
+        expected_pytest = _read_pytest_pin(Path(args.dev_lock))
+        installed_pytest = metadata.version("pytest")
+        if installed_pytest != expected_pytest:
+            raise SystemExit(
+                f"pytest version mismatch: {installed_pytest} != {expected_pytest}"
+            )
+        print(f"pytest pinned: {installed_pytest}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -23,3 +23,5 @@ Python environment setup now follows a contract-based protocol:
 - bootstrap tooling is pinned in `.github/config/python-bootstrap.lock`,
 - runtime verification is centralized in `.github/scripts/verify_toolchain_contract.py`,
 - `pytest` version is reconciled against `requirements-dev.lock`.
+
+In short: CI enforces pinned `pip` and `pytest` versions to stay reproducible across runner updates.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -10,3 +10,16 @@ Only these workflows are active:
    - Scheduled/manual deep security scans.
 
 If a proposed workflow does not define a distinct decision boundary, do not add it.
+
+## Runtime hardening note
+
+All canonical workflows opt into GitHub's Node.js 24 runtime for JavaScript-based actions via:
+
+`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'`
+
+Frontend workflows also pin `actions/setup-node` to `node-version: '24'` to avoid mixed runtime drift.
+
+Python environment setup now follows a contract-based protocol:
+- bootstrap tooling is pinned in `.github/config/python-bootstrap.lock`,
+- runtime verification is centralized in `.github/scripts/verify_toolchain_contract.py`,
+- `pytest` version is reconciled against `requirements-dev.lock`.

--- a/.github/workflows/main-validation.yml
+++ b/.github/workflows/main-validation.yml
@@ -8,6 +8,9 @@ on:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 concurrency:
   group: main-validation-${{ github.ref }}
   cancel-in-progress: false
@@ -75,7 +78,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: npm
           cache-dependency-path: apps/web/package-lock.json
 

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -9,6 +9,9 @@ permissions:
   contents: read
   pull-requests: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 concurrency:
   group: pr-gate-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
@@ -57,6 +60,20 @@ jobs:
               print('\n'.join(violations))
               raise SystemExit(1)
           print('Pinned action policy passed.')
+          PY
+
+      - name: Validate CI toolchain contracts
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          from pathlib import Path
+          lock = Path('.github/config/python-bootstrap.lock')
+          required = {'pip', 'setuptools', 'wheel'}
+          present = {line.split('==', 1)[0].strip() for line in lock.read_text(encoding='utf-8').splitlines() if '==' in line}
+          missing = sorted(required - present)
+          if missing:
+              raise SystemExit(f'Missing required toolchain pins: {missing}')
+          print('CI toolchain contract shape validated.')
           PY
 
       - name: Actionlint validation
@@ -189,7 +206,7 @@ jobs:
         if: steps.changes.outputs.frontend_changed == 'true'
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: npm
           cache-dependency-path: apps/web/package-lock.json
 

--- a/.github/workflows/security-deep.yml
+++ b/.github/workflows/security-deep.yml
@@ -9,6 +9,9 @@ permissions:
   contents: read
   security-events: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 concurrency:
   group: security-deep-${{ github.ref }}
   cancel-in-progress: false


### PR DESCRIPTION
### Motivation

- Ensure CI runtime consistency by pinning bootstrap Python tooling (`pip`, `setuptools`, `wheel`) and verifying installed versions at workflow setup.
- Harden workflow runtimes by forcing JavaScript actions onto Node.js 24 and updating `actions/setup-node` usage accordingly.

### Description

- Add a bootstrap lockfile at `.github/config/python-bootstrap.lock` with pinned `pip`, `setuptools`, and `wheel` versions and use it to install bootstrap tooling during action setup via the composite action `/.github/actions/setup-geosync/action.yml`.
- Extend the `setup-geosync` composite action to include additional files in the cache key and to run a new verification script `.github/scripts/verify_toolchain_contract.py` that validates installed package versions against lockfiles and optionally enforces `pytest` pin reconciliation when `install-dev` is true.
- Add a repository-level validation in the PR gate to ensure the bootstrap lock contains the required pins and update the canonical workflows and README to set `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'` and bump `node-version` from `20` to `24` where Node is used.

### Testing

- No automated tests were executed as part of this change; repository CI will exercise the new validations (including `actionlint` and the added toolchain contract checks) when the workflows run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d1228cef9c83249e65b5f6450ea76f)