### PR TITLE
feat(longrun): multi-day L2 collector + systemd + health monitor

### DIFF
--- a/deploy/systemd/README.md
+++ b/deploy/systemd/README.md
@@ -1,0 +1,61 @@
+# GeoSync L2 collector — systemd deployment
+
+Production-grade long-running Binance USDT-M perp depth@100ms collector
+under systemd, with periodic health-check timer. Closes the U1 multi-day
+substrate gap documented in PR #240's adversarial review.
+
+## Files
+
+- `geosync-l2-collector.service` — long-running unbounded collector
+- `geosync-l2-health.service` — one-shot health probe (exit codes
+  classify verdict)
+- `geosync-l2-health.timer` — fires the probe every 60s
+
+## Install (Linux, systemd ≥ 240)
+
+1. Clone the repo to `/opt/geosync` (or edit paths in the unit files).
+2. Create a venv at `/opt/geosync/.venv` and install dependencies.
+3. Copy the three unit files into `/etc/systemd/system/`:
+
+   ```bash
+   sudo install -m 0644 deploy/systemd/geosync-l2-collector.service \
+       /etc/systemd/system/geosync-l2-collector@<user>.service
+   sudo install -m 0644 deploy/systemd/geosync-l2-health.service \
+       /etc/systemd/system/geosync-l2-health@<user>.service
+   sudo install -m 0644 deploy/systemd/geosync-l2-health.timer \
+       /etc/systemd/system/geosync-l2-health@<user>.timer
+   ```
+
+4. Enable and start:
+
+   ```bash
+   sudo systemctl daemon-reload
+   sudo systemctl enable --now geosync-l2-collector@<user>.service
+   sudo systemctl enable --now geosync-l2-health@<user>.timer
+   ```
+
+5. Verify:
+
+   ```bash
+   systemctl status geosync-l2-collector@<user>.service
+   journalctl -u geosync-l2-collector@<user>.service -f
+   systemctl list-timers | grep geosync
+   ```
+
+## Health verdict taxonomy
+
+| exit | verdict | thresholds |
+|---|---|---|
+| 0 | HEALTHY | gap_sec < 120 AND disconnects/hr < 10 |
+| 1 | DEGRADED | 120 ≤ gap_sec < 600 OR disconnects/hr ≥ 10 |
+| 2 | STALE | gap_sec ≥ 3600 |
+| 3 | UNREACHABLE | log missing or zero flush lines |
+
+`OnFailure=<alert-unit>` on `geosync-l2-health@<user>.service` wires
+alerts to any downstream notifier (systemd-email, ntfy, telegram-send).
+
+## U1 closure criterion
+
+≥10 disjoint 24-hour windows with zero STALE verdicts, zero DNS-outage
+downtime > 300s. Measured from `logs/collector_health_history.jsonl`.
+Once closed, diurnal filter calibration (U4) unblocks.

--- a/deploy/systemd/geosync-l2-collector.service
+++ b/deploy/systemd/geosync-l2-collector.service
@@ -1,0 +1,42 @@
+[Unit]
+Description=GeoSync — Binance USDT-M perp L2 depth collector (unbounded)
+Documentation=https://github.com/neuron7xLab/GeoSync
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=simple
+# Adjust these to your deployment
+User=%i
+WorkingDirectory=/opt/geosync
+Environment=PYTHONUNBUFFERED=1
+Environment=PYTHONPATH=/opt/geosync
+
+# Unbounded run; duration_sec is ignored with --unbounded
+ExecStart=/opt/geosync/.venv/bin/python /opt/geosync/scripts/collect_binance_perp_l2.py \
+    --unbounded \
+    --out /opt/geosync/data/binance_l2_perp_longrun
+
+# Reliability
+Restart=always
+RestartSec=10
+StartLimitIntervalSec=120
+StartLimitBurst=10
+
+# Graceful shutdown: collector handles SIGTERM (drains to parquet then exits)
+KillSignal=SIGTERM
+TimeoutStopSec=60
+
+# Hardening
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=read-only
+ReadWritePaths=/opt/geosync/data /opt/geosync/logs
+PrivateTmp=true
+
+# Logs go to journal; also tee to file for the health check script
+StandardOutput=append:/opt/geosync/logs/collector_longrun.log
+StandardError=append:/opt/geosync/logs/collector_longrun.log
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/systemd/geosync-l2-health.service
+++ b/deploy/systemd/geosync-l2-health.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=GeoSync — one-shot health check over L2 collector log tail
+Documentation=https://github.com/neuron7xLab/GeoSync
+
+[Service]
+Type=oneshot
+User=%i
+WorkingDirectory=/opt/geosync
+Environment=PYTHONPATH=/opt/geosync
+
+# Exit codes: 0 HEALTHY, 1 DEGRADED, 2 STALE, 3 UNREACHABLE.
+# Non-zero exit triggers systemd's OnFailure chain if configured.
+ExecStart=/opt/geosync/.venv/bin/python /opt/geosync/scripts/check_l2_collector_health.py \
+    --log /opt/geosync/logs/collector_longrun.log \
+    --output /opt/geosync/logs/collector_health_history.jsonl

--- a/deploy/systemd/geosync-l2-health.timer
+++ b/deploy/systemd/geosync-l2-health.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=GeoSync — periodic health check of L2 collector
+Requires=geosync-l2-health.service
+
+[Timer]
+# Every 60 seconds after the service boots; then fixed 60s cadence.
+OnBootSec=60s
+OnUnitActiveSec=60s
+AccuracySec=5s
+
+[Install]
+WantedBy=timers.target

--- a/research/microstructure/longrun_monitor.py
+++ b/research/microstructure/longrun_monitor.py
@@ -1,0 +1,144 @@
+"""Health monitor for the long-running L2 collector.
+
+Parses the collector's log tail and emits structured health metrics:
+
+    * last_flush_ts         — timestamp of most recent successful flush
+    * gap_sec               — seconds since last successful flush
+    * disconnects_last_hour — count of `connection dropped` in last 3600s
+    * dns_failures_last_hour — gaierror subclass of disconnects
+    * rows_last_flush       — row count of the last flushed shard batch
+    * verdict               — HEALTHY | DEGRADED | STALE | UNREACHABLE
+
+Zero network calls; read-only on log file. Designed for cron / systemd
+watchdog invocation and for tests on synthetic log fixtures.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+_TS_FMT = "%Y-%m-%d %H:%M:%S"
+_TS_LEN = 19  # len("YYYY-MM-DD HH:MM:SS"), NOT len(_TS_FMT) which counts % directives
+_FLUSH_RE = re.compile(
+    r"^(?P<ts>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}),\d+\s+INFO\s+\S+\s+flushed\s+(?P<rows>\d+)\s+rows"
+)
+_DROP_RE = re.compile(
+    r"^(?P<ts>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}),\d+\s+WARNING\s+\S+\s+connection dropped"
+)
+_DNS_RE = re.compile(r"gaierror")
+
+GAP_HEALTHY_SEC: int = 120
+GAP_DEGRADED_SEC: int = 600
+GAP_STALE_SEC: int = 3600
+DISCONNECTS_DEGRADED_PER_HOUR: int = 10
+
+
+@dataclass(frozen=True)
+class HealthReport:
+    verdict: str
+    gap_sec: float
+    disconnects_last_hour: int
+    dns_failures_last_hour: int
+    last_flush_ts_utc: str | None
+    last_flush_rows: int | None
+    log_path: str
+    reason: str | None
+
+
+def _parse_line_timestamp(line: str) -> datetime | None:
+    if len(line) < _TS_LEN:
+        return None
+    try:
+        return datetime.strptime(line[:_TS_LEN], _TS_FMT).replace(tzinfo=timezone.utc)
+    except ValueError:
+        return None
+
+
+def parse_log_tail(text: str, now_utc: datetime) -> HealthReport:
+    """Parse up-to-N-lines of collector log and produce a HealthReport.
+
+    The caller is responsible for reading the tail of the log file and
+    passing the text in; this keeps the module IO-free and testable.
+    """
+    last_flush_ts: datetime | None = None
+    last_flush_rows: int | None = None
+    disconnects: int = 0
+    dns_failures: int = 0
+    cutoff = now_utc.timestamp() - 3600.0
+
+    for line in text.splitlines():
+        flush_match = _FLUSH_RE.match(line)
+        if flush_match:
+            ts = _parse_line_timestamp(line)
+            if ts is not None and (last_flush_ts is None or ts > last_flush_ts):
+                last_flush_ts = ts
+                last_flush_rows = int(flush_match.group("rows"))
+            continue
+        drop_match = _DROP_RE.match(line)
+        if drop_match:
+            ts = _parse_line_timestamp(line)
+            if ts is None:
+                continue
+            if ts.timestamp() >= cutoff:
+                disconnects += 1
+                if _DNS_RE.search(line):
+                    dns_failures += 1
+
+    if last_flush_ts is None:
+        return HealthReport(
+            verdict="UNREACHABLE",
+            gap_sec=float("inf"),
+            disconnects_last_hour=disconnects,
+            dns_failures_last_hour=dns_failures,
+            last_flush_ts_utc=None,
+            last_flush_rows=None,
+            log_path="",
+            reason="no flush line found in log tail",
+        )
+
+    gap_sec = max(0.0, now_utc.timestamp() - last_flush_ts.timestamp())
+
+    reasons: list[str] = []
+    if gap_sec >= GAP_STALE_SEC:
+        verdict = "STALE"
+        reasons.append(f"gap_sec={gap_sec:.0f} >= STALE threshold {GAP_STALE_SEC}")
+    elif gap_sec >= GAP_DEGRADED_SEC:
+        verdict = "DEGRADED"
+        reasons.append(f"gap_sec={gap_sec:.0f} >= DEGRADED threshold {GAP_DEGRADED_SEC}")
+    elif disconnects >= DISCONNECTS_DEGRADED_PER_HOUR:
+        verdict = "DEGRADED"
+        reasons.append(
+            f"disconnects_last_hour={disconnects} >= threshold {DISCONNECTS_DEGRADED_PER_HOUR}"
+        )
+    elif gap_sec >= GAP_HEALTHY_SEC:
+        verdict = "DEGRADED"
+        reasons.append(f"gap_sec={gap_sec:.0f} >= HEALTHY threshold {GAP_HEALTHY_SEC}")
+    else:
+        verdict = "HEALTHY"
+
+    return HealthReport(
+        verdict=verdict,
+        gap_sec=gap_sec,
+        disconnects_last_hour=disconnects,
+        dns_failures_last_hour=dns_failures,
+        last_flush_ts_utc=last_flush_ts.isoformat(timespec="seconds"),
+        last_flush_rows=last_flush_rows,
+        log_path="",
+        reason=" ; ".join(reasons) if reasons else None,
+    )
+
+
+def read_log_tail(path: Path, max_bytes: int = 256 * 1024) -> str:
+    """Read the last `max_bytes` of a log file (safe on very large files)."""
+    if not path.exists():
+        return ""
+    size = path.stat().st_size
+    with path.open("rb") as fh:
+        if size > max_bytes:
+            fh.seek(size - max_bytes)
+            fh.readline()  # skip potentially partial first line
+        data = fh.read()
+    return data.decode("utf-8", errors="replace")

--- a/scripts/check_l2_collector_health.py
+++ b/scripts/check_l2_collector_health.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Long-running L2 collector health check — CLI over longrun_monitor.
+
+Intended invocation: cron every ~60 s, or systemd watchdog sidecar.
+
+Exit codes:
+    0 — HEALTHY
+    1 — DEGRADED
+    2 — STALE
+    3 — UNREACHABLE (log missing or no flush ever)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import asdict
+from datetime import datetime, timezone
+from pathlib import Path
+
+from research.microstructure.longrun_monitor import (
+    parse_log_tail,
+    read_log_tail,
+)
+
+_EXIT = {"HEALTHY": 0, "DEGRADED": 1, "STALE": 2, "UNREACHABLE": 3}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--log",
+        type=Path,
+        default=Path("logs/collector_longrun.log"),
+        help="Path to collector log file",
+    )
+    parser.add_argument(
+        "--max-bytes",
+        type=int,
+        default=256 * 1024,
+        help="Max bytes to read from tail of log (default 256 KiB)",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Optional append-only JSONL history path",
+    )
+    args = parser.parse_args()
+
+    text = read_log_tail(Path(args.log), max_bytes=int(args.max_bytes))
+    now = datetime.now(timezone.utc)
+    report = parse_log_tail(text, now_utc=now)
+    payload = asdict(report)
+    payload["log_path"] = str(args.log)
+
+    print(json.dumps(payload, indent=2, sort_keys=True, default=str))
+
+    if args.output is not None:
+        out = Path(args.output)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        with out.open("a") as fh:
+            fh.write(
+                json.dumps({**payload, "checked_at_utc": now.isoformat(timespec="seconds")}) + "\n"
+            )
+
+    return _EXIT.get(report.verdict, 3)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/collect_binance_perp_l2.py
+++ b/scripts/collect_binance_perp_l2.py
@@ -190,7 +190,12 @@ def main() -> int:
         "--duration-sec",
         type=float,
         default=6 * 3600.0,
-        help="Run duration in seconds (default 6h)",
+        help="Run duration in seconds (default 6h). Ignored if --unbounded.",
+    )
+    parser.add_argument(
+        "--unbounded",
+        action="store_true",
+        help="Run indefinitely until SIGTERM/SIGINT (systemd-managed lifetime).",
     )
     parser.add_argument(
         "--log-level",
@@ -220,12 +225,16 @@ def main() -> int:
         loop.add_signal_handler(signal.SIGTERM, _handle_sigterm)
         loop.add_signal_handler(signal.SIGINT, _handle_sigterm)
 
+    effective_duration_sec = float("inf") if bool(args.unbounded) else float(args.duration_sec)
+    if bool(args.unbounded):
+        _log.info("unbounded mode — running until SIGTERM/SIGINT")
+
     try:
         total = loop.run_until_complete(
             _run_collector(
                 symbols=symbols,
                 out_dir=Path(args.out),
-                duration_sec=float(args.duration_sec),
+                duration_sec=effective_duration_sec,
                 stop_event=stop_event,
             )
         )

--- a/tests/test_l2_longrun_monitor.py
+++ b/tests/test_l2_longrun_monitor.py
@@ -1,0 +1,141 @@
+"""Tests for the long-running collector health monitor."""
+
+from __future__ import annotations
+
+import tempfile
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from research.microstructure.longrun_monitor import (
+    DISCONNECTS_DEGRADED_PER_HOUR,
+    HealthReport,
+    parse_log_tail,
+    read_log_tail,
+)
+
+
+def _line(ts: datetime, kind: str, payload: str) -> str:
+    stamp = ts.strftime("%Y-%m-%d %H:%M:%S") + ",000"
+    if kind == "flush":
+        return f"{stamp} INFO binance_perp_l2 flushed {payload}"
+    if kind == "drop":
+        return f"{stamp} WARNING binance_perp_l2 connection dropped: {payload}"
+    return f"{stamp} INFO binance_perp_l2 {payload}"
+
+
+def test_parse_log_tail_healthy_under_recent_flush() -> None:
+    now = datetime(2026, 4, 18, 12, 0, 0, tzinfo=timezone.utc)
+    text = "\n".join(
+        [
+            _line(now - timedelta(seconds=180), "flush", "4500 rows across 10 shards"),
+            _line(now - timedelta(seconds=60), "flush", "4700 rows across 10 shards"),
+        ]
+    )
+    r = parse_log_tail(text, now_utc=now)
+    assert r.verdict == "HEALTHY"
+    assert r.gap_sec == 60.0
+    assert r.last_flush_rows == 4700
+    assert r.disconnects_last_hour == 0
+
+
+def test_parse_log_tail_degraded_on_old_flush() -> None:
+    now = datetime(2026, 4, 18, 12, 0, 0, tzinfo=timezone.utc)
+    text = _line(now - timedelta(seconds=700), "flush", "4500 rows across 10 shards")
+    r = parse_log_tail(text, now_utc=now)
+    assert r.verdict == "DEGRADED"
+    assert 600 <= r.gap_sec < 3600
+
+
+def test_parse_log_tail_stale_after_hour() -> None:
+    now = datetime(2026, 4, 18, 12, 0, 0, tzinfo=timezone.utc)
+    text = _line(now - timedelta(seconds=4000), "flush", "4500 rows across 10 shards")
+    r = parse_log_tail(text, now_utc=now)
+    assert r.verdict == "STALE"
+    assert r.gap_sec >= 3600
+
+
+def test_parse_log_tail_unreachable_on_empty_log() -> None:
+    now = datetime(2026, 4, 18, 12, 0, 0, tzinfo=timezone.utc)
+    r = parse_log_tail("", now_utc=now)
+    assert r.verdict == "UNREACHABLE"
+    assert r.last_flush_ts_utc is None
+    assert r.last_flush_rows is None
+
+
+def test_parse_log_tail_counts_disconnects_and_dns() -> None:
+    now = datetime(2026, 4, 18, 12, 0, 0, tzinfo=timezone.utc)
+    lines = [_line(now - timedelta(seconds=60), "flush", "5000 rows across 10 shards")]
+    for k in range(3):
+        lines.append(
+            _line(now - timedelta(seconds=300 + k * 10), "drop", "ConnectionClosedError(None)")
+        )
+    for k in range(2):
+        lines.append(
+            _line(
+                now - timedelta(seconds=1800 + k * 30),
+                "drop",
+                "gaierror(-3, 'Temporary failure in name resolution')",
+            )
+        )
+    r = parse_log_tail("\n".join(lines), now_utc=now)
+    assert r.verdict == "HEALTHY"  # gap 60s, disconnects 5 < 10 threshold
+    assert r.disconnects_last_hour == 5
+    assert r.dns_failures_last_hour == 2
+
+
+def test_parse_log_tail_degraded_on_disconnect_storm_even_when_gap_low() -> None:
+    now = datetime(2026, 4, 18, 12, 0, 0, tzinfo=timezone.utc)
+    lines = [_line(now - timedelta(seconds=30), "flush", "5000 rows across 10 shards")]
+    for k in range(DISCONNECTS_DEGRADED_PER_HOUR + 2):
+        lines.append(_line(now - timedelta(seconds=60 + k * 10), "drop", "OSError"))
+    r = parse_log_tail("\n".join(lines), now_utc=now)
+    assert r.verdict == "DEGRADED"
+    assert r.disconnects_last_hour >= DISCONNECTS_DEGRADED_PER_HOUR
+    assert r.gap_sec < 120
+
+
+def test_parse_log_tail_ignores_disconnects_older_than_one_hour() -> None:
+    now = datetime(2026, 4, 18, 12, 0, 0, tzinfo=timezone.utc)
+    lines = [_line(now - timedelta(seconds=30), "flush", "5000 rows across 10 shards")]
+    for k in range(20):
+        lines.append(
+            _line(
+                now - timedelta(seconds=3600 + 60 + k * 10),
+                "drop",
+                "stale noise",
+            )
+        )
+    r = parse_log_tail("\n".join(lines), now_utc=now)
+    assert r.disconnects_last_hour == 0
+    assert r.verdict == "HEALTHY"
+
+
+def test_read_log_tail_handles_large_file(tmp_path: Path) -> None:
+    log = tmp_path / "big.log"
+    payload = "2026-04-18 12:00:00,000 INFO binance_perp_l2 flushed 1 rows across 10 shards\n"
+    log.write_text(payload * 50000, encoding="utf-8")  # ~4MB
+    text = read_log_tail(log, max_bytes=4096)
+    assert len(text) <= 4096
+    assert "flushed" in text
+
+
+def test_read_log_tail_missing_file_returns_empty() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        missing = Path(td) / "no-such-file.log"
+        assert read_log_tail(missing) == ""
+
+
+def test_health_report_schema_fields() -> None:
+    r = HealthReport(
+        verdict="HEALTHY",
+        gap_sec=0.5,
+        disconnects_last_hour=0,
+        dns_failures_last_hour=0,
+        last_flush_ts_utc="2026-04-18T12:00:00+00:00",
+        last_flush_rows=4500,
+        log_path="/tmp/x",
+        reason=None,
+    )
+    assert r.verdict == "HEALTHY"
+    assert r.last_flush_rows == 4500
+    assert r.reason is None


### PR DESCRIPTION
## Summary

Closes **U1** from PR #240's adversarial review ("multi-day OOS beyond 11h22m cumulative"). Enables the long-running substrate collection that gates diurnal-filter calibration (U4) and, downstream, live-trading readiness.

## Components

| File | Role |
|---|---|
| `scripts/collect_binance_perp_l2.py` | +`--unbounded` flag, override `duration_sec → inf`; SIGTERM handled by existing stop_event |
| `research/microstructure/longrun_monitor.py` | pure-function health classifier: `HEALTHY / DEGRADED / STALE / UNREACHABLE` over log tail |
| `scripts/check_l2_collector_health.py` | thin CLI; exit codes 0/1/2/3 map to verdict |
| `deploy/systemd/geosync-l2-collector.service` | Restart=always, hardened (NoNewPrivileges, ProtectSystem=strict) |
| `deploy/systemd/geosync-l2-health.{service,timer}` | one-shot probe fired every 60s |
| `deploy/systemd/README.md` | install + U1 closure criterion |
| `tests/test_l2_longrun_monitor.py` | 10 tests: verdict taxonomy, disconnect counting inside/outside 1h, DNS subset, empty log, large-file tail-read |

## Health verdict taxonomy

| exit | verdict | condition |
|---|---|---|
| 0 | HEALTHY | `gap_sec < 120` AND `disconnects/hr < 10` |
| 1 | DEGRADED | `120 ≤ gap_sec < 600` OR `disconnects/hr ≥ 10` |
| 2 | STALE | `gap_sec ≥ 3600` |
| 3 | UNREACHABLE | log missing or zero flush lines |

## One subtle bug caught during test authoring

`len(_TS_FMT)` on `"%Y-%m-%d %H:%M:%S"` is 17 (format-directive chars); the formatted output is 19. Slicing `line[:len(_TS_FMT)]` truncated the timestamp → every `strptime` raised ValueError → verdict UNREACHABLE on valid logs. Fix: explicit `_TS_LEN = 19` with comment. Guarded by 6 of the 10 new tests.

## U1 closure protocol (ops, not code)

```
sudo systemctl enable --now geosync-l2-collector@<user>.service
sudo systemctl enable --now geosync-l2-health@<user>.timer
# Monitor logs/collector_health_history.jsonl for:
#   ≥10 disjoint 24h windows
#   zero STALE verdicts
#   zero DNS-outage downtime >300s
```

On achievement → unblocks **U4** (diurnal_filter.py calibration).

## Quality gates

- ruff + black + mypy --strict --follow-imports=silent clean on all 4 new/modified source files
- test regression: 49 → 59 (+10 longrun)
- numerical locks bit-identical: `ic_test_q75=0.23638402111955653`, `breakeven_q75=0.4072465349699599`

## Non-goals

- Actually running the collector for 10 days (that's operational, begins after merge)
- Diurnal filter logic (blocked on U1; scoped for follow-up PR)
- Maker execution engine (blocked on U2; separate architectural track)

🤖 Generated with [Claude Code](https://claude.com/claude-code)