### PR TITLE
Add Python 3.10 datetime.UTC compatibility shims

### DIFF
--- a/core/altdata/social_listening.py
+++ b/core/altdata/social_listening.py
@@ -14,12 +14,13 @@ import math
 import re
 from collections import defaultdict, deque
 from dataclasses import dataclass
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Iterable, Mapping, Sequence
 
 import pandas as pd
 
 from .sentiment import SentimentFeatureBuilder, SentimentSignal
+UTC = timezone.utc
 
 _TOKEN_PATTERN = re.compile(r"[A-Za-z]+")
 _CASHTAG_PATTERN = re.compile(r"\$([A-Z]{1,6})(?=\b)")

--- a/core/compliance/mifid2.py
+++ b/core/compliance/mifid2.py
@@ -5,11 +5,12 @@ from __future__ import annotations
 import json
 import logging
 from dataclasses import dataclass, field, fields
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Mapping
 
 LOGGER = logging.getLogger(__name__)
+UTC = timezone.utc
 
 
 def _slots_to_dict(obj: Any) -> dict[str, Any]:

--- a/core/data/backfill.py
+++ b/core/data/backfill.py
@@ -25,7 +25,7 @@ import uuid
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
-from datetime import UTC
+from datetime import timezone
 from queue import Empty, PriorityQueue
 from typing import Iterator, List, MutableMapping, Optional
 
@@ -33,6 +33,7 @@ import pandas as pd
 from pandas.tseries.frequencies import to_offset
 
 from core.data.timeutils import normalize_timestamp
+UTC = timezone.utc
 
 
 @dataclass(frozen=True)

--- a/core/data/feature_store.py
+++ b/core/data/feature_store.py
@@ -11,7 +11,7 @@ import shutil
 import sqlite3
 import ssl
 from dataclasses import dataclass, field
-from datetime import UTC
+from datetime import timezone
 from decimal import Decimal, InvalidOperation
 from io import StringIO
 from pathlib import Path
@@ -30,6 +30,8 @@ from core.utils.dataframe_io import (
     read_dataframe,
     write_dataframe,
 )
+
+UTC = timezone.utc
 
 try:  # pragma: no cover - optional dependency shim for real Redis connections
     import redis

--- a/core/data/parity.py
+++ b/core/data/parity.py
@@ -3,13 +3,14 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import UTC
+from datetime import timezone
 from typing import Iterable, Sequence
 
 import pandas as pd
 from pandas.api import types as pd_types
 
 from core.data.feature_store import IntegrityReport, OnlineFeatureStore
+UTC = timezone.utc
 
 
 class FeatureParityError(RuntimeError):

--- a/core/data/pipeline.py
+++ b/core/data/pipeline.py
@@ -34,7 +34,7 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass, field
-from datetime import UTC
+from datetime import timezone
 from hashlib import blake2b
 from time import perf_counter
 from typing import Any, Callable, Mapping, MutableMapping, Protocol
@@ -54,6 +54,7 @@ from core.data.quality_control import (
 )
 from core.data.validation import TimeSeriesValidationConfig, validate_timeseries_frame
 from observability.drift import DriftDetector, FeatureDriftSummary, FeatureSnapshot
+UTC = timezone.utc
 
 # ---------------------------------------------------------------------------
 # Configuration dataclasses

--- a/core/events/sourcing.py
+++ b/core/events/sourcing.py
@@ -14,7 +14,7 @@ import json
 import logging
 from contextlib import contextmanager
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from typing import (
     Any,
     ClassVar,
@@ -50,6 +50,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session, sessionmaker
 
 from domain.order import OrderSide, OrderStatus, OrderType
+UTC = timezone.utc
 
 LOGGER = logging.getLogger(__name__)
 

--- a/scripts/localization/sync_translations.py
+++ b/scripts/localization/sync_translations.py
@@ -8,11 +8,13 @@ import json
 import sys
 from copy import deepcopy
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, Iterable, Mapping, Set
 
 import yaml
 from jsonschema import Draft202012Validator
+UTC = timezone.utc
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_LOCALES_YAML = REPO_ROOT / "configs" / "localization" / "locales.yaml"
@@ -298,8 +300,6 @@ def main(argv: Iterable[str]) -> int:
 
     write_translations(translations, args.translations_dir, check=False)
     dump_json(args.metadata_output, metadata_payload)
-    from datetime import UTC, datetime
-
     coverage["generatedAt"] = datetime.now(UTC).isoformat().replace("+00:00", "Z")
     dump_json(args.coverage_report, coverage)
 

--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -12,9 +12,13 @@ from __future__ import annotations
 import os
 import shutil
 import tarfile
+import datetime as _dt
 from typing import TYPE_CHECKING
 
 os.environ.setdefault("GEOSYNC_LIGHT_IMPORT", "1")
+
+if not hasattr(_dt, "UTC"):  # pragma: no cover - Python < 3.11 compatibility
+    _dt.UTC = _dt.timezone.utc  # type: ignore[attr-defined]
 
 # ── Compute maximization ──────────────────────��──────────────────────
 # Expose all CPU cores to OpenMP/MKL/torch threading backends.

--- a/src/data/macro/pipeline.py
+++ b/src/data/macro/pipeline.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from typing import Iterable, Mapping
 
 import pandas as pd
@@ -18,6 +18,7 @@ from ..etl.stores import (
 from .clients import MacroDataClient
 from .feature_engineering import MacroFeatureBuilder
 from .models import MacroDataSet, MacroIndicatorConfig
+UTC = timezone.utc
 
 __all__ = ["MacroSignalPipeline", "MacroPipelineContext"]
 

--- a/src/data/social_listening.py
+++ b/src/data/social_listening.py
@@ -6,7 +6,7 @@ import asyncio
 import contextlib
 import json
 from dataclasses import dataclass
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import AsyncIterator, Callable, Mapping, Protocol, Sequence
 
 import pandas as pd
@@ -18,6 +18,7 @@ from core.altdata.social_listening import (
 )
 
 from .event_bus import BrokerMessage, MessageBroker, NullMessageBroker
+UTC = timezone.utc
 
 
 class SocialStreamClient(Protocol):

--- a/src/data/streaming_aggregator.py
+++ b/src/data/streaming_aggregator.py
@@ -10,7 +10,7 @@ aggregator.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from typing import Callable, Iterable, Sequence
 
 import numpy as np
@@ -29,6 +29,7 @@ from core.data.models import InstrumentType, PriceTick
 from core.data.timeutils import get_market_calendar, normalize_timestamp
 
 from .ingestion_service import DataIngestionCacheService
+UTC = timezone.utc
 
 TickPayload = Iterable[PriceTick] | pd.DataFrame | None
 GapFetcher = Callable[[datetime, datetime], TickPayload]

--- a/src/geosync/core/security/audit.py
+++ b/src/geosync/core/security/audit.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import json
 import logging
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
+UTC = timezone.utc
 
 
 class AuditLogger:

--- a/src/geosync/core/security/incident.py
+++ b/src/geosync/core/security/incident.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 import logging
 import os
 import smtplib
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from email.mime.text import MIMEText
 from typing import Any, Callable
+UTC = timezone.utc
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
### Motivation

- Tests and CI runs on older Python runtimes raised `ImportError: cannot import name 'UTC' from 'datetime'`, so startup-time modules that import `UTC` directly fail on Python < 3.11. This change restores compatibility for those environments without changing runtime semantics.

### Description

- Replaced direct `from datetime import UTC, ...` imports with `from datetime import ..., timezone` and added a local `UTC = timezone.utc` alias in modules that are imported during startup to preserve UTC-aware behavior; updated 14 modules touched during startup.
- Added a defensive shim in `sitecustomize.py` that defines `datetime.UTC = datetime.timezone.utc` when the interpreter lacks `UTC`, ensuring the symbol exists early during interpreter startup.
- Adjusted `scripts/localization/sync_translations.py` to import `datetime`/`timezone` at module scope and use the `UTC` alias for coverage timestamp generation to keep semantics identical.
- Kept changes minimal and local to import sites so behaviour remains unchanged for Python >= 3.11 while restoring compatibility for older runtimes.

### Testing

- Successfully compiled the modified modules with `python -m py_compile ...` for the impacted files, which completed without syntax errors.
- Running the full test suite with `pytest tests/ -q --tb=line --timeout=120` in this container fails early with `ModuleNotFoundError: No module named 'omegaconf'` (environmental dependency missing), so a complete test run could not be validated here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d248df7b908324bff6e96bf9b020b1)