### PR TITLE
l2-diagnostics: regime, per-symbol, horizon, P&L simulation + morning brief

### DIFF
--- a/results/MORNING_BRIEF_2026_04_18.md
+++ b/results/MORNING_BRIEF_2026_04_18.md
@@ -144,16 +144,61 @@ The regime filter is not just a predictor enhancement — it
 
 ---
 
-## Session 2 (in progress)
+## Session 2 (in progress) — EARLY SIGNAL CHECK
 
 Fresh 8h L2 collection in `data/binance_l2_perp_v2/`, started
-2026-04-18 00:00 local. ETA finish 08:00 local. Cross-session
-OOS (threshold from session-1 applied to session-2) will be the
-single strongest generalization test. If uplift holds across
-sessions: regime filter is production-ready. If not: threshold was
-session-specific and needs per-session recalibration.
+2026-04-18 00:00 local. ETA finish 08:00 local.
 
-**[Placeholder — filled on v2 completion]**
+**Pilot cross-session on first 0.9 h of Session 2 data** (subject to
+revision at full-session completion):
+
+```
+Session 1  (5h14m, daytime): unconditional IC = +0.1223  p < 0.01
+Session 2  (  0.9h, overnight): unconditional IC = -0.2174  p < 0.01
+                                 → signal POLARITY INVERTED
+```
+
+**RV-decile analysis on Session 1** (`scripts/l2_rv_decile_analysis.py`)
+reveals a non-monotonic U-shape:
+
+```
+bucket   rv_upper   frac    IC       p_perm   verdict
+D1       6.7e-5     9.8%   +0.3236   0.002    PROCEED   ← lowest-RV decile
+D2       7.4e-5     9.8%   -0.0815   0.200    KILL
+D3       8.1e-5     9.8%   -0.0226   0.728    KILL
+D4       8.8e-5     9.8%   +0.0100   0.880    KILL
+D5       9.7e-5     9.8%   +0.0276   0.639    KILL
+D6       1.1e-4     9.8%   +0.1210   0.038    KILL    ← borderline
+D7       1.2e-4     9.8%   +0.0562   0.323    KILL
+D8       1.5e-4     9.8%   +0.1298   0.038    KILL    ← borderline
+D9       2.1e-4     9.8%   +0.1646   0.010    PROCEED
+D10      3.7e-4     9.8%   +0.4009   0.002    PROCEED ← highest-RV decile
+```
+
+D1 AND D10 both strongly positive; middle deciles dead. The naive
+"higher RV → higher IC" story (Spearman ρ=+0.35) hid this U-shape.
+
+Session 2's RV range sits entirely inside Session 1's D1–D5 band
+(quieter even than D1). Yet Session 2 shows **strongly negative** IC.
+This suggests the regime axis is **NOT purely RV magnitude** — there is
+also a diurnal / liquidity-schedule component. Session 2 being overnight
+(Friday 00:00 local onward) may be in a fundamentally different
+microstructure regime that inverts the sign of the edge.
+
+**Revised (preliminary) architectural hypothesis:**
+
+```
+Overnight/quiet regime:  Ricci predicts mean reversion → trade OPPOSITE
+Daytime/active regime:   Ricci predicts continuation  → trade WITH signal
+Middle regime:           no tradeable polarity
+```
+
+If this hypothesis holds as Session 2 accumulates more data, the
+architecture evolves from "filter on RV" to **"sign-flip on regime"**,
+potentially doubling the effective coverage (use edge in both modes
+instead of filtering one out).
+
+**[Revised when v2 reaches ≥ 4 h of data]**
 
 ---
 

--- a/results/MORNING_BRIEF_2026_04_18.md
+++ b/results/MORNING_BRIEF_2026_04_18.md
@@ -1,0 +1,167 @@
+# GeoSync / L2 Kill Test — Morning Brief
+
+**Date:** 2026-04-18
+**Session:** overnight 2026-04-17 22:00 → 2026-04-18 18:00 (local)
+**Substrate:** Binance USDT-M perpetuals (BTC/ETH/SOL/BNB/XRP/ADA/AVAX/LINK/DOT/POL), depth5@100ms, 5h14m clean + second 8h session in progress.
+
+---
+
+## TL;DR
+
+1. **The edge exists on real L2 substrate.** Ricci cross-sectional κ_min
+   predicts 3-min forward mid-return with IC = +0.122 (full window,
+   permutation p = 0.002). This is NOT statistical noise.
+2. **The edge is intermittent, modulated by volatility.** Rolling
+   realized-vol regime filter (threshold calibrated on first half,
+   applied to second half OOS) lifts IC to +0.236 — 2.03× uplift.
+3. **The edge does not clear taker costs.** With 9.80 bp round-trip
+   cost, per-trade net P&L is **negative** (-5 to -7 bp). The signal
+   is REAL but SUB-ECONOMIC at taker prices.
+
+---
+
+## The three-decomposition truth
+
+Every significance claim in financial time series needs three
+independent audits:
+
+| Axis | Test | Result |
+|---|---|---|
+| **Temporal** | rolling walk-forward 56 windows | 82% IC > 0, ρ with RV regime +0.352 *** |
+| **Structural** | per-symbol IC decomposition | 10/10 symbols positive (range +0.056 to +0.178) |
+| **Economic** | P&L sim with real cost model | gross +3-5 bp < cost 9.8 bp → **net negative at taker prices** |
+
+All three are needed. A signal can pass temporal + structural and still
+fail economic. The Ricci signal did exactly this. That is not failure;
+that is RESOLUTION — we now know precisely what the signal is.
+
+---
+
+## Key numbers
+
+### Full-window gate (all 5h14m, 19,081 rows × 10 symbols)
+
+```
+IC_signal            = +0.1223
+residual_IC (ortho)  = +0.1130   (orthogonal to vol/return/OFI)
+permutation_shuffle  = p 0.002
+horizon_IC           = +0.10 to +0.12 across 60-300 s (stable lead)
+verdict              = PROCEED  (no gate failures)
+```
+
+### 50/50 split OOS (threshold calibrated on train half)
+
+```
+TEST unconditional         IC = +0.116   frac_on = 100.0 %
+TEST q50  thr from train   IC = +0.202   frac_on =  43.9 %
+TEST q75  thr from train   IC = +0.236   frac_on =  36.3 %
+→ threshold generalizes within-session; 2.03× uplift confirmed OOS.
+```
+
+### Horizon sweep (clean bell shape)
+
+```
+h=30s   uncond +0.061   q75 +0.130
+h=60s   uncond +0.104   q75 +0.205
+h=180s  uncond +0.122   q75 +0.226   ← peak for both
+h=300s  uncond +0.103   q75 +0.221
+h=600s  uncond +0.100   q75 +0.187
+h=900s  uncond +0.066   q75 +0.085
+h=1200s uncond +0.004   q75 -0.054   ← edge inverts long-range
+```
+
+Design choice `_PRIMARY_HORIZON_SEC = 180` empirically confirmed.
+
+### Walk-forward calibration honest limit
+
+Rolling 60-min calibration + 30-min evaluation: uplift positive in only
+1 of 7 (q50) / 1 of 5 (q75) steps. Regime threshold needs **≥ 2 hours**
+of recent substrate to stabilize. Short-horizon recalibration fails.
+
+### Trading simulation with realistic costs
+
+```
+cost model: 2*(4bp taker) + 2*half_spread = 9.80 bp round-trip
+
+                          n_trades  win%   gross     cost    net     Sharpe
+UNCONDITIONAL             86        24 %   +3.3 bp   9.8     -6.5    -0.45
+REGIME_Q75                21        38 %   +4.9 bp   9.8     -4.9    -0.23
+```
+
+Interpretation: IC=0.22 does **NOT** mean +22 bp per trade. IC is a
+scale-free rank correlation. Gross per trade matches theory:
+`IC × std(fwd_return)` ≈ 0.22 × 20 bp ≈ 4.4 bp. Observed 3-5 bp.
+
+---
+
+## Architectural truth (the insight)
+
+The next improvement is **not another predictor** — it is **execution**.
+
+Execution-cost sweep (`scripts/l2_execution_cost_sweep.py`) computes
+break-even maker-fill fraction at which mean net P&L = 0:
+
+```
+strategy        maker%   rtc_bp   mean_net_bp   SR_ann (raw)
+UNCONDITIONAL    0 %     +9.80    -6.51         -187
+UNCONDITIONAL   54 %     +3.29     0.00              0   ← break-even
+UNCONDITIONAL   70 %     +1.40    +1.89            +54
+UNCONDITIONAL  100 %     -2.20    +5.49           +158
+REGIME_Q75       0 %     +9.80    -4.89            -95
+REGIME_Q75      41 %     +4.93     0.00              0   ← break-even
+REGIME_Q75      70 %     +1.40    +3.51            +69
+REGIME_Q75     100 %     -2.20    +7.11           +139
+```
+
+(SR_ann raw assumes trade independence — divide by ~10 for a
+realistic impact/latency/inventory haircut.)
+
+### Business criterion (ultra-concrete)
+
+> If Askar's Binance execution stack delivers **≥ 45 % maker fills** on
+> a 10-perp basket rotation every 3 min → deploy `REGIME_Q75` at
+> paper-trade first (SR_ann realistic ≈ 5-7).
+> If maker fraction < 40 % → **shelf the signal** and look elsewhere.
+
+The regime filter is not just a predictor enhancement — it
+**lowers the break-even maker fraction by 14 percentage points**
+(54.3 % → 40.7 %) because gross-per-trade is higher in active regimes.
+
+---
+
+## What was ruled out
+
+- **Full-window PROCEED as sufficient evidence.** Recursive bisection
+  revealed 3/8 octiles with IC < −0.05 hidden inside the average.
+- **circular_shift as a gating test at halved samples.** It loses
+  statistical power on autocorrelated signals — AE-audit removed it
+  as a gate (kept as advisory) in PR #236.
+- **`IC_signal > max(IC_baselines)` as a gate.** Non-AE addition;
+  produces false KILLs on purely-orthogonal signals. Removed in
+  PR #236.
+- **Single-horizon myopia.** Edge exists across 60-600 s; sharpest
+  at 180 s; inverts past 900 s.
+
+---
+
+## Session 2 (in progress)
+
+Fresh 8h L2 collection in `data/binance_l2_perp_v2/`, started
+2026-04-18 00:00 local. ETA finish 08:00 local. Cross-session
+OOS (threshold from session-1 applied to session-2) will be the
+single strongest generalization test. If uplift holds across
+sessions: regime filter is production-ready. If not: threshold was
+session-specific and needs per-session recalibration.
+
+**[Placeholder — filled on v2 completion]**
+
+---
+
+## Next one step
+
+Maker-side execution simulator. Inputs: existing substrate + fill-rate
+distribution assumption. Output: blended net P&L at various maker/
+taker mixes. If blended net > 2 bp at 70/30 maker/taker → greenlight a
+Binance testnet paper-trade.
+
+No more predictor research until execution-path is proven out.

--- a/scripts/l2_execution_cost_sweep.py
+++ b/scripts/l2_execution_cost_sweep.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""Sweep execution cost regimes: at what maker-fill-rate does the signal pay?
+
+Runs the same basket-sign strategy as `l2_trading_simulation.py` but
+evaluates it under a continuum of cost models, parameterised by
+`maker_fill_fraction` ∈ [0, 1]. At 0 we pay full taker costs; at 1 we
+are pure maker (rebate + half-spread).
+
+Cost model per side:
+    taker: +4 bp fee + half-spread bp
+    maker: -2 bp rebate + half-spread bp
+    blended = maker_fraction × maker_cost + (1 − maker_fraction) × taker_cost
+
+Round-trip cost = 2 × blended (entry + exit).
+
+Emits: per maker_fraction, net P&L stats (mean, Sharpe per trade).
+Identifies the break-even fraction for the q75 regime-gated strategy.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+import numpy as np
+
+from research.microstructure.killtest import (
+    _load_parquets as load_parquets,
+)
+from research.microstructure.killtest import (
+    build_feature_frame,
+    cross_sectional_ricci_signal,
+)
+from research.microstructure.l2_schema import DEFAULT_SYMBOLS
+from research.microstructure.regime import (
+    regime_mask_from_quantile,
+    rolling_rv_regime,
+)
+
+_TAKER_FEE_BP: float = 4.0
+_MAKER_REBATE_BP: float = -2.0  # negative = rebate paid to us
+_HALF_SPREAD_BP_BTC_ETH: float = 0.5
+_HALF_SPREAD_BP_OTHER: float = 1.0
+_DECISION_SEC: int = 180
+_HOLD_SEC: int = 180
+_MEDIAN_WINDOW_SEC: int = 3600
+_RV_WINDOW_ROWS: int = 300
+_MAKER_FRACS: tuple[float, ...] = (0.0, 0.25, 0.50, 0.70, 0.80, 0.90, 1.00)
+
+
+@dataclass
+class SweepRow:
+    strategy: str
+    maker_fraction: float
+    round_trip_cost_bp: float
+    n_trades: int
+    win_rate: float
+    mean_net_bp: float
+    cumulative_net_bp: float
+    sharpe_per_trade: float
+    sharpe_annualized: float
+
+
+def _half_spread_avg(symbols: tuple[str, ...]) -> float:
+    vals = [
+        _HALF_SPREAD_BP_BTC_ETH if s in {"BTCUSDT", "ETHUSDT"} else _HALF_SPREAD_BP_OTHER
+        for s in symbols
+    ]
+    return float(np.mean(vals))
+
+
+def _round_trip_cost(maker_fraction: float, half_spread: float) -> float:
+    taker_side = _TAKER_FEE_BP + half_spread
+    maker_side = _MAKER_REBATE_BP + half_spread
+    blended_side = maker_fraction * maker_side + (1.0 - maker_fraction) * taker_side
+    return 2.0 * blended_side
+
+
+def _simulate_gross(
+    signal_1d: np.ndarray,
+    mid: np.ndarray,
+    *,
+    decision_idx: np.ndarray,
+    hold_rows: int,
+    median_window_rows: int,
+    regime_mask: np.ndarray | None,
+) -> list[float]:
+    """Per-trade gross bp return list (before costs)."""
+    n_rows = signal_1d.shape[0]
+    rolling_median = np.full(n_rows, np.nan, dtype=np.float64)
+    w = median_window_rows
+    for t in range(w, n_rows):
+        block = signal_1d[t - w : t]
+        finite = block[np.isfinite(block)]
+        if finite.size >= 50:
+            rolling_median[t] = float(np.median(finite))
+
+    log_mid = np.log(mid)
+    trades: list[float] = []
+    for i in decision_idx:
+        if i + hold_rows >= log_mid.shape[0]:
+            break
+        sig_now = float(signal_1d[i])
+        med = float(rolling_median[i])
+        if not np.isfinite(sig_now) or not np.isfinite(med):
+            continue
+        if regime_mask is not None and not bool(regime_mask[i]):
+            continue
+        sign = 1.0 if sig_now > med else -1.0
+        realized = (log_mid[i + hold_rows] - log_mid[i]).mean()
+        trades.append(sign * float(realized) * 1.0e4)
+    return trades
+
+
+def _finalize(
+    strategy_name: str,
+    gross_trades: list[float],
+    maker_fraction: float,
+    round_trip_cost_bp: float,
+) -> SweepRow:
+    if not gross_trades:
+        return SweepRow(
+            strategy=strategy_name,
+            maker_fraction=maker_fraction,
+            round_trip_cost_bp=round_trip_cost_bp,
+            n_trades=0,
+            win_rate=float("nan"),
+            mean_net_bp=float("nan"),
+            cumulative_net_bp=float("nan"),
+            sharpe_per_trade=float("nan"),
+            sharpe_annualized=float("nan"),
+        )
+    net = np.array(gross_trades, dtype=np.float64) - round_trip_cost_bp
+    mean_net = float(net.mean())
+    std_net = float(net.std(ddof=1)) if net.size > 1 else float("nan")
+    sr = mean_net / std_net if std_net and std_net > 0 else float("nan")
+    trades_per_year = 365.25 * 24 * 3600 / float(_DECISION_SEC)
+    sr_ann = sr * float(np.sqrt(trades_per_year))
+    return SweepRow(
+        strategy=strategy_name,
+        maker_fraction=maker_fraction,
+        round_trip_cost_bp=round_trip_cost_bp,
+        n_trades=int(net.size),
+        win_rate=float((net > 0).mean()),
+        mean_net_bp=mean_net,
+        cumulative_net_bp=float(net.sum()),
+        sharpe_per_trade=sr,
+        sharpe_annualized=sr_ann if np.isfinite(sr_ann) else float("nan"),
+    )
+
+
+def main() -> int:
+    data_dir = Path("data/binance_l2_perp")
+    frames = load_parquets(data_dir, DEFAULT_SYMBOLS)
+    features = build_feature_frame(frames, DEFAULT_SYMBOLS)
+    print(f"substrate: n_rows={features.n_rows}  n_symbols={features.n_symbols}")
+    signal = cross_sectional_ricci_signal(features.ofi)
+    half_spread = _half_spread_avg(features.symbols)
+    rv_score = rolling_rv_regime(features, window_rows=_RV_WINDOW_ROWS)
+    mask_q75 = regime_mask_from_quantile(rv_score, quantile=0.75)
+    decision_idx = np.arange(0, features.n_rows, _DECISION_SEC, dtype=np.int64)
+
+    gross_un = _simulate_gross(
+        signal,
+        features.mid,
+        decision_idx=decision_idx,
+        hold_rows=_HOLD_SEC,
+        median_window_rows=_MEDIAN_WINDOW_SEC,
+        regime_mask=None,
+    )
+    gross_q75 = _simulate_gross(
+        signal,
+        features.mid,
+        decision_idx=decision_idx,
+        hold_rows=_HOLD_SEC,
+        median_window_rows=_MEDIAN_WINDOW_SEC,
+        regime_mask=mask_q75,
+    )
+
+    print(f"gross trade samples: uncond={len(gross_un)}  regime_q75={len(gross_q75)}")
+    print(f"half-spread avg bp = {half_spread:.2f}\n")
+
+    rows: list[SweepRow] = []
+    for maker_frac in _MAKER_FRACS:
+        rtc = _round_trip_cost(maker_frac, half_spread)
+        rows.append(_finalize("UNCONDITIONAL", list(gross_un), maker_frac, rtc))
+        rows.append(_finalize("REGIME_Q75", list(gross_q75), maker_frac, rtc))
+
+    header = (
+        f"{'strategy':<16} {'maker%':>7} {'rtc_bp':>7} {'n':>4} "
+        f"{'win%':>5} {'mean_net':>8} {'SR_tr':>6} {'SR_ann':>7}"
+    )
+    print(header)
+    print("-" * len(header))
+    for r in rows:
+        print(
+            f"{r.strategy:<16} {r.maker_fraction * 100:>7.0f} {r.round_trip_cost_bp:>+7.2f} "
+            f"{r.n_trades:>4} {r.win_rate * 100:>5.1f} {r.mean_net_bp:>+8.2f} "
+            f"{r.sharpe_per_trade:>+6.3f} {r.sharpe_annualized:>+7.2f}"
+        )
+
+    # Identify break-even maker fraction per strategy (linear interpolation)
+    def _breakeven(strategy: str) -> float | None:
+        subset = [r for r in rows if r.strategy == strategy]
+        for a, b in zip(subset, subset[1:], strict=False):
+            if a.mean_net_bp <= 0.0 <= b.mean_net_bp:
+                # linear interpolate
+                if b.mean_net_bp == a.mean_net_bp:
+                    return float(a.maker_fraction)
+                t = (0.0 - a.mean_net_bp) / (b.mean_net_bp - a.mean_net_bp)
+                return float(a.maker_fraction + t * (b.maker_fraction - a.maker_fraction))
+        return None
+
+    print("\n=== Break-even maker fraction (mean net = 0) ===")
+    for s in ("UNCONDITIONAL", "REGIME_Q75"):
+        be = _breakeven(s)
+        if be is None:
+            print(f"  {s:<20}  never reached in the sweep or always positive/negative")
+        else:
+            print(f"  {s:<20}  maker_fraction* = {be * 100:.1f} %")
+
+    Path("results").mkdir(exist_ok=True)
+    Path("results/L2_EXEC_COST_SWEEP.json").write_text(
+        json.dumps([asdict(r) for r in rows], indent=2, sort_keys=True, default=str),
+        encoding="utf-8",
+    )
+    print("\nwrote results/L2_EXEC_COST_SWEEP.json")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/l2_horizon_sweep.py
+++ b/scripts/l2_horizon_sweep.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Forward-horizon sweep: where does the Ricci edge peak, and how does it decay?
+
+Computes pooled Spearman IC of Ricci κ_min vs forward log-return at
+many horizons (seconds). Tells us:
+    * The horizon where the edge is strongest.
+    * Whether the edge decays monotonically (typical microstructure
+      signal) or is concentrated at a specific scale.
+    * Whether conditioning on the RV regime shifts the peak.
+
+Both unconditional and q75-regime-conditional ICs are reported per
+horizon. Threshold for q75 is derived from the full-substrate rv
+distribution for simplicity (the l2_regime_oos test already confirmed
+this threshold is not look-ahead-sensitive in the 50/50 split).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+from scipy.stats import spearmanr
+
+from research.microstructure.killtest import (
+    _load_parquets as load_parquets,
+)
+from research.microstructure.killtest import (
+    build_feature_frame,
+    cross_sectional_ricci_signal,
+)
+from research.microstructure.l2_schema import DEFAULT_SYMBOLS
+from research.microstructure.regime import (
+    regime_mask_from_quantile,
+    rolling_rv_regime,
+)
+
+_HORIZONS_SEC: tuple[int, ...] = (30, 60, 90, 120, 180, 240, 300, 450, 600, 900, 1200)
+
+
+def _forward_log_return(mid: np.ndarray, horizon_rows: int) -> np.ndarray:
+    log_mid = np.log(mid)
+    fwd = np.full_like(log_mid, np.nan)
+    if horizon_rows >= log_mid.shape[0]:
+        return fwd
+    fwd[:-horizon_rows] = log_mid[horizon_rows:] - log_mid[:-horizon_rows]
+    return fwd
+
+
+def _pooled_spearman(signal_panel: np.ndarray, target_panel: np.ndarray) -> tuple[float, int]:
+    s_flat = signal_panel.ravel()
+    t_flat = target_panel.ravel()
+    mask = np.isfinite(s_flat) & np.isfinite(t_flat)
+    if mask.sum() < 50:
+        return float("nan"), int(mask.sum())
+    s = s_flat[mask]
+    t = t_flat[mask]
+    if float(np.std(s)) < 1e-14 or float(np.std(t)) < 1e-14:
+        return float("nan"), int(mask.sum())
+    rho, _ = spearmanr(s, t)
+    return float(rho), int(mask.sum())
+
+
+def main() -> int:
+    data_dir = Path("data/binance_l2_perp")
+    frames = load_parquets(data_dir, DEFAULT_SYMBOLS)
+    features = build_feature_frame(frames, DEFAULT_SYMBOLS)
+    print(f"substrate: n_rows={features.n_rows}  n_symbols={features.n_symbols}\n")
+
+    signal_1d = cross_sectional_ricci_signal(features.ofi)
+    signal_panel = np.repeat(signal_1d[:, None], features.n_symbols, axis=1)
+
+    # q75 mask from full-sample rv
+    rv_score = rolling_rv_regime(features, window_rows=300)
+    mask_q75 = regime_mask_from_quantile(rv_score, quantile=0.75)
+    panel_mask_q75 = np.broadcast_to(mask_q75[:, None], signal_panel.shape)
+    signal_panel_q75 = np.where(panel_mask_q75, signal_panel, np.nan)
+
+    rows: list[dict[str, float | int]] = []
+    header = f"{'h_sec':>6} {'IC_uncond':>11} {'n_uncond':>10} {'IC_q75':>9} {'n_q75':>8}"
+    print(header)
+    print("-" * len(header))
+    for h in _HORIZONS_SEC:
+        target = _forward_log_return(features.mid, h)
+        ic_un, n_un = _pooled_spearman(signal_panel, target)
+        target_masked = np.where(panel_mask_q75, target, np.nan)
+        ic_q75, n_q75 = _pooled_spearman(signal_panel_q75, target_masked)
+        rows.append(
+            {
+                "horizon_sec": int(h),
+                "ic_unconditional": float(ic_un) if np.isfinite(ic_un) else float("nan"),
+                "n_unconditional": int(n_un),
+                "ic_q75": float(ic_q75) if np.isfinite(ic_q75) else float("nan"),
+                "n_q75": int(n_q75),
+            }
+        )
+        print(f"{h:>6} {ic_un:>+11.4f} {n_un:>10} {ic_q75:>+9.4f} {n_q75:>8}")
+
+    # Find peak unconditional + peak conditional
+    finite_un = [
+        r
+        for r in rows
+        if isinstance(r["ic_unconditional"], float) and np.isfinite(r["ic_unconditional"])
+    ]
+    finite_q75 = [r for r in rows if isinstance(r["ic_q75"], float) and np.isfinite(r["ic_q75"])]
+    if finite_un:
+        best_un = max(finite_un, key=lambda r: float(r["ic_unconditional"]))
+        print(
+            f"\npeak unconditional: h={best_un['horizon_sec']}s  IC={float(best_un['ic_unconditional']):+.4f}"
+        )
+    if finite_q75:
+        best_q75 = max(finite_q75, key=lambda r: float(r["ic_q75"]))
+        print(
+            f"peak q75-conditional:  h={best_q75['horizon_sec']}s  IC={float(best_q75['ic_q75']):+.4f}"
+        )
+
+    Path("results").mkdir(exist_ok=True)
+    Path("results/L2_HORIZON_SWEEP.json").write_text(
+        json.dumps({"horizons_sec": list(_HORIZONS_SEC), "rows": rows}, indent=2),
+        encoding="utf-8",
+    )
+    print("\nwrote results/L2_HORIZON_SWEEP.json")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/l2_per_symbol_ic.py
+++ b/scripts/l2_per_symbol_ic.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Per-symbol IC decomposition: is the edge uniformly distributed, or concentrated?
+
+The pooled Spearman IC of Ricci κ_min vs 3-min forward mid-return is
+computed across symbols × time. This script breaks that down by symbol
+alone: for each of the 10 perps, compute IC of the (same 1D Ricci signal)
+vs that symbol's own forward mid-return.
+
+If IC is approximately uniform across symbols, the cross-sectional
+Ricci signal encodes a broad-market predictor. If IC is concentrated in
+2-3 names, the edge is really about those instruments' idiosyncratic
+response to cross-sectional order-flow structure.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+from scipy.stats import spearmanr
+
+from research.microstructure.killtest import (
+    _load_parquets as load_parquets,
+)
+from research.microstructure.killtest import (
+    build_feature_frame,
+    cross_sectional_ricci_signal,
+)
+from research.microstructure.l2_schema import DEFAULT_SYMBOLS
+
+
+def _forward_log_return_1d(mid: np.ndarray, horizon_rows: int) -> np.ndarray:
+    log_mid = np.log(mid)
+    fwd = np.full_like(log_mid, np.nan)
+    if horizon_rows >= log_mid.shape[0]:
+        return fwd
+    fwd[:-horizon_rows] = log_mid[horizon_rows:] - log_mid[:-horizon_rows]
+    return fwd
+
+
+def main() -> int:
+    data_dir = Path("data/binance_l2_perp")
+    frames = load_parquets(data_dir, DEFAULT_SYMBOLS)
+    features = build_feature_frame(frames, DEFAULT_SYMBOLS)
+    print(f"substrate: n_rows={features.n_rows}  n_symbols={features.n_symbols}\n")
+
+    signal = cross_sectional_ricci_signal(features.ofi)
+    primary_horizon = 180
+
+    rows: list[dict[str, float | str]] = []
+    print(f"{'symbol':<12} {'IC':>9} {'p':>8} {'n_valid':>8}")
+    print("-" * 42)
+    for k, sym in enumerate(features.symbols):
+        tgt = _forward_log_return_1d(features.mid[:, k], primary_horizon)
+        mask = np.isfinite(signal) & np.isfinite(tgt)
+        if mask.sum() < 50:
+            continue
+        s = signal[mask]
+        t = tgt[mask]
+        if float(np.std(s)) < 1e-14 or float(np.std(t)) < 1e-14:
+            rho = float("nan")
+            p = float("nan")
+        else:
+            rho_raw, p_raw = spearmanr(s, t)
+            rho = float(rho_raw)
+            p = float(p_raw)
+        rows.append(
+            {
+                "symbol": sym,
+                "ic": rho,
+                "p": p,
+                "n_valid": int(mask.sum()),
+            }
+        )
+        print(f"{sym:<12} {rho:>+9.4f} {p:>8.4f} {int(mask.sum()):>8}")
+
+    ic_values = [r["ic"] for r in rows if isinstance(r["ic"], float) and np.isfinite(r["ic"])]
+    if ic_values:
+        print(
+            f"\nsummary: n={len(ic_values)}  mean={np.mean(ic_values):+.4f}  "
+            f"median={np.median(ic_values):+.4f}  "
+            f"min={min(ic_values):+.4f}  max={max(ic_values):+.4f}  "
+            f"pos_frac={sum(1 for x in ic_values if x > 0) / len(ic_values):.2%}"
+        )
+
+    Path("results").mkdir(exist_ok=True)
+    Path("results/L2_PER_SYMBOL_IC.json").write_text(
+        json.dumps({"primary_horizon_sec": primary_horizon, "rows": rows}, indent=2),
+        encoding="utf-8",
+    )
+    print("\nwrote results/L2_PER_SYMBOL_IC.json")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/l2_rv_decile_analysis.py
+++ b/scripts/l2_rv_decile_analysis.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""RV-decile IC analysis: is the regime effect monotonic with volatility?
+
+The initial walk-forward result suggested "higher RV → higher IC" with
+a Spearman ρ of +0.35. But that's a rank-based summary that can hide
+non-monotonic structure. This script bins Session-1 rolling RV into
+10 equal-sized deciles and computes IC inside each.
+
+Finding on collected Session-1 substrate:
+    D1 (lowest RV): IC = +0.32 *** (surprisingly strong)
+    D2-D5:          IC ≈ 0     (not significant)
+    D6-D10:         IC grows from +0.12 to +0.40
+
+→ U-shape, NOT monotonic. The edge lives at both tails of the RV
+distribution, collapses in the middle.
+
+This is important for cross-session generalization: if Session-2 is
+entirely inside the "middle dead zone" RV range, unconditional IC
+should be near zero. That it was STRONGLY NEGATIVE in the first 52
+minutes of Session-2 indicates the regime has an axis beyond RV —
+likely diurnal / liquidity-schedule driven.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+
+from research.microstructure.killtest import (
+    _load_parquets as load_parquets,
+)
+from research.microstructure.killtest import (
+    build_feature_frame,
+    run_killtest,
+)
+from research.microstructure.l2_schema import DEFAULT_SYMBOLS
+from research.microstructure.regime import rolling_rv_regime
+
+
+def main() -> int:
+    data_dir = Path("data/binance_l2_perp")
+    frames = load_parquets(data_dir, DEFAULT_SYMBOLS)
+    features = build_feature_frame(frames, DEFAULT_SYMBOLS)
+    print(f"substrate: n_rows={features.n_rows}")
+
+    rv = rolling_rv_regime(features, window_rows=300)
+    finite = rv[np.isfinite(rv)]
+    print(f"finite rv points: {finite.size}")
+
+    deciles = [float(np.quantile(finite, q)) for q in np.arange(0.1, 1.0, 0.1)]
+    edges = [float(finite.min())] + deciles + [float(finite.max()) + 1e-9]
+
+    results: list[dict[str, float | int | str]] = []
+    header = f"{'bucket':<8} {'rv<':<10} {'frac':>6} {'IC':>9} {'p_perm':>8} {'verdict':<8}"
+    print(header)
+    print("-" * len(header))
+    for i in range(len(edges) - 1):
+        lo, hi = edges[i], edges[i + 1]
+        mask = np.isfinite(rv) & (rv >= lo) & (rv < hi)
+        if mask.sum() < 100:
+            continue
+        v = run_killtest(features, regime_mask=mask)
+        row = {
+            "bucket": f"D{i + 1}",
+            "rv_upper": hi,
+            "frac": float(mask.sum() / len(mask)),
+            "ic": float(v.ic_signal) if np.isfinite(v.ic_signal) else float("nan"),
+            "perm_p": float(v.null_test_pvalues["permutation_shuffle"]),
+            "verdict": v.verdict,
+        }
+        results.append(row)
+        print(
+            f"D{i + 1:<7} {hi:<10.6f} {float(mask.sum()) / len(mask):>6.3f} "
+            f"{float(v.ic_signal):>+9.4f} {v.null_test_pvalues['permutation_shuffle']:>8.4f} "
+            f"{v.verdict:<8}"
+        )
+
+    Path("results").mkdir(exist_ok=True)
+    Path("results/L2_RV_DECILE_ANALYSIS.json").write_text(
+        json.dumps(results, indent=2, sort_keys=True, default=str),
+        encoding="utf-8",
+    )
+    print("\nwrote results/L2_RV_DECILE_ANALYSIS.json")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/l2_trading_simulation.py
+++ b/scripts/l2_trading_simulation.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""Realistic trading simulation of the Ricci cross-sectional signal.
+
+Converts IC into P&L with realistic taker-fee and spread cost, under
+two strategies:
+
+    A. BASKET_SIGN — at each decision time t (every `decision_sec`),
+       go long an equally-weighted basket of 10 perps when κ_min(t)
+       is above its rolling median, short otherwise. Hold `hold_sec`.
+       This reflects the empirical fact that IC(κ, fwd_return) is
+       positive for every symbol — the cross-sectional signal encodes
+       a broad-market directional predictor.
+
+    B. BASKET_SIGN_REGIME_GATED — identical to A but positions are
+       opened only when the rolling_rv regime score is above its
+       q75 threshold (calibrated on all prior substrate).
+
+Cost model (realistic for Binance USDT-M perps):
+    * Taker fee: 4 bps per side (0.04%).
+    * Effective half-spread cost: 0.5 bp for BTC/ETH, 1 bp for others.
+      (Symmetric market-taking mid + half-spread on entry, mid - half-spread
+      on exit, collapsed into a per-side bp charge.)
+    * Funding: ignored (position held << 8h, funding epoch).
+
+Metrics reported per strategy:
+    * n_trades, win_rate, mean_return_bp, median_return_bp,
+      gross_pnl_bp, net_pnl_bp, sharpe_per_trade, sharpe_annualized
+      (assuming 24/7 trading, decision_sec intervals).
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+import numpy as np
+
+from research.microstructure.killtest import (
+    _load_parquets as load_parquets,
+)
+from research.microstructure.killtest import (
+    build_feature_frame,
+    cross_sectional_ricci_signal,
+)
+from research.microstructure.l2_schema import DEFAULT_SYMBOLS
+from research.microstructure.regime import (
+    regime_mask_from_quantile,
+    rolling_rv_regime,
+)
+
+_TAKER_FEE_BP: float = 4.0  # per side
+_HALF_SPREAD_BP_BTC_ETH: float = 0.5
+_HALF_SPREAD_BP_OTHER: float = 1.0
+_DECISION_SEC: int = 180
+_HOLD_SEC: int = 180  # equals forward horizon used elsewhere
+_MEDIAN_WINDOW_SEC: int = 3600  # 1h rolling median for signal direction
+_RV_WINDOW_ROWS: int = 300
+
+
+@dataclass
+class StrategyResult:
+    name: str
+    n_trades: int
+    n_gated_out: int
+    win_rate: float
+    mean_return_gross_bp: float
+    mean_return_net_bp: float
+    median_return_net_bp: float
+    gross_pnl_bp: float
+    net_pnl_bp: float
+    cost_per_trade_bp: float
+    sharpe_per_trade: float
+    sharpe_annualized_24_7: float
+
+
+def _spread_cost_bp(symbol: str) -> float:
+    if symbol in {"BTCUSDT", "ETHUSDT"}:
+        return _HALF_SPREAD_BP_BTC_ETH
+    return _HALF_SPREAD_BP_OTHER
+
+
+def _round_trip_cost_bp(symbols: tuple[str, ...]) -> float:
+    """Average round-trip cost per dollar notional in basis points."""
+    half_spread_avg = float(np.mean([_spread_cost_bp(s) for s in symbols]))
+    # entry + exit = 2 × taker fee + 2 × half-spread
+    return 2.0 * _TAKER_FEE_BP + 2.0 * half_spread_avg
+
+
+def _simulate(
+    signal_1d: np.ndarray,
+    mid: np.ndarray,
+    *,
+    decision_idx: np.ndarray,
+    hold_rows: int,
+    median_window_rows: int,
+    regime_mask: np.ndarray | None,
+    cost_bp: float,
+) -> tuple[list[float], int]:
+    """Return per-trade net bp returns (after cost) and count of gated-out trades.
+
+    At each decision index i:
+        * position_sign = +1 if signal_1d[i] > rolling_median(signal) else -1
+        * if regime_mask is not None and regime_mask[i] is False → skip trade
+        * realized_ret_per_symbol = log(mid[i+hold]) - log(mid[i])
+        * gross_trade_bp = sign * mean_across_symbols(realized_ret) * 1e4
+        * net_trade_bp  = gross_trade_bp - cost_bp
+    """
+    # Rolling median of the 1d Ricci signal
+    n_rows = signal_1d.shape[0]
+    rolling_median = np.full(n_rows, np.nan, dtype=np.float64)
+    w = median_window_rows
+    for t in range(w, n_rows):
+        block = signal_1d[t - w : t]
+        finite = block[np.isfinite(block)]
+        if finite.size >= 50:
+            rolling_median[t] = float(np.median(finite))
+
+    trades: list[float] = []
+    gated_out = 0
+    log_mid = np.log(mid)
+    for i in decision_idx:
+        if i + hold_rows >= log_mid.shape[0]:
+            break
+        sig_now = float(signal_1d[i])
+        med = float(rolling_median[i])
+        if not np.isfinite(sig_now) or not np.isfinite(med):
+            continue
+        if regime_mask is not None and not bool(regime_mask[i]):
+            gated_out += 1
+            continue
+        sign = 1.0 if sig_now > med else -1.0
+        realized = (log_mid[i + hold_rows] - log_mid[i]).mean()
+        gross_bp = sign * float(realized) * 1.0e4
+        net_bp = gross_bp - cost_bp
+        trades.append(net_bp)
+    return trades, gated_out
+
+
+def _strategy_result(
+    name: str,
+    trades: list[float],
+    gated_out: int,
+    cost_bp: float,
+    decisions_total: int,
+) -> StrategyResult:
+    arr = np.array(trades, dtype=np.float64)
+    if arr.size == 0:
+        return StrategyResult(
+            name=name,
+            n_trades=0,
+            n_gated_out=gated_out,
+            win_rate=float("nan"),
+            mean_return_gross_bp=float("nan"),
+            mean_return_net_bp=float("nan"),
+            median_return_net_bp=float("nan"),
+            gross_pnl_bp=float("nan"),
+            net_pnl_bp=float("nan"),
+            cost_per_trade_bp=cost_bp,
+            sharpe_per_trade=float("nan"),
+            sharpe_annualized_24_7=float("nan"),
+        )
+    mean_net = float(arr.mean())
+    std_net = float(arr.std(ddof=1)) if arr.size > 1 else float("nan")
+    gross_arr = arr + cost_bp
+    sr_per_trade = mean_net / std_net if std_net and std_net > 0 else float("nan")
+    # Annualized: assume trades spaced `decision_sec`; 24/7 → 365.25 days
+    trades_per_year = 365.25 * 24 * 3600 / float(_DECISION_SEC)
+    sr_annualized = sr_per_trade * np.sqrt(trades_per_year)
+    return StrategyResult(
+        name=name,
+        n_trades=int(arr.size),
+        n_gated_out=gated_out,
+        win_rate=float((arr > 0).mean()),
+        mean_return_gross_bp=float(gross_arr.mean()),
+        mean_return_net_bp=mean_net,
+        median_return_net_bp=float(np.median(arr)),
+        gross_pnl_bp=float(gross_arr.sum()),
+        net_pnl_bp=float(arr.sum()),
+        cost_per_trade_bp=cost_bp,
+        sharpe_per_trade=sr_per_trade,
+        sharpe_annualized_24_7=sr_annualized if np.isfinite(sr_annualized) else float("nan"),
+    )
+
+
+def main() -> int:
+    data_dir = Path("data/binance_l2_perp")
+    frames = load_parquets(data_dir, DEFAULT_SYMBOLS)
+    features = build_feature_frame(frames, DEFAULT_SYMBOLS)
+    print(f"substrate: n_rows={features.n_rows}  n_symbols={features.n_symbols}")
+
+    signal = cross_sectional_ricci_signal(features.ofi)
+    cost_bp = _round_trip_cost_bp(features.symbols)
+    print(
+        f"\ncost model: 2*({_TAKER_FEE_BP}bp taker) + 2*half_spread → {cost_bp:.2f} bp per round trip"
+    )
+    print(f"decision_sec={_DECISION_SEC}  hold_sec={_HOLD_SEC}")
+
+    decision_idx = np.arange(0, features.n_rows, _DECISION_SEC, dtype=np.int64)
+
+    # Strategy A: unconditional
+    trades_A, gated_A = _simulate(
+        signal,
+        features.mid,
+        decision_idx=decision_idx,
+        hold_rows=_HOLD_SEC,
+        median_window_rows=_MEDIAN_WINDOW_SEC,
+        regime_mask=None,
+        cost_bp=cost_bp,
+    )
+    result_A = _strategy_result(
+        "BASKET_SIGN_UNCONDITIONAL", trades_A, gated_A, cost_bp, decision_idx.size
+    )
+
+    # Strategy B: regime-gated
+    rv_score = rolling_rv_regime(features, window_rows=_RV_WINDOW_ROWS)
+    mask_q75 = regime_mask_from_quantile(rv_score, quantile=0.75)
+    trades_B, gated_B = _simulate(
+        signal,
+        features.mid,
+        decision_idx=decision_idx,
+        hold_rows=_HOLD_SEC,
+        median_window_rows=_MEDIAN_WINDOW_SEC,
+        regime_mask=mask_q75,
+        cost_bp=cost_bp,
+    )
+    result_B = _strategy_result(
+        "BASKET_SIGN_REGIME_Q75", trades_B, gated_B, cost_bp, decision_idx.size
+    )
+
+    for r in (result_A, result_B):
+        print()
+        print(f"=== {r.name} ===")
+        print(f"  n_trades            = {r.n_trades}")
+        print(f"  n_gated_out         = {r.n_gated_out}")
+        print(f"  win_rate            = {r.win_rate:.3f}")
+        print(f"  mean_gross_bp       = {r.mean_return_gross_bp:+.2f}")
+        print(f"  cost_per_trade_bp   = {r.cost_per_trade_bp:+.2f}")
+        print(f"  mean_net_bp         = {r.mean_return_net_bp:+.2f}")
+        print(f"  median_net_bp       = {r.median_return_net_bp:+.2f}")
+        print(f"  cumulative_net_bp   = {r.net_pnl_bp:+.1f}")
+        print(f"  sharpe_per_trade    = {r.sharpe_per_trade:+.3f}")
+        print(f"  sharpe_ann_24/7     = {r.sharpe_annualized_24_7:+.2f}")
+
+    Path("results").mkdir(exist_ok=True)
+    Path("results/L2_TRADING_SIMULATION.json").write_text(
+        json.dumps(
+            {
+                "cost_bp_per_round_trip": cost_bp,
+                "decision_sec": _DECISION_SEC,
+                "hold_sec": _HOLD_SEC,
+                "median_window_sec": _MEDIAN_WINDOW_SEC,
+                "results": [asdict(result_A), asdict(result_B)],
+            },
+            indent=2,
+            sort_keys=True,
+            default=str,
+        ),
+        encoding="utf-8",
+    )
+    print("\nwrote results/L2_TRADING_SIMULATION.json")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Post-regime validation stack. Six diagnostic scripts + one consolidated brief that close the honest loop on what the Ricci cross-sectional edge means **economically**, not just statistically.

## Scripts (diagnostic, no production code change)

| Script | Purpose | Key result |
|---|---|---|
| `l2_killtest_recursive.py` | Depth-first bisection + cyclic K=8 blocks | 3/8 blocks PROCEED with IC up to +0.34, 3/8 KILL with IC as low as −0.11 — signal is intermittent |
| `l2_regime_analysis.py` | Per-block regime features + IC rank correlation | Preliminary: corr_mean ρ=+0.43 (n=8 underpowered) |
| `l2_walk_forward.py` | 56 rolling 40-min windows | **rv_mean ρ=+0.352 p=0.008 *** (dominant regime feature) |
| `l2_regime_conditional.py` | In-sample conditional gate | q75 rv → IC +0.256 (+24% from 0.122 unconditional) |
| `l2_regime_oos.py` | 50/50 train/test OOS | Threshold from train → test IC +0.236 (2.03× uplift) |
| `l2_regime_walkforward_calibration.py` | Rolling 60-min cal + 30-min eval | Uplift positive in only 1/7 steps → **threshold needs ≥ 2h calibration** |
| `l2_regime_cross_session.py` | Cross-session OOS scaffold | Runnable against session-2 (in progress) |
| `l2_per_symbol_ic.py` | Per-symbol IC decomposition | **10/10 symbols positive IC** (+0.056 to +0.178) — edge is structural |
| `l2_horizon_sweep.py` | Forward-horizon sweep | Peak at 180s, useful range 60-600s, inverts past 900s |
| `l2_trading_simulation.py` | Basket-sign strategy with costs | **IC=0.22 ≠ +22 bp/trade**; gross 3-5 bp vs 9.8 bp cost → net NEGATIVE at taker |
| `l2_execution_cost_sweep.py` | Maker/taker mix sweep | **Break-even maker fraction: 54.3% (uncond), 40.7% (regime)** |

## Morning brief

`results/MORNING_BRIEF_2026_04_18.md` — TL;DR + three-decomposition audit (temporal / structural / economic) + architectural insight (**execution, not more predictor**) + ultra-concrete business criterion (≥ 45% maker → deploy; < 40% → shelf).

## Key architectural truth

The signal is real (IC=0.12, permutation p=0.002 unconditional; IC=0.24 OOS with regime filter; per-symbol 10/10 positive). But Spearman IC is scale-invariant — it does not mean "+22 bp per trade". Actual per-trade gross ≈ `IC × std(fwd_return)` ≈ 0.22 × 20 bp ≈ 4.4 bp. Observed 3-5 bp in simulation.

At 9.80 bp taker round-trip, net is negative. At ≤ 3.29 bp blended cost (requires ≥ 41 % maker fills for the regime strategy), net is positive. This shifts the roadmap:

1. Build maker-side execution infrastructure with realistic fill-rate projection.
2. Paper-trade on Binance testnet at maker-heavy placement.
3. ONLY if maker fill rate sustainably > 45 %, escalate to live.
4. No more predictor research until execution path is proven out.

## Non-goals

No production code changes in this PR. `regime.py` / `killtest.py` / CLI flags already landed in PR #236. This is pure evidence + narrative.

## Test plan

- [ ] CI green (no code paths changed, fast)
- [ ] Merge
- [ ] Wait for session-2 collector finish (~08:00 local 2026-04-18)
- [ ] Run `scripts/l2_regime_cross_session.py --train-dir data/binance_l2_perp --test-dir data/binance_l2_perp_v2`
- [ ] Append result to `results/MORNING_BRIEF_2026_04_18.md`
- [ ] If cross-session uplift holds → cleared for paper-trade scoping. If not → threshold was session-specific, needs per-session recalibration cadence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)