### PR TITLE
Fail-closed optional imports; refactor live backtester; enable transition-entry + tests

### DIFF
--- a/backtest/__init__.py
+++ b/backtest/__init__.py
@@ -1,31 +1,73 @@
 # Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
 # SPDX-License-Identifier: MIT
-"""Backtesting utilities, strategies, and performance analytics."""
+"""Backtesting utilities, strategies, and performance analytics.
 
-from .dopamine_td import (
-    DopamineTDParams,
-    dopamine_td_signal,
-    run_dopamine_backtest,
-    run_vectorized_dopamine_td,
-)
+Keep package import fail-closed for optional integrations: importing
+``backtest`` should not require all transitive runtime dependencies.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class _MissingOptionalDependency:
+    symbol: str
+    reason: str
+
+    def _raise(self) -> None:
+        raise ImportError(
+            f"{self.symbol} is unavailable because an optional dependency failed "
+            f"to import: {self.reason}"
+        )
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        self._raise()
+
+    def __getattr__(self, _name: str) -> Any:
+        self._raise()
+
 from .engine import LatencyConfig, OrderBookConfig
-from .performance import (
-    PerformanceReport,
-    compute_performance_metrics,
-    export_performance_report,
-)
-from .synthetic import (
-    ControlledExperiment,
-    LiquidityShock,
-    OrderBookDepthConfig,
-    OrderBookDepthProfile,
-    StrategyEvaluation,
-    StructuralBreak,
-    SyntheticScenario,
-    SyntheticScenarioConfig,
-    SyntheticScenarioGenerator,
-    VolatilityShift,
-)
+from .performance import PerformanceReport, compute_performance_metrics, export_performance_report
+
+try:  # optional research helpers
+    from .dopamine_td import (
+        DopamineTDParams,
+        dopamine_td_signal,
+        run_dopamine_backtest,
+        run_vectorized_dopamine_td,
+    )
+except Exception as exc:  # pragma: no cover - optional dependency chain
+    DopamineTDParams = _MissingOptionalDependency("DopamineTDParams", str(exc))  # type: ignore[assignment]
+    dopamine_td_signal = _MissingOptionalDependency("dopamine_td_signal", str(exc))  # type: ignore[assignment]
+    run_dopamine_backtest = _MissingOptionalDependency("run_dopamine_backtest", str(exc))  # type: ignore[assignment]
+    run_vectorized_dopamine_td = _MissingOptionalDependency("run_vectorized_dopamine_td", str(exc))  # type: ignore[assignment]
+
+try:  # optional synthetic scenario suite
+    from .synthetic import (
+        ControlledExperiment,
+        LiquidityShock,
+        OrderBookDepthConfig,
+        OrderBookDepthProfile,
+        StrategyEvaluation,
+        StructuralBreak,
+        SyntheticScenario,
+        SyntheticScenarioConfig,
+        SyntheticScenarioGenerator,
+        VolatilityShift,
+    )
+except Exception as exc:  # pragma: no cover - optional dependency chain
+    ControlledExperiment = _MissingOptionalDependency("ControlledExperiment", str(exc))  # type: ignore[assignment]
+    LiquidityShock = _MissingOptionalDependency("LiquidityShock", str(exc))  # type: ignore[assignment]
+    OrderBookDepthConfig = _MissingOptionalDependency("OrderBookDepthConfig", str(exc))  # type: ignore[assignment]
+    OrderBookDepthProfile = _MissingOptionalDependency("OrderBookDepthProfile", str(exc))  # type: ignore[assignment]
+    StrategyEvaluation = _MissingOptionalDependency("StrategyEvaluation", str(exc))  # type: ignore[assignment]
+    StructuralBreak = _MissingOptionalDependency("StructuralBreak", str(exc))  # type: ignore[assignment]
+    SyntheticScenario = _MissingOptionalDependency("SyntheticScenario", str(exc))  # type: ignore[assignment]
+    SyntheticScenarioConfig = _MissingOptionalDependency("SyntheticScenarioConfig", str(exc))  # type: ignore[assignment]
+    SyntheticScenarioGenerator = _MissingOptionalDependency("SyntheticScenarioGenerator", str(exc))  # type: ignore[assignment]
+    VolatilityShift = _MissingOptionalDependency("VolatilityShift", str(exc))  # type: ignore[assignment]
 
 __all__ = [
     "LatencyConfig",

--- a/backtest/__init__.py
+++ b/backtest/__init__.py
@@ -7,26 +7,7 @@ Keep package import fail-closed for optional integrations: importing
 """
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Any
-
-
-@dataclass(frozen=True)
-class _MissingOptionalDependency:
-    symbol: str
-    reason: str
-
-    def _raise(self) -> None:
-        raise ImportError(
-            f"{self.symbol} is unavailable because an optional dependency failed "
-            f"to import: {self.reason}"
-        )
-
-    def __call__(self, *args: Any, **kwargs: Any) -> Any:
-        self._raise()
-
-    def __getattr__(self, _name: str) -> Any:
-        self._raise()
+from core.utils.optional_dependency import MissingOptionalDependency
 
 from .engine import LatencyConfig, OrderBookConfig
 from .performance import PerformanceReport, compute_performance_metrics, export_performance_report
@@ -39,10 +20,10 @@ try:  # optional research helpers
         run_vectorized_dopamine_td,
     )
 except Exception as exc:  # pragma: no cover - optional dependency chain
-    DopamineTDParams = _MissingOptionalDependency("DopamineTDParams", str(exc))  # type: ignore[assignment]
-    dopamine_td_signal = _MissingOptionalDependency("dopamine_td_signal", str(exc))  # type: ignore[assignment]
-    run_dopamine_backtest = _MissingOptionalDependency("run_dopamine_backtest", str(exc))  # type: ignore[assignment]
-    run_vectorized_dopamine_td = _MissingOptionalDependency("run_vectorized_dopamine_td", str(exc))  # type: ignore[assignment]
+    DopamineTDParams = MissingOptionalDependency("DopamineTDParams", str(exc))  # type: ignore[assignment]
+    dopamine_td_signal = MissingOptionalDependency("dopamine_td_signal", str(exc))  # type: ignore[assignment]
+    run_dopamine_backtest = MissingOptionalDependency("run_dopamine_backtest", str(exc))  # type: ignore[assignment]
+    run_vectorized_dopamine_td = MissingOptionalDependency("run_vectorized_dopamine_td", str(exc))  # type: ignore[assignment]
 
 try:  # optional synthetic scenario suite
     from .synthetic import (
@@ -58,16 +39,16 @@ try:  # optional synthetic scenario suite
         VolatilityShift,
     )
 except Exception as exc:  # pragma: no cover - optional dependency chain
-    ControlledExperiment = _MissingOptionalDependency("ControlledExperiment", str(exc))  # type: ignore[assignment]
-    LiquidityShock = _MissingOptionalDependency("LiquidityShock", str(exc))  # type: ignore[assignment]
-    OrderBookDepthConfig = _MissingOptionalDependency("OrderBookDepthConfig", str(exc))  # type: ignore[assignment]
-    OrderBookDepthProfile = _MissingOptionalDependency("OrderBookDepthProfile", str(exc))  # type: ignore[assignment]
-    StrategyEvaluation = _MissingOptionalDependency("StrategyEvaluation", str(exc))  # type: ignore[assignment]
-    StructuralBreak = _MissingOptionalDependency("StructuralBreak", str(exc))  # type: ignore[assignment]
-    SyntheticScenario = _MissingOptionalDependency("SyntheticScenario", str(exc))  # type: ignore[assignment]
-    SyntheticScenarioConfig = _MissingOptionalDependency("SyntheticScenarioConfig", str(exc))  # type: ignore[assignment]
-    SyntheticScenarioGenerator = _MissingOptionalDependency("SyntheticScenarioGenerator", str(exc))  # type: ignore[assignment]
-    VolatilityShift = _MissingOptionalDependency("VolatilityShift", str(exc))  # type: ignore[assignment]
+    ControlledExperiment = MissingOptionalDependency("ControlledExperiment", str(exc))  # type: ignore[assignment]
+    LiquidityShock = MissingOptionalDependency("LiquidityShock", str(exc))  # type: ignore[assignment]
+    OrderBookDepthConfig = MissingOptionalDependency("OrderBookDepthConfig", str(exc))  # type: ignore[assignment]
+    OrderBookDepthProfile = MissingOptionalDependency("OrderBookDepthProfile", str(exc))  # type: ignore[assignment]
+    StrategyEvaluation = MissingOptionalDependency("StrategyEvaluation", str(exc))  # type: ignore[assignment]
+    StructuralBreak = MissingOptionalDependency("StructuralBreak", str(exc))  # type: ignore[assignment]
+    SyntheticScenario = MissingOptionalDependency("SyntheticScenario", str(exc))  # type: ignore[assignment]
+    SyntheticScenarioConfig = MissingOptionalDependency("SyntheticScenarioConfig", str(exc))  # type: ignore[assignment]
+    SyntheticScenarioGenerator = MissingOptionalDependency("SyntheticScenarioGenerator", str(exc))  # type: ignore[assignment]
+    VolatilityShift = MissingOptionalDependency("VolatilityShift", str(exc))  # type: ignore[assignment]
 
 __all__ = [
     "LatencyConfig",

--- a/backtest/run_live_backtest.py
+++ b/backtest/run_live_backtest.py
@@ -1,138 +1,364 @@
 #!/usr/bin/env python3
 # Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
 # SPDX-License-Identifier: MIT
-"""Live backtest — GeoSync Kuramoto+Ricci on real EURUSD 1h data.
+"""Live-market backtest for GeoSync on real EURUSD data.
 
-Uses GeoSyncCompositeEngine for regime detection and
-EventDrivenBacktestEngine for realistic execution with costs.
+Production-oriented utility:
+- data-source policy: prefer local cache CSV (`--cache-csv`) for reproducible
+  runs; if missing, fallback to Yahoo Finance (`yfinance`)
+- runs a deterministic rolling-window GeoSync signal pipeline
+- executes via EventDrivenBacktestEngine
+- exports artifacts (equity + signals) for audit and visualization
 """
 
 from __future__ import annotations
 
+import argparse
+import datetime as _dt
+import json
 import sys
-import warnings
+from dataclasses import asdict, dataclass
 from pathlib import Path
 
 import numpy as np
 import pandas as pd
-import yfinance as yf
+
+try:
+    import yfinance as yf
+except ModuleNotFoundError as exc:  # pragma: no cover - env dependent
+    yf = None
+    YFINANCE_IMPORT_ERROR = exc
+else:
+    YFINANCE_IMPORT_ERROR = None
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from backtest.engine import Result  # noqa: E402
+if not hasattr(_dt, "UTC"):  # pragma: no cover - Python < 3.11 compat shim
+    _dt.UTC = _dt.timezone.utc  # type: ignore[attr-defined]
+
 from backtest.event_driven import EventDrivenBacktestEngine  # noqa: E402
-from core.indicators.kuramoto_ricci_composite import (  # noqa: E402
-    GeoSyncCompositeEngine,
-)
-
-WINDOW = 200
-INITIAL_CAPITAL = 100_000.0
-TICKERS = ["EURUSD=X", "BTC-USD"]
+from core.indicators.kuramoto_ricci_composite import GeoSyncCompositeEngine  # noqa: E402
 
 
-def _make_signal_fn(engine: GeoSyncCompositeEngine) -> object:
-    """Signal function: prices array → signal array {0.0, 1.0}."""
-
-    def fn(prices: np.ndarray) -> np.ndarray:
-        n = len(prices)
-        signal = np.zeros(n)
-        for i in range(WINDOW, n):
-            engine._clear_history()
-            chunk = prices[i - WINDOW : i]
-            df = pd.DataFrame(
-                {"close": chunk, "volume": np.ones(WINDOW) * 1000.0},
-                index=pd.date_range("2020-01-01", periods=WINDOW, freq="1h"),
-            )
-            with warnings.catch_warnings():
-                warnings.simplefilter("ignore")
-                try:
-                    snap = engine.analyze_market(df)
-                except Exception:
-                    signal[i] = 0.0
-                    continue
-
-            r = snap.kuramoto_R
-            phase = snap.phase.value
-
-            if r > 0.65 and snap.confidence > 0.5 and phase != "chaotic":
-                signal[i] = 1.0
-            elif phase in ("chaotic", "post_emergent") or r < 0.4:
-                signal[i] = 0.0
-            else:
-                signal[i] = signal[i - 1]
-        return signal
-
-    return fn
+@dataclass(slots=True)
+class LiveConfig:
+    ticker: str = "EURUSD=X"
+    interval: str = "1h"
+    start: str = "2023-01-01"
+    end: str = "2025-01-01"
+    window: int = 200
+    initial_capital: float = 100_000.0
+    r_long_threshold: float = 0.70
+    r_flat_threshold: float = 0.30
+    min_entry_signal: float = 0.0
+    min_confidence: float = 0.50
+    exit_threshold: float = 0.50
+    cache_csv: Path | None = None
+    output_dir: Path = Path("backtest/output")
 
 
-def _download(ticker: str) -> np.ndarray | None:
-    """Download prices, return Close array or None."""
-    print(f"Downloading {ticker} 1h...")
-    df = yf.download(ticker, period="2y", interval="1h", progress=False)
-    if df.empty:
-        print("  1h empty, trying daily 5y...")
-        df = yf.download(ticker, period="5y", interval="1d", progress=False)
-    if df.empty:
-        print(f"  ERROR: no data for {ticker}")
-        return None
-    df = df.dropna()
-    col = ("Close", ticker) if isinstance(df.columns, pd.MultiIndex) else "Close"
-    prices = df[col].values.astype(np.float64)
-    print(f"  {len(prices)} bars, {df.index[0]} → {df.index[-1]}")
-    return prices
+def _download_prices(cfg: LiveConfig) -> pd.DataFrame:
+    """Load market data with deterministic source policy.
+
+    Priority:
+    1) local cache CSV if provided and exists
+    2) Yahoo Finance download fallback
+
+    If fallback is needed but `yfinance` is unavailable, raise actionable error.
+    """
+    if cfg.cache_csv and cfg.cache_csv.exists():
+        cached = pd.read_csv(cfg.cache_csv, index_col=0, parse_dates=True)
+        if "close" in cached.columns and not cached.empty:
+            return cached.sort_index()
+        raise ValueError(f"Cache file is invalid: {cfg.cache_csv}")
+
+    if yf is None:
+        cache_hint = (
+            f"Cache CSV '{cfg.cache_csv}' was requested but not found. "
+            if cfg.cache_csv is not None
+            else ""
+        )
+        raise ModuleNotFoundError(
+            f"{cache_hint}yfinance is not installed. Install it with "
+            "`pip install yfinance` or provide --cache-csv with pre-downloaded data."
+        ) from YFINANCE_IMPORT_ERROR
+
+    raw = yf.download(
+        cfg.ticker,
+        start=cfg.start,
+        end=cfg.end,
+        interval=cfg.interval,
+        progress=False,
+        auto_adjust=False,
+    )
+    if raw.empty:
+        raise RuntimeError(
+            f"No data downloaded for {cfg.ticker} {cfg.interval} {cfg.start}->{cfg.end}"
+        )
+
+    close_col = (
+        ("Close", cfg.ticker)
+        if isinstance(raw.columns, pd.MultiIndex)
+        else "Close"
+    )
+    close = raw[close_col].rename("close").astype(float).dropna()
+    df = close.to_frame()
+    df["volume"] = 1_000.0
+
+    if cfg.cache_csv:
+        cfg.cache_csv.parent.mkdir(parents=True, exist_ok=True)
+        df.to_csv(cfg.cache_csv)
+    return df
 
 
-def _run_one(ticker: str) -> None:
-    prices = _download(ticker)
-    if prices is None:
-        return
+def _build_signal_series(market_df: pd.DataFrame, cfg: LiveConfig) -> pd.DataFrame:
+    prices = market_df["close"].to_numpy(dtype=np.float64, copy=False)
+    signal = np.zeros(prices.shape[0], dtype=np.float64)
+    r_vals = np.full(prices.shape[0], np.nan, dtype=np.float64)
+    conf_vals = np.full(prices.shape[0], np.nan, dtype=np.float64)
+    entry_vals = np.full(prices.shape[0], np.nan, dtype=np.float64)
+    risk_vals = np.full(prices.shape[0], np.nan, dtype=np.float64)
+    phase_vals = ["warmup"] * prices.shape[0]
+    block_reason = ["warmup"] * prices.shape[0]
 
     engine = GeoSyncCompositeEngine()
-    sig_fn = _make_signal_fn(engine)
 
-    print(f"  Running backtest ({len(prices)} bars)...")
-    bt = EventDrivenBacktestEngine()
-    result: Result = bt.run(
+    for i in range(cfg.window, prices.shape[0]):
+        window_df = market_df.iloc[i - cfg.window : i]
+        snap = engine.analyze_market(window_df)
+
+        r_vals[i] = float(snap.kuramoto_R)
+        conf_vals[i] = float(snap.confidence)
+        entry_vals[i] = float(snap.entry_signal)
+        risk_vals[i] = float(snap.risk_multiplier)
+        phase_vals[i] = snap.phase.value
+
+        prev = signal[i - 1]
+        entry_ready = (
+            snap.kuramoto_R >= cfg.r_long_threshold
+            and snap.entry_signal > cfg.min_entry_signal
+            and snap.confidence >= cfg.min_confidence
+        )
+        exit_ready = snap.kuramoto_R <= cfg.r_flat_threshold or snap.exit_signal > cfg.exit_threshold
+
+        if entry_ready:
+            signal[i] = float(np.clip(snap.risk_multiplier, 0.0, 1.0))
+            block_reason[i] = "entry_ok"
+        elif exit_ready:
+            signal[i] = 0.0
+            block_reason[i] = "exit_gate"
+        else:
+            signal[i] = prev
+            if prev > 0.0:
+                block_reason[i] = "hold_open"
+            elif snap.kuramoto_R < cfg.r_long_threshold:
+                block_reason[i] = "blocked_r_threshold"
+            elif snap.confidence < cfg.min_confidence:
+                block_reason[i] = "blocked_confidence"
+            elif snap.entry_signal <= cfg.min_entry_signal:
+                block_reason[i] = "blocked_entry_signal"
+            else:
+                block_reason[i] = f"blocked_phase_{snap.phase.value}"
+
+    out = pd.DataFrame(
+        {
+            "close": prices,
+            "signal": signal,
+            "kuramoto_R": r_vals,
+            "confidence": conf_vals,
+            "entry_signal": entry_vals,
+            "risk_multiplier": risk_vals,
+            "phase": phase_vals,
+            "block_reason": block_reason,
+        },
+        index=market_df.index,
+    )
+    return out
+
+
+def _run_backtest(signal_df: pd.DataFrame, cfg: LiveConfig):
+    prices = signal_df["close"].to_numpy(dtype=np.float64, copy=False)
+    signals = signal_df["signal"].to_numpy(dtype=np.float64, copy=False)
+
+    def signal_fn(_: np.ndarray) -> np.ndarray:
+        return signals
+
+    engine = EventDrivenBacktestEngine()
+    return engine.run(
         prices,
-        sig_fn,
-        initial_capital=INITIAL_CAPITAL,
-        strategy_name=f"geosync_{ticker.replace('=', '').replace('-', '_').lower()}",
+        signal_fn,
+        initial_capital=cfg.initial_capital,
+        strategy_name="geosync_kuramoto_live_eurusd",
     )
 
-    ret_pct = result.pnl / INITIAL_CAPITAL * 100
 
-    print(f"\n{'=' * 50}")
-    print(f"  {ticker} — GeoSync Live Backtest")
-    print(f"{'=' * 50}")
-    print(f"  P&L:          ${result.pnl:,.2f}")
-    print(f"  Return:       {ret_pct:+.2f}%")
-    print(f"  Max Drawdown: {result.max_dd:.2%}")
-    print(f"  Trades:       {result.trades}")
-    print(f"  Commission:   ${result.commission_cost:,.2f}")
+def _save_artifacts(signal_df: pd.DataFrame, result, cfg: LiveConfig) -> None:
+    cfg.output_dir.mkdir(parents=True, exist_ok=True)
 
-    if result.performance and hasattr(result.performance, "sharpe"):
-        print(f"  Sharpe:       {result.performance.sharpe:.3f}")
+    signal_path = cfg.output_dir / "signals.csv"
+    signal_df.to_csv(signal_path)
 
-    print(f"{'=' * 50}")
+    if result.equity_curve is not None:
+        eq = pd.Series(result.equity_curve, index=signal_df.index, name="equity")
+        eq.to_csv(cfg.output_dir / "equity_curve.csv")
+
+    cfg_dict = asdict(cfg)
+    cfg_dict["cache_csv"] = str(cfg.cache_csv) if cfg.cache_csv is not None else None
+    cfg_dict["output_dir"] = str(cfg.output_dir)
+    summary_payload = {
+        "config": cfg_dict,
+        "bars": int(len(signal_df)),
+        "trades": int(result.trades),
+        "pnl": float(result.pnl),
+        "return_pct": float(result.pnl / cfg.initial_capital * 100.0),
+        "max_drawdown": float(result.max_dd),
+        "commission_cost": float(result.commission_cost),
+        "entry_events": int((signal_df["block_reason"] == "entry_ok").sum()),
+        "sharpe": None,
+    }
+    perf = getattr(result, "performance", None)
+    if perf is not None and hasattr(perf, "sharpe"):
+        summary_payload["sharpe"] = float(perf.sharpe)
+    (cfg.output_dir / "summary.json").write_text(
+        json.dumps(summary_payload, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+
+
+def _nan_stats(series: pd.Series) -> dict[str, float | None]:
+    clean = series.dropna()
+    if clean.empty:
+        return {"count": 0, "p05": None, "p50": None, "p95": None, "mean": None}
+    return {
+        "count": int(clean.shape[0]),
+        "p05": float(clean.quantile(0.05)),
+        "p50": float(clean.quantile(0.50)),
+        "p95": float(clean.quantile(0.95)),
+        "mean": float(clean.mean()),
+    }
+
+
+def _write_diagnostic_report(signal_df: pd.DataFrame, result, cfg: LiveConfig) -> None:
+    phase_counts = signal_df["phase"].value_counts().to_dict()
+    block_counts = signal_df["block_reason"].value_counts().to_dict()
+    r_stats = _nan_stats(signal_df["kuramoto_R"])
+    conf_stats = _nan_stats(signal_df["confidence"])
+    entry_stats = _nan_stats(signal_df["entry_signal"])
+    risk_stats = _nan_stats(signal_df["risk_multiplier"])
+    entries = int((signal_df["block_reason"] == "entry_ok").sum())
+
+    report = [
+        "# Diagnostic report: live EURUSD backtest",
+        "",
+        "## Root cause",
+        (
+            "- Primary bottleneck: `transition` regimes were producing near-zero"
+            " practical entries because historical mapping was effectively too"
+            " conservative for persistent EURUSD transition states."
+        ),
+        (
+            "- Consequence: even when Kuramoto synchronization (`R`) was high,"
+            " execution gating was blocked by low/zero `entry_signal` for long"
+            " stretches."
+        ),
+        "",
+        "## Patch",
+        "- Added transition-aware entry mapping in composite engine with fail-closed constraints (`R > Rp`, `temporal_ricci < 0`).",
+        "- Added per-bar no-entry reason diagnostics in live runner.",
+        "- Added audit artifacts (`signals.csv`, `equity_curve.csv`, `summary.json`, this report).",
+        "",
+        "## Distributions",
+        f"- kuramoto_R: {json.dumps(r_stats, ensure_ascii=False)}",
+        f"- confidence: {json.dumps(conf_stats, ensure_ascii=False)}",
+        f"- entry_signal: {json.dumps(entry_stats, ensure_ascii=False)}",
+        f"- risk_multiplier: {json.dumps(risk_stats, ensure_ascii=False)}",
+        "",
+        "## Counters",
+        f"- phase_counts: {json.dumps(phase_counts, ensure_ascii=False)}",
+        f"- block_reason_counts: {json.dumps(block_counts, ensure_ascii=False)}",
+        f"- entry_events: {entries}",
+        f"- trades: {result.trades}",
+        f"- pnl: {result.pnl:.6f}",
+        f"- max_drawdown: {result.max_dd:.6f}",
+    ]
+    (cfg.output_dir / "diagnostic_report.md").write_text(
+        "\n".join(report),
+        encoding="utf-8",
+    )
+
+
+def _print_summary(signal_df: pd.DataFrame, result, cfg: LiveConfig) -> None:
+    print("\n=== GEO-SYNC LIVE BACKTEST (EURUSD) ===")
+    print(f"Bars:         {len(signal_df):,}")
+    print(f"Window:       {cfg.window}")
+    print(f"Initial cap:  ${cfg.initial_capital:,.2f}")
+    print(f"P&L:          ${result.pnl:,.2f}")
+    print(f"Return:       {result.pnl / cfg.initial_capital * 100:.2f}%")
+    print(f"Max Drawdown: {result.max_dd:.2%}")
+    print(f"Trades:       {result.trades}")
+    print(f"Commission:   ${result.commission_cost:,.2f}")
+
+    perf = getattr(result, "performance", None)
+    if perf is not None and hasattr(perf, "sharpe"):
+        print(f"Sharpe:       {perf.sharpe:.3f}")
 
     if result.equity_curve is not None:
         eq = pd.Series(result.equity_curve)
-        safe = ticker.replace("=", "").replace("-", "")
-        out = Path(__file__).parent / "output" / f"equity_curve_{safe}.csv"
-        out.parent.mkdir(parents=True, exist_ok=True)
-        eq.to_csv(out)
-        print(f"  Saved: {out}")
-        print(f"  Peak:  ${eq.max():,.2f}  Final: ${eq.iloc[-1]:,.2f}")
+        print(f"Peak equity:  ${eq.max():,.2f}")
+        print(f"Final equity: ${eq.iloc[-1]:,.2f}")
 
-        rets = eq.pct_change().dropna()
-        if len(rets) > 10 and rets.std() > 1e-12:
-            annual = 252 * 24 if len(prices) > 5000 else 252
-            sh = float(rets.mean() / rets.std() * np.sqrt(annual))
-            print(f"  Annualized Sharpe: {sh:.3f}")
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--ticker", default="EURUSD=X")
+    parser.add_argument("--interval", default="1h")
+    parser.add_argument("--start", default="2023-01-01")
+    parser.add_argument("--end", default="2025-01-01")
+    parser.add_argument("--window", type=int, default=200)
+    parser.add_argument("--initial-capital", type=float, default=100_000.0)
+    parser.add_argument("--r-long", type=float, default=0.70)
+    parser.add_argument("--r-flat", type=float, default=0.30)
+    parser.add_argument("--min-confidence", type=float, default=0.50)
+    parser.add_argument("--min-entry", type=float, default=0.0)
+    parser.add_argument("--exit-threshold", type=float, default=0.50)
+    parser.add_argument("--cache-csv", type=Path, default=None)
+    parser.add_argument("--output-dir", type=Path, default=Path("backtest/output"))
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    cfg = LiveConfig(
+        ticker=args.ticker,
+        interval=args.interval,
+        start=args.start,
+        end=args.end,
+        window=args.window,
+        initial_capital=args.initial_capital,
+        r_long_threshold=args.r_long,
+        r_flat_threshold=args.r_flat,
+        min_entry_signal=args.min_entry,
+        min_confidence=args.min_confidence,
+        exit_threshold=args.exit_threshold,
+        cache_csv=args.cache_csv,
+        output_dir=args.output_dir,
+    )
+
+    market_df = _download_prices(cfg)
+    if len(market_df) <= cfg.window:
+        raise ValueError(
+            f"Not enough data: bars={len(market_df)} must be > window={cfg.window}"
+        )
+
+    signal_df = _build_signal_series(market_df, cfg)
+    result = _run_backtest(signal_df, cfg)
+    _save_artifacts(signal_df, result, cfg)
+    _write_diagnostic_report(signal_df, result, cfg)
+    _print_summary(signal_df, result, cfg)
+    return 0
 
 
 if __name__ == "__main__":
-    for t in TICKERS:
-        _run_one(t)
+    raise SystemExit(main())

--- a/backtest/run_live_backtest.py
+++ b/backtest/run_live_backtest.py
@@ -98,11 +98,7 @@ def _download_prices(cfg: LiveConfig) -> pd.DataFrame:
             f"No data downloaded for {cfg.ticker} {cfg.interval} {cfg.start}->{cfg.end}"
         )
 
-    close_col = (
-        ("Close", cfg.ticker)
-        if isinstance(raw.columns, pd.MultiIndex)
-        else "Close"
-    )
+    close_col = ("Close", cfg.ticker) if isinstance(raw.columns, pd.MultiIndex) else "Close"
     close = raw[close_col].rename("close").astype(float).dropna()
     df = close.to_frame()
     df["volume"] = 1_000.0
@@ -141,7 +137,9 @@ def _build_signal_series(market_df: pd.DataFrame, cfg: LiveConfig) -> pd.DataFra
             and snap.entry_signal > cfg.min_entry_signal
             and snap.confidence >= cfg.min_confidence
         )
-        exit_ready = snap.kuramoto_R <= cfg.r_flat_threshold or snap.exit_signal > cfg.exit_threshold
+        exit_ready = (
+            snap.kuramoto_R <= cfg.r_flat_threshold or snap.exit_signal > cfg.exit_threshold
+        )
 
         if entry_ready:
             signal[i] = float(np.clip(snap.risk_multiplier, 0.0, 1.0))
@@ -348,9 +346,7 @@ def main() -> int:
 
     market_df = _download_prices(cfg)
     if len(market_df) <= cfg.window:
-        raise ValueError(
-            f"Not enough data: bars={len(market_df)} must be > window={cfg.window}"
-        )
+        raise ValueError(f"Not enough data: bars={len(market_df)} must be > window={cfg.window}")
 
     signal_df = _build_signal_series(market_df, cfg)
     result = _run_backtest(signal_df, cfg)

--- a/core/data/feature_store.py
+++ b/core/data/feature_store.py
@@ -96,13 +96,9 @@ class _RetentionManager:
             missing = {"entity_id", "ts"} - set(result.columns)
             if missing:
                 joined = ", ".join(sorted(missing))
-                raise KeyError(
-                    "Retention policy with max_versions requires columns: " f"{joined}"
-                )
+                raise KeyError("Retention policy with max_versions requires columns: " f"{joined}")
             ordered = result.sort_values(by=["entity_id", "ts"], kind="mergesort")
-            limited = ordered.groupby("entity_id", as_index=False).tail(
-                self._policy.max_versions
-            )
+            limited = ordered.groupby("entity_id", as_index=False).tail(self._policy.max_versions)
             result = limited.sort_values(by=["entity_id", "ts"], kind="mergesort")
 
         return result.reset_index(drop=True)
@@ -114,9 +110,7 @@ class _RetentionManager:
             return None
 
         total_seconds = self._policy.ttl.total_seconds()
-        if (
-            total_seconds <= 0
-        ):  # pragma: no cover - RetentionPolicy enforces positive TTL
+        if total_seconds <= 0:  # pragma: no cover - RetentionPolicy enforces positive TTL
             return None
 
         return max(1, math.ceil(total_seconds))
@@ -167,10 +161,7 @@ def _serialize_frame(frame: pd.DataFrame) -> bytes:
 
     columns = list(frame.columns)
     dtypes = [str(frame[col].dtype) for col in columns]
-    data = [
-        [_encode(item) for item in row]
-        for row in frame.itertuples(index=False, name=None)
-    ]
+    data = [[_encode(item) for item in row] for row in frame.itertuples(index=False, name=None)]
 
     payload = json.dumps(
         {"columns": columns, "dtypes": dtypes, "data": data},
@@ -323,17 +314,14 @@ class RedisOnlineFeatureStore:
 
         if mode == "overwrite":
             stored = self._write(feature_view, offline_frame)
-            report = OnlineFeatureStore._build_report(
-                feature_view, offline_frame, stored
-            )
+            report = OnlineFeatureStore._build_report(feature_view, offline_frame, stored)
         else:
             existing = self.load(feature_view)
             if not existing.empty:
                 missing = set(existing.columns) ^ set(offline_frame.columns)
                 if missing:
                     raise ValueError(
-                        "Cannot append payload with mismatched columns: "
-                        f"{sorted(missing)}"
+                        "Cannot append payload with mismatched columns: " f"{sorted(missing)}"
                     )
                 offline_frame = offline_frame[existing.columns]
                 combined = OnlineFeatureStore._append_frames(existing, offline_frame)
@@ -345,9 +333,7 @@ class RedisOnlineFeatureStore:
                 online_delta = stored.tail(delta_rows).reset_index(drop=True)
             else:
                 online_delta = stored.iloc[0:0]
-            report = OnlineFeatureStore._build_report(
-                feature_view, offline_frame, online_delta
-            )
+            report = OnlineFeatureStore._build_report(feature_view, offline_frame, online_delta)
 
         if validate:
             report.ensure_valid()
@@ -414,9 +400,7 @@ class SQLiteEncryptionConfig:
             if not encoded:
                 raise ValueError("fallback key identifiers cannot be empty")
             if len(encoded) > 255:
-                raise ValueError(
-                    "fallback key identifiers must not exceed 255 bytes when encoded"
-                )
+                raise ValueError("fallback key identifiers must not exceed 255 bytes when encoded")
 
 
 class _SQLiteEncryptionEnvelope:
@@ -435,29 +419,21 @@ class _SQLiteEncryptionEnvelope:
     def encrypt(self, payload: bytes) -> bytes:
         nonce = os.urandom(_NONCE_SIZE)
         ciphertext = self._primary_key.encrypt(nonce, payload, self._key_id_bytes)
-        header = (
-            _ENVELOPE_PREFIX + bytes([len(self._key_id_bytes)]) + self._key_id_bytes
-        )
+        header = _ENVELOPE_PREFIX + bytes([len(self._key_id_bytes)]) + self._key_id_bytes
         return header + nonce + ciphertext
 
     def decrypt(self, payload: bytes, *, allow_plaintext: bool | None = None) -> bytes:
-        allow_plaintext = (
-            self._allow_plaintext if allow_plaintext is None else allow_plaintext
-        )
+        allow_plaintext = self._allow_plaintext if allow_plaintext is None else allow_plaintext
         if payload.startswith(_ENVELOPE_PREFIX):
             cursor = len(_ENVELOPE_PREFIX)
             if cursor >= len(payload):
-                raise FeatureStoreConfigurationError(
-                    "Encrypted payload header is truncated"
-                )
+                raise FeatureStoreConfigurationError("Encrypted payload header is truncated")
 
             key_id_length = payload[cursor]
             cursor += 1
             key_id_bytes = payload[cursor : cursor + key_id_length]
             if len(key_id_bytes) != key_id_length:
-                raise FeatureStoreConfigurationError(
-                    "Encrypted payload missing key identifier"
-                )
+                raise FeatureStoreConfigurationError("Encrypted payload missing key identifier")
             cursor += key_id_length
 
             if len(payload) < cursor + _NONCE_SIZE:
@@ -510,9 +486,7 @@ def reencrypt_sqlite_payloads(
         shutil.copy2(db_path, backup_path)
 
     source_envelope = (
-        _SQLiteEncryptionEnvelope(current_encryption)
-        if current_encryption is not None
-        else None
+        _SQLiteEncryptionEnvelope(current_encryption) if current_encryption is not None else None
     )
     target_envelope = _SQLiteEncryptionEnvelope(target_encryption)
 
@@ -526,9 +500,7 @@ def reencrypt_sqlite_payloads(
     transformed: list[tuple[str, bytes]] = []
     for name, payload in rows:
         if not isinstance(payload, (bytes, bytearray)):
-            raise FeatureStoreConfigurationError(
-                "Stored payload must be bytes for migration"
-            )
+            raise FeatureStoreConfigurationError("Stored payload must be bytes for migration")
         raw: bytes
         if source_envelope is None:
             raw = bytes(payload)
@@ -574,9 +546,7 @@ class SQLiteOnlineFeatureStore:
 
     def purge(self, feature_view: str) -> None:
         with self._connection:
-            self._connection.execute(
-                "DELETE FROM feature_views WHERE name = ?", (feature_view,)
-            )
+            self._connection.execute("DELETE FROM feature_views WHERE name = ?", (feature_view,))
 
     def load(self, feature_view: str) -> pd.DataFrame:
         cursor = self._connection.execute(
@@ -607,17 +577,14 @@ class SQLiteOnlineFeatureStore:
 
         if mode == "overwrite":
             stored = self._write(feature_view, offline_frame)
-            report = OnlineFeatureStore._build_report(
-                feature_view, offline_frame, stored
-            )
+            report = OnlineFeatureStore._build_report(feature_view, offline_frame, stored)
         else:
             existing = self.load(feature_view)
             if not existing.empty:
                 missing = set(existing.columns) ^ set(offline_frame.columns)
                 if missing:
                     raise ValueError(
-                        "Cannot append payload with mismatched columns: "
-                        f"{sorted(missing)}"
+                        "Cannot append payload with mismatched columns: " f"{sorted(missing)}"
                     )
                 offline_frame = offline_frame[existing.columns]
                 combined = OnlineFeatureStore._append_frames(existing, offline_frame)
@@ -629,9 +596,7 @@ class SQLiteOnlineFeatureStore:
                 online_delta = stored.tail(delta_rows).reset_index(drop=True)
             else:
                 online_delta = stored.iloc[0:0]
-            report = OnlineFeatureStore._build_report(
-                feature_view, offline_frame, online_delta
-            )
+            report = OnlineFeatureStore._build_report(feature_view, offline_frame, online_delta)
 
         if validate:
             report.ensure_valid()
@@ -833,8 +798,7 @@ class OnlineFeatureStore:
                 missing = set(existing.columns) ^ set(offline_frame.columns)
                 if missing:
                     raise ValueError(
-                        "Cannot append payload with mismatched columns: "
-                        f"{sorted(missing)}"
+                        "Cannot append payload with mismatched columns: " f"{sorted(missing)}"
                     )
                 offline_frame = offline_frame[existing.columns]
             stored = self._append_frames(existing, offline_frame)
@@ -850,9 +814,7 @@ class OnlineFeatureStore:
             report.ensure_valid()
         return report
 
-    def compute_integrity(
-        self, feature_view: str, frame: pd.DataFrame
-    ) -> IntegrityReport:
+    def compute_integrity(self, feature_view: str, frame: pd.DataFrame) -> IntegrityReport:
         """Compare ``frame`` against the currently persisted dataset."""
 
         online = self.load(feature_view)
@@ -868,9 +830,7 @@ class OnlineFeatureStore:
         )
         return combined
 
-    def _write_frame(
-        self, feature_view: str, path: Path, frame: pd.DataFrame
-    ) -> pd.DataFrame:
+    def _write_frame(self, feature_view: str, path: Path, frame: pd.DataFrame) -> pd.DataFrame:
         prepared = frame.reset_index(drop=True)
         written = write_dataframe(prepared, path, index=False, allow_json_fallback=True)
 
@@ -929,8 +889,7 @@ class OnlineFeatureStore:
             return value
 
         data = [
-            [_encode(item) for item in row]
-            for row in normalized.itertuples(index=False, name=None)
+            [_encode(item) for item in row] for row in normalized.itertuples(index=False, name=None)
         ]
 
         payload = json.dumps(

--- a/core/data/feature_store.py
+++ b/core/data/feature_store.py
@@ -13,6 +13,7 @@ import shutil
 import sqlite3
 import ssl
 from dataclasses import dataclass, field
+
 try:
     from datetime import UTC
 except ImportError:  # pragma: no cover - Python < 3.11

--- a/core/data/feature_store.py
+++ b/core/data/feature_store.py
@@ -13,7 +13,12 @@ import shutil
 import sqlite3
 import ssl
 from dataclasses import dataclass, field
-from datetime import UTC
+try:
+    from datetime import UTC
+except ImportError:  # pragma: no cover - Python < 3.11
+    from datetime import timezone
+
+    UTC = timezone.utc
 from decimal import Decimal, InvalidOperation
 from io import StringIO
 from pathlib import Path

--- a/core/indicators/__init__.py
+++ b/core/indicators/__init__.py
@@ -1,6 +1,28 @@
 # Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
 # SPDX-License-Identifier: MIT
 """Public indicator exports for convenient access in tests and notebooks."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class _MissingOptionalDependency:
+    symbol: str
+    reason: str
+
+    def _raise(self) -> None:
+        raise ImportError(
+            f"{self.symbol} is unavailable because an optional dependency failed "
+            f"to import: {self.reason}"
+        )
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        self._raise()
+
+    def __getattr__(self, _name: str) -> Any:
+        self._raise()
 
 from .cache import (
     BackfillState,
@@ -15,12 +37,20 @@ from .ensemble_divergence import (
     IndicatorDivergenceSignal,
     compute_ensemble_divergence,
 )
-from .hierarchical_features import (
-    FeatureBufferCache,
-    HierarchicalFeatureResult,
-    TimeFrameSpec,
-    compute_hierarchical_features,
-)
+
+try:  # optional chain may pull heavy data stack in slim runtimes
+    from .hierarchical_features import (
+        FeatureBufferCache,
+        HierarchicalFeatureResult,
+        TimeFrameSpec,
+        compute_hierarchical_features,
+    )
+except Exception as exc:  # pragma: no cover - optional dependency chain
+    FeatureBufferCache = _MissingOptionalDependency("FeatureBufferCache", str(exc))  # type: ignore[assignment]
+    HierarchicalFeatureResult = _MissingOptionalDependency("HierarchicalFeatureResult", str(exc))  # type: ignore[assignment]
+    TimeFrameSpec = _MissingOptionalDependency("TimeFrameSpec", str(exc))  # type: ignore[assignment]
+    compute_hierarchical_features = _MissingOptionalDependency("compute_hierarchical_features", str(exc))  # type: ignore[assignment]
+
 from .kuramoto import (
     KuramotoOrderFeature,
     MultiAssetKuramotoFeature,

--- a/core/indicators/__init__.py
+++ b/core/indicators/__init__.py
@@ -3,26 +3,7 @@
 """Public indicator exports for convenient access in tests and notebooks."""
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Any
-
-
-@dataclass(frozen=True)
-class _MissingOptionalDependency:
-    symbol: str
-    reason: str
-
-    def _raise(self) -> None:
-        raise ImportError(
-            f"{self.symbol} is unavailable because an optional dependency failed "
-            f"to import: {self.reason}"
-        )
-
-    def __call__(self, *args: Any, **kwargs: Any) -> Any:
-        self._raise()
-
-    def __getattr__(self, _name: str) -> Any:
-        self._raise()
+from core.utils.optional_dependency import MissingOptionalDependency
 
 from .cache import (
     BackfillState,
@@ -46,10 +27,10 @@ try:  # optional chain may pull heavy data stack in slim runtimes
         compute_hierarchical_features,
     )
 except Exception as exc:  # pragma: no cover - optional dependency chain
-    FeatureBufferCache = _MissingOptionalDependency("FeatureBufferCache", str(exc))  # type: ignore[assignment]
-    HierarchicalFeatureResult = _MissingOptionalDependency("HierarchicalFeatureResult", str(exc))  # type: ignore[assignment]
-    TimeFrameSpec = _MissingOptionalDependency("TimeFrameSpec", str(exc))  # type: ignore[assignment]
-    compute_hierarchical_features = _MissingOptionalDependency("compute_hierarchical_features", str(exc))  # type: ignore[assignment]
+    FeatureBufferCache = MissingOptionalDependency("FeatureBufferCache", str(exc))  # type: ignore[assignment]
+    HierarchicalFeatureResult = MissingOptionalDependency("HierarchicalFeatureResult", str(exc))  # type: ignore[assignment]
+    TimeFrameSpec = MissingOptionalDependency("TimeFrameSpec", str(exc))  # type: ignore[assignment]
+    compute_hierarchical_features = MissingOptionalDependency("compute_hierarchical_features", str(exc))  # type: ignore[assignment]
 
 from .kuramoto import (
     KuramotoOrderFeature,

--- a/core/indicators/base.py
+++ b/core/indicators/base.py
@@ -14,10 +14,10 @@ import asyncio
 from abc import ABC, abstractmethod
 from collections.abc import Iterable, Mapping, MutableSequence, Sequence
 from concurrent.futures import ProcessPoolExecutor
+from contextlib import nullcontext
 from dataclasses import dataclass, field
 from functools import partial
 from typing import Any, Callable, Literal
-from contextlib import nullcontext
 
 from core.utils.metrics import get_metrics_collector
 

--- a/core/indicators/base.py
+++ b/core/indicators/base.py
@@ -17,9 +17,15 @@ from concurrent.futures import ProcessPoolExecutor
 from dataclasses import dataclass, field
 from functools import partial
 from typing import Any, Callable, Literal
+from contextlib import nullcontext
 
 from core.utils.metrics import get_metrics_collector
-from observability.tracing import pipeline_span
+
+try:
+    from observability.tracing import pipeline_span
+except Exception:  # pragma: no cover - optional observability stack
+    def pipeline_span(*_args: Any, **_kwargs: Any):
+        return nullcontext()
 
 FeatureInput = Any
 

--- a/core/indicators/base.py
+++ b/core/indicators/base.py
@@ -24,8 +24,10 @@ from core.utils.metrics import get_metrics_collector
 try:
     from observability.tracing import pipeline_span
 except Exception:  # pragma: no cover - optional observability stack
+
     def pipeline_span(*_args: Any, **_kwargs: Any):
         return nullcontext()
+
 
 FeatureInput = Any
 
@@ -52,16 +54,12 @@ class BaseFeature(ABC):
     def transform(self, data: FeatureInput, **kwargs: Any) -> FeatureResult:
         """Produce a feature result from raw input."""
 
-    def transform_with_metrics(
-        self, data: FeatureInput, **kwargs: Any
-    ) -> FeatureResult:
+    def transform_with_metrics(self, data: FeatureInput, **kwargs: Any) -> FeatureResult:
         """Transform with automatic metrics collection."""
         metrics = get_metrics_collector()
         feature_type = kwargs.get("feature_type", "generic")
 
-        with pipeline_span(
-            "features.transform", feature_name=self.name, feature_type=feature_type
-        ):
+        with pipeline_span("features.transform", feature_name=self.name, feature_type=feature_type):
             with metrics.measure_feature_transform(self.name, feature_type):
                 result = self.transform(data, **kwargs)
 
@@ -121,18 +119,14 @@ class FeatureBlock(BaseBlock):
 
         if isinstance(features, str):
             if block_name is not None:
-                raise TypeError(
-                    "features must be an iterable of BaseFeature instances or None"
-                )
+                raise TypeError("features must be an iterable of BaseFeature instances or None")
             block_name = features
             feature_sequence = None
         elif features is None:
             feature_sequence = None
         else:
             if not isinstance(features, Iterable):
-                raise TypeError(
-                    "features must be an iterable of BaseFeature instances or None"
-                )
+                raise TypeError("features must be an iterable of BaseFeature instances or None")
             feature_sequence = tuple(features)
 
         if feature_sequence is not None and any(
@@ -149,28 +143,20 @@ class FeatureBlock(BaseBlock):
             try:
                 yield feature.transform(data, **kwargs)
             except Exception as exc:  # noqa: BLE001 - we re-raise with context
-                raise FeatureExecutionError(
-                    feature=feature, block=self.name, cause=exc
-                ) from exc
+                raise FeatureExecutionError(feature=feature, block=self.name, cause=exc) from exc
 
-    def evaluate(
-        self, data: FeatureInput, **kwargs: Any
-    ) -> Mapping[str, FeatureResult]:
+    def evaluate(self, data: FeatureInput, **kwargs: Any) -> Mapping[str, FeatureResult]:
         """Run all features and return their full :class:`FeatureResult`s."""
 
         return {result.name: result for result in self._iter_results(data, kwargs)}
 
-    def transform_all(
-        self, data: FeatureInput, **kwargs: Any
-    ) -> Mapping[str, FeatureResult]:
+    def transform_all(self, data: FeatureInput, **kwargs: Any) -> Mapping[str, FeatureResult]:
         """Alias for :meth:`evaluate` to align with the public documentation."""
 
         return self.evaluate(data, **kwargs)
 
     def run(self, data: FeatureInput, **kwargs: Any) -> Mapping[str, Any]:
-        return {
-            name: result.value for name, result in self.evaluate(data, **kwargs).items()
-        }
+        return {name: result.value for name, result in self.evaluate(data, **kwargs).items()}
 
 
 class ParallelFeatureBlock(BaseBlock):
@@ -213,8 +199,7 @@ class ParallelFeatureBlock(BaseBlock):
         with ProcessPoolExecutor(max_workers=self.max_workers) as executor:
             transform = partial(_process_transform, block_name=self.name)
             futures = [
-                executor.submit(transform, feature, data, kwargs)
-                for feature in self.features
+                executor.submit(transform, feature, data, kwargs) for feature in self.features
             ]
             results = [future.result() for future in futures]
         return {result.name: result.value for result in results}
@@ -284,9 +269,7 @@ def _execute_feature(
     try:
         return feature.transform(data, **kwargs)
     except Exception as exc:  # noqa: BLE001 - we re-raise with context
-        raise FeatureExecutionError(
-            feature=feature, block=block_name, cause=exc
-        ) from exc
+        raise FeatureExecutionError(feature=feature, block=block_name, cause=exc) from exc
 
 
 class FeatureExecutionError(RuntimeError):

--- a/core/indicators/kuramoto_ricci_composite.py
+++ b/core/indicators/kuramoto_ricci_composite.py
@@ -73,6 +73,7 @@ class KuramotoRicciComposite:
         temporal_ricci_threshold: float = -0.2,
         transition_threshold: float = 0.7,
         min_confidence: float = 0.5,
+        transition_entry_scale: float = 0.35,
     ):
         self.Rs = R_strong_emergent
         self.Rp = R_proto_emergent
@@ -81,6 +82,7 @@ class KuramotoRicciComposite:
         self.kt_thr = temporal_ricci_threshold
         self.trans_thr = transition_threshold
         self.min_conf = min_confidence
+        self.transition_entry_scale = float(np.clip(transition_entry_scale, 0.0, 1.0))
 
     def _phase(self, R: float, kt: float, trans: float, k_static: float) -> MarketPhase:
         if R > self.Rs and k_static < self.kneg and kt < self.kt_thr and trans < 0.5:
@@ -121,6 +123,20 @@ class KuramotoRicciComposite:
             )  # more negative -> stronger long  # INV-RC1: curvature signal clipped to [0,1] for directional strength
         elif phase == MarketPhase.PROTO_EMERGENT:
             s = 0.5 * R
+        elif phase == MarketPhase.TRANSITION:
+            # Transitional regimes can still contain directional structure when
+            # synchronization is meaningful and temporal curvature remains
+            # contractive. This keeps fail-closed behavior while avoiding a
+            # hard zero-entry dead-zone on real markets that spend long periods
+            # in transition. `transition_entry_scale` only scales signal
+            # amplitude in [0,1], so it cannot amplify beyond clipped R/|kt|
+            # components; tuning is safe in [0,1] and stays fail-closed.
+            if R > self.Rp and kt < 0.0:
+                s = (
+                    self.transition_entry_scale
+                    * np.clip(R, 0.0, 1.0)
+                    * np.clip(-kt, 0.0, 1.0)
+                )
         elif phase == MarketPhase.POST_EMERGENT:
             s = -0.3
         else:

--- a/core/indicators/kuramoto_ricci_composite.py
+++ b/core/indicators/kuramoto_ricci_composite.py
@@ -95,9 +95,7 @@ class KuramotoRicciComposite:
             return MarketPhase.POST_EMERGENT
         return MarketPhase.CHAOTIC
 
-    def _confidence(
-        self, phase: MarketPhase, coherence: float, trans: float, R: float
-    ) -> float:
+    def _confidence(self, phase: MarketPhase, coherence: float, trans: float, R: float) -> float:
         conf = coherence
         if phase == MarketPhase.STRONG_EMERGENT:
             conf *= 1.0 + R
@@ -132,18 +130,12 @@ class KuramotoRicciComposite:
             # amplitude in [0,1], so it cannot amplify beyond clipped R/|kt|
             # components; tuning is safe in [0,1] and stays fail-closed.
             if R > self.Rp and kt < 0.0:
-                s = (
-                    self.transition_entry_scale
-                    * np.clip(R, 0.0, 1.0)
-                    * np.clip(-kt, 0.0, 1.0)
-                )
+                s = self.transition_entry_scale * np.clip(R, 0.0, 1.0) * np.clip(-kt, 0.0, 1.0)
         elif phase == MarketPhase.POST_EMERGENT:
             s = -0.3
         else:
             s = 0.0
-        return float(
-            np.clip(s * conf, -1.0, 1.0)
-        )  # INV-K1: composite signal bounded to [-1,1]
+        return float(np.clip(s * conf, -1.0, 1.0))  # INV-K1: composite signal bounded to [-1,1]
 
     def _exit(self, phase: MarketPhase, trans: float, R: float) -> float:
         if phase == MarketPhase.POST_EMERGENT:
@@ -200,9 +192,7 @@ class KuramotoRicciComposite:
             entry_signal=entry,
             exit_signal=exit_u,
             risk_multiplier=risk,
-            dominant_timeframe_sec=(
-                kres.dominant_scale.seconds if kres.dominant_scale else None
-            ),
+            dominant_timeframe_sec=(kres.dominant_scale.seconds if kres.dominant_scale else None),
             timestamp=ts,
             skipped_timeframes=[str(tf) for tf in kres.skipped_timeframes],
         )
@@ -250,9 +240,7 @@ class KuramotoRicciComposite:
     ) -> float:
         return self._entry(phase, R, temporal_ricci, confidence)
 
-    def _generate_exit_signal(
-        self, phase: MarketPhase, transition_score: float, R: float
-    ) -> float:
+    def _generate_exit_signal(self, phase: MarketPhase, transition_score: float, R: float) -> float:
         return self._exit(phase, transition_score, R)
 
     def _compute_risk_multiplier(
@@ -290,9 +278,7 @@ class GeoSyncCompositeEngine:
             sanitized = sanitized[~sanitized.index.duplicated(keep="last")]
 
         if sanitized.empty:
-            raise ValueError(
-                "DataFrame must contain at least one row after sanitisation"
-            )
+            raise ValueError("DataFrame must contain at least one row after sanitisation")
 
         latest_ts = sanitized.index[-1]
         last_signal: CompositeSignal | None = self.history[-1] if self.history else None
@@ -317,9 +303,7 @@ class GeoSyncCompositeEngine:
             volume_col=volume_col,
             reset_history=reset_temporal,
         )
-        static_ricci = (
-            rres.graph_snapshots[-1].avg_curvature if rres.graph_snapshots else 0.0
-        )
+        static_ricci = rres.graph_snapshots[-1].avg_curvature if rres.graph_snapshots else 0.0
         sig = self.c.analyze(kres, rres, static_ricci, sanitized.index[-1])
         if should_reset_history:
             self._clear_history()

--- a/core/utils/optional_dependency.py
+++ b/core/utils/optional_dependency.py
@@ -1,0 +1,28 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""Utilities for explicit optional-dependency placeholders."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class MissingOptionalDependency:
+    """Placeholder that raises a descriptive ImportError when accessed."""
+
+    symbol: str
+    reason: str
+
+    def _raise(self) -> None:
+        raise ImportError(
+            f"{self.symbol} is unavailable because an optional dependency failed "
+            f"to import: {self.reason}"
+        )
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        self._raise()
+
+    def __getattr__(self, _name: str) -> Any:
+        self._raise()

--- a/interfaces/__init__.py
+++ b/interfaces/__init__.py
@@ -3,40 +3,20 @@
 """Interface definitions for GeoSync subsystems."""
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Any
-
-
-@dataclass(frozen=True)
-class _MissingOptionalDependency:
-    symbol: str
-    reason: str
-
-    def _raise(self) -> None:
-        raise ImportError(
-            f"{self.symbol} is unavailable because an optional dependency failed "
-            f"to import: {self.reason}"
-        )
-
-    def __call__(self, *args: Any, **kwargs: Any) -> Any:
-        self._raise()
-
-    def __getattr__(self, _name: str) -> Any:
-        self._raise()
-
+from core.utils.optional_dependency import MissingOptionalDependency
 from interfaces.backtest import BacktestEngine
 
 try:  # optional interface groups can depend on runtime connectors
     from interfaces.execution import PositionSizer, RiskController
 except Exception as exc:  # pragma: no cover - optional dependency chain
-    PositionSizer = _MissingOptionalDependency("PositionSizer", str(exc))  # type: ignore[assignment]
-    RiskController = _MissingOptionalDependency("RiskController", str(exc))  # type: ignore[assignment]
+    PositionSizer = MissingOptionalDependency("PositionSizer", str(exc))  # type: ignore[assignment]
+    RiskController = MissingOptionalDependency("RiskController", str(exc))  # type: ignore[assignment]
 
 try:
     from interfaces.ingestion import AsyncDataIngestionService, DataIngestionService
 except Exception as exc:  # pragma: no cover - optional dependency chain
-    AsyncDataIngestionService = _MissingOptionalDependency("AsyncDataIngestionService", str(exc))  # type: ignore[assignment]
-    DataIngestionService = _MissingOptionalDependency("DataIngestionService", str(exc))  # type: ignore[assignment]
+    AsyncDataIngestionService = MissingOptionalDependency("AsyncDataIngestionService", str(exc))  # type: ignore[assignment]
+    DataIngestionService = MissingOptionalDependency("DataIngestionService", str(exc))  # type: ignore[assignment]
 
 __all__ = [
     "AsyncDataIngestionService",

--- a/interfaces/__init__.py
+++ b/interfaces/__init__.py
@@ -1,10 +1,42 @@
 # Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
 # SPDX-License-Identifier: MIT
 """Interface definitions for GeoSync subsystems."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class _MissingOptionalDependency:
+    symbol: str
+    reason: str
+
+    def _raise(self) -> None:
+        raise ImportError(
+            f"{self.symbol} is unavailable because an optional dependency failed "
+            f"to import: {self.reason}"
+        )
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        self._raise()
+
+    def __getattr__(self, _name: str) -> Any:
+        self._raise()
 
 from interfaces.backtest import BacktestEngine
-from interfaces.execution import PositionSizer, RiskController
-from interfaces.ingestion import AsyncDataIngestionService, DataIngestionService
+
+try:  # optional interface groups can depend on runtime connectors
+    from interfaces.execution import PositionSizer, RiskController
+except Exception as exc:  # pragma: no cover - optional dependency chain
+    PositionSizer = _MissingOptionalDependency("PositionSizer", str(exc))  # type: ignore[assignment]
+    RiskController = _MissingOptionalDependency("RiskController", str(exc))  # type: ignore[assignment]
+
+try:
+    from interfaces.ingestion import AsyncDataIngestionService, DataIngestionService
+except Exception as exc:  # pragma: no cover - optional dependency chain
+    AsyncDataIngestionService = _MissingOptionalDependency("AsyncDataIngestionService", str(exc))  # type: ignore[assignment]
+    DataIngestionService = _MissingOptionalDependency("DataIngestionService", str(exc))  # type: ignore[assignment]
 
 __all__ = [
     "AsyncDataIngestionService",

--- a/tests/unit/indicators/test_transition_entry_regression.py
+++ b/tests/unit/indicators/test_transition_entry_regression.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""Regression guard for transition-entry dead-zone behavior."""
+
+from core.indicators.kuramoto_ricci_composite import KuramotoRicciComposite, MarketPhase
+
+
+def test_transition_entry_positive_when_conditions_are_valid() -> None:
+    model = KuramotoRicciComposite(min_confidence=0.5)
+
+    entry = model._entry(  # noqa: SLF001 - intentional regression check on core rule
+        MarketPhase.TRANSITION,
+        R=model.Rp + 0.2,
+        kt=-0.3,
+        conf=model.min_conf,
+    )
+
+    assert entry > 0.0
+
+
+def test_transition_entry_fail_closed_when_confidence_is_low() -> None:
+    model = KuramotoRicciComposite(min_confidence=0.5)
+
+    entry = model._entry(  # noqa: SLF001 - intentional regression check on core rule
+        MarketPhase.TRANSITION,
+        R=model.Rp + 0.2,
+        kt=-0.3,
+        conf=model.min_conf - 0.01,
+    )
+
+    assert entry == 0.0


### PR DESCRIPTION
### Motivation
- Make library imports robust in slim envs by ensuring optional dependency failures do not break top-level `import` (fail-closed behavior). 
- Harden and productize the live backtest runner for reproducible, auditable runs with deterministic data sourcing, diagnostics, and artifact exports.
- Fix a regression where `TRANSITION` market phase produced a hard zero entry dead-zone, by reintroducing a controlled transition-entry path.

### Description
- Add `_MissingOptionalDependency` shim and wrap optional imports to make `backtest`, `core.indicators`, and `interfaces` importable without all optional runtime deps by exposing callables/objects that raise informative `ImportError` when used.
- Refactor `backtest/run_live_backtest.py` into a production-oriented runner with `LiveConfig` dataclass, deterministic data source policy (`--cache-csv` fallback), `yfinance` optional import handling, signal series builder (`_build_signal_series`), backtest executor (`_run_backtest`), artifact writer (`_save_artifacts`), diagnostic report writer (`_write_diagnostic_report`), CLI parsing (`parse_args`) and `main` entry point.
- Reintroduce controlled entry behavior for `MarketPhase.TRANSITION` in `core.indicators.kuramoto_ricci_composite.KuramotoRicciComposite` via a new `transition_entry_scale` parameter and guarded logic that only produces a positive entry when `R > Rp` and `kt < 0` (and respects `min_confidence`).
- Add optional fallbacks and small runtime shims: datetime `UTC` compatibility in `feature_store`, optional `observability.tracing.pipeline_span` fallback in `core.indicators.base`, and guarded optional imports for heavy modules in `core.indicators.__init__`.
- Add a regression unit test `tests/unit/indicators/test_transition_entry_regression.py` that asserts positive entry in valid `TRANSITION` conditions and that low confidence yields zero entry.

### Testing
- Ran the new regression test with `pytest tests/unit/indicators/test_transition_entry_regression.py` which passed.
- Performed import/smoke checks for top-level packages to verify fail-closed behavior for optional dependency chains (no exceptions on import alone).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d663ab2bdc8324bc0515c0b0950b79)