### PR TITLE
fix(ci): bump Go to 1.24 — unblock CodeQL

### DIFF
--- a/examples/go-client/go.mod
+++ b/examples/go-client/go.mod
@@ -1,5 +1,5 @@
 module github.com/neuron7xLab/GeoSync/examples/go-client
 
-go 1.21
+go 1.24
 
 require google.golang.org/grpc v1.79.3

--- a/go.work
+++ b/go.work
@@ -1,4 +1,4 @@
-go 1.21
+go 1.24
 
 use (
     ./examples/go-client


### PR DESCRIPTION
## Summary

- go.work: 1.21 → 1.24
- go-client/go.mod: 1.21 → 1.24
- grpc v1.79.3 requires go >= 1.24, CodeQL autobuild fails without it

## Test plan

- [ ] CodeQL Go autobuild passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)