### PR TITLE
Fix Python 3.10 UTC timezone import compatibility in core modules

### DIFF
--- a/core/altdata/social_listening.py
+++ b/core/altdata/social_listening.py
@@ -16,7 +16,9 @@ import math
 import re
 from collections import defaultdict, deque
 from dataclasses import dataclass
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
+
+UTC = timezone.utc
 from typing import Iterable, Mapping, Sequence
 
 import pandas as pd

--- a/core/compliance/mifid2.py
+++ b/core/compliance/mifid2.py
@@ -7,11 +7,12 @@ from __future__ import annotations
 import json
 import logging
 from dataclasses import dataclass, field, fields
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Mapping
 
 LOGGER = logging.getLogger(__name__)
+UTC = timezone.utc
 
 
 def _slots_to_dict(obj: Any) -> dict[str, Any]:

--- a/core/data/backfill.py
+++ b/core/data/backfill.py
@@ -27,7 +27,9 @@ import uuid
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
-from datetime import UTC
+from datetime import timezone
+
+UTC = timezone.utc
 from queue import Empty, PriorityQueue
 from typing import Iterator, List, MutableMapping, Optional
 

--- a/core/data/feature_store.py
+++ b/core/data/feature_store.py
@@ -13,7 +13,7 @@ import shutil
 import sqlite3
 import ssl
 from dataclasses import dataclass, field
-from datetime import UTC
+from datetime import timezone
 from decimal import Decimal, InvalidOperation
 from io import StringIO
 from pathlib import Path
@@ -24,6 +24,7 @@ import pandas as pd
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 from pandas.api import types as pd_types
 
+UTC = timezone.utc
 if not hasattr(pd, "_pandas_datetime_CAPI"):  # pragma: no cover - runtime shim
     pd._pandas_datetime_CAPI = None
 

--- a/core/data/parity.py
+++ b/core/data/parity.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import UTC
+from datetime import timezone
 from typing import Iterable, Sequence
 
 import pandas as pd
@@ -14,6 +14,7 @@ from pandas.api import types as pd_types
 from core.data.feature_store import IntegrityReport, OnlineFeatureStore
 
 
+UTC = timezone.utc
 class FeatureParityError(RuntimeError):
     """Base error for offline/online parity coordination."""
 

--- a/core/data/pipeline.py
+++ b/core/data/pipeline.py
@@ -36,7 +36,9 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass, field
-from datetime import UTC
+from datetime import timezone
+
+UTC = timezone.utc
 from hashlib import blake2b
 from time import perf_counter
 from typing import Any, Callable, Mapping, MutableMapping, Protocol

--- a/core/events/sourcing.py
+++ b/core/events/sourcing.py
@@ -16,7 +16,7 @@ import json
 import logging
 from contextlib import contextmanager
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from typing import (
     Any,
     ClassVar,
@@ -54,6 +54,7 @@ from sqlalchemy.orm import Session, sessionmaker
 from domain.order import OrderSide, OrderStatus, OrderType
 
 LOGGER = logging.getLogger(__name__)
+UTC = timezone.utc
 
 __all__ = [
     "AggregateRoot",


### PR DESCRIPTION
### Motivation
- Several core modules imported `UTC` directly from `datetime`, which raises `ImportError` on Python 3.10 and prevents module import/test collection during startup. 
- The import-time failure blocked downstream test discovery and runtime paths touching observability/compliance/altdata components.

### Description
- Replaced imports that attempted `from datetime import UTC` with `from datetime import timezone` and introduced a local `UTC = timezone.utc` constant where needed. 
- Changes applied to these modules: `core/compliance/mifid2.py`, `core/events/sourcing.py`, `core/data/backfill.py`, `core/data/feature_store.py`, `core/data/parity.py`, `core/data/pipeline.py`, and `core/altdata/social_listening.py`. 
- The change preserves previous semantics while ensuring compatibility across Python 3.10+ runtimes.

### Testing
- Ran `python -m py_compile` against the modified modules and it completed successfully. 
- Verified runtime import by executing `importlib.import_module('core.compliance.mifid2')`, which succeeded and exposed `UTC` as expected. 
- Attempted to run targeted `pytest` suites, but full test runs in this environment failed to proceed due to a missing external dependency (`omegaconf`); the original `ImportError` from `UTC` is resolved by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d65259d9308324a271ff0482eb17ad)