### PR TITLE
deps(security): align lock files with pillow >= 12.2.0 (GHSA-whj4-6x5x-4v2j)

### DIFF
--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -395,7 +395,7 @@ pathspec==1.0.0
     # via
     #   black
     #   mypy
-pillow==12.1.1
+pillow==12.2.0
     # via
     #   captcha
     #   streamlit

--- a/requirements-scan.lock
+++ b/requirements-scan.lock
@@ -75,7 +75,7 @@ optuna==3.6.2
 packaging==25.0
 pandas==2.3.3
 pandera==0.26.1
-pillow==12.1.1
+pillow==12.2.0
 prometheus-client==0.23.1
 propcache==0.4.1
 protobuf==6.33.5

--- a/requirements.lock
+++ b/requirements.lock
@@ -285,7 +285,7 @@ pandera==0.26.1
     # via
     #   -c constraints/security.txt
     #   geosync (pyproject.toml)
-pillow==12.1.1
+pillow==12.2.0
     # via
     #   captcha
     #   streamlit


### PR DESCRIPTION
## Summary

Follow-up to [`da5b55a86`](https://github.com/neuron7xLab/GeoSync/commit/da5b55a86) — that commit pinned `pillow >= 12.2.0` in `constraints/security.txt` and refreshed `sbom/combined-requirements.txt`, but the three pip-tools lock files were not regenerated and still held `pillow==12.1.1`.

CI now fails at the **Setup Python environment** step of every job that resolves against both the lock and the constraint:

```
ERROR: Cannot install pillow==12.1.1 because these package versions have conflicting dependencies.
    The user requested pillow==12.1.1
    The user requested (constraint) pillow>=12.2.0
ERROR: ResolutionImpossible
```

Each open PR that hits that step is blocked. Verified on PR #230 (dependabot python-multipart bump):
- `python-quality` — [job/71537241656](https://github.com/neuron7xLab/GeoSync/actions/runs/24478599121/job/71537241656?pr=230)
- `secrets-supply-chain` — [job/71537241640](https://github.com/neuron7xLab/GeoSync/actions/runs/24478599121/job/71537241640?pr=230)

## Change

Minimal, surgical edit of three lines across three files — align pip-tools locks with the security constraint floor already enforced elsewhere:

| File                     | Before            | After             |
| ------------------------ | ----------------- | ----------------- |
| `requirements.lock`      | `pillow==12.1.1`  | `pillow==12.2.0`  |
| `requirements-dev.lock`  | `pillow==12.1.1`  | `pillow==12.2.0`  |
| `requirements-scan.lock` | `pillow==12.1.1`  | `pillow==12.2.0`  |

`constraints/security.txt` and `sbom/combined-requirements.txt` are already on `>= 12.2.0` / `==12.2.0` since `da5b55a86`.

Not regenerating the lock files via `pip-compile` in this PR so the change stays easy to audit; a full lock refresh can be a separate tidy-up.

## Security context

[GHSA-whj4-6x5x-4v2j](https://github.com/advisories/GHSA-whj4-6x5x-4v2j) — FITS GZIP decompression bomb in Pillow, high severity, vulnerable range `>= 10.3.0, < 12.2.0`. Unchanged from `da5b55a86` — this PR only propagates the already-decided pin into the lock files so the resolver can succeed.

## Test plan

- [ ] PR Gate job `python-quality` passes Setup Python environment
- [ ] PR Gate job `secrets-supply-chain` passes Setup Python environment
- [ ] Downstream jobs (`python-fast-tests`, `python-heavy-tests`) are unblocked
- [ ] After merge: re-run PR #230 and other open PRs; Setup Python environment no longer errors