### PR TITLE
fix(kuramoto): canonicalise signed-community labels for recalibration stability

### DIFF
--- a/core/kuramoto/metrics.py
+++ b/core/kuramoto/metrics.py
@@ -176,6 +176,64 @@ def rolling_csd(R: np.ndarray, window: int) -> tuple[np.ndarray, np.ndarray]:
 # ---------------------------------------------------------------------------
 
 
+def _canonical_eigvec_sign(v: np.ndarray) -> np.ndarray:
+    """Return ``v`` with a deterministic sign convention.
+
+    ``np.linalg.eigh`` returns eigenvectors with arbitrary sign: ``v``
+    and ``-v`` are both valid principal eigenvectors. When the downstream
+    split rule is ``v >= 0`` this ambiguity permutes the two halves of
+    the bipartition. We fix the sign by requiring the coordinate of
+    largest magnitude to be non-negative; tie-breaks on magnitude fall
+    to the smallest index, so the convention is deterministic for every
+    non-zero ``v``.
+
+    The zero vector is returned unchanged — the caller must handle the
+    degenerate split separately because both halves are empty by
+    construction.
+    """
+    if v.size == 0:
+        return v
+    idx = int(np.argmax(np.abs(v)))
+    pivot = float(v[idx])
+    if pivot < 0.0:
+        return -v
+    return v
+
+
+def _canonicalize_labels(labels: np.ndarray) -> np.ndarray:
+    """Rewrite community ids so the ordering is permutation-invariant.
+
+    The primary sort key is community *size*, descending: the biggest
+    community always receives id ``0``. Ties break on the *smallest
+    member index* ascending, so two communities of equal size fall
+    into a stable order determined only by node identity. This removes
+    two sources of label instability:
+
+    1. **Eigenvector sign ambiguity** — when the recursive splitter
+       flips which half receives ``new_id = max + 1`` the raw labels
+       permute; after canonicalisation the partition is unchanged.
+    2. **Split-order dependence** — recursive splits of different
+       sub-communities can interleave in different orders on perturbed
+       inputs; the size-then-min-index ordering is invariant under
+       those interleavings.
+
+    The partition (the equivalence classes on nodes) is preserved
+    exactly — only the integer ids are rewritten. The returned labels
+    are a dense ``0..C-1`` range where ``C`` is the number of
+    communities.
+    """
+    labels = np.ascontiguousarray(labels, dtype=np.int64)
+    unique, first_occurrence = np.unique(labels, return_index=True)
+    sizes = np.array([int((labels == u).sum()) for u in unique], dtype=np.int64)
+    # Sort by (-size, first_occurrence) so the biggest community wins;
+    # ties break on the smallest node index.
+    order = np.lexsort((first_occurrence, -sizes))
+    remap = np.empty(unique.max() + 1, dtype=np.int64)
+    for new_id, old_pos in enumerate(order):
+        remap[unique[old_pos]] = new_id
+    return np.asarray(remap[labels], dtype=np.int64)
+
+
 def _signed_modularity(W: np.ndarray, labels: np.ndarray) -> float:
     """Signed modularity ``Q⁺ − Q⁻`` (Gómez, Jensen & Arenas, 2009).
 
@@ -234,6 +292,19 @@ def signed_communities(
     graphs that avoids bringing in ``leidenalg`` as a dependency; on
     planted-partition benchmarks it recovers the ground-truth
     communities with NMI ≥ 0.9 for typical sparsity levels.
+
+    Label canonicalisation
+    ----------------------
+    The returned labels form a dense ``0..C-1`` range canonicalised
+    so that the biggest community always has id ``0``; ties on size
+    break on the smallest member index ascending. Together with the
+    eigenvector-sign canonicalisation applied during every recursive
+    split this makes the output *permutation-invariant* under small
+    perturbations of ``K``: if two inputs produce the same partition
+    they produce the same labels bit-for-bit. Downstream callers
+    (``EmergentMetrics.R_cluster``, ``NetworkKuramotoFeature``) bind
+    to these ids across batch recalibrations, so stability is a
+    correctness invariant, not a cosmetic.
     """
     N = K.shape[0]
     W = 0.5 * (K + K.T)
@@ -259,8 +330,12 @@ def signed_communities(
             eigvals, eigvecs = np.linalg.eigh(sub_sym)
             # Fiedler-like split: use the eigenvector corresponding
             # to the largest eigenvalue (maximises intra-cluster
-            # positive weight)
-            v = eigvecs[:, -1]
+            # positive weight). ``eigh`` returns eigenvectors with
+            # arbitrary sign; canonicalise so ``v >= 0`` has a
+            # deterministic meaning (otherwise ``sub_a`` / ``sub_b``
+            # permute under numerical perturbation and the new-id
+            # assignment swaps cluster labels between calls).
+            v = _canonical_eigvec_sign(eigvecs[:, -1])
             sub_a = v >= 0
             sub_b = ~sub_a
             if sub_a.sum() < min_community_size or sub_b.sum() < min_community_size:
@@ -280,7 +355,12 @@ def signed_communities(
         _, labels = best_split
         current_q = current_q + best_gain
 
-    return labels
+    # Canonicalise labels: biggest community first, ties broken by the
+    # smallest member index. Without this, two runs on tiny
+    # perturbations of the same ``K`` return the same partition but
+    # with permuted ids — which breaks ``R_cluster`` dict keys and
+    # downstream ``kuramoto_R_cluster_{c}`` feature vocabulary.
+    return _canonicalize_labels(labels)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/core/test_kuramoto_network_engine.py
+++ b/tests/unit/core/test_kuramoto_network_engine.py
@@ -158,6 +158,175 @@ class TestSignedCommunities:
         assert labels.shape == (10,)
         assert int(labels.min()) >= 0
 
+    def test_labels_dense_range_starting_at_zero(self) -> None:
+        """Canonicalised labels occupy the dense range ``0..C-1``.
+
+        This contract is relied on by ``EmergentMetrics.R_cluster``
+        (integer dict keys) and by the ``NetworkKuramotoFeature``
+        feature vocabulary ``kuramoto_R_cluster_{c}``.
+        """
+        rng = np.random.default_rng(1)
+        for n in (6, 10, 15):
+            K = rng.standard_normal((n, n))
+            K = 0.5 * (K + K.T)
+            np.fill_diagonal(K, 0.0)
+            labels = signed_communities(K, n_clusters_max=4)
+            unique = np.unique(labels)
+            assert int(unique.min()) == 0
+            assert int(unique.max()) == unique.size - 1, (
+                f"labels must be dense 0..C-1; got {unique.tolist()}"
+            )
+
+    def test_biggest_community_gets_id_zero(self) -> None:
+        """Canonical ordering: the largest community always has id 0.
+
+        Ties on size fall back to the smallest member index ascending;
+        the two-block planted partition has equal-size communities so
+        id 0 must be assigned to the block starting at index 0.
+        """
+        N = 12
+        block = 6
+        K = np.zeros((N, N))
+        for i in range(block):
+            for j in range(block):
+                if i != j:
+                    K[i, j] = 1.0
+                    K[i + block, j + block] = 1.0
+        for i in range(block):
+            for j in range(block):
+                K[i, j + block] = -0.5
+                K[j + block, i] = -0.5
+        labels = signed_communities(K, n_clusters_max=4)
+        # Tie on size (6-6); min-index tie-breaker assigns 0 to the
+        # block containing node 0.
+        assert labels[0] == 0
+
+        # Imbalanced planted partition — the bigger block wins id 0.
+        N2 = 10
+        K2 = np.zeros((N2, N2))
+        # Block A: nodes 0..6 (size 7), block B: nodes 7..9 (size 3).
+        for i in range(7):
+            for j in range(7):
+                if i != j:
+                    K2[i, j] = 1.0
+        for i in range(7, N2):
+            for j in range(7, N2):
+                if i != j:
+                    K2[i, j] = 1.0
+        for i in range(7):
+            for j in range(7, N2):
+                K2[i, j] = -0.5
+                K2[j, i] = -0.5
+        labels2 = signed_communities(K2, n_clusters_max=4)
+        # The bigger (size-7) block must carry id 0.
+        assert int(labels2[0]) == 0
+        assert int(labels2[-1]) == 1
+
+    def test_labels_stable_under_small_perturbation(self) -> None:
+        """Label *permutation invariance*: tiny ``K`` noise keeps ids fixed.
+
+        This is the falsification witness for the recalibration
+        stability contract. Before canonicalisation, flipping the
+        principal eigenvector sign on a perturbed ``K`` would swap
+        labels 0 and 1 even though the partition is unchanged — which
+        corrupted every downstream ``R_cluster[c]`` and
+        ``kuramoto_R_cluster_{c}`` binding between recalibrations.
+        """
+        N_block = 6
+        N = 2 * N_block
+        K = np.zeros((N, N))
+        for i in range(N_block):
+            for j in range(N_block):
+                if i != j:
+                    K[i, j] = 1.0
+                    K[i + N_block, j + N_block] = 1.0
+        for i in range(N_block):
+            for j in range(N_block):
+                K[i, j + N_block] = -0.5
+                K[j + N_block, i] = -0.5
+        base = signed_communities(K, n_clusters_max=4)
+        for seed in range(10):
+            noise = 1e-5 * np.random.default_rng(seed).standard_normal(K.shape)
+            K_perturbed = K + 0.5 * (noise + noise.T)
+            perturbed = signed_communities(K_perturbed, n_clusters_max=4)
+            np.testing.assert_array_equal(
+                base,
+                perturbed,
+                err_msg=(
+                    f"labels changed under 1e-5 perturbation (seed={seed}); "
+                    f"recalibration stability broken"
+                ),
+            )
+
+    def test_labels_stable_under_sign_ambiguity(self) -> None:
+        """Negating ``K`` negates every eigenvector → must not flip ids.
+
+        Regression witness for the eigenvector-sign canonicaliser. If
+        the canonicaliser is removed, two calls on ``K`` and ``-K``
+        (when only the positive subgraph is active) can return swapped
+        labels because ``np.linalg.eigh`` picks an arbitrary sign for
+        each eigenvector.
+        """
+        # Use a purely positive-coupling two-block graph where
+        # behaviour is fully determined by the Fiedler-like split.
+        N_block = 5
+        N = 2 * N_block
+        K = np.zeros((N, N))
+        for i in range(N_block):
+            for j in range(N_block):
+                if i != j:
+                    K[i, j] = 1.0
+                    K[i + N_block, j + N_block] = 1.0
+        # Two independent calls on the *same* matrix must be bit-identical.
+        a = signed_communities(K, n_clusters_max=2)
+        b = signed_communities(K, n_clusters_max=2)
+        np.testing.assert_array_equal(a, b)
+        # Partition must be the planted one: block [0..N_block) together.
+        assert np.all(a[:N_block] == a[0])
+        assert np.all(a[N_block:] == a[-1])
+
+    def test_labels_invariant_under_node_relabeling(self) -> None:
+        """Permuting node indices and un-permuting recovers the labels.
+
+        Because the canonical tie-breaker is the *smallest member
+        index*, arbitrary relabelings alter which equivalence class
+        carries id 0 when sizes tie. This test fixes an imbalanced
+        planted partition so the size-based primary key is
+        discriminative and the labels are invariant under permutation.
+        """
+        N = 10
+        K = np.zeros((N, N))
+        # Bigger block (size 7) and smaller block (size 3)
+        for i in range(7):
+            for j in range(7):
+                if i != j:
+                    K[i, j] = 1.0
+        for i in range(7, N):
+            for j in range(7, N):
+                if i != j:
+                    K[i, j] = 1.0
+        for i in range(7):
+            for j in range(7, N):
+                K[i, j] = -0.5
+                K[j, i] = -0.5
+
+        base = signed_communities(K, n_clusters_max=3)
+        rng = np.random.default_rng(42)
+        for trial in range(5):
+            perm = rng.permutation(N)
+            K_perm = K[np.ix_(perm, perm)]
+            labels_perm = signed_communities(K_perm, n_clusters_max=3)
+            undone = np.empty_like(labels_perm)
+            undone[perm] = labels_perm
+            np.testing.assert_array_equal(
+                base,
+                undone,
+                err_msg=(
+                    f"labels not invariant under node permutation "
+                    f"(trial={trial}, perm={perm.tolist()})"
+                ),
+            )
+
 
 class TestPermutationEntropy:
     def test_monotonic_series_has_zero_entropy(self) -> None:
@@ -374,9 +543,7 @@ class TestNetworkKuramotoEngine:
         )
         engine = NetworkKuramotoEngine(
             NetworkEngineConfig(
-                phase=PhaseExtractionConfig(
-                    fs=fs, f_low=0.5, f_high=1.5, detrend_window=None
-                ),
+                phase=PhaseExtractionConfig(fs=fs, f_low=0.5, f_high=1.5, detrend_window=None),
                 coupling=CouplingEstimationConfig(
                     penalty="mcp",
                     lambda_reg=0.1,
@@ -467,9 +634,7 @@ class TestNetworkKuramotoFeature:
             ),
         )
         feat.warmup(returns[:400])
-        feat.recalibrate(
-            returns[:600], timestamps=np.arange(600, dtype=np.float64) * 0.05
-        )
+        feat.recalibrate(returns[:600], timestamps=np.arange(600, dtype=np.float64) * 0.05)
         # Measure per-bar online latency across 20 updates
         t0 = time.perf_counter()
         last_features: dict[str, float] = {}
@@ -511,9 +676,7 @@ class TestNetworkKuramotoFeature:
             ),
         )
         feat.warmup(returns[:300])
-        feat.recalibrate(
-            returns[:500], timestamps=np.arange(500, dtype=np.float64) * 0.05
-        )
+        feat.recalibrate(returns[:500], timestamps=np.arange(500, dtype=np.float64) * 0.05)
         for k, row in enumerate(returns[500:530]):
             features = feat.update(row, timestamp=float(500 + k) * 0.05)
             for v in features.values():

--- a/tests/unit/core/test_kuramoto_network_engine.py
+++ b/tests/unit/core/test_kuramoto_network_engine.py
@@ -173,9 +173,9 @@ class TestSignedCommunities:
             labels = signed_communities(K, n_clusters_max=4)
             unique = np.unique(labels)
             assert int(unique.min()) == 0
-            assert int(unique.max()) == unique.size - 1, (
-                f"labels must be dense 0..C-1; got {unique.tolist()}"
-            )
+            assert (
+                int(unique.max()) == unique.size - 1
+            ), f"labels must be dense 0..C-1; got {unique.tolist()}"
 
     def test_biggest_community_gets_id_zero(self) -> None:
         """Canonical ordering: the largest community always has id 0.

--- a/tests/unit/physics/test_T24_kuramoto_metrics_witness.py
+++ b/tests/unit/physics/test_T24_kuramoto_metrics_witness.py
@@ -373,9 +373,9 @@ def test_rolling_csd_rejects_window_outside_range() -> None:
 
     # Legal edge: window = 2 must succeed and yield finite output.
     var, ac1 = rolling_csd(R, window=2)
-    assert var.shape == (T,), (
-        f"INV-HPC2 VIOLATED: var shape={var.shape}, expected ({T},). Observed at T={T}, window=2."
-    )
+    assert var.shape == (
+        T,
+    ), f"INV-HPC2 VIOLATED: var shape={var.shape}, expected ({T},). Observed at T={T}, window=2."
     assert np.all(np.isfinite(var)), (
         "INV-HPC2 VIOLATED: rolling_csd var contains NaN/Inf at window=2. "
         f"Observed at T={T}. "
@@ -522,12 +522,12 @@ def test_signed_communities_label_stability_under_noise(
 
     # Contract on label range: labels must form a dense 0..C-1 range.
     unique = np.unique(base)
-    assert int(unique.min()) == 0, (
-        f"INV-K-CLUSTER VIOLATED: labels must start at 0; got min={int(unique.min())}."
-    )
-    assert int(unique.max()) == unique.size - 1, (
-        f"INV-K-CLUSTER VIOLATED: labels must be dense 0..C-1; got unique={unique.tolist()}."
-    )
+    assert (
+        int(unique.min()) == 0
+    ), f"INV-K-CLUSTER VIOLATED: labels must start at 0; got min={int(unique.min())}."
+    assert (
+        int(unique.max()) == unique.size - 1
+    ), f"INV-K-CLUSTER VIOLATED: labels must be dense 0..C-1; got unique={unique.tolist()}."
 
 
 def test_signed_communities_biggest_first_ordering() -> None:

--- a/tests/unit/physics/test_T24_kuramoto_metrics_witness.py
+++ b/tests/unit/physics/test_T24_kuramoto_metrics_witness.py
@@ -55,6 +55,7 @@ from core.kuramoto.metrics import (
     order_parameter,
     permutation_entropy,
     rolling_csd,
+    signed_communities,
 )
 
 # ---------------------------------------------------------------------------
@@ -372,9 +373,9 @@ def test_rolling_csd_rejects_window_outside_range() -> None:
 
     # Legal edge: window = 2 must succeed and yield finite output.
     var, ac1 = rolling_csd(R, window=2)
-    assert var.shape == (
-        T,
-    ), f"INV-HPC2 VIOLATED: var shape={var.shape}, expected ({T},). Observed at T={T}, window=2."
+    assert var.shape == (T,), (
+        f"INV-HPC2 VIOLATED: var shape={var.shape}, expected ({T},). Observed at T={T}, window=2."
+    )
     assert np.all(np.isfinite(var)), (
         "INV-HPC2 VIOLATED: rolling_csd var contains NaN/Inf at window=2. "
         f"Observed at T={T}. "
@@ -448,3 +449,122 @@ def test_permutation_entropy_max_entropy_formula() -> None:
     )
     # Sanity: entropy must be a finite real in [0, 1].
     assert math.isfinite(h)
+
+
+# ---------------------------------------------------------------------------
+# INV-K-CLUSTER — signed_communities label canonicalisation
+# ---------------------------------------------------------------------------
+
+
+@given(
+    arrays(
+        dtype=np.float64,
+        shape=st.tuples(
+            st.integers(min_value=6, max_value=14),
+            st.integers(min_value=6, max_value=14),
+        ).filter(lambda s: s[0] == s[1]),
+        elements=st.floats(min_value=-5.0, max_value=5.0, allow_nan=False, allow_infinity=False),
+    ),
+    st.floats(min_value=0.0, max_value=1e-4, allow_nan=False, allow_infinity=False),
+)
+@settings(max_examples=40, deadline=None)
+def test_signed_communities_label_stability_under_noise(
+    K_raw: np.ndarray, noise_scale: float
+) -> None:
+    """INV-K-CLUSTER: tiny ``K`` noise preserves labels bit-for-bit.
+
+    The inverse-problem stack feeds ``signed_communities`` a coupling
+    matrix that carries estimator noise. Under the recalibration
+    stability contract, label identifiers are part of the public
+    feature vocabulary (``EmergentMetrics.R_cluster`` keys,
+    ``NetworkKuramotoFeature`` ``kuramoto_R_cluster_{c}``). If the
+    partition is unchanged under a tiny perturbation then the labels
+    must be unchanged too — otherwise downstream consumers that bind
+    to ``R_cluster[0]`` see their semantics swap across recalibrations.
+
+    Falsification design: draw an arbitrary ``K`` in ``[-5, 5]``
+    (symmetrise) and a perturbation of magnitude ``≤ 1e-4``. Run
+    ``signed_communities`` on both. When the two calls yield the same
+    *partition* (equivalence relation on nodes) the integer labels
+    themselves must also match exactly.
+
+    Tolerance: the canonicaliser is a pure function of the partition,
+    so the expected tolerance on label equality is 0. We only compare
+    labels when the partitions are equivalent — otherwise the noise
+    has crossed a modularity boundary and the partitions genuinely
+    differ (outside this witness's scope).
+    """
+    # Symmetrise (signed_communities symmetrises internally but the
+    # noise we add must match the symmetric structure to keep the
+    # perturbation small in operator norm).
+    K = 0.5 * (K_raw + K_raw.T)
+    np.fill_diagonal(K, 0.0)
+
+    rng = np.random.default_rng(seed=0)
+    noise = noise_scale * rng.standard_normal(K.shape)
+    noise = 0.5 * (noise + noise.T)
+    K_pert = K + noise
+
+    base = signed_communities(K, n_clusters_max=4)
+    pert = signed_communities(K_pert, n_clusters_max=4)
+
+    # Partition equivalence: same equivalence relation on nodes?
+    same_partition = np.array_equal(base[:, None] == base[None, :], pert[:, None] == pert[None, :])
+    if same_partition:
+        # epsilon: canonicalisation is structural, tolerance = 0.
+        assert np.array_equal(base, pert), (
+            f"INV-K-CLUSTER VIOLATED: identical partition gave different "
+            f"labels {base.tolist()} vs {pert.tolist()} under noise "
+            f"scale={noise_scale:.3e}. "
+            f"Expected bit-for-bit label equality under the "
+            f"size-then-min-index canonicalisation contract."
+        )
+
+    # Contract on label range: labels must form a dense 0..C-1 range.
+    unique = np.unique(base)
+    assert int(unique.min()) == 0, (
+        f"INV-K-CLUSTER VIOLATED: labels must start at 0; got min={int(unique.min())}."
+    )
+    assert int(unique.max()) == unique.size - 1, (
+        f"INV-K-CLUSTER VIOLATED: labels must be dense 0..C-1; got unique={unique.tolist()}."
+    )
+
+
+def test_signed_communities_biggest_first_ordering() -> None:
+    """INV-K-CLUSTER: cluster id 0 is always the largest community.
+
+    The canonical ordering is: primary key = community size descending,
+    secondary key = smallest member index ascending. We exercise the
+    primary key with an imbalanced planted partition where the sizes
+    are strictly different (7 vs 3) so the size ordering is
+    discriminative.
+
+    Tolerance: exact — the canonicaliser returns a deterministic
+    integer mapping, tolerance = 0.
+    """
+    N = 10
+    K = np.zeros((N, N))
+    # Block A: 7 nodes, block B: 3 nodes.
+    for i in range(7):
+        for j in range(7):
+            if i != j:
+                K[i, j] = 1.0
+    for i in range(7, N):
+        for j in range(7, N):
+            if i != j:
+                K[i, j] = 1.0
+    for i in range(7):
+        for j in range(7, N):
+            K[i, j] = -0.5
+            K[j, i] = -0.5
+
+    labels = signed_communities(K, n_clusters_max=4)
+    sizes = np.bincount(labels)
+    # Community id 0 must be the biggest (size 7, not 3).
+    assert int(sizes[0]) == 7, (
+        f"INV-K-CLUSTER VIOLATED: community 0 has size {int(sizes[0])}, "
+        f"expected 7 (biggest first). Sizes={sizes.tolist()}."
+    )
+    # Node 0 (biggest block) carries id 0; node N-1 (smaller block) does not.
+    assert int(labels[0]) == 0
+    assert int(labels[-1]) != 0


### PR DESCRIPTION
## Summary
- Deterministic canonicalisation of inverse-cluster labels in `core/kuramoto/metrics.py::signed_communities`.
- Closes a real correctness defect: partition-preserving perturbations of `K` were swapping cluster ids between calls, silently changing the semantics of every consumer bound to `kuramoto_R_cluster_{c}` / `R_cluster[c]` across batch recalibrations.

## Root cause (2 sources of label ambiguity)
1. `np.linalg.eigh` returns principal eigenvectors with arbitrary sign — so at `metrics.py:270`, the `v >= 0` split sent different halves to `new_id = max + 1` under sub-epsilon noise.
2. Raw recursive output had no canonical ordering, so downstream bindings silently shifted.

Demonstrated: a two-block planted partition + `K` noise `1e-5` produced identical partitions with labels `[0]*6 + [1]*6` ↔ `[1]*6 + [0]*6`.

## Fix (core/kuramoto/metrics.py)
- `_canonical_eigvec_sign` — deterministic sign via max-|coordinate| ≥ 0 rule.
- `_canonicalize_labels` — sort clusters by descending size, tie-break by ascending smallest-member-index, relabel to dense `0..C-1`.
- Wired both into `signed_communities`: sign-fix at the spectral split, canonicalisation at return.
- Expanded docstring with the new invariants.

## Tests added (7, all green)
`tests/unit/core/test_kuramoto_network_engine.py::TestSignedCommunities` — 5 unit tests:
- dense-range contract
- biggest-first ordering (balanced + imbalanced)
- stability across 10 random `1e-5` perturbations
- stability across back-to-back identical calls
- invariance under input node relabeling

`tests/unit/physics/test_T24_kuramoto_metrics_witness.py` — 2 Hypothesis property tests (40 examples, `noise_scale ∈ [0, 1e-4]`): bit-identical labels under partition-preserving perturbation + biggest-first ordering regression witness.

## Status
| Check | Before | After |
|---|---|---|
| Full Kuramoto suite | 228 passed, 1 skipped | **235 passed, 1 skipped** |
| Regressions | — | 0 |
| `ruff check` / `format` | — | clean |
| `mypy --strict core/kuramoto/metrics.py` | — | clean |

Pre-existing `mypy --strict` errors in `adaptive.py` / `delayed.py` / `early_stopping.py` / `ricci_flow_engine.py` are untouched — unrelated files.

## Deliberately deferred
- Plumbing `random_state` through `compute_metrics` / `_current_cluster_assignments` — after sign canonicalisation the default-seed `1e-9` tie-break noise no longer flips labels, so payoff is low.
- Vectorising `_signed_modularity` — performance concern, not correctness; out of scope for this change.

## Test plan
- [x] Full Kuramoto suite: 235 pass, 1 skip, 0 fail (locally)
- [x] `mypy --strict core/kuramoto/metrics.py` clean
- [x] `ruff check` + `ruff format --check` clean on all changed files
- [ ] CI green on all matrix entries
- [ ] Review: verify invariant `cluster_id == 0 is always the largest cluster` matches downstream expectations in `contracts.py:439` and `feature.py:264`

🤖 Generated with [Claude Code](https://claude.com/claude-code)