### PR TITLE
fix(ci): polish go-workspace-integrity from #154

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -413,7 +413,7 @@ jobs:
           else
             changed=$(git diff-tree --no-commit-id --name-only -r "$GITHUB_SHA")
           fi
-          printf '%s\n' "$changed" | grep -qE '(go\.work|go\.mod|go\.sum)' \
+          printf '%s\n' "$changed" | grep -qE '(go\.work|go\.mod|go\.sum|\.go$)' \
             && echo "applicable=true" >> "$GITHUB_OUTPUT" \
             || echo "applicable=false" >> "$GITHUB_OUTPUT"
 
@@ -429,11 +429,30 @@ jobs:
         run: |
           set -euo pipefail
           go work sync
-          git diff --exit-code go.work || (echo "go.work out of sync — run 'go work sync'" && exit 1)
+          git diff --exit-code go.work || {
+            echo "go.work out of sync — run 'go work sync' locally"
+            exit 1
+          }
 
-      - name: go build
+      - name: go vet + build (workspace modules only)
         if: steps.go-changes.outputs.applicable == 'true'
-        run: go build ./...
+        run: |
+          set -euo pipefail
+          cd examples/go-client
+          go mod tidy
+          git diff --exit-code go.mod || {
+            echo "go.mod out of sync — run 'cd examples/go-client && go mod tidy' locally"
+            exit 1
+          }
+          go vet ./...
+          go build ./...
+
+      - name: go test (workspace modules only)
+        if: steps.go-changes.outputs.applicable == 'true'
+        run: |
+          set -euo pipefail
+          cd examples/go-client
+          go test -race -count=1 ./...
 
       - name: Skip (no Go changes)
         if: steps.go-changes.outputs.applicable != 'true'

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -402,6 +402,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          fetch-depth: 0
 
       - name: Detect Go changes
         id: go-changes


### PR DESCRIPTION
## Summary

Fixes issues in #154 (Codex-generated Go workspace CI):

1. `go build ./...` from root hit infra/terraform (not in go.work) → scoped to examples/go-client
2. go.work.sum diff check fails on Go version differences → check go.work only
3. No go test step → added `go test -race -count=1`
4. Pattern missed .go file changes → added `\.go$` to detection

## Test plan

- [ ] go-workspace-integrity CI job passes
- [ ] CodeQL Go build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)