### PR TITLE
chore(ci): fix python-quality + secrets-supply-chain post-#238

### DIFF
--- a/.github/detect-secrets.baseline
+++ b/.github/detect-secrets.baseline
@@ -140,6 +140,24 @@
         "type": "Hex High Entropy String"
       }
     ],
+    "results/gate_fixtures/breakeven_q75.json": [
+      {
+        "filename": "results/gate_fixtures/breakeven_q75.json",
+        "hashed_secret": "c3ad0ce01e106f5ad19b6b7066357ea4abda6f6d",
+        "is_verified": false,
+        "line_number": 12,
+        "type": "Hex High Entropy String"
+      }
+    ],
+    "results/gate_fixtures/ic_test_q75.json": [
+      {
+        "filename": "results/gate_fixtures/ic_test_q75.json",
+        "hashed_secret": "c3ad0ce01e106f5ad19b6b7066357ea4abda6f6d",
+        "is_verified": false,
+        "line_number": 8,
+        "type": "Hex High Entropy String"
+      }
+    ],
     "results/ofi_unity_dukascopy_verdict.json": [
       {
         "filename": "results/ofi_unity_dukascopy_verdict.json",

--- a/archive/diagnostics/l2_rv_decile_analysis.py
+++ b/archive/diagnostics/l2_rv_decile_analysis.py
@@ -52,7 +52,7 @@ def main() -> int:
     deciles = [float(np.quantile(finite, q)) for q in np.arange(0.1, 1.0, 0.1)]
     edges = [float(finite.min())] + deciles + [float(finite.max()) + 1e-9]
 
-    results: list[dict[str, float | int | str]] = []
+    results: list[dict[str, object]] = []
     header = f"{'bucket':<8} {'rv<':<10} {'frac':>6} {'IC':>9} {'p_perm':>8} {'verdict':<8}"
     print(header)
     print("-" * len(header))


### PR DESCRIPTION
## Summary

Two CI gates that failed on PR #238 (despite clean local runs) are fixed here with surgical minimal diff.

### 1. secrets-supply-chain
detect-secrets flagged two SHA-hex strings in `results/gate_fixtures/*.json` (.frozen_from_sha field) as 'Hex High Entropy String'. They're git commit SHAs frozen into forensic fixtures, not credentials. Allowlisted in `.github/detect-secrets.baseline` (+18 lines, two explicit entries, no wildcard).

### 2. python-quality
mypy (non-strict CI mode, stricter than local `--strict --follow-imports=silent`) flagged a pre-existing annotation mismatch in `archive/diagnostics/l2_rv_decile_analysis.py:55`:
    `list[dict[str, float | int | str]]` vs inferred `dict[str, object]` at `.append(row)`.
The file was in `scripts/` pre-#238; the git-move to archive/ re-triggered the gate on it. One-line fix: widen declaration to `list[dict[str, object]]`. Zero logic change.

## Verify

- `.venv/bin/detect-secrets-hook --baseline .github/detect-secrets.baseline results/gate_fixtures/*.json` → exit 0
- `.venv/bin/mypy archive/diagnostics/*.py` → 10/10 clean
- `pytest tests/test_l2_{killtest,regime,pnl}.py tests/test_binance_perp_l2_collector.py` → 42/42 green
- Numerical gates unchanged (fixtures untouched): 0.23638402111955653 / 0.4072465349699599

🤖 Generated with [Claude Code](https://claude.com/claude-code)