### PR TITLE
docs(exocortex): elevate research-provenance layer to audit-grade

### DIFF
--- a/.exocortex/GLOSSARY.md
+++ b/.exocortex/GLOSSARY.md
@@ -1,0 +1,46 @@
+# Glossary
+
+Definitions of in-house terms used across [`CLAUDE.md`](../CLAUDE.md), the
+`.claude/physics/` documents, and this directory. Terms defined elsewhere in
+mainstream literature (e.g. *Lyapunov exponent*, *Ricci curvature*) are
+referenced rather than redefined here; see the cited sources.
+
+## Notation
+
+| Symbol | Meaning |
+| --- | --- |
+| `γ` (gamma) | Metastable-computation scaling exponent. Hypothesized to be ≈ 1 across substrates with critical neural-like dynamics. See [`RESEARCH_TIMELINE.md`](./RESEARCH_TIMELINE.md). |
+| `R(t)` | Kuramoto order parameter at time *t*: `\| (1/N) Σ_j exp(i θ_j(t)) \|`. Bounded in `[0, 1]`. See [`.claude/physics/KURAMOTO_THEORY.md`](../.claude/physics/KURAMOTO_THEORY.md). |
+| `K_c` | Critical coupling for Kuramoto synchrony onset. `K_c = 2 / (π · g(0))` for unimodal `g`. |
+| `INV-*` | Stable identifier for a physics invariant. Listed in [`INVARIANTS_INDEX.md`](./INVARIANTS_INDEX.md). |
+
+## Acronyms
+
+| Term | Expansion | Where it lives |
+| --- | --- | --- |
+| **TACL** | Tonic-Adaptive Coupling Layer — neuromodulator-gated coupling matrix used by the GeoSync neural controller | [`src/geosync/neural_controller/`](../src/geosync/neural_controller/) |
+| **MFN** | Mycelium-Fractal-Net — fractal-routing substrate inspired by hyphal-network growth | [`src/mycelium_fractal_net/`](../src/mycelium_fractal_net/) |
+| **BN-Syn** | Biophysical-Network Synthetic — spiking-network simulator (external repo); first place `γ ≈ 1` was observed | external |
+| **NFI** | Neuro-Fractal-Inference platform composing ML-SDM, CA1-LAM, BN-Syn, MFN+ | external |
+| **ML-SDM** | Multi-Layer Sparse Distributed Memory | external (NFI) |
+| **CA1-LAM** | CA1-inspired Local Associative Memory | external (NFI) |
+| **ECS** | Energy-Constraint System — Lyapunov-bounded controller used to keep strategies inside a free-energy budget | [`src/geosync/`](../src/geosync/) |
+| **OMS** | Order-Management System | [`src/geosync/`](../src/geosync/), invariants under `oms.*` |
+
+## Roles (see [`METHODOLOGY.md`](./METHODOLOGY.md))
+
+| Role | Authority |
+| --- | --- |
+| **Creator** | Proposes a change. Cannot self-approve. |
+| **Critic** | Challenges the change. May block on physics or architectural grounds. |
+| **Auditor** | Confirms the gates passed. Signs CI status. |
+| **Verifier** | Confirms reproducibility. Signs the release tag. |
+| **Human** | Central decision node. Only signer of the merge commit. |
+
+## Priority levels for invariants
+
+| Priority | Meaning | CI behavior |
+| --- | --- | --- |
+| **P0** | Universal invariant. Violation = bug, not numerical artefact. | Block release. |
+| **P1** | Asymptotic / regime-dependent invariant. Violation under documented conditions = bug. | Block release. |
+| **P2** | Soft invariant. Violation = warning + tracked regression budget. | Report-only by default; can be promoted to P1. |

--- a/.exocortex/INVARIANTS_INDEX.md
+++ b/.exocortex/INVARIANTS_INDEX.md
@@ -1,0 +1,63 @@
+# Invariants Index
+
+Authoritative source: [`.claude/physics/INVARIANTS.yaml`](../.claude/physics/INVARIANTS.yaml).
+This file is a derived overview; if it disagrees with the YAML, the YAML wins.
+
+## Summary
+
+| Total | P0 | P1 | P2 | Categories |
+| ---: | ---: | ---: | ---: | ---: |
+| **60** | 40 | 17 | 3 | 16 |
+
+Regenerate this summary via `python .claude/physics/validate_tests.py --summary`
+(see [`VALIDATION.md`](./VALIDATION.md)).
+
+## By category
+
+| Category | Theory doc | P0 | P1 | P2 | IDs |
+| --- | --- | ---: | ---: | ---: | --- |
+| **kuramoto** | [KURAMOTO_THEORY.md](../.claude/physics/KURAMOTO_THEORY.md) | 3 | 3 | 1 | INV-K1 … INV-K7 |
+| **explosive_sync** | [KURAMOTO_THEORY.md](../.claude/physics/KURAMOTO_THEORY.md) | 1 | 1 | 0 | INV-ES1, INV-ES2 |
+| **serotonin** | [SEROTONIN_THEORY.md](../.claude/physics/SEROTONIN_THEORY.md) | 5 | 2 | 0 | INV-5HT1 … INV-5HT7 |
+| **dopamine** | [DOPAMINE_THEORY.md](../.claude/physics/DOPAMINE_THEORY.md) | 3 | 3 | 1 | INV-DA1 … INV-DA7 |
+| **gaba** | [GABA_THEORY.md](../.claude/physics/GABA_THEORY.md) | 3 | 2 | 0 | INV-GABA1 … INV-GABA5 |
+| **free_energy** | — | 2 | 0 | 0 | INV-FE1, INV-FE2 |
+| **thermodynamics** | — | 0 | 2 | 0 | INV-TH1, INV-TH2 |
+| **ricci** | — | 1 | 1 | 1 | INV-RC1 … INV-RC3 |
+| **kelly** | — | 2 | 1 | 0 | INV-KELLY1 … INV-KELLY3 |
+| **oms** | — | 3 | 0 | 0 | INV-OMS1, INV-OMS2, INV-OMS3 |
+| **signalbus** | — | 2 | 0 | 0 | INV-SB1, INV-SB2 |
+| **hpc** | — | 2 | 0 | 0 | INV-HPC1, INV-HPC2 |
+| **cryptobiosis** | [CRYPTOBIOSIS_THEORY.md](../.claude/physics/CRYPTOBIOSIS_THEORY.md) | 6 | 2 | 0 | INV-CB1 … INV-CB8 |
+| **lyapunov_exponent** | [LYAPUNOV_EXPONENT_THEORY.md](../.claude/physics/LYAPUNOV_EXPONENT_THEORY.md) | 2 | 0 | 0 | INV-LE1, INV-LE2 |
+| **spectral_gap** | — | 2 | 0 | 0 | INV-SG1, INV-SG2 |
+| **ott_antonsen** | — | 3 | 0 | 0 | INV-OA1, INV-OA2, INV-OA3 |
+
+## Parallel layer: `physics_contracts/`
+
+The `.claude/physics/` registry above is the *theory-anchored* layer. A second,
+*module-anchored* layer lives in
+[`physics_contracts/catalog.yaml`](../physics_contracts/catalog.yaml) and
+currently contains **26 laws**. The two layers serve different purposes:
+
+| Layer | Anchor | Audience | Test reference |
+| --- | --- | --- | --- |
+| `.claude/physics/INVARIANTS.yaml` | Physical theory (Kuramoto 1975, Ott-Antonsen 2008, …) | Theorists, reviewers | `INV-*` IDs in test docstrings |
+| `physics_contracts/catalog.yaml` | Module of origin (`kuramoto.*`, `oms.*`, …) | Module owners, integrators | dotted IDs in test markers |
+
+Both must stay in sync; mass-deleting either is forbidden (see
+`feedback_geosync_physics_layers` in the contributor playbook).
+
+## How to add a new invariant
+
+1. Append the entry to `.claude/physics/INVARIANTS.yaml` with `id`, `type`,
+   `statement`, `falsification`, `priority`, and (where relevant) `parameters`
+   and `common_mistake`.
+2. If the invariant is module-anchored, add the matching law to
+   `physics_contracts/catalog.yaml` with the same numeric tolerance derivation.
+3. Add at least one witness test that references the new `INV-*` ID.
+4. Update this file's category row.
+5. Re-run `python .claude/physics/validate_tests.py` and the `pytest` heavy
+   gate to confirm the witness fires under falsification inputs.
+
+A new invariant lands only when steps 1–5 are complete in the same PR.

--- a/.exocortex/METHODOLOGY.md
+++ b/.exocortex/METHODOLOGY.md
@@ -1,15 +1,71 @@
-# Adversarial Orchestration
+# Adversarial Orchestration Methodology
 
-Creator -> Critic -> Auditor -> Verifier
-Human = central decision node. No agent has autonomous authority.
+GeoSync development uses an **adversarial multi-role workflow**. Every change
+passes through four roles before it can land. No role has autonomous authority:
+the human contributor is the central decision node and the only signer.
 
-Physics Kernel (CLAUDE.md + .claude/physics/) = embedded Critic.
-57 invariants. Every test references INV-*. Every threshold derived from theory.
+## Roles
 
-## Validation layers
+| Role | Responsibility | Concrete artifact |
+| --- | --- | --- |
+| **Creator** | Proposes the change — code, test, doc | The diff |
+| **Critic** | Challenges the change against physical and architectural constraints | Inline review comments + the embedded physics kernel (see below) |
+| **Auditor** | Verifies that the change does not break invariants or contracts | CI gate output, `validate_tests.py` report |
+| **Verifier** | Confirms the artifact is reproducible bit-for-bit | `MANIFEST.sha256` diff + signed tag |
 
-1. **AST validator** — `python .claude/physics/validate_tests.py` — structural
-2. **mypy --strict** — type-level soundness
-3. **ruff format + check** — style determinism
-4. **pytest** — runtime correctness
-5. **MANIFEST.sha256** — reproducibility seal
+The Critic role is partially **embedded in the repository**, not in the
+contributor's head: [`CLAUDE.md`](../CLAUDE.md) and the documents under
+[`.claude/physics/`](../.claude/physics/) state the rules a Critic must apply,
+so any reviewer (human or automated) reaches the same verdict.
+
+## The five validation gates
+
+Every PR must pass these gates **in this order**. Failure at any gate halts the
+pipeline; the failure does not get masked or skipped.
+
+1. **AST validator** — `python .claude/physics/validate_tests.py`
+   - Parses every test, checks that assertions reference an `INV-*` ID, and
+     that numeric tolerances derive from a documented formula rather than a
+     magic literal.
+2. **`mypy --strict`** — type-level soundness on the entire `src/` tree.
+3. **`ruff format --check` + `ruff check`** — style and lint determinism.
+4. **`pytest`** — runtime correctness, including the property-based
+     (Hypothesis) suites.
+5. **`MANIFEST.sha256`** — reproducibility seal: regeneration must produce
+     byte-identical artifacts.
+
+The exact commands for each gate live in [`VALIDATION.md`](./VALIDATION.md).
+
+## Invariant references in tests
+
+Each test is required to declare which invariant it witnesses. The minimum form is:
+
+```python
+def test_kuramoto_order_parameter_bounded() -> None:
+    """Witness for INV-K1: 0 ≤ R(t) ≤ 1 for all t."""
+    ...
+```
+
+The AST validator (gate 1) rejects tests whose docstring or marker does not
+contain an `INV-*` token from [`INVARIANTS_INDEX.md`](./INVARIANTS_INDEX.md).
+This makes coverage of the physics layer **structurally measurable**, not a
+matter of opinion.
+
+## Escalation
+
+A failing gate is never "patched around" by relaxing the invariant. If a test
+genuinely cannot pass:
+
+1. Document the falsification attempt (input, observed output, expected bound).
+2. Open an issue tagged `physics-falsification`.
+3. Either the implementation is wrong (fix the code) or the invariant was
+   wrong (amend `INVARIANTS.yaml` with a dated changelog entry and a citation).
+
+Both branches produce a permanent audit trail; neither lets the failing test
+silently pass.
+
+## Why adversarial, not consensus
+
+A consensus workflow optimizes for agreement; an adversarial workflow optimizes
+for finding the case that breaks the claim. Physical systems do not care about
+agreement, so neither does this codebase.

--- a/.exocortex/README.md
+++ b/.exocortex/README.md
@@ -1,0 +1,37 @@
+# `.exocortex/` — Provenance & Methodology Index
+
+This directory is the **research-provenance layer** of GeoSync: the small set of
+documents required to reconstruct *why* the codebase looks the way it does and
+*how* it stays correct. It is not API documentation. It is the trail an external
+auditor follows from a passing test back to a falsifiable physical claim.
+
+## Contents
+
+| File | Purpose | Audience |
+| --- | --- | --- |
+| [`METHODOLOGY.md`](./METHODOLOGY.md) | Adversarial-orchestration roles, validation gates, escalation rules | Contributors, reviewers |
+| [`RESEARCH_TIMELINE.md`](./RESEARCH_TIMELINE.md) | Chronology of substrates, models, and milestones the codebase rests on | Auditors, scientific reviewers |
+| [`GLOSSARY.md`](./GLOSSARY.md) | Precise definitions of γ, INV, TACL, MFN, BN-Syn, and other in-house terms | New contributors |
+| [`INVARIANTS_INDEX.md`](./INVARIANTS_INDEX.md) | Map of the 60 physics invariants in [`.claude/physics/INVARIANTS.yaml`](../.claude/physics/INVARIANTS.yaml) by category and priority | Test authors, CI gatekeepers |
+| [`VALIDATION.md`](./VALIDATION.md) | Exact commands for the five validation gates, in order | Contributors, CI engineers |
+
+## Authority hierarchy
+
+When two artifacts disagree, the right one to trust is the one closer to the
+top of this list:
+
+1. [`.claude/physics/INVARIANTS.yaml`](../.claude/physics/INVARIANTS.yaml) — machine-readable physics constraints
+2. [`physics_contracts/catalog.yaml`](../physics_contracts/catalog.yaml) — module-anchored law catalog (parallel layer)
+3. The Python tests under [`tests/`](../tests/) that reference `INV-*` IDs
+4. The narrative documents in this directory
+5. Anything else
+
+If a doc here contradicts the YAML, fix the doc. If a test contradicts the YAML,
+fix the test or escalate the invariant — never weaken the assertion.
+
+## Scope boundary
+
+`.exocortex/` documents claims that are **provable from the repository** or
+**published in cited literature**. It does not contain hypotheses that have not
+yet been falsified. Speculative work lives under [`docs/`](../docs/) or in
+external research notes — not here.

--- a/.exocortex/RESEARCH_TIMELINE.md
+++ b/.exocortex/RESEARCH_TIMELINE.md
@@ -1,29 +1,63 @@
 # Research Timeline
 
+This timeline records the substrate-level results and architectural milestones
+that the GeoSync codebase rests on. Numbers are stated as of the last commit
+to this file (see `git log`); when in doubt, re-derive from the source of
+truth shown in the **Source** column.
+
+> Convention: `γ` denotes the metastable-computation scaling exponent
+> hypothesized in this research line. See [`GLOSSARY.md`](./GLOSSARY.md).
+
 ## 2022
-- Self-directed computational neuroscience study
-- First experiments with neural dynamics simulation
+
+| Milestone | Source |
+| --- | --- |
+| Self-directed computational neuroscience study begins | — |
+| First experiments with neural-dynamics simulation | — |
 
 ## 2023
-- Mycelium-fractal-net (MFN) initial codebase
-- gamma observation in BN-Syn spiking network simulations
-- GeoSync repository — Kuramoto synchronization + market microstructure
-- Adversarial Orchestration methodology formalized
+
+| Milestone | Source |
+| --- | --- |
+| Mycelium-Fractal-Net (MFN) initial codebase | [`src/mycelium_fractal_net/`](../src/mycelium_fractal_net/) |
+| `γ ≈ 1.0` first observed in BN-Syn spiking-network simulations | external repo `BN-Syn` |
+| GeoSync repository created — Kuramoto synchronization × market microstructure | this repo |
+| Adversarial Orchestration methodology formalized | [`METHODOLOGY.md`](./METHODOLOGY.md) |
 
 ## 2024
-- gamma~1.0 hypothesis: metastable computation invariant across substrates
-- NFI architecture: ML-SDM, CA1-LAM, BN-Syn, MFN+
-- 6-substrate validation: zebrafish 0.967, Gray-Scott 1.000, Kuramoto 1.081,
-  BN-Syn 0.959, NFI unified 0.8993, CNS-AI 1.059 (mean 0.994 +/- 0.077)
-- NeoSynaptex monorepo
-- GeoSync neuromodulation: serotonin ODE, dopamine TD, GABA gate, ECS Lyapunov
+
+| Milestone | Source |
+| --- | --- |
+| `γ ≈ 1.0` hypothesis: metastable computation invariant across substrates | external research notes |
+| NFI architecture defined: ML-SDM, CA1-LAM, BN-Syn, MFN+ | external `NFI` repo |
+| 6-substrate validation, mean γ = 0.994 ± 0.077 (zebrafish 0.967, Gray-Scott 1.000, Kuramoto 1.081, BN-Syn 0.959, NFI unified 0.8993, CNS-AI 1.059) | external substrate logs |
+| NeoSynaptex monorepo created | external `NeoSynaptex` repo |
+| GeoSync neuromodulation layer: serotonin ODE, dopamine TD, GABA gate, ECS Lyapunov | [`src/geosync/`](../src/geosync/) |
 
 ## 2025
-- NeoSynaptex: 232 tests, 13 scientific gaps closed, Protocol 7X
-- GeoSync: HPC Active Inference v4, 9759+ tests
-- Physics Kernel: 57 invariants, AST-based 7-level validator
+
+| Milestone | Source |
+| --- | --- |
+| NeoSynaptex: 232 tests, 13 scientific gaps closed, Protocol 7X | external `NeoSynaptex` repo |
+| GeoSync: HPC Active Inference v4 | [`src/geosync/`](../src/geosync/) |
+| Physics Kernel formalized: AST-based validator + invariant registry | [`.claude/physics/`](../.claude/physics/) |
 
 ## 2026-Q2
-- Cryptobiosis module (tardigrade-inspired phase-transition survival)
-- Ontology of Gradient (INV-YV1)
-- GeoSync v0.1.0 public release candidate
+
+| Milestone | Source |
+| --- | --- |
+| Cryptobiosis module (tardigrade-inspired phase-transition survival) | [`.claude/physics/CRYPTOBIOSIS_THEORY.md`](../.claude/physics/CRYPTOBIOSIS_THEORY.md) |
+| Ontology of Gradient — invariant `INV-YV1` | [`.claude/physics/INVARIANTS.yaml`](../.claude/physics/INVARIANTS.yaml) |
+| GeoSync v0.1.0 public release candidate | repository tag |
+| Physics Kernel: **60 invariants** across 16 categories (40 P0 / 17 P1 / 3 P2) | derived from [`.claude/physics/INVARIANTS.yaml`](../.claude/physics/INVARIANTS.yaml) |
+| Parallel `physics_contracts/` law catalog: **26 module-anchored laws** | [`physics_contracts/catalog.yaml`](../physics_contracts/catalog.yaml) |
+| pytest suite size on `main`: ≈8.8k test functions across 844 files | derive via `grep -rh "^def test_" tests/ \| wc -l` |
+
+## How to update this file
+
+1. State the milestone in one line.
+2. Cite a source the reader can open today.
+3. If the milestone is a numeric claim, name the script that re-derives it,
+   not the value. Numbers drift; commands stay valid until the schema changes.
+4. Any change to the substrate-validation block (2024) must be co-signed by a
+   commit that also updates the underlying logs in the originating repo.

--- a/.exocortex/VALIDATION.md
+++ b/.exocortex/VALIDATION.md
@@ -1,0 +1,96 @@
+# Validation Commands
+
+Reference card for the five gates declared in [`METHODOLOGY.md`](./METHODOLOGY.md).
+Run them in this order. Each gate must exit `0` before moving to the next.
+
+The same gates run in CI (`.github/workflows/pr-gate.yml` and friends); these
+local commands are the canonical regeneration recipes.
+
+## 1. AST validator — invariant references in tests
+
+```bash
+python .claude/physics/validate_tests.py
+```
+
+Walks every `tests/**/test_*.py`, parses it, and rejects:
+
+- assertions whose tolerance is a magic literal (no formula reference);
+- tests whose docstring or marker omits the `INV-*` token they witness;
+- tests that mutate global physics constants without a `# physics-override`
+  marker plus a justification comment.
+
+The validator also emits a per-category coverage table so a contributor can
+see which `INV-*` IDs still lack a witness.
+
+## 2. `mypy --strict`
+
+```bash
+mypy --strict src/
+```
+
+Required for every `.py` file under `src/`. The PostToolUse hook in
+`.claude/settings.json` runs this on every edit, so violations should
+never reach commit time. CI runs it again as a backstop.
+
+## 3. `ruff format --check` + `ruff check`
+
+```bash
+ruff format --check .
+ruff check .
+```
+
+Together these enforce the lockstep style policy. `ruff format --write` is the
+canonical formatter — do not run `black` or `isort` separately.
+
+## 4. `pytest`
+
+Run the gate that matches the change:
+
+```bash
+# Fast gate — runs on every PR
+make test-fast
+
+# Heavy gate — runs when src/, tests/, core/, formal/, scripts/, or Makefile change
+make test-heavy
+
+# Full gate — for release tags
+make test-ci-full
+```
+
+Hypothesis property suites are inside the heavy gate. Locally you can also
+run them directly:
+
+```bash
+pytest tests/ -m "slow or heavy_math or nightly" --maxfail=3 -q
+```
+
+## 5. `MANIFEST.sha256`
+
+```bash
+make release
+sha256sum -c MANIFEST.sha256
+```
+
+Reproducible build seal. A clean checkout plus a fresh `make release` must
+produce a `MANIFEST.sha256` whose contents match the committed copy line for
+line. If they diverge, find the source of nondeterminism (timestamps,
+unsorted iteration, random seed) and fix it before merging.
+
+## Convenience aggregates
+
+```bash
+make audit         # runs gates 1–3 plus dep audits
+make test-ci-full  # runs all unit + property + integration suites
+make formal-verify # invokes formal/proof_invariant.py for invariants with proof obligations
+```
+
+## When CI fails but the local run passes
+
+The most common cause is shallow-fetch divergence on dependabot branches:
+the `python-heavy-tests` job uses `git fetch --depth=1 origin main` and then
+`git diff main...HEAD` to decide whether to skip. If the PR branch was
+created before recent merges to `main`, the diff has no merge base and the
+job exits with `fatal: ... no merge base`.
+
+Fix: rebase the PR branch onto current `origin/main` and force-push with
+`--force-with-lease`. Do not bypass the gate.


### PR DESCRIPTION
## Summary

Elevates `.exocortex/` from a 2-file sketch (1.6 KB total) to a 6-file,
self-contained audit trail that walks an external reviewer from a passing test
back to a falsifiable physical claim — without requiring any out-of-band
context.

Every numeric claim is **verified against current repo state**:

| Claim | Value | Source of truth |
| --- | ---: | --- |
| Total invariants | 60 (not 57) | `grep -c '    id: INV-' .claude/physics/INVARIANTS.yaml` |
| Priority breakdown | 40 P0 / 17 P1 / 3 P2 | same file |
| Categories | 16 | same file |
| Module-anchored laws | 26 | `grep -c '^  - id:' physics_contracts/catalog.yaml` |
| Test functions on `main` | ≈ 8.8 k across 844 files | `grep -rh '^def test_' tests/ \| wc -l` |

## Files

| File | Status | Purpose |
| --- | --- | --- |
| `README.md` | new | Directory index + authority hierarchy |
| `METHODOLOGY.md` | rewritten | 4 roles × 5 validation gates + escalation rules |
| `RESEARCH_TIMELINE.md` | rewritten | Source-cited milestones, 2022 → 2026-Q2 |
| `GLOSSARY.md` | new | γ, INV, TACL, MFN, BN-Syn, ECS, OMS, role authority |
| `INVARIANTS_INDEX.md` | new | All 60 invariants by category × priority, cross-linked to theory docs |
| `VALIDATION.md` | new | Canonical command for each of the 5 gates + dependabot-rebase recipe |

## Non-goals

- Does not modify `.claude/physics/INVARIANTS.yaml` or
  `physics_contracts/catalog.yaml` — these remain the sources of truth and the
  new docs are derived from them.
- Does not introduce any new physics claim. Anything that was not previously
  written down or derivable from the YAMLs is omitted by design.

## Test plan

- [ ] CI green (docs-only change; expect frontend/python gates to skip)
- [ ] Spot-check internal links resolve (README → all 5 sibling docs, all docs → physics theory files)
- [ ] Re-run the verification commands from the table above and confirm the numbers in `RESEARCH_TIMELINE.md` and `INVARIANTS_INDEX.md` match