### PR TITLE
deps(security): cryptography >= 46.0.7 (GHSA-p423-j2cm-9vmq)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ dependencies = [
     "streamlit-authenticator>=0.3.1",
     # Security: security-critical transitive dependencies pinned via constraints/security.txt
     "PyJWT[crypto]>=2.12.0",
-    "cryptography>=46.0.6",
+    "cryptography>=46.0.7",
     "requests>=2.33.0",
 ]
 

--- a/requirements-scan.txt
+++ b/requirements-scan.txt
@@ -54,5 +54,5 @@ streamlit-authenticator>=0.3.1
 
 # Security: security-critical transitive dependencies are pinned via constraints/security.txt
 PyJWT[crypto]>=2.12.0
-cryptography>=46.0.6
+cryptography>=46.0.7
 requests>=2.32.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -51,5 +51,5 @@ streamlit-authenticator>=0.3.1
 
 # Security: security-critical transitive dependencies are pinned via constraints/security.txt
 PyJWT[crypto]>=2.12.0
-cryptography>=46.0.6
+cryptography>=46.0.7
 requests>=2.32.5

--- a/sbom/combined-requirements.txt
+++ b/sbom/combined-requirements.txt
@@ -28,7 +28,7 @@ cffi==2.0.0
 charset-normalizer==3.4.4
 click==8.3.0
 colorlog==6.10.1
-cryptography==46.0.6
+cryptography==46.0.7
 deap==1.4.3
 exchange-calendars==4.11.1
 extra-streamlit-components==0.1.81


### PR DESCRIPTION
## Summary
Closes the single open Dependabot advisory on main:
- **GHSA-p423-j2cm-9vmq** (moderate) — Cryptography buffer overflow with non-contiguous buffers. Vulnerable `>= 45.0.0, < 46.0.7`; current pin `46.0.6`; fix in `46.0.7+`.

## Changes
Bumps floor in the three source-of-truth manifests + regenerated SBOM row:
- \`pyproject.toml\`
- \`requirements.txt\`
- \`requirements-scan.txt\`
- \`sbom/combined-requirements.txt\` (pin updated to match)

## Risk
Minor point-release. No API change on cipher/hash/x509 paths we use.

## Test plan
- [ ] CI green (python-quality + fast/heavy tests)
- [ ] Dependabot rescan closes GHSA-p423-j2cm-9vmq on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)