### PR TITLE
ci(pr-gate): fix recurring 'no merge base' on dependabot rebases

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -130,7 +130,7 @@ jobs:
         run: |
           set -euo pipefail
           if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
-            git fetch --no-tags --depth=1 origin "${{ github.base_ref }}"
+            git fetch --no-tags origin "${{ github.base_ref }}"
             base_ref="origin/${{ github.base_ref }}"
             changed_files=$(git diff --name-only "$base_ref...$GITHUB_SHA")
           else
@@ -190,7 +190,7 @@ jobs:
         run: |
           set -euo pipefail
           if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
-            git fetch --no-tags --depth=1 origin "${{ github.base_ref }}"
+            git fetch --no-tags origin "${{ github.base_ref }}"
             base_ref="origin/${{ github.base_ref }}"
             changed_files=$(git diff --name-only "$base_ref...$GITHUB_SHA")
           else
@@ -230,7 +230,7 @@ jobs:
         run: |
           set -euo pipefail
           if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
-            git fetch --no-tags --depth=1 origin "${{ github.base_ref }}"
+            git fetch --no-tags origin "${{ github.base_ref }}"
             base_ref="origin/${{ github.base_ref }}"
             changed_files=$(git diff --name-only "$base_ref...$GITHUB_SHA")
           else
@@ -275,7 +275,7 @@ jobs:
         run: |
           set -euo pipefail
           if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
-            git fetch --no-tags --depth=1 origin "${{ github.base_ref }}"
+            git fetch --no-tags origin "${{ github.base_ref }}"
             base_ref="origin/${{ github.base_ref }}"
             changed_files=$(git diff --name-only "$base_ref...$GITHUB_SHA")
           else
@@ -318,7 +318,7 @@ jobs:
         run: |
           set -euo pipefail
           if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
-            git fetch --no-tags --depth=1 origin "${{ github.base_ref }}"
+            git fetch --no-tags origin "${{ github.base_ref }}"
             base_ref="origin/${{ github.base_ref }}"
             changed_files=$(git diff --name-only "$base_ref...$GITHUB_SHA")
           else
@@ -421,7 +421,7 @@ jobs:
         run: |
           set -euo pipefail
           if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
-            git fetch --no-tags --depth=1 origin "${{ github.base_ref }}"
+            git fetch --no-tags origin "${{ github.base_ref }}"
             base_ref="origin/${{ github.base_ref }}"
             git diff --name-only "$base_ref...$GITHUB_SHA" > /tmp/changed-files.txt
           else
@@ -473,7 +473,7 @@ jobs:
         run: |
           set -euo pipefail
           if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
-            git fetch --no-tags --depth=1 origin "${{ github.base_ref }}"
+            git fetch --no-tags origin "${{ github.base_ref }}"
             changed=$(git diff --name-only "origin/${{ github.base_ref }}...$GITHUB_SHA")
           else
             changed=$(git diff-tree --no-commit-id --name-only -r "$GITHUB_SHA")

--- a/INVENTORY.json
+++ b/INVENTORY.json
@@ -11,7 +11,7 @@
   "files": [
     {
       "path": ".github/workflows/pr-gate.yml",
-      "sha256": "4affdb64493fdc22d416700750594213d10b771a52b6e323e0005f30e7c57e46"
+      "sha256": "415a311120234dbb9338c83205b589f034bec76b043ff62484c5c169d4c30ab6"
     },
     {
       "path": "scripts/ci/check_central_files_touched.py",


### PR DESCRIPTION
## Root cause

Each job in \`.github/workflows/pr-gate.yml\` does:

\`\`\`yaml
- uses: actions/checkout@...
  with:
    fetch-depth: 0          # full history pulled here
...
- run: |
    git fetch --no-tags --depth=1 origin \"\${{ github.base_ref }}\"   # ⚠️ shallows it back
    base_ref=\"origin/\${{ github.base_ref }}\"
    changed_files=\$(git diff --name-only \"\$base_ref...\$GITHUB_SHA\")
\`\`\`

The inline \`--depth=1\` fetch overwrites the full-depth history that the
\`actions/checkout@v5\` step just pulled, leaving \`$base_ref\` with no commits in
common with \`$GITHUB_SHA\` whenever the PR branch and \`main\` have diverged.

Observed symptom:

> \`fatal: origin/main...<sha>: no merge base\`
> \`##[error]Process completed with exit code 128.\`

This fired on every dependabot PR after the last batch of merges to \`main\`
(#206 MUI v9, #208 web-api, #217-219 Go). The workaround so far has been
\`--admin\` merge. This PR removes the root cause.

## Fix

Drop \`--depth=1\` from the 7 inline fetches. The step still runs \`git fetch\` to
refresh the ref tip, but no longer truncates history. Checkout's \`fetch-depth: 0\`
is respected end-to-end.

## Affected jobs

| Job | Line (before) |
| --- | ---: |
| python-quality | 133 |
| python-fast-tests | 193 |
| python-heavy-tests | 233 |
| physics-code-audit | 278 |
| physics-test-validation | 321 |
| physics-kernel-self-check | 424 |
| physics-invariants | 476 |

## Test plan

- [ ] This PR's own \`python-quality\` / \`python-fast-tests\` / \`python-heavy-tests\` gates pass without \`--admin\` override
- [ ] Next dependabot PR to land after merge passes heavy-tests without \`no merge base\` error