### PR TITLE
feat: Cryptobiosis module + 53 invariants + Gradient Constitution

### DIFF
--- a/.claude/physics/INVARIANTS.yaml
+++ b/.claude/physics/INVARIANTS.yaml
@@ -469,3 +469,79 @@ hpc:
       kappa_max: "condition-number ceiling configured per kernel"
     falsification: "any finite input within spec yields NaN/Inf or cond(A) > kappa_max"
     priority: P0
+
+# ═══════════════════════════════════════════════════
+# CRYPTOBIOSIS — Phase-Transition Survival
+# Physics: tardigrade-inspired state machine. System exits threat space
+# rather than resisting. DORMANT = zero metabolism = zero computation.
+# Source: core/neuro/cryptobiosis.py
+# ═══════════════════════════════════════════════════
+
+cryptobiosis:
+  dormant_zero_multiplier:
+    id: INV-CB1
+    type: universal
+    statement: "DORMANT state produces multiplier == 0.0 EXACTLY (not approximately)"
+    test_type: property_test
+    falsification: "CryptobiosisController in DORMANT state returns multiplier != 0.0"
+    priority: P0
+
+  vitrification_o1:
+    id: INV-CB2
+    type: universal
+    statement: "Vitrification (ACTIVE → DORMANT) completes in O(1) ticks — no iterative wind-down"
+    test_type: property_test
+    parameters:
+      max_ticks: "2 (one tick VITRIFYING, next tick DORMANT)"
+    falsification: "System remains in VITRIFYING for more than 1 tick after entry"
+    priority: P0
+
+  snapshot_sufficiency:
+    id: INV-CB3
+    type: universal
+    statement: "The snapshot captured at vitrification contains all data required for recovery"
+    test_type: property_test
+    falsification: "snapshot is None while in DORMANT state"
+    priority: P1
+
+  rehydration_monotone:
+    id: INV-CB4
+    type: monotonic
+    statement: "Rehydration stages are non-decreasing: stage(t+1) ≥ stage(t) while T < entry"
+    test_type: trajectory_test
+    falsification: "rehydration_stage decreases between consecutive ticks with T < entry_threshold"
+    priority: P0
+
+  entry_above_modules:
+    id: INV-CB5
+    type: conditional
+    statement: "Cryptobiosis entry threshold exceeds individual module distress thresholds"
+    test_type: property_test
+    parameters:
+      rationale: "Cryptobiosis is a last resort — individual modules (GABA, Serotonin veto) should fire first"
+    falsification: "entry_threshold ≤ any individual module's crisis threshold"
+    priority: P1
+
+  distress_bounded:
+    id: INV-CB6
+    type: universal
+    statement: "Combined distress score T ∈ [0, 1] for every input"
+    test_type: property_test
+    falsification: "T outside [0, 1] after any update call"
+    priority: P0
+
+  hysteresis:
+    id: INV-CB7
+    type: universal
+    statement: "exit_threshold < entry_threshold (hysteresis prevents oscillation)"
+    test_type: property_test
+    falsification: "CryptobiosisConfig accepts exit >= entry without raising ValueError"
+    priority: P0
+
+  rehydration_abort:
+    id: INV-CB8
+    type: conditional
+    statement: "T ≥ entry_threshold during REHYDRATING → immediate return to DORMANT"
+    test_type: property_test
+    falsification: "System stays in REHYDRATING after receiving T ≥ entry_threshold"
+    priority: P0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,272 +1,284 @@
 # CLAUDE.md — GeoSync Physics-First Development Protocol
 
+## Section 0: Ontology of Gradient
+
+Being is not a state. Being is a sustained potential difference.
+
+Structure exists only while non-equilibrium passes through it. When the gradient vanishes (ΔV → 0), the system does not degrade — it ceases to exist as a system. What remains is noise.
+
+**INV-YV1: ΔV > 0 ∧ dΔV/dt ≠ 0** — the gradient must be positive and dynamic. A static gradient is a capacitor. A living gradient is a process. Intelligence requires the second.
+
+Na⁺/K⁺-ATPase consumes 40% of brain energy on maintaining −70 mV resting potential. Not on thinking — on **readiness to think**. When maintenance drops below critical: `M(t) < M_crit ⟹ P(t) → noise`. Processing does not slow — it undergoes phase transition into thermal noise.
+
+**This applies to GeoSync directly.** Every module either generates, sustains, or protects a gradient:
+
+| Role | Modules | What they do |
+|------|---------|-------------|
+| **Generators** | Kuramoto, Dopamine TD, HPC PWPE | Create signal from difference |
+| **Sustainers** | ECS Lyapunov, Serotonin tonic, NAk | Hold gradient within viable range |
+| **Protectors** | GABA gate, Serotonin veto, Cryptobiosis | Prevent gradient collapse |
+
+**Protectors have unconditional priority over Generators.** A system without a gradient cannot use a gradient.
+
+**Maintenance hierarchy:**
+
+```
+Layer 0: Gradient exists        (INV-YV1: ΔV > 0)
+Layer 1: Gradient bounded       (ECS Lyapunov: dF/dt ≤ 0)
+Layer 2: Gradient protected     (GABA + Serotonin veto)
+Layer 3: Gradient preserved     (Cryptobiosis: exit threat space)
+Layer 4: Gradient utilized      (Kuramoto + Dopamine + Kelly: computation)
+```
+
+Layers 0–3 = Maintenance (40%). Layer 4 = Processing (60%). If any of 0–3 fails, Layer 4 computes noise. This is not metaphor — it is thermodynamic law.
+
+**The physics kernel below (invariants, theories, validator) IS the 40%.** It costs context window every session. Without it, Claude Code generates syntactically valid, physically meaningless output. Processing without Maintenance = discharged battery computing its own disappearance.
+
+---
+
 ## Identity
 
-GeoSync is a quantitative trading platform with neuroscience-inspired risk
-management. It implements Kuramoto synchronization, serotonin/dopamine/GABA
-neuromodulation, free energy minimization, Ricci curvature, and thermodynamic
-constraints on top of a Kelly-criterion execution engine.
+GeoSync is a quantitative trading platform with neuroscience-inspired risk management: Kuramoto synchronization, serotonin/dopamine/GABA neuromodulation, free energy minimization, Ricci curvature, thermodynamic constraints on a Kelly-criterion execution engine.
 
-**This is a physics system that happens to trade, not a trading system
-that happens to use physics metaphors.**
+**This is a physics system that happens to trade, not a trading system that happens to use physics metaphors.**
 
 ## Rule Zero
 
-**Before writing or modifying ANY test that involves a physical quantity
-(R, K, δ, s(t), F, V, κ, energy, entropy), you MUST:**
+**Before writing or modifying ANY test that involves a physical quantity (R, K, δ, s(t), F, V, κ, energy, entropy), you MUST consult the invariants and theory below.** Numbers pass accidentally. Physics doesn't.
 
-1. Read `.claude/physics/INVARIANTS.yaml` — find ALL invariants for that quantity
-2. Read the relevant theory file in `.claude/physics/` (e.g., `KURAMOTO_THEORY.md`)
-3. Read `.claude/physics/TEST_TAXONOMY.md` — determine the correct test TYPE
-4. Only then write the test
+---
 
-If you skip this, you will write tests that check numbers instead of physics.
-Numbers pass accidentally. Physics doesn't.
+## INVARIANT REGISTRY — 53 invariants, 13 modules
 
-## The Physics Kernel (`.claude/physics/`)
+### Kuramoto Synchronization
 
 ```
-.claude/physics/
-├── INVARIANTS.yaml        # Machine-readable invariant registry (ALL modules)
-├── KURAMOTO_THEORY.md     # Kuramoto synchronization: K_c, R, finite-size, Lyapunov
-├── SEROTONIN_THEORY.md    # Serotonin ODE: aversive state, sigmoid, desensitization
-├── DOPAMINE_THEORY.md     # Dopamine TD-error: δ = r + γV' - V, convergence
-├── GABA_THEORY.md         # GABA inhibition: sigmoid gate, monotonicity, position reduction
-├── TEST_TAXONOMY.md       # How to write each test type (falsification → regression)
-├── EXAMPLES.md            # Before/after transformations of real tests from this codebase
-└── validate_tests.py      # 7-level validator: L1-L5 tests, C1-C2 code audit, --self-check
+INV-K1 | universal     | 0 ≤ R(t) ≤ 1 for all t                        | P0
+INV-K2 | asymptotic    | K < K_c ⟹ R(t→∞) → 0                         | P0
+         K_c = 2/(π·g(0)). For Lorentzian: K_c = 2γ.
+         Finite-size: R ~ O(1/√N). Use ε = 3/√N, NOT magic numbers.
+         FALSIFICATION: R > 3/√N after 10⁴ steps with K = 0.1·K_c and N > 100.
+INV-K3 | asymptotic    | K > K_c ⟹ R(t→∞) > 0. R_∞ ∝ √(K-K_c)        | P0
+INV-K4 | conditional   | R_∞(K₁) ≤ R_∞(K₂) if K₁ < K₂ (standard only) | P1
+INV-K5 | statistical   | ⟨R⟩ ≈ O(1/√N) incoherent. ≥50 realizations   | P1
+INV-K6 | distributional| K < K_c ⟹ phases uniform [-π,π]. Rayleigh     | P2
+INV-K7 | monotonic     | V = -(K·N/2)·R² non-increasing (ω_i = 0)      | P1
 ```
 
-### Key Invariants (P0 — block merge)
+### Explosive Synchronization
 
-| ID | Statement | Type | Module |
-|----|-----------|------|--------|
-| INV-K1 | R(t) ∈ [0,1] always | universal | kuramoto |
-| INV-K2 | K < K_c → R(t→∞) → 0 | asymptotic | kuramoto |
-| INV-K3 | K > K_c → R(t→∞) > 0 | asymptotic | kuramoto |
-| INV-ES1 | Hysteresis width ≥ 0 | universal | explosive_sync |
-| INV-5HT2 | s(t) ∈ [0, 1] always | universal | serotonin |
-| INV-5HT4 | sensitivity ∈ [0.1, 1.0] | universal | serotonin |
-| INV-5HT6 | tonic_level finite and ≥ 0 | universal | serotonin |
-| INV-5HT7 | stress ≥ 1 OR |dd| ≥ 0.5 → veto | conditional | serotonin |
-| INV-DA1 | δ = r + γV' − V (sign correct) | conditional | dopamine |
-| INV-DA3 | γ ∈ (0, 1] enforced | universal | dopamine |
-| INV-DA7 | ∂δ/∂r = 1 (linearity) | algebraic | dopamine |
-| INV-GABA1 | Gate output ∈ [0, 1] | universal | gaba |
-| INV-GABA2 | Higher vol → higher inhibition | qualitative | gaba |
-| INV-GABA3 | effective ≤ raw position | universal | gaba |
-| INV-FE1 | Free energy non-increasing | monotonic | free_energy |
-| INV-FE2 | Free energy ≥ 0 | universal | free_energy |
-| INV-RC1 | κ ∈ [-1, 1] (unweighted) | universal | ricci |
-
-Full registry: 34 invariants across 8 modules. See INVARIANTS.yaml.
-
-### Critical Formula
-
-**Kuramoto critical coupling**: K_c = 2 / (π · g(0))
-
-where g(0) is the value of the frequency distribution at zero.
-For Lorentzian g(ω) = (γ/π)/(ω² + γ²): g(0) = 1/(πγ), so K_c = 2γ.
-
-**Never hardcode K_c. Always compute from the distribution.**
-
-## Testing Discipline
-
-### Priorities
-- **P0** (CI gate, blocks merge): Universal bounds, Lyapunov monotonicity, critical transitions
-- **P1** (warning): Finite-size scaling, monotonicity sweeps, convergence rates
-- **P2** (informational): Distribution tests, exact scaling exponents
-
-### Test Error Messages Must Include (L4 enforced)
-Every physics test assertion error MUST contain:
-1. Invariant ID (e.g., "INV-K2 VIOLATED") — L4 checks regex
-2. Expected value/behavior (from theory) — L4 checks "expect|should|must|violat"
-3. Observed value — L4 checks "R=|delta=|level=|got|actual" + digits
-4. Physical reasoning for why it's wrong
-5. Parameters (K, N, steps, seed) — L4 checks "N=|seed=|K_c=|at|with"
-
-### Finite-Size Awareness
-- R = 0 exactly is impossible for finite N
-- Incoherent regime: R fluctuates as O(1/√N)
-- Use ε = C/√N (C ∈ [2,3]) not arbitrary thresholds
-- For ensemble statistics: ≥ 50 realizations at minimum
-
-### Production Code Audit (--audit-code)
-When modifying physics production code (not tests), run:
 ```
-python .claude/physics/validate_tests.py core/neuro/ --audit-code
+INV-ES1 | universal    | Hysteresis width ≥ 0                           | P0
+INV-ES2 | qualitative  | Freq-degree correlation → discontinuous        | P1
 ```
-This catches:
-- **C1**: Silent clamp/clip without logging — may hide physics violation
-- **C2**: Numeric bounds without INV-* comment — undocumented constraint
 
-If you add `np.clip(R, 0, 1)` or `max(0.1, sensitivity)` — add a comment
-explaining which invariant justifies the bound, or add logging so the
-clamp event is observable. Silent projection of invalid state into valid
-range masks the root cause.
+### Serotonin ODE
 
-### Forbidden Patterns
+```
+INV-5HT1 | monotonic   | Lyapunov V(s) non-increasing (zero stress)    | P0
+INV-5HT2 | universal   | s(t) ∈ [0, 1] always                         | P0
+INV-5HT3 | qualitative | Higher stress → higher serotonin (pre-desens)  | P1
+INV-5HT4 | universal   | sensitivity ∈ [0.1, 1.0] always               | P0
+INV-5HT5 | universal   | temperature_floor ∈ [floor_min, floor_max]     | P1
+INV-5HT6 | universal   | tonic_level finite and ≥ 0                    | P0
+INV-5HT7 | conditional | stress ≥ 1.0 OR |dd| ≥ 0.5 → veto. SAFETY.   | P0
+```
+
+### Dopamine TD-Error
+
+```
+INV-DA1 | conditional | δ sign = surprise direction                    | P0
+INV-DA2 | asymptotic  | V → V* (Robbins-Monro)                        | P1
+INV-DA3 | universal   | γ ∈ (0, 1]. Scope: DopamineController only     | P0
+INV-DA4 | asymptotic  | V stabilizes with fixed reward                 | P1
+INV-DA5 | statistical | At equilibrium E[δ] ≈ 0                       | P1
+INV-DA6 | qualitative | Larger α → faster + more variance              | P2
+INV-DA7 | algebraic   | ∂δ/∂r = 1 (raw TD, not tanh adapter)          | P0
+```
+
+### GABA Inhibition Gate
+
+```
+INV-GABA1 | universal    | Gate ∈ [0, 1]                               | P0
+INV-GABA2 | qualitative  | Higher vol → higher inhibition              | P0
+INV-GABA3 | universal    | effective ≤ raw always                      | P0
+INV-GABA4 | asymptotic   | vol → 0 ⟹ inhibition ≈ 0                  | P1
+INV-GABA5 | asymptotic   | vol → ∞ ⟹ inhibition → 1                  | P1
+```
+
+### Free Energy / ECS
+
+```
+INV-FE1 | monotonic  | F(t) non-increasing under active inference      | P0
+INV-FE2 | universal  | Components non-negative: U≥0, T≥0, S_q≥0       | P0
+         Note: F = U − T·S itself CAN be negative (Helmholtz).
+         INV-FE2 guards components, not the composite.
+```
+
+### Thermodynamics
+
+```
+INV-TH1 | conservation | Energy change = work + dissipation            | P1
+INV-TH2 | universal    | Entropy production ≥ 0                       | P1
+```
+
+### Ricci Curvature
+
+```
+INV-RC1 | universal   | κ ≤ 1 (upper bound, any connected graph)       | P0
+         Note: lower bound κ ≥ −1 holds only for lazy walks on
+         combinatorial metric. Implementation uses 1D positional
+         embedding — κ can go below −1 for non-price-graph topologies.
+INV-RC2 | qualitative | κ > 0 → clustering                            | P2
+INV-RC3 | universal   | κ ∈ [−1, 1] for build_price_graph output       | P1
+```
+
+### Kelly Sizing
+
+```
+INV-KELLY1 | algebraic  | f* = μ/σ² (continuous small-edge limit)      | P0
+INV-KELLY2 | universal  | Applied fraction ≤ configured cap             | P0
+INV-KELLY3 | statistical| E[log(1+f*X)] ≥ E[log(1+f'X)] ∀ f'          | P1
+```
+
+### OMS (Order Management)
+
+```
+INV-OMS1 | universal    | E_kinetic = ½Σ|pos|·ret² ≥ 0                | P0
+INV-OMS2 | universal    | Idempotent submit (same correlation_id)       | P0
+INV-OMS3 | universal    | Lifecycle timestamps monotone per order_id    | P0
+```
+
+### SignalBus
+
+```
+INV-SB1 | universal    | DAG fanout: each subscriber fires once/publish | P0
+         Bus is flat pub/sub — no cycle detector. Cyclic subscriptions
+         cause RecursionError, not clean rejection.
+INV-SB2 | universal    | Deterministic by construction (pure latch)     | P0
+```
+
+### HPC Kernels
+
+```
+INV-HPC1 | universal   | Seeded reproducibility: bit-identical output   | P0
+INV-HPC2 | universal   | Finite inputs → finite outputs (no NaN/Inf)   | P0
+```
+
+### Cryptobiosis (Phase-Transition Survival)
+
+ACTIVE → VITRIFYING → DORMANT → REHYDRATING → ACTIVE. System exits threat space. T = combined neuromodulator distress.
+
+```
+INV-CB1 | universal   | DORMANT ⟹ multiplier == 0.0 EXACTLY           | P0
+INV-CB2 | universal   | Vitrification O(1) — one tick                  | P0
+INV-CB3 | universal   | Snapshot non-None in DORMANT                   | P1
+INV-CB4 | monotonic   | Rehydration stages non-decreasing              | P0
+INV-CB5 | conditional | entry > all individual module thresholds        | P1
+INV-CB6 | universal   | T ∈ [0, 1]                                    | P0
+INV-CB7 | universal   | exit < entry (hysteresis)                     | P0
+INV-CB8 | conditional | T ≥ entry during rehydration → DORMANT        | P0
+```
+
+---
+
+## TEST TAXONOMY
+
+| Invariant type | Test structure | AST signals |
+|---|---|---|
+| `universal` | Sweep/fuzz many inputs | `@given`, `for` loop, `np.all`, ≥3 asserts |
+| `asymptotic` | Simulate, check late values | `arr[-N:]`, `final`/`steady`, `steps > 100` |
+| `monotonic` | Trajectory, check no reversal | `np.diff`, `violations`, for + assert |
+| `statistical` | Ensemble ≥50 realizations | `np.mean`/`np.std`, loop over seeds |
+| `algebraic` | Exact at float precision | `abs(x-y) < 1e-12`, `assert_allclose` |
+| `qualitative` | Sweep parameter, check direction | `for` loop, ≥2 asserts |
+| `conservation` | Before/after comparison | `before`/`after`/`initial`/`final` vars |
+
+### Error messages (5 fields, enforced):
+
 ```python
-# BAD: arbitrary threshold, no physics
-assert R < 0.3
-
-# BAD: exact equality on stochastic quantity  
-assert R == 0.0
-
-# BAD: no invariant reference, no error context
-assert result.order_parameter > 0
-
-# BAD: testing implementation detail, not physics
-assert len(phases) == N  # this is a shape test, not physics
-```
-
-```python
-# GOOD: physics-grounded, identified, contextualized
-epsilon = 3.0 / np.sqrt(N)
 assert R_final < epsilon, (
     f"INV-K2 VIOLATED: R={R_final:.4f} > ε={epsilon:.4f} "
-    f"at K={K:.4f} < K_c={K_c:.4f} with N={N}. "
-    f"Subcritical regime requires R→0."
+    f"expected R→0 in subcritical regime. "
+    f"Finite-size bound ε=3/√N. "
+    f"At K={K:.4f}, K_c={K_c:.4f}, N={N}, steps=10000"
 )
 ```
 
-## Module → Theory Routing Table
+### Forbidden:
 
-**Use this to decide WHICH theory file to read. Don't read all — read the relevant one.**
-
-| If working on files matching... | Read this theory file | Key invariants |
-|---|---|---|
-| `*kuramoto*`, `*sync*`, `*phase*`, `*order_param*` | KURAMOTO_THEORY.md | INV-K1..K7 |
-| `*explosive*`, `*hysteresis*` | KURAMOTO_THEORY.md §4 | INV-ES1..ES2 |
-| `*serotonin*`, `*5ht*`, `*aversive*` | SEROTONIN_THEORY.md | INV-5HT1..7 |
-| `*dopamine*`, `*rpe*`, `*td_error*`, `*reward_pred*` | DOPAMINE_THEORY.md | INV-DA1..7 |
-| `*gaba*`, `*inhibit*`, `*position_gate*` | GABA_THEORY.md | INV-GABA1..5 |
-| `*energy*`, `*free_energy*`, `*lyapunov*`, `*ecs*` | INVARIANTS.yaml §free_energy | INV-FE1..2 |
-| `*thermo*`, `*conservation*`, `*entropy*` | INVARIANTS.yaml §thermodynamics | INV-TH1..2 |
-| `*ricci*`, `*curvature*` | INVARIANTS.yaml §ricci | INV-RC1..2 |
-| `*regime*` | KURAMOTO_THEORY.md + SEROTONIN_THEORY.md | Multiple |
-| `application/`, `connectors/`, `cli/`, `ui/` | None (infra, no physics) | Standard tests |
-
-### Module Map
-
-**Physics Core** (theory-heavy, invariant-dense):
-- `core/physics/` — conservation laws, higher-order Kuramoto, explosive sync
-- `core/indicators/kuramoto*.py` — order parameter, Hilbert phases
-- `core/indicators/kuramoto_ricci_composite.py` — Kuramoto + Ricci composite
-
-**Neuromodulation** (ODE stability, Lyapunov proofs):
-- `core/neuro/`, `src/geosync/core/neuro/` — serotonin, dopamine, GABA, ECS
-- `rl/core/` — actor-critic, reward prediction error, modulation signal
-
-**Market Structure** (thermodynamic constraints):
-- `markets/` — orderbook, regime detection
-- `analytics/regime/` — regime classification, phase transitions
-- `backtest/physics_validation.py` — physics checks in backtesting
-
-**Infrastructure** (standard software tests, no physics):
-- `application/`, `connectors/`, `cli/`, `ui/`
-
-## When Asked to "Write Tests for Module X"
-
-1. Classify: is X physics-core, neuromodulation, market-structure, or infra?
-2. If physics-related → read the physics kernel files first
-3. Identify which invariants apply
-4. Write P0 tests first (falsification), then P1 (convergence), then P2 (stats)
-5. For each test, ask: "What physics does this test? If the physics is wrong, does this test catch it?"
-6. If the answer to (5) is "no" → the test has zero physics value, rewrite it
-
-## When Asked to "Fix a Failing Test"
-
-1. Is the test checking physics? → Read the invariant it references
-2. Is the PHYSICS wrong, or is the TEST wrong?
-   - Physics violation = BUG IN IMPLEMENTATION → fix the code
-   - Test using wrong threshold/method = BUG IN TEST → fix the test
-3. Never "fix" a test by loosening a physics bound without understanding WHY
-
-## Architecture Notes
-
-- See `CANONICAL_OBJECT.md` for full system architecture
-- See `PHYSICS_IMPLEMENTATION_SUMMARY.md` for current implementation status
-- See `tests/TEST_PLAN.md` for existing test organization
-
-## Collaboration Protocol
-
-This project uses Adversarial Orchestration:
-- **Creator** (Claude Code) → generates code and tests
-- **Critic** (human or this protocol) → checks physics grounding
-- **Auditor** → verifies invariants hold across modules
-- **Verifier** → runs CI, checks no regressions
-
-Claude Code is the Creator. The physics kernel is the embedded Critic.
-When in doubt, the physics wins. Always.
-
-## Session Protocol (FOLLOW THIS SEQUENCE)
-
-When starting ANY task involving physics modules:
-
-### Step 1: Classify
-```
-Is this task about: kuramoto/sync/phase/regime → KURAMOTO_THEORY.md
-                     serotonin/5ht/aversive    → SEROTONIN_THEORY.md
-                     dopamine/rpe/td_error      → DOPAMINE_THEORY.md
-                     gaba/inhibition/gate        → GABA_THEORY.md
-                     energy/lyapunov/thermo      → INVARIANTS.yaml
-                     infra/api/cli/ui            → No physics, standard tests
+```python
+assert R < 0.3              # magic number
+assert R == 0.0              # exact on stochastic
+assert result.order > 0      # no INV, no context
 ```
 
-### Step 2: Load Theory
-Read the relevant theory file. Confirm you understand:
-- What physical quantity is computed
-- What invariants MUST hold (check INVARIANTS.yaml for IDs)
-- What the falsification criteria are
-- What common bugs the theory prevents
+---
 
-### Step 3: Execute Task
-Write code/tests following the physics contract.
+## CRITICAL FORMULAS
 
-### Step 4: Self-Validate
-```bash
-# Test validation (L1-L5):
-python .claude/physics/validate_tests.py <your_test_file>
+**Kuramoto**: K_c = 2/(π·g(0)). Lorentzian: K_c = 2γ. NEVER hardcode K_c.
 
-# Production code audit (C1-C2):
-python .claude/physics/validate_tests.py <module_dir> --audit-code
+**Finite-size**: ⟨R⟩ ~ 1/√N incoherent. ε = C/√N, C ∈ [2,3]. N=10: R ~ 0.32. `assert R < 0.01` is WRONG.
 
-# Kernel self-check (34 invariants, cross-refs, dispatch):
-python .claude/physics/validate_tests.py --self-check
-```
-Fix any issues BEFORE presenting results.
+**Dopamine**: δ = r + γ·V' - V. Algebraic — CAN test exact. ∂δ/∂r = 1. Scope: DopamineController.compute_rpe (NOT DopamineExecutionAdapter which applies tanh).
 
-### Step 5: Report
-In your response, state which invariants you tested and which theory
-file you consulted. Example:
-"Tested INV-K1 (bounds), INV-K2 (subcritical decay), INV-K4 (monotonicity).
- Consulted KURAMOTO_THEORY.md. All P0 invariants covered."
+**Serotonin**: s = σ(k·(tonic-θ)) · sensitivity. sensitivity ∈ [0.1, 1.0]. Drawdown NEGATIVE.
 
-## Prompt Templates for Task Delegation
+**GABA**: effective = raw × (1 - inhibition). Inhibition only reduces.
 
-### When Yaroslav says "write tests for X":
-```
-1. cat .claude/physics/INVARIANTS.yaml | grep -A5 "<module>"
-2. cat .claude/physics/<RELEVANT>_THEORY.md
-3. cat .claude/physics/EXAMPLES.md
-4. Write tests following TEST_TAXONOMY.md patterns
-5. python .claude/physics/validate_tests.py <test_file>
-```
+**Free Energy**: F = U − T·S. F itself can be negative. Components (U, T, S) each ≥ 0.
 
-### When Yaroslav says "fix failing test in X":
-```
-1. Read the test — does it reference INV-*?
-2. If yes → read that invariant's theory, determine if PHYSICS or TEST is wrong
-3. If no → the test is physics-blind, needs rewrite not just fix
-4. cat .claude/physics/<RELEVANT>_THEORY.md for context
-```
+**Ricci**: κ ≤ 1 universal. κ ∈ [−1,1] only for build_price_graph output (consecutive integer node IDs match combinatorial distance).
 
-### When Yaroslav says "add physics validation to module X":
-```
-1. Read the module source code
-2. cat .claude/physics/INVARIANTS.yaml — identify ALL applicable invariants
-3. For each invariant: write the appropriate test type (see TEST_TAXONOMY.md)
-4. Priority order: P0 first, then P1, then P2
-5. Run validate_tests.py to confirm all tests reference invariants
-```
+**Cryptobiosis**: DORMANT multiplier = 0.0 EXACTLY. Vitrification O(1). exit < entry (hysteresis). Rehydration abortable.
+
+---
+
+## MODULE → INVARIANT ROUTING
+
+| Files matching... | Invariants |
+|---|---|
+| `*kuramoto*`, `*sync*`, `*phase*` | INV-K1..K7 |
+| `*explosive*`, `*hysteresis*` | INV-ES1..2 |
+| `*serotonin*`, `*5ht*` | INV-5HT1..7 |
+| `*dopamine*`, `*rpe*`, `*td_error*` | INV-DA1..7 |
+| `*gaba*`, `*inhibit*` | INV-GABA1..5 |
+| `*energy*`, `*lyapunov*`, `*ecs*` | INV-FE1..2 |
+| `*thermo*`, `*conservation*` | INV-TH1..2 |
+| `*ricci*`, `*curvature*` | INV-RC1..3 |
+| `*kelly*`, `*sizing*` | INV-KELLY1..3 |
+| `*oms*`, `*order*`, `*execution*` | INV-OMS1..3 |
+| `*signal_bus*`, `*signalbus*` | INV-SB1..2 |
+| `*hpc*`, `*kernel*` | INV-HPC1..2 |
+| `*cryptobiosis*`, `*dormant*` | INV-CB1..8 |
+| `application/`, `cli/`, `ui/` | No physics |
+
+---
+
+## PRODUCTION CODE
+
+When adding clamp/clip (`np.clip`, `max(0, x)`, `min(1, x)`):
+- Add `# INV-*:` comment linking clamp to its invariant
+- OR add `# bounds:` comment for non-physics justification
+- OR add logging so the clamp event is observable
+- Silent repair masks root cause — forbidden
+
+`python .claude/physics/validate_tests.py core/ --audit-code`
+
+---
+
+## SESSION PROTOCOL
+
+1. **Classify**: physics or infra?
+2. **Find invariants**: which INV-* apply?
+3. **Execute**: code/tests following contract
+4. **Validate**: `python .claude/physics/validate_tests.py <file>`
+5. **Report**: which invariants tested, P0/P1/P2
+
+## DECISION RULES
+
+- "Write tests" → find ALL invariants → P0 first → each test asks: "if physics wrong, does this catch it?"
+- "Fix test" → INV-* referenced? → physics wrong or test wrong? → NEVER loosen bound without WHY
+- When in doubt: physics wins. Always.
+- Gradient first. Processing second. INV-YV1.

--- a/core/neuro/cryptobiosis.py
+++ b/core/neuro/cryptobiosis.py
@@ -1,0 +1,230 @@
+# SPDX-License-Identifier: MIT
+"""Cryptobiosis — phase-transition survival for the neuromodulation stack.
+
+Biological basis:
+    Tardigrades survive lethal conditions (vacuum, radiation, desiccation)
+    not by resisting them but by **exiting the space** where the threat
+    applies: vitrifying into a tun state where metabolism drops to zero.
+    Recovery is staged: rehydration is cautious, multi-phase, and
+    abortable if the threat returns.
+
+GeoSync analogue:
+    When combined neuromodulator distress T exceeds the entry threshold,
+    the system vitrifies: all position multipliers drop to **exactly 0.0**
+    (not 0.01, not "close to zero" — zero). No computation on a
+    discharged gradient. On recovery, rehydration proceeds through staged
+    ramp-up with hysteresis to prevent oscillation at the threshold
+    boundary.
+
+State machine::
+
+    ACTIVE ─── T ≥ entry ───▶ VITRIFYING ── O(1) ──▶ DORMANT
+      ▲                                                  │
+      │                                          T < exit │
+      │                                                  ▼
+      └──────── ramp complete ◀── REHYDRATING ◀──────────┘
+                                    │
+                                    │ T ≥ entry
+                                    ▼
+                                  DORMANT (abort)
+
+Invariants (see INVARIANTS.yaml INV-CB1..CB8):
+    CB1: DORMANT ⟹ multiplier == 0.0 EXACTLY
+    CB2: Vitrification is O(1) — no iterative wind-down
+    CB3: Snapshot sufficient for recovery
+    CB4: Rehydration stages non-decreasing
+    CB5: Entry threshold > every individual module threshold
+    CB6: T ∈ [0, 1]
+    CB7: exit < entry (hysteresis)
+    CB8: T ≥ entry during rehydration → DORMANT
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import asdict, dataclass, field
+from enum import Enum
+from typing import Any
+
+
+class CryptobiosisState(Enum):
+    """Phase of the cryptobiosis lifecycle."""
+
+    ACTIVE = "ACTIVE"
+    VITRIFYING = "VITRIFYING"
+    DORMANT = "DORMANT"
+    REHYDRATING = "REHYDRATING"
+
+
+@dataclass(frozen=True, slots=True)
+class CryptobiosisSnapshot:
+    """Minimal state sufficient for recovery (INV-CB3).
+
+    Captures everything the system needs to resume from DORMANT:
+    the distress score at entry, the timestamp, and any metadata the
+    caller wants to persist (e.g. last known positions, risk state).
+    """
+
+    entry_T: float
+    entry_timestamp: float
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class CryptobiosisConfig:
+    """Tunable parameters for the cryptobiosis state machine.
+
+    entry_threshold must be strictly greater than exit_threshold
+    (INV-CB7: hysteresis).
+    """
+
+    entry_threshold: float = 0.85
+    exit_threshold: float = 0.60
+    n_rehydration_stages: int = 4
+
+    def __post_init__(self) -> None:
+        if not (0.0 < self.exit_threshold < self.entry_threshold <= 1.0):
+            raise ValueError(
+                f"Must have 0 < exit ({self.exit_threshold}) "
+                f"< entry ({self.entry_threshold}) ≤ 1. "
+                f"INV-CB7: hysteresis requires exit < entry."
+            )
+        if self.n_rehydration_stages < 1:
+            raise ValueError("n_rehydration_stages must be ≥ 1")
+
+
+class CryptobiosisController:
+    """Phase-transition survival controller.
+
+    Usage::
+
+        ctrl = CryptobiosisController()
+        T = compute_distress(bus.snapshot())  # ∈ [0, 1]
+        result = ctrl.update(T)
+        position_multiplier = result["multiplier"]
+        # Apply: effective_size = raw_size * position_multiplier
+    """
+
+    def __init__(self, config: CryptobiosisConfig | None = None) -> None:
+        self._cfg = config or CryptobiosisConfig()
+        self._state = CryptobiosisState.ACTIVE
+        self._rehydration_stage: int = 0
+        self._snapshot: CryptobiosisSnapshot | None = None
+        self._last_T: float = 0.0
+
+    # ── Properties ───────────────────────────────────────────────────
+
+    @property
+    def state(self) -> CryptobiosisState:
+        return self._state
+
+    @property
+    def multiplier(self) -> float:
+        """Current position multiplier.
+
+        INV-CB1: DORMANT ⟹ exactly 0.0.
+        INV-CB4: REHYDRATING ⟹ staged ramp in (0, 1).
+        ACTIVE / VITRIFYING ⟹ 1.0.
+        """
+        if self._state == CryptobiosisState.DORMANT:
+            return 0.0  # INV-CB1: EXACTLY zero, not approximately
+        if self._state == CryptobiosisState.REHYDRATING:
+            # INV-CB4: staged non-decreasing ramp
+            n = self._cfg.n_rehydration_stages
+            return float(self._rehydration_stage) / float(n)
+        return 1.0
+
+    @property
+    def snapshot(self) -> CryptobiosisSnapshot | None:
+        """The snapshot taken at vitrification, or None if ACTIVE."""
+        return self._snapshot
+
+    @property
+    def distress(self) -> float:
+        """Last observed distress T."""
+        return self._last_T
+
+    # ── Core transition logic ────────────────────────────────────────
+
+    def update(
+        self,
+        T: float,
+        *,
+        metadata: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Advance the state machine by one tick.
+
+        Parameters
+        ----------
+        T : float
+            Combined neuromodulator distress score ∈ [0, 1] (INV-CB6).
+        metadata : dict, optional
+            Extra state to include in the vitrification snapshot.
+
+        Returns
+        -------
+        dict
+            state, multiplier, rehydration_stage, distress, snapshot.
+        """
+        # INV-CB6: T ∈ [0, 1]
+        T = max(0.0, min(1.0, float(T)))  # INV-CB6: distress score clamped to [0, 1]
+        self._last_T = T
+
+        if self._state == CryptobiosisState.ACTIVE:
+            if T >= self._cfg.entry_threshold:
+                self._enter_vitrification(T, metadata or {})
+        elif self._state == CryptobiosisState.VITRIFYING:
+            # INV-CB2: O(1) transition — vitrification completes in ONE tick
+            self._state = CryptobiosisState.DORMANT
+        elif self._state == CryptobiosisState.DORMANT:
+            if T < self._cfg.exit_threshold:
+                self._begin_rehydration()
+        elif self._state == CryptobiosisState.REHYDRATING:
+            # INV-CB8: if distress returns above entry during rehydration → abort
+            if T >= self._cfg.entry_threshold:
+                self._state = CryptobiosisState.DORMANT
+                self._rehydration_stage = 0
+            else:
+                self._advance_rehydration()
+
+        return {
+            "state": self._state.value,
+            "multiplier": self.multiplier,
+            "rehydration_stage": self._rehydration_stage,
+            "distress": T,
+            "snapshot": asdict(self._snapshot) if self._snapshot else None,
+        }
+
+    # ── Internal transitions ─────────────────────────────────────────
+
+    def _enter_vitrification(self, T: float, metadata: dict[str, Any]) -> None:
+        """ACTIVE → VITRIFYING. Capture snapshot (INV-CB3)."""
+        self._state = CryptobiosisState.VITRIFYING
+        self._snapshot = CryptobiosisSnapshot(
+            entry_T=T,
+            entry_timestamp=time.time(),
+            metadata=dict(metadata),
+        )
+        self._rehydration_stage = 0
+
+    def _begin_rehydration(self) -> None:
+        """DORMANT → REHYDRATING at stage 0."""
+        self._state = CryptobiosisState.REHYDRATING
+        self._rehydration_stage = 0
+
+    def _advance_rehydration(self) -> None:
+        """Advance rehydration by one stage. Complete → ACTIVE."""
+        self._rehydration_stage += 1
+        if self._rehydration_stage >= self._cfg.n_rehydration_stages:
+            self._state = CryptobiosisState.ACTIVE
+            self._rehydration_stage = 0
+            self._snapshot = None
+
+    # ── Reset ────────────────────────────────────────────────────────
+
+    def reset(self) -> None:
+        """Force-reset to ACTIVE. For testing / emergency override only."""
+        self._state = CryptobiosisState.ACTIVE
+        self._rehydration_stage = 0
+        self._snapshot = None
+        self._last_T = 0.0

--- a/tests/unit/physics/test_T17_cryptobiosis.py
+++ b/tests/unit/physics/test_T17_cryptobiosis.py
@@ -1,0 +1,291 @@
+# SPDX-License-Identifier: MIT
+"""T17 — Cryptobiosis state-machine witnesses for INV-CB1 through INV-CB8.
+
+The cryptobiosis controller is a tardigrade-inspired survival mechanism:
+when combined neuromodulator distress exceeds a threshold, the system
+**exits the space where the threat applies** by zeroing all position
+multipliers (DORMANT). Recovery is staged, hysteretic, and abortable.
+
+These witnesses exercise every P0 invariant of the state machine against
+the production ``core.neuro.cryptobiosis.CryptobiosisController``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from core.neuro.cryptobiosis import (
+    CryptobiosisConfig,
+    CryptobiosisController,
+    CryptobiosisState,
+)
+
+# ── INV-CB1: DORMANT multiplier == 0.0 EXACTLY ──────────────────────
+
+
+def test_dormant_multiplier_is_exactly_zero() -> None:
+    """INV-CB1: DORMANT ⟹ multiplier == 0.0, not approximately.
+
+    Drives the controller through ACTIVE → VITRIFYING → DORMANT and
+    asserts the multiplier is bitwise 0.0. The tolerance is zero
+    because this is a safety contract: any nonzero multiplier in
+    DORMANT means the system is trading during a threat.
+    """
+    ctrl = CryptobiosisController()
+    # Push into DORMANT: tick 1 = VITRIFYING, tick 2 = DORMANT
+    ctrl.update(T=0.95)  # ACTIVE → VITRIFYING
+    result = ctrl.update(T=0.95)  # VITRIFYING → DORMANT
+    assert ctrl.state.value == CryptobiosisState.DORMANT.value, (
+        f"INV-CB1 pre-check failed: state={ctrl.state}, expected DORMANT. "
+        f"Observed at T=0.95, entry=0.85."
+    )
+    # INV-CB1: EXACTLY zero — not 1e-10, not 0.001, not float min.
+    assert result["multiplier"] == 0.0, (
+        f"INV-CB1 VIOLATED: DORMANT multiplier={result['multiplier']} ≠ 0.0. "
+        f"Expected exactly 0.0 — system must not trade during DORMANT. "
+        f"Observed at T=0.95, entry_threshold=0.85. "
+        f"Physical reasoning: DORMANT = zero metabolism = zero computation."
+    )
+    assert ctrl.multiplier == 0.0, (
+        f"INV-CB1 VIOLATED: property multiplier={ctrl.multiplier} ≠ 0.0. "
+        f"Expected exactly 0.0 via property accessor. "
+        f"Observed at T=0.95, state=DORMANT."
+    )
+
+
+# ── INV-CB2: Vitrification O(1) ─────────────────────────────────────
+
+
+def test_vitrification_completes_in_one_tick() -> None:
+    """INV-CB2: VITRIFYING → DORMANT in exactly 1 tick.
+
+    Vitrification is O(1): the system spends at most 1 tick in
+    VITRIFYING before landing in DORMANT. No iterative wind-down.
+    """
+    ctrl = CryptobiosisController()
+    ctrl.update(T=0.90)
+    assert (
+        ctrl.state.value == CryptobiosisState.VITRIFYING.value
+    ), f"INV-CB2 pre-check: expected VITRIFYING, got {ctrl.state}. Observed at T=0.90, entry=0.85."
+    ctrl.update(T=0.90)
+    assert ctrl.state.value == CryptobiosisState.DORMANT.value, (
+        f"INV-CB2 VIOLATED: state={ctrl.state} after 2nd tick, expected DORMANT. "
+        f"Expected O(1) vitrification: 1 tick VITRIFYING → DORMANT. "
+        f"Observed at T=0.90, entry_threshold=0.85. "
+        f"Physical reasoning: vitrification is a phase transition, not a process."
+    )
+
+
+# ── INV-CB3: Snapshot sufficiency ────────────────────────────────────
+
+
+def test_snapshot_exists_in_dormant() -> None:
+    """INV-CB3: snapshot is non-None in DORMANT state.
+
+    The vitrification snapshot must contain the data needed for recovery.
+    A None snapshot in DORMANT means the system cannot resume.
+    """
+    ctrl = CryptobiosisController()
+    ctrl.update(T=0.90, metadata={"positions": [100, 200]})
+    ctrl.update(T=0.90)  # → DORMANT
+    assert ctrl.state.value == CryptobiosisState.DORMANT.value
+    snap = ctrl.snapshot
+    assert snap is not None, (
+        "INV-CB3 VIOLATED: snapshot is None in DORMANT. "
+        "Expected non-None snapshot with entry_T, timestamp, metadata. "
+        "Observed at T=0.90, state=DORMANT. "
+        "Physical reasoning: recovery requires a checkpoint."
+    )
+    assert snap.entry_T == 0.90, (
+        f"INV-CB3 VIOLATED: snapshot.entry_T={snap.entry_T} ≠ 0.90. "
+        f"Expected entry_T to match the T that triggered vitrification. "
+        f"Observed at T=0.90. "
+        f"Physical reasoning: recovery needs to know the distress at entry."
+    )
+    assert snap.metadata.get("positions") == [100, 200], (
+        f"INV-CB3 VIOLATED: metadata={snap.metadata} lost caller data. "
+        f"Expected positions=[100,200] in metadata. "
+        f"Observed at T=0.90. "
+        f"Physical reasoning: snapshot must capture all caller-provided state."
+    )
+
+
+# ── INV-CB4: Rehydration non-decreasing ─────────────────────────────
+
+
+def test_rehydration_stages_non_decreasing() -> None:
+    """INV-CB4: rehydration_stage(t+1) ≥ rehydration_stage(t) under safe T.
+
+    Pushes controller through full lifecycle and records rehydration
+    stages. Each tick at T < exit must advance or hold (never regress).
+    """
+    cfg = CryptobiosisConfig(
+        entry_threshold=0.80, exit_threshold=0.50, n_rehydration_stages=5
+    )
+    ctrl = CryptobiosisController(cfg)
+    # Enter DORMANT
+    ctrl.update(T=0.90)
+    ctrl.update(T=0.90)
+    assert ctrl.state.value == CryptobiosisState.DORMANT.value
+
+    # Begin rehydration
+    stages: list[int] = []
+    for tick in range(10):
+        result = ctrl.update(T=0.30)
+        if ctrl.state.value == CryptobiosisState.REHYDRATING.value:
+            stages.append(result["rehydration_stage"])
+        elif ctrl.state.value == CryptobiosisState.ACTIVE.value:
+            break
+
+    # INV-CB4: non-decreasing trajectory
+    for i in range(1, len(stages)):
+        assert stages[i] >= stages[i - 1], (
+            f"INV-CB4 VIOLATED at tick={i}: stage dropped from "
+            f"{stages[i - 1]} to {stages[i]}. "
+            f"Expected non-decreasing rehydration stages. "
+            f"Observed at T=0.30, exit=0.50, n_stages=5. "
+            f"Physical reasoning: rehydration is a monotone ramp-up."
+        )
+
+
+# ── INV-CB6: Distress bounded ───────────────────────────────────────
+
+
+def test_distress_clamped_to_unit_interval() -> None:
+    """INV-CB6: T ∈ [0, 1] after any update, regardless of input.
+
+    Feeds extreme inputs (negative, >1, huge) and asserts the internal
+    distress is clamped to [0, 1] on every tick.
+    """
+    ctrl = CryptobiosisController()
+    extreme_inputs = [-100.0, -0.5, 0.0, 0.5, 1.0, 1.5, 999.0]
+    # epsilon: T is clamped by definition to [0, 1]
+    for raw_T in extreme_inputs:
+        ctrl.update(T=raw_T)
+        assert 0.0 <= ctrl.distress <= 1.0, (
+            f"INV-CB6 VIOLATED: distress={ctrl.distress} outside [0, 1] "
+            f"for input T={raw_T}. "
+            f"Expected clamped distress ∈ [0, 1]. "
+            f"Observed at raw_T={raw_T}. "
+            f"Physical reasoning: distress is a normalised signal."
+        )
+
+
+# ── INV-CB7: Hysteresis ─────────────────────────────────────────────
+
+
+def test_hysteresis_exit_less_than_entry() -> None:
+    """INV-CB7: exit_threshold < entry_threshold enforced at config time.
+
+    Attempts to create configs with exit ≥ entry and asserts ValueError.
+    """
+    invalid_configs = [
+        (0.80, 0.80),  # exit == entry
+        (0.80, 0.90),  # exit > entry
+        (0.50, 0.50),
+        (1.00, 1.00),
+    ]
+    for entry, exit_val in invalid_configs:
+        with pytest.raises(ValueError):
+            CryptobiosisConfig(entry_threshold=entry, exit_threshold=exit_val)
+
+    # Valid config must pass
+    valid = CryptobiosisConfig(entry_threshold=0.85, exit_threshold=0.60)
+    assert valid.exit_threshold < valid.entry_threshold, (
+        f"INV-CB7 VIOLATED: exit={valid.exit_threshold} ≥ entry="
+        f"{valid.entry_threshold}. "
+        f"Expected strict hysteresis: exit < entry. "
+        f"Observed at entry=0.85, exit=0.60. "
+        f"Physical reasoning: without hysteresis the system oscillates."
+    )
+
+
+# ── INV-CB8: Rehydration abort ──────────────────────────────────────
+
+
+def test_rehydration_aborts_on_distress_return() -> None:
+    """INV-CB8: T ≥ entry during REHYDRATING → immediate DORMANT.
+
+    Starts rehydration, then re-introduces distress above entry.
+    The controller must abort rehydration and return to DORMANT
+    in the same tick — no delay, no partial ramp.
+    """
+    ctrl = CryptobiosisController()
+    # Enter DORMANT
+    ctrl.update(T=0.90)
+    ctrl.update(T=0.90)
+    assert ctrl.state.value == CryptobiosisState.DORMANT.value
+
+    # Start rehydration
+    ctrl.update(T=0.30)
+    assert ctrl.state.value == CryptobiosisState.REHYDRATING.value
+
+    # Distress returns above entry
+    result = ctrl.update(T=0.90)
+    assert ctrl.state.value == CryptobiosisState.DORMANT.value, (
+        f"INV-CB8 VIOLATED: state={ctrl.state} after distress return "
+        f"during rehydration. "
+        f"Expected immediate DORMANT on T={0.90} ≥ entry={0.85}. "
+        f"Observed at T=0.90, previous state=REHYDRATING. "
+        f"Physical reasoning: if threat returns during recovery, "
+        f"abort immediately — do not finish ramp-up into danger."
+    )
+    # INV-CB1 must also hold: multiplier back to 0.0
+    assert result["multiplier"] == 0.0, (
+        f"INV-CB1 VIOLATED after abort: multiplier={result['multiplier']}. "
+        f"Expected 0.0 in DORMANT after rehydration abort. "
+        f"Observed at T=0.90. "
+        f"Physical reasoning: aborted rehydration = back to zero metabolism."
+    )
+
+
+# ── Full lifecycle integration ───────────────────────────────────────
+
+
+def test_full_lifecycle_active_dormant_rehydrate_active() -> None:
+    """INV-CB1 + CB2 + CB4 + CB6: full round-trip lifecycle.
+
+    Drives the controller through the complete state machine:
+    ACTIVE → VITRIFYING → DORMANT → REHYDRATING → ACTIVE
+    and asserts every invariant holds at every stage.
+    """
+    cfg = CryptobiosisConfig(
+        entry_threshold=0.80, exit_threshold=0.50, n_rehydration_stages=3
+    )
+    ctrl = CryptobiosisController(cfg)
+
+    # Phase 1: ACTIVE at low distress
+    result = ctrl.update(T=0.30)
+    assert ctrl.state.value == CryptobiosisState.ACTIVE.value
+    assert result["multiplier"] == 1.0
+
+    # Phase 2: enter vitrification
+    result = ctrl.update(T=0.85)
+    assert ctrl.state.value == CryptobiosisState.VITRIFYING.value
+
+    # Phase 3: DORMANT
+    result = ctrl.update(T=0.85)
+    assert ctrl.state.value == CryptobiosisState.DORMANT.value
+    assert result["multiplier"] == 0.0  # INV-CB1
+
+    # Phase 4: start rehydration
+    result = ctrl.update(T=0.30)
+    assert ctrl.state.value == CryptobiosisState.REHYDRATING.value
+    prev_stage = result["rehydration_stage"]
+
+    # Phase 5: advance through rehydration stages
+    for _ in range(5):
+        result = ctrl.update(T=0.30)
+        if ctrl.state.value == CryptobiosisState.ACTIVE.value:
+            break
+        assert result["rehydration_stage"] >= prev_stage  # INV-CB4
+        prev_stage = result["rehydration_stage"]
+
+    # Phase 6: back to ACTIVE
+    assert ctrl.state.value == CryptobiosisState.ACTIVE.value, (
+        f"Full lifecycle failed: state={ctrl.state}, expected ACTIVE. "
+        f"Observed at T=0.30, n_stages=3. "
+        f"Physical reasoning: 3 rehydration stages + sufficient ticks "
+        f"should complete recovery."
+    )
+    assert ctrl.multiplier == 1.0


### PR DESCRIPTION
## Summary

- **New module**: `core/neuro/cryptobiosis.py` — tardigrade-inspired phase-transition survival (ACTIVE → VITRIFYING → DORMANT → REHYDRATING → ACTIVE)
- **8 new invariants** INV-CB1..CB8 in INVARIANTS.yaml (total: **53**)
- **CLAUDE.md** replaced with Gradient Constitution: Section 0 (INV-YV1 gradient ontology), all 53 invariants across 13 modules, corrected FE2/RC1/DA3/DA7
- **8 witnesses** in test_T17_cryptobiosis.py (8/8 pass, 100% grounded)

## Key invariants

| ID | Statement | Priority |
|---|---|---|
| INV-CB1 | DORMANT ⟹ multiplier == 0.0 EXACTLY | P0 |
| INV-CB2 | Vitrification O(1) — one tick | P0 |
| INV-CB4 | Rehydration stages non-decreasing | P0 |
| INV-CB7 | exit < entry (hysteresis) | P0 |
| INV-CB8 | T ≥ entry during rehydration → DORMANT | P0 |

## Test plan

- [x] `python .claude/physics/validate_tests.py --self-check` → 53 invariants, PASSED
- [x] `pytest test_T17_cryptobiosis.py` → 8/8 passed
- [x] `mypy --strict` clean on both new files
- [x] `black` formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)