### PR TITLE
feat(pnl): break-even for REGIME_Q75+DIURNAL — 0.2317 (−43% SLA)

### DIFF
--- a/.github/detect-secrets.baseline
+++ b/.github/detect-secrets.baseline
@@ -149,6 +149,15 @@
         "type": "Hex High Entropy String"
       }
     ],
+    "results/gate_fixtures/breakeven_q75_diurnal.json": [
+      {
+        "filename": "results/gate_fixtures/breakeven_q75_diurnal.json",
+        "hashed_secret": "41fe8081f306636f0bee023c6631de500d07919d",
+        "is_verified": false,
+        "line_number": 19,
+        "type": "Hex High Entropy String"
+      }
+    ],
     "results/gate_fixtures/ic_test_q75.json": [
       {
         "filename": "results/gate_fixtures/ic_test_q75.json",

--- a/results/gate_fixtures/breakeven_q75_diurnal.json
+++ b/results/gate_fixtures/breakeven_q75_diurnal.json
@@ -1,0 +1,20 @@
+{
+  "gate": "breakeven_maker_regime_q75_diurnal",
+  "value": 0.23166569020507446,
+  "tolerance": 1.0e-3,
+  "source": "scripts/run_l2_pnl.py --data-dir data/binance_l2_perp --cost-sweep --diurnal-filter results/L2_DIURNAL_PROFILE.json",
+  "source_method": "linear_interp_between_bracketing_rows",
+  "bracket_rows": [
+    {"maker_fraction": 0.0, "mean_net_bp": -2.7799882824608937},
+    {"maker_fraction": 0.25, "mean_net_bp": 0.22001171753910626}
+  ],
+  "strategy": "REGIME_Q75+DIURNAL",
+  "compares_to": {
+    "gate": "breakeven_maker_regime_q75",
+    "value": 0.4072465349699599,
+    "delta_absolute": -0.17558084476488544,
+    "delta_relative_pct": -43.1
+  },
+  "frozen_at_utc": "2026-04-18T15:08:06Z",
+  "frozen_from_sha": "3671781ba19242a156ad2b5c493d69347b22e015"
+}

--- a/scripts/run_l2_pnl.py
+++ b/scripts/run_l2_pnl.py
@@ -91,7 +91,7 @@ def main() -> int:
     parser.add_argument("--cost-sweep", action="store_true")
     parser.add_argument(
         "--emit-gate-value",
-        choices=["breakeven_q75"],
+        choices=["breakeven_q75", "breakeven_q75_diurnal"],
         default=None,
     )
     parser.add_argument("--log-level", default="INFO")
@@ -204,6 +204,27 @@ def main() -> int:
         be_uncond = breakeven_maker_fraction(rows_uncond)
         be_q75 = breakeven_maker_fraction(rows_q75)
 
+        rows_q75_diurnal = None
+        be_q75_diurnal = None
+        if direction_override is not None:
+            trades_q75_diurnal = simulate_gross_trades(
+                signal,
+                features.mid,
+                decision_idx=decision_idx,
+                hold_rows=DEFAULT_HOLD_SEC,
+                median_window_rows=DEFAULT_MEDIAN_WINDOW_SEC,
+                regime_mask=mask_q75,
+                direction_override=direction_override,
+                name="REGIME_Q75+DIURNAL",
+            )
+            rows_q75_diurnal = sweep_maker_fractions(
+                trades_q75_diurnal,
+                symbols=features.symbols,
+                cost_model=cost_model,
+                maker_fractions=DEFAULT_MAKER_FRACTIONS,
+            )
+            be_q75_diurnal = breakeven_maker_fraction(rows_q75_diurnal)
+
         if args.emit_gate_value == "breakeven_q75":
             if be_q75 is None:
                 _log.error("break-even maker fraction not bracketed in sweep")
@@ -220,13 +241,36 @@ def main() -> int:
             )
             return 0
 
+        if args.emit_gate_value == "breakeven_q75_diurnal":
+            if be_q75_diurnal is None:
+                _log.error(
+                    "breakeven_q75_diurnal requires --diurnal-filter and a "
+                    "zero-crossing bracket; none found"
+                )
+                return 2
+            print(
+                json.dumps(
+                    {
+                        "gate": "breakeven_q75_diurnal",
+                        "value": float(be_q75_diurnal),
+                        "tolerance": 1.0e-3,
+                    },
+                    indent=2,
+                )
+            )
+            return 0
+
         payload: dict[str, Any] = {
             "mode": "cost_sweep",
             "maker_fractions": list(DEFAULT_MAKER_FRACTIONS),
             "breakeven_uncond": be_uncond,
             "breakeven_regime_q75": be_q75,
+            "breakeven_regime_q75_diurnal": be_q75_diurnal,
             "rows_uncond": [asdict(r) for r in rows_uncond],
             "rows_regime_q75": [asdict(r) for r in rows_q75],
+            "rows_regime_q75_diurnal": (
+                [asdict(r) for r in rows_q75_diurnal] if rows_q75_diurnal is not None else None
+            ),
         }
         Path(args.output).parent.mkdir(parents=True, exist_ok=True)
         Path(args.output).write_text(


### PR DESCRIPTION
## Summary

Computes and freezes the break-even maker-fill fraction for the combined REGIME_Q75+DIURNAL strategy. Extends `scripts/run_l2_pnl.py --cost-sweep` to include the third strategy when `--diurnal-filter` is supplied.

## Headline

| Strategy | Break-even maker fill | Δ vs REGIME_Q75 |
|---|---|---|
| UNCONDITIONAL | 0.5430 | — |
| REGIME_Q75 (frozen PR #238) | **0.4072** | 0 (baseline) |
| **REGIME_Q75+DIURNAL** (new) | **0.2317** | **−0.176 = −43 %** |

The maker-fill-rate SLA drops from 41 % → 23 %. Single biggest economic lever pullable without more data.

## Components

- `scripts/run_l2_pnl.py` — `--emit-gate-value breakeven_q75_diurnal`; payload gains `rows_regime_q75_diurnal` + `breakeven_regime_q75_diurnal`.
- `results/gate_fixtures/breakeven_q75_diurnal.json` — new frozen fixture, bracket rows: maker 0.0 → net −2.78 bp, maker 0.25 → net +0.22 bp, linear-interp → 0.2317.
- `.github/detect-secrets.baseline` — new fixture SHA allowlisted.

## Regression

`ic_test_q75` and `breakeven_q75` fixtures bit-identical:
- `ic_test_q75` = 0.23638402111955653
- `breakeven_q75` = 0.4072465349699599

## Quality gates

ruff + black + mypy --strict --follow-imports=silent clean on modified file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)