### PR TITLE
contracts(dro-ara): register INV-DRO1..5 across physics layers

### DIFF
--- a/.claude/physics/INVARIANTS.yaml
+++ b/.claude/physics/INVARIANTS.yaml
@@ -632,3 +632,56 @@ ott_antonsen:
       critical_slowing: "at K → K_c, decay rate → 0 (excluded from test at K=0.99)"
     falsification: "R stays above 1e-4 after T=100 with K ≤ 0.8·K_c"
     priority: P0
+
+# ═══════════════════════════════════════════════════
+# DRO-ARA REGIME OBSERVER (Hurst + ADF + ARA loop)
+# Scope: core/dro_ara/*.py
+# ═══════════════════════════════════════════════════
+
+dro_ara:
+  gamma_derivation:
+    id: INV-DRO1
+    type: algebraic
+    statement: "γ = 2·H + 1 to floating-point precision for every admissible input"
+    test_type: property_test
+    parameters:
+      tolerance: "|γ − (2·H + 1)| < 1e-5"
+      source: "core/dro_ara/engine.py::derive_gamma"
+    falsification: "derive_gamma returns γ, H with |γ − (2·H + 1)| ≥ 1e-5"
+    priority: P0
+
+  risk_scalar_bounds:
+    id: INV-DRO2
+    type: universal
+    statement: "risk_scalar(γ) = max(0, 1 − |γ − 1|) ∈ [0, 1] for all γ ∈ ℝ"
+    test_type: property_test
+    parameters:
+      lipschitz_constant: "|rs(a) − rs(b)| ≤ |a − b|"
+    falsification: "risk_scalar returns value < 0 or > 1 for any γ"
+    priority: P0
+
+  invalid_regime_gate:
+    id: INV-DRO3
+    type: conditional
+    statement: "regime == INVALID iff (!stationary ∨ r2 < R2_MIN)"
+    condition: "R2_MIN = 0.90 (core/dro_ara/engine.py:R2_MIN)"
+    test_type: property_test
+    falsification: "classify(gamma, r2<0.90, stationary=True) != INVALID, or classify(gamma, r2, False) != INVALID"
+    priority: P0
+
+  long_signal_gate:
+    id: INV-DRO4
+    type: conditional
+    statement: "signal == LONG ⟹ regime == CRITICAL ∧ rs > RS_LONG_THRESH ∧ trend ∈ {CONVERGING, STABLE}"
+    condition: "RS_LONG_THRESH = 0.33"
+    test_type: property_test
+    falsification: "geosync_observe emits LONG with any of the three conjuncts false"
+    priority: P0
+
+  fail_closed_input:
+    id: INV-DRO5
+    type: universal
+    statement: "NaN ∨ Inf ∨ constant ∨ rank != 1 ∨ len < window+step ⟹ ValueError"
+    test_type: property_test
+    falsification: "geosync_observe returns silently on any degenerate input above"
+    priority: P0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,6 +215,22 @@ INV-AC1-rev | universal | κ(node) ≥ κ_critical OR node ISOLATED         | P0
     λ_local → 1.0 (persistent): κ_critical ≈ -3.00 (tight gate)
 ```
 
+### DRO-ARA Regime Observer (Hurst + ADF + ARA loop)
+
+```
+INV-DRO1 | algebraic    | γ = 2·H + 1 to float precision                | P0
+         H = DFA-1 on diff(log(price)); tolerance |γ−(2H+1)| < 1e-5.
+         Source: Peng et al. 1994; core/dro_ara/engine.py::derive_gamma.
+INV-DRO2 | universal    | rs = max(0, 1 − |γ − 1|) ∈ [0, 1]              | P0
+         Lipschitz-1 in γ. Fail-closed on all regimes ≠ CRITICAL/TRANS.
+INV-DRO3 | conditional  | regime == INVALID iff (!stationary ∨ r2<0.90) | P0
+         ADF with AIC lag selection (max 4 lags). R2_MIN = 0.90.
+INV-DRO4 | conditional  | signal == LONG ⇒ CRITICAL ∧ rs > 0.33          | P0
+                        ∧ trend ∈ {CONVERGING, STABLE}
+INV-DRO5 | universal    | NaN/Inf/constant/rank/short input → ValueError | P0
+         Fail-closed; no silent numeric repair.
+```
+
 ---
 
 ## TEST TAXONOMY
@@ -288,6 +304,7 @@ assert result.order > 0      # no INV, no context
 | `*hpc*`, `*kernel*` | INV-HPC1..2 |
 | `*cryptobiosis*`, `*dormant*` | INV-CB1..8 |
 | `*dfa*`, `*hurst*`, `*criticality*` | INV-AC1-rev |
+| `*dro_ara*`, `*regime_observer*` | INV-DRO1..5 |
 | `application/`, `cli/`, `ui/` | No physics |
 
 ---

--- a/docs/physics/dro_ara_invariants.md
+++ b/docs/physics/dro_ara_invariants.md
@@ -1,0 +1,62 @@
+# DRO-ARA Regime Observer — Invariant Registry
+
+**Module:** `core/dro_ara/`
+**Test modules:** `tests/core/dro_ara/test_invariants.py`, `tests/core/dro_ara/test_falsification.py`
+**Catalog entries:** `.claude/physics/INVARIANTS.yaml::dro_ara`,
+`physics_contracts/catalog.yaml::dro_ara.*`
+
+The DRO-ARA v7 observer measures the statistical regime of a price series via
+DFA-1 Hurst (on log-returns) and a lag-augmented Augmented Dickey–Fuller test
+with AIC lag selection. It emits a regime classification and a deterministic
+trading signal through a bounded Action Result Acceptor (ARA) loop.
+
+---
+
+## Invariants
+
+| ID | Type | Statement | Priority | Source |
+|----|------|-----------|----------|--------|
+| **INV-DRO1** | algebraic   | `γ = 2·H + 1` to float precision | P0 | Peng 1994 |
+| **INV-DRO2** | universal   | `rs = max(0, 1 − \|γ − 1\|) ∈ [0, 1]`, Lipschitz-1 in γ | P0 | internal |
+| **INV-DRO3** | conditional | `regime == INVALID ⇔ (¬stationary ∨ r² < 0.90)` | P0 | Dickey–Fuller 1979 |
+| **INV-DRO4** | conditional | `signal == LONG ⇒ regime == CRITICAL ∧ rs > 0.33 ∧ trend ∈ {CONVERGING, STABLE}` | P0 | internal |
+| **INV-DRO5** | universal   | NaN/Inf/constant/rank/short input ⇒ `ValueError` (fail-closed) | P0 | internal |
+
+## Test mapping
+
+| Invariant | Tests                                                                                   |
+|-----------|-----------------------------------------------------------------------------------------|
+| INV-DRO1  | `test_invariants.py::test_gamma_is_derived_from_H`                                       |
+| INV-DRO2  | `test_invariants.py::test_risk_scalar_bounds`, `::test_rs_long_threshold_constant`       |
+| INV-DRO3  | `test_invariants.py::test_classify_invalid_when_not_stationary`, `::test_classify_invalid_when_r2_below_gate` |
+| INV-DRO4  | `test_falsification.py::test_signal_never_long_on_gbm`; signal logic checked in `test_invariants.py::test_observe_deterministic` |
+| INV-DRO5  | `test_invariants.py::test_observe_rejects_nan`, `::test_observe_rejects_inf`, `::test_observe_rejects_constant`, `::test_observe_rejects_too_short`, `::test_observe_rejects_2d` |
+
+## Falsification battery (known-regime sanity checks)
+
+| Synthetic generator          | Expected regime                  | Test                                               |
+|------------------------------|----------------------------------|----------------------------------------------------|
+| OU mean-reverting            | CRITICAL or TRANSITION           | `test_falsification.py::test_ou_mean_reverting_is_critical` |
+| GBM with positive drift      | INVALID (ADF rejects)            | `test_falsification.py::test_gbm_with_drift_is_non_stationary` |
+| Pure random walk             | INVALID or TRANSITION            | `test_falsification.py::test_random_walk_is_invalid_or_transition` |
+| White noise on price levels  | stationary                       | `test_falsification.py::test_white_noise_prices_are_stationary`    |
+
+## Empirical reality check
+
+Empirical IC measurement on FX hourly (PR #283): pooled best IC = 0.032 at
+horizon 4 (CI95 [−0.015, +0.074]) — **below** the GeoSync `SIGNAL_READY` gate
+of 0.08. The module therefore ships as a **regime filter** (`core/strategies/
+dro_ara_filter.py`), not as a standalone alpha. See
+`scripts/research/dro_ara_ic_fx.py` for the reproducible measurement.
+
+## References
+
+- Dickey, D. A., & Fuller, W. A. (1979). *Distribution of the estimators for
+  autoregressive time series with a unit root.* JASA 74(366a), 427–431.
+- Ng, S., & Perron, P. (2001). *Lag length selection and the construction of
+  unit root tests with good size and power.* Econometrica 69(6), 1519–1554.
+- Peng, C.-K., Buldyrev, S. V., Havlin, S., Simons, M., Stanley, H. E., &
+  Goldberger, A. L. (1994). *Mosaic organization of DNA nucleotides.*
+  Phys. Rev. E 49(2), 1685–1689.
+- MacKinnon, J. G. (1994). *Approximate asymptotic distribution functions for
+  unit-root and cointegration tests.* J. Bus. Econ. Stat. 12(2), 167–176.

--- a/physics_contracts/catalog.yaml
+++ b/physics_contracts/catalog.yaml
@@ -287,3 +287,54 @@ laws:
     validity: "inputs within documented range"
     source: "geosync_hpc/*.py"
     severity: block
+
+  # ───────────────────────── DRO-ARA ─────────────────────────
+  - id: dro_ara.gamma_derivation
+    module: dro_ara
+    statement: "γ is derived from H, never assigned independently."
+    formula: "γ = 2·H + 1"
+    variables: {H: DFA-1 Hurst exponent on log-returns, gamma: derived scalar}
+    tolerance: "|γ − (2·H + 1)| < 1e-5 for all admissible inputs"
+    validity: "1-D finite non-constant price array, length ≥ window+step"
+    source: "Peng et al. 1994; core/dro_ara/engine.py::derive_gamma"
+    severity: block
+
+  - id: dro_ara.risk_scalar_bounds
+    module: dro_ara
+    statement: "The risk scalar is bounded in [0, 1] and Lipschitz-1 in γ."
+    formula: "rs(γ) = max(0, 1 − |γ − 1|)"
+    variables: {gamma: derived scaling exponent, rs: risk scalar ∈ [0, 1]}
+    tolerance: "strict; violation is a bug, not a numerical artefact"
+    validity: "all real γ"
+    source: "core/dro_ara/engine.py::risk_scalar"
+    severity: block
+
+  - id: dro_ara.invalid_regime_gate
+    module: dro_ara
+    statement: "INVALID is declared iff the series fails ADF OR R² of the DFA fit is below R2_MIN."
+    formula: "regime == INVALID ⇔ (!stationary ∨ r2 < R2_MIN)"
+    variables: {stationary: ADF rejection of unit root, r2: DFA linear-fit R², R2_MIN: 0.90}
+    tolerance: "strict; no tolerance relaxation"
+    validity: "admissible non-constant finite 1-D input"
+    source: "Dickey-Fuller 1979; Ng-Perron 2001; core/dro_ara/engine.py::classify"
+    severity: block
+
+  - id: dro_ara.long_signal_gate
+    module: dro_ara
+    statement: "A LONG signal requires CRITICAL regime, rs above threshold, and a converging/stable trend."
+    formula: "signal == LONG  ⇒  regime == CRITICAL ∧ rs > RS_LONG_THRESH ∧ trend ∈ {CONVERGING, STABLE}"
+    variables: {RS_LONG_THRESH: 0.33, trend: ARA trajectory classification}
+    tolerance: "strict logical conjunction; all three must hold"
+    validity: "geosync_observe output dict"
+    source: "core/dro_ara/engine.py::geosync_observe"
+    severity: block
+
+  - id: dro_ara.fail_closed_input
+    module: dro_ara
+    statement: "Degenerate input raises ValueError; no silent repair."
+    formula: "NaN ∨ Inf ∨ constant ∨ rank != 1 ∨ len < window+step  ⇒  raise ValueError"
+    variables: {price: input array, window: DFA window, step: ARA stride}
+    tolerance: "exact exception type; no fall-through to numeric path"
+    validity: "all inputs to geosync_observe"
+    source: "core/dro_ara/engine.py::_validate"
+    severity: block


### PR DESCRIPTION
## Summary

Registers the DRO-ARA v7 regime observer (merged in PR #277) into GeoSync's dual physics-contract stack — no test changes, pure contract registration.

## 5 new P0 invariants

| ID        | Type        | Statement                                                     |
|-----------|-------------|---------------------------------------------------------------|
| INV-DRO1  | algebraic   | `γ = 2·H + 1` to float precision                              |
| INV-DRO2  | universal   | `rs = max(0, 1 − \|γ − 1\|) ∈ [0, 1]`, Lipschitz-1 in γ        |
| INV-DRO3  | conditional | `regime == INVALID ⇔ (!stationary ∨ r² < R2_MIN)`             |
| INV-DRO4  | conditional | `signal == LONG ⇒ CRITICAL ∧ rs > 0.33 ∧ trend ∈ {CONV,STABLE}` |
| INV-DRO5  | universal   | NaN/Inf/constant/rank/short input ⇒ `ValueError`              |

## Files touched

- `.claude/physics/INVARIANTS.yaml` — new `dro_ara:` block (5 entries)
- `physics_contracts/catalog.yaml` — 5 mirror law entries
- `CLAUDE.md` — new `### DRO-ARA Regime Observer` block in INVARIANT REGISTRY + `*dro_ara*` → INV-DRO1..5 row in routing table
- `docs/physics/dro_ara_invariants.md` — new prose doc with invariant → test mapping and references

## Test plan

- [x] All 5 invariants already covered by existing `tests/core/dro_ara/test_invariants.py` and `test_falsification.py` (25 tests green)
- [x] `python3 .claude/physics/validate_tests.py tests/core/dro_ara/` passes with 0 issues (loads 65 INVs, was 60)
- [x] No edits to `core/dro_ara/` code
- [x] No mass-delete of either contract layer — both are extended in-place

🤖 Generated with [Claude Code](https://claude.com/claude-code)