### PR TITLE
feat(strategies): DRO-ARA regime filter (fail-closed gate for primary signals)

### DIFF
--- a/core/strategies/dro_ara_filter.py
+++ b/core/strategies/dro_ara_filter.py
@@ -1,0 +1,82 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""DRO-ARA regime filter for primary trading signals.
+
+The DRO-ARA v7 observer is a regime classifier, not a standalone alpha (empirical
+IC is in the `HEADROOM_ONLY` band — see `scripts/research/dro_ara_ic_fx.py`).
+Its highest-value use is as a *gate* on another primary signal: pass-through when
+the market is CRITICAL with a converging/stable trend, scale down on TRANSITION,
+go flat when the regime is DRIFT or INVALID.
+
+Contract:
+    regime_multiplier is a deterministic function of (regime, trend) only;
+    no floating-point tolerances are introduced — boundaries compare exact
+    enum values. Fail-closed: INVALID → 0.0 exactly.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+from numpy.typing import NDArray
+
+from core.dro_ara import Regime, geosync_observe
+
+__all__ = [
+    "MULTIPLIER_CRITICAL",
+    "MULTIPLIER_TRANSITION",
+    "MULTIPLIER_DRIFT",
+    "MULTIPLIER_INVALID",
+    "regime_multiplier",
+    "apply_regime_filter",
+]
+
+MULTIPLIER_CRITICAL: Final[float] = 1.0
+MULTIPLIER_TRANSITION: Final[float] = 0.5
+MULTIPLIER_DRIFT: Final[float] = 0.0
+MULTIPLIER_INVALID: Final[float] = 0.0
+
+
+def regime_multiplier(regime: str, trend: str | None) -> float:
+    """Map (regime, trend) → position-size multiplier in [0, 1].
+
+    * CRITICAL + trend ∈ {CONVERGING, STABLE} → 1.0
+    * CRITICAL + DIVERGING                    → 0.5 (converging-check failed)
+    * TRANSITION                              → 0.5
+    * DRIFT                                   → 0.0
+    * INVALID                                 → 0.0 (fail-closed)
+    """
+    if regime == Regime.INVALID.value:
+        return MULTIPLIER_INVALID
+    if regime == Regime.DRIFT.value:
+        return MULTIPLIER_DRIFT
+    if regime == Regime.TRANSITION.value:
+        return MULTIPLIER_TRANSITION
+    if regime == Regime.CRITICAL.value:
+        if trend in ("CONVERGING", "STABLE"):
+            return MULTIPLIER_CRITICAL
+        return MULTIPLIER_TRANSITION
+    return MULTIPLIER_INVALID
+
+
+def apply_regime_filter(
+    raw_signal: float,
+    price_window: NDArray,
+    *,
+    window: int = 512,
+    step: int = 64,
+) -> tuple[float, dict[str, object]]:
+    """Scale ``raw_signal`` by the DRO-ARA regime multiplier for ``price_window``.
+
+    Returns a pair ``(filtered_signal, observation)`` where ``observation`` is
+    the raw output of :func:`core.dro_ara.geosync_observe` augmented with the
+    chosen ``multiplier`` under the key ``regime_multiplier``.
+
+    Fail-closed: any :class:`ValueError` raised by ``geosync_observe`` (constant
+    input, NaN, too short) propagates to the caller; callers that want
+    silent-flat behaviour must catch and zero explicitly.
+    """
+    out = geosync_observe(price_window, window=window, step=step)
+    mult = regime_multiplier(str(out["regime"]), out.get("trend"))  # type: ignore[arg-type]
+    out["regime_multiplier"] = mult
+    return float(raw_signal) * mult, out

--- a/tests/core/strategies/test_dro_ara_filter.py
+++ b/tests/core/strategies/test_dro_ara_filter.py
@@ -1,0 +1,116 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""Unit tests for the DRO-ARA regime filter.
+
+Tests use real :func:`core.dro_ara.geosync_observe` on seeded synthetic series —
+no mocks, no fakes.  Fail-closed multiplier semantics on INVALID/DRIFT are
+pinned exactly (==, not isclose).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from numpy.typing import NDArray
+
+from core.strategies.dro_ara_filter import (
+    MULTIPLIER_CRITICAL,
+    MULTIPLIER_DRIFT,
+    MULTIPLIER_INVALID,
+    MULTIPLIER_TRANSITION,
+    apply_regime_filter,
+    regime_multiplier,
+)
+
+
+def _ou(seed: int, n: int = 2048) -> NDArray[np.float64]:
+    rng = np.random.default_rng(seed)
+    x = np.empty(n, dtype=np.float64)
+    x[0] = 100.0
+    for t in range(1, n):
+        x[t] = x[t - 1] + 0.08 * (100.0 - x[t - 1]) + 0.6 * rng.normal()
+    return x
+
+
+def _gbm(seed: int, n: int = 2048) -> NDArray[np.float64]:
+    rng = np.random.default_rng(seed)
+    r = 0.002 + 0.01 * rng.normal(size=n)
+    return 100.0 * np.exp(np.cumsum(r))
+
+
+def test_invalid_regime_is_exactly_zero() -> None:
+    assert regime_multiplier("INVALID", "STABLE") == 0.0
+    assert regime_multiplier("INVALID", None) == 0.0
+
+
+def test_drift_regime_is_exactly_zero() -> None:
+    assert regime_multiplier("DRIFT", "CONVERGING") == 0.0
+    assert regime_multiplier("DRIFT", None) == 0.0
+
+
+def test_transition_regime_halves_signal() -> None:
+    assert regime_multiplier("TRANSITION", "STABLE") == MULTIPLIER_TRANSITION
+    assert regime_multiplier("TRANSITION", "CONVERGING") == MULTIPLIER_TRANSITION
+    assert regime_multiplier("TRANSITION", None) == MULTIPLIER_TRANSITION
+
+
+def test_critical_converging_passes_through() -> None:
+    assert regime_multiplier("CRITICAL", "CONVERGING") == MULTIPLIER_CRITICAL
+    assert regime_multiplier("CRITICAL", "STABLE") == MULTIPLIER_CRITICAL
+
+
+def test_critical_diverging_reduced_to_half() -> None:
+    assert regime_multiplier("CRITICAL", "DIVERGING") == MULTIPLIER_TRANSITION
+    assert regime_multiplier("CRITICAL", None) == MULTIPLIER_TRANSITION
+
+
+def test_unknown_regime_is_fail_closed() -> None:
+    assert regime_multiplier("BOGUS", "STABLE") == 0.0
+
+
+def test_apply_on_ou_yields_nonzero_multiplier() -> None:
+    price = _ou(seed=1)
+    filtered, obs = apply_regime_filter(raw_signal=1.0, price_window=price)
+    mult = float(obs["regime_multiplier"])  # type: ignore[arg-type]
+    assert obs["regime"] in {"CRITICAL", "TRANSITION"}
+    assert mult >= MULTIPLIER_TRANSITION
+    assert filtered == pytest.approx(mult)  # raw == 1.0
+
+
+def test_apply_on_gbm_drifts_to_zero() -> None:
+    price = _gbm(seed=2)
+    filtered, obs = apply_regime_filter(raw_signal=1.0, price_window=price)
+    mult = float(obs["regime_multiplier"])  # type: ignore[arg-type]
+    assert obs["regime"] in {"INVALID", "DRIFT"}
+    assert mult == 0.0
+    assert filtered == 0.0
+
+
+def test_apply_preserves_raw_sign_on_critical() -> None:
+    price = _ou(seed=3)
+    pos, _ = apply_regime_filter(raw_signal=+2.0, price_window=price)
+    neg, _ = apply_regime_filter(raw_signal=-2.0, price_window=price)
+    assert pos >= 0.0 and neg <= 0.0
+    assert pos == pytest.approx(-neg)
+
+
+def test_apply_raises_on_nan_input() -> None:
+    price = _ou(seed=4).copy()
+    price[500] = np.nan
+    with pytest.raises(ValueError):
+        apply_regime_filter(raw_signal=1.0, price_window=price)
+
+
+def test_multiplier_constants_are_bounded() -> None:
+    for mult in (
+        MULTIPLIER_CRITICAL,
+        MULTIPLIER_TRANSITION,
+        MULTIPLIER_DRIFT,
+        MULTIPLIER_INVALID,
+    ):
+        assert 0.0 <= mult <= 1.0
+
+
+def test_invalid_multiplier_is_exactly_zero_constant() -> None:
+    assert MULTIPLIER_INVALID == 0.0
+    assert MULTIPLIER_DRIFT == 0.0


### PR DESCRIPTION
## Summary

Wires `core/dro_ara` into `core/strategies` as a **gate**, not a standalone alpha. Rationale: PR #283 measured pooled OOS IC ≈ 0.032 on FX hourly (HEADROOM_ONLY), so DRO-ARA's highest-value use is as a fail-closed regime filter on a stronger primary signal.

## Regime → multiplier (exact `==` comparisons, no epsilons)

| Regime + trend                          | Multiplier |
|-----------------------------------------|-----------:|
| CRITICAL + CONVERGING/STABLE            |      1.0   |
| CRITICAL + DIVERGING                    |      0.5   |
| TRANSITION                              |      0.5   |
| DRIFT                                   |      0.0   |
| INVALID                                 |      0.0   |
| unknown regime string                   |      0.0   |

`apply_regime_filter(raw, price_window)` returns `(filtered_signal, observation)` with the full `geosync_observe` dict plus `regime_multiplier` key. NaN / constant / short input propagates `ValueError` — no silent zero.

## Test plan

- [x] 12/12 tests green (real OU / GBM synthetic prices, no mocks)
- [x] Exact-equality assertions on 0.0 multipliers (INVALID, DRIFT) — fail-closed
- [x] Sign preservation on CRITICAL
- [x] NaN propagates ValueError
- [x] black + ruff + mypy all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)