### PR TITLE
deps(security): pin pillow >= 12.2.0 (GHSA-whj4-6x5x-4v2j)

### DIFF
--- a/constraints/security.txt
+++ b/constraints/security.txt
@@ -90,3 +90,12 @@ fastapi>=0.119.0,<1.0.0
 # Brotli: Compression algorithm support, required for secure decompression
 # Version 1.2.0+ required for urllib3 2.6.0 security fixes
 Brotli>=1.2.0
+
+# ============================================================================
+# Image processing - Memory-safety critical (transitive)
+# ============================================================================
+# pillow: GHSA-whj4-6x5x-4v2j — FITS GZIP decompression bomb
+# Vulnerable: >= 10.3.0, < 12.2.0. Pillow enters the install tree via
+# scientific/ML extras (e.g. torchvision-adjacent paths). Pin the floor
+# here so transitive resolution cannot regress below the fix line.
+pillow>=12.2.0

--- a/sbom/combined-requirements.txt
+++ b/sbom/combined-requirements.txt
@@ -92,7 +92,7 @@ optuna==3.6.2
 packaging==25.0
 pandas==3.0.2
 pandera==0.26.1
-pillow==12.1.1
+pillow==12.2.0
 prometheus-client==0.25.0
 propcache==0.4.1
 protobuf==6.33.5


### PR DESCRIPTION
## Summary
Closes GeoSync's one remaining open Dependabot advisory:
- **GHSA-whj4-6x5x-4v2j** (high) — Pillow FITS GZIP decompression bomb. Vulnerable `>= 10.3.0, < 12.2.0`; SBOM recorded `12.1.1`; fix in `12.2.0+`.

## Why a constraint pin, not a direct dep bump
Pillow is pure transitive here — not in \`requirements.txt\` / \`pyproject.toml\`. It enters the tree via ML/scientific extras. Following the existing pattern in \`constraints/security.txt\` (cryptography, PyJWT, starlette, etc.) we pin the floor there so any resolution of the tree cannot fall below the fix.

## Changes
- \`constraints/security.txt\` — add \`pillow>=12.2.0\` under a new "Image processing" section with GHSA rationale.
- \`sbom/combined-requirements.txt\` — refresh the pillow row from \`12.1.1\` → \`12.2.0\` so SBOM stays consistent with the new constraint.

## Risk
Pillow 12.1 → 12.2 is a minor patch across standard codec paths.

## Test plan
- [ ] python-quality + fast/heavy tests green
- [ ] Dependabot rescan closes GHSA-whj4-6x5x-4v2j on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)