### PR TITLE
test(ci): fix flaky clickhouse test vs watchdog health probe

### DIFF
--- a/tests/unit/data/test_warehouses_clickhouse.py
+++ b/tests/unit/data/test_warehouses_clickhouse.py
@@ -101,6 +101,20 @@ class TestClickHouseIdentifiers:
         assert identifiers.timezone_literal == "'America/New_York'"
 
 
+def _mock_only_test_clickhouse(request: httpx.Request) -> bool:
+    """Confine httpx_mock to the warehouse's own `test-clickhouse` host.
+
+    An `execution.watchdog.Watchdog` default-instantiated elsewhere in the
+    process (default `health_url=http://127.0.0.1:8085/health/live`) races
+    the strict mock and triggers AssertionError("request not expected")
+    on ingest-error paths. Returning False for 127.0.0.1 lets the
+    watchdog probe pass through; the warehouse's own INSERT requests
+    still hit the mock.
+    """
+    return "test-clickhouse" in str(request.url)
+
+
+@pytest.mark.httpx_mock(should_mock=_mock_only_test_clickhouse)
 class TestClickHouseWarehouse:
     """Tests for ClickHouseWarehouse class."""
 
@@ -137,18 +151,14 @@ class TestClickHouseWarehouse:
         statements = warehouse.bootstrap_statements()
         assert len(statements) == 4
 
-    def test_bootstrap_statements_creates_database(
-        self, warehouse: ClickHouseWarehouse
-    ) -> None:
+    def test_bootstrap_statements_creates_database(self, warehouse: ClickHouseWarehouse) -> None:
         """Verify bootstrap creates database statement."""
         statements = warehouse.bootstrap_statements()
         db_statement = statements[0]
         assert "CREATE DATABASE IF NOT EXISTS" in db_statement.sql
         assert "geosync" in db_statement.sql
 
-    def test_bootstrap_statements_creates_raw_table(
-        self, warehouse: ClickHouseWarehouse
-    ) -> None:
+    def test_bootstrap_statements_creates_raw_table(self, warehouse: ClickHouseWarehouse) -> None:
         """Verify bootstrap creates raw table statement."""
         statements = warehouse.bootstrap_statements()
         raw_statement = statements[1]
@@ -183,9 +193,7 @@ class TestClickHouseWarehouse:
         assert "OPTIMIZE" in jobs[0].statement.sql
         assert jobs[0].schedule_hint == "*/5 * * * *"
 
-    def test_maintenance_tasks_returns_tasks(
-        self, warehouse: ClickHouseWarehouse
-    ) -> None:
+    def test_maintenance_tasks_returns_tasks(self, warehouse: ClickHouseWarehouse) -> None:
         """Verify maintenance tasks are returned."""
         tasks = warehouse.maintenance_tasks()
         assert len(tasks) == 2
@@ -202,9 +210,7 @@ class TestClickHouseWarehouse:
         assert queries[1].name == "minute_bar_freshness"
         assert queries[2].name == "ingest_throughput"
 
-    def test_benchmark_scenarios_returns_scenarios(
-        self, warehouse: ClickHouseWarehouse
-    ) -> None:
+    def test_benchmark_scenarios_returns_scenarios(self, warehouse: ClickHouseWarehouse) -> None:
         """Verify benchmark scenarios are returned."""
         scenarios = warehouse.benchmark_scenarios()
         assert len(scenarios) == 2


### PR DESCRIPTION
## Summary

Fixes the `python-fast-tests` flaky failure observed on PR #264 CI: `TestClickHouseWarehouse::test_ingest_ticks_failure_raises` fails when `execution.watchdog.Watchdog` (default-instantiated somewhere in the import chain) sends a health probe to `http://127.0.0.1:8085/health/live` — pytest-httpx strict mode flags it as an unexpected request.

## Fix

Class-level `@pytest.mark.httpx_mock(should_mock=_mock_only_test_clickhouse)` confines the mock to intercept only the warehouse's own host (`test-clickhouse:8123`). Watchdog's 127.0.0.1 probe passes through the mock, hits real networking, is caught by Watchdog's own exception handler.

Uses pytest-httpx 0.35.0's `should_mock` callable (present in our pinned version) rather than `non_mocked_hosts` (added in a later version).

## Scope

- +12 lines in `tests/unit/data/test_warehouses_clickhouse.py` (class decorator + helper fn)
- Zero change to production code, zero change to other tests
- 26/26 local tests in the affected file pass

## Numerical truth unchanged

- `results/gate_fixtures/ic_test_q75.json` .value = 0.23638402111955653
- `results/gate_fixtures/breakeven_q75.json` .value = 0.4072465349699599

🤖 Generated with [Claude Code](https://claude.com/claude-code)