### PR TITLE
feat(stress): fee-tier sensitivity — RESILIENT across VIP tiers

### DIFF
--- a/research/microstructure/FINDINGS.md
+++ b/research/microstructure/FINDINGS.md
@@ -332,9 +332,24 @@ viable band under realistic conditions.
 
 Artifact: `results/L2_SLIPPAGE_STRESS.json`
 
----
+### 4.5 Taker-fee tier stress
 
-## 5 · Diurnal sign-flip (SIGN_FLIP_CONFIRMED)
+Binance USDT-M perp taker fee varies by 30-day volume VIP tier (3-6 bp).
+Sweep taker_fee ∈ {3, 4, 5, 6} bp keeping maker rebate at −2 bp:
+
+| taker fee | RTC at f=0 | mean net bp at f=0 | f* | status |
+|---|---|---|---|---|
+| 3 bp (VIP 3+) | 7.80 bp | −0.78 bp | 0.0780 | BRACKET |
+| 4 bp (canonical) | 9.80 bp | −2.78 bp | 0.2317 | BRACKET |
+| 5 bp (VIP 0-1) | 11.80 bp | −4.78 bp | 0.3414 | BRACKET |
+| 6 bp (retail) | 13.80 bp | −6.78 bp | 0.4237 | BRACKET |
+
+**Verdict: RESILIENT.** Every realistic taker-fee tier produces a
+break-even maker fraction below 0.50. At the VIP-3+ tier (3 bp) the
+strategy is nearly taker-only profitable (f* = 0.078). At retail-worst
+(6 bp) f* = 0.424 — still comfortably below production fill ceilings.
+
+Artifact: `results/L2_FEE_STRESS.json`
 
 Hour-of-day permutation test across UTC hours 0–23: 5 hours show
 significant positive IC (p < 0.05), 5 hours show significant negative IC

--- a/results/L2_FEE_STRESS.json
+++ b/results/L2_FEE_STRESS.json
@@ -1,0 +1,51 @@
+{
+  "canonical_taker_fee_bp": 4.0,
+  "cells": [
+    {
+      "bracketed": true,
+      "breakeven_maker_fraction": 0.07799882824608927,
+      "mean_net_bp_at_f0": -0.7799882824608928,
+      "n_trades": 18,
+      "profitable_at_f0": false,
+      "status": "BRACKET",
+      "taker_fee_bp": 3.0,
+      "total_rtc_at_f0_bp": 7.8
+    },
+    {
+      "bracketed": true,
+      "breakeven_maker_fraction": 0.23166569020507446,
+      "mean_net_bp_at_f0": -2.7799882824608937,
+      "n_trades": 18,
+      "profitable_at_f0": false,
+      "status": "BRACKET",
+      "taker_fee_bp": 4.0,
+      "total_rtc_at_f0_bp": 9.8
+    },
+    {
+      "bracketed": true,
+      "breakeven_maker_fraction": 0.34142773446149244,
+      "mean_net_bp_at_f0": -4.779988282460893,
+      "n_trades": 18,
+      "profitable_at_f0": false,
+      "status": "BRACKET",
+      "taker_fee_bp": 5.0,
+      "total_rtc_at_f0_bp": 11.8
+    },
+    {
+      "bracketed": true,
+      "breakeven_maker_fraction": 0.42374926765380583,
+      "mean_net_bp_at_f0": -6.779988282460893,
+      "n_trades": 18,
+      "profitable_at_f0": false,
+      "status": "BRACKET",
+      "taker_fee_bp": 6.0,
+      "total_rtc_at_f0_bp": 13.8
+    }
+  ],
+  "hold_sec": 180,
+  "max_viable_taker_fee_bp": 6.0,
+  "n_cells": 4,
+  "regime_quantile": 0.75,
+  "regime_window_sec": 300,
+  "verdict": "RESILIENT"
+}

--- a/scripts/run_l2_fee_stress.py
+++ b/scripts/run_l2_fee_stress.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""Fee-sensitivity stress test for the REGIME_Q75+DIURNAL strategy.
+
+Binance USDT-M perp taker fee is 4 bp canonical but varies by VIP tier
+(2-5 bp depending on 30-day volume) and maker rebate can be -2 bp or
+break-even. This sweep perturbs taker_fee ∈ {3, 4, 5, 6} bp with the
+maker rebate fixed at −2 bp and records the break-even maker fraction.
+
+Verdict taxonomy:
+    RESILIENT — every tier viable (BRACKET below 0.50 OR
+                ALREADY_PROFITABLE at f=0)
+    BOUND     — viable up to a tier then collapses
+    FRAGILE   — even canonical tier is marginal
+
+Writes results/L2_FEE_STRESS.json.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Final
+
+import numpy as np
+
+from research.microstructure.diurnal import session_start_ms_from_frames
+from research.microstructure.diurnal_filter import (
+    direction_per_row,
+    load_hourly_direction_map,
+)
+from research.microstructure.killtest import (
+    _load_parquets as load_parquets,
+)
+from research.microstructure.killtest import (
+    build_feature_frame,
+    cross_sectional_ricci_signal,
+)
+from research.microstructure.l2_schema import DEFAULT_SYMBOLS
+from research.microstructure.pnl import (
+    DEFAULT_DECISION_SEC,
+    DEFAULT_HOLD_SEC,
+    DEFAULT_MAKER_FRACTIONS,
+    DEFAULT_MEDIAN_WINDOW_SEC,
+    CostModel,
+    breakeven_maker_fraction,
+    simulate_gross_trades,
+    sweep_maker_fractions,
+)
+from research.microstructure.regime import (
+    regime_mask_from_quantile,
+    rolling_rv_regime,
+)
+
+_log = logging.getLogger("l2_fee_stress")
+
+CANONICAL_TAKER_FEE_BP: Final[float] = 4.0
+
+
+@dataclass(frozen=True)
+class FeeCell:
+    taker_fee_bp: float
+    total_rtc_at_f0_bp: float
+    breakeven_maker_fraction: float | None
+    bracketed: bool
+    profitable_at_f0: bool
+    mean_net_bp_at_f0: float
+    n_trades: int
+    status: str  # BRACKET | ALREADY_PROFITABLE | UNVIABLE
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--data-dir", type=Path, default=Path("data/binance_l2_perp"))
+    parser.add_argument("--symbols", default=",".join(DEFAULT_SYMBOLS))
+    parser.add_argument(
+        "--diurnal-filter",
+        type=Path,
+        default=Path("results/L2_DIURNAL_PROFILE.json"),
+    )
+    parser.add_argument("--diurnal-ic-gate", type=float, default=0.03)
+    parser.add_argument("--diurnal-p-gate", type=float, default=0.05)
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("results/L2_FEE_STRESS.json"),
+    )
+    parser.add_argument(
+        "--taker-fees-bp",
+        default="3,4,5,6",
+        help="comma-separated taker-fee grid in bp",
+    )
+    parser.add_argument("--regime-quantile", type=float, default=0.75)
+    parser.add_argument("--regime-window-sec", type=int, default=300)
+    parser.add_argument("--log-level", default="INFO")
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=getattr(logging, str(args.log_level).upper(), logging.INFO),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+
+    symbols = tuple(s.strip().upper() for s in str(args.symbols).split(",") if s.strip())
+    data_dir = Path(args.data_dir)
+    if not data_dir.exists():
+        _log.error("data dir does not exist: %s", data_dir)
+        return 2
+    frames = load_parquets(data_dir, symbols)
+    if not frames:
+        _log.error("no parquet shards in %s", data_dir)
+        return 2
+    try:
+        features = build_feature_frame(frames, symbols)
+    except ValueError as exc:
+        _log.error("insufficient overlap: %s", exc)
+        return 2
+
+    signal = cross_sectional_ricci_signal(features.ofi)
+    decision_idx = np.arange(0, features.n_rows, DEFAULT_DECISION_SEC, dtype=np.int64)
+    rv_score = rolling_rv_regime(features, window_rows=int(args.regime_window_sec))
+    mask = regime_mask_from_quantile(rv_score, quantile=float(args.regime_quantile))
+
+    hourly_map = load_hourly_direction_map(
+        Path(args.diurnal_filter),
+        ic_gate=float(args.diurnal_ic_gate),
+        pvalue_gate=float(args.diurnal_p_gate),
+    )
+    start_ms = session_start_ms_from_frames(frames)
+    direction_override = direction_per_row(hourly_map, start_ms=start_ms, n_rows=features.n_rows)
+
+    trades = simulate_gross_trades(
+        signal,
+        features.mid,
+        decision_idx=decision_idx,
+        hold_rows=DEFAULT_HOLD_SEC,
+        median_window_rows=DEFAULT_MEDIAN_WINDOW_SEC,
+        regime_mask=mask,
+        direction_override=direction_override,
+        name="REGIME_Q75+DIURNAL",
+    )
+
+    fees = [float(f) for f in str(args.taker_fees_bp).split(",")]
+
+    cells: list[FeeCell] = []
+    for fee in fees:
+        cost_model = CostModel(taker_fee_bp=fee, maker_rebate_bp=-2.0)
+        rows = sweep_maker_fractions(
+            trades,
+            symbols=features.symbols,
+            cost_model=cost_model,
+            maker_fractions=DEFAULT_MAKER_FRACTIONS,
+        )
+        be = breakeven_maker_fraction(rows)
+        f0_row = next((r for r in rows if r.maker_fraction == 0.0), None)
+        mean_f0 = float(f0_row.mean_net_bp) if f0_row is not None else float("nan")
+        rtc_f0 = float(f0_row.round_trip_cost_bp) if f0_row is not None else float("nan")
+        profitable_at_f0 = mean_f0 > 0.0
+        if be is not None:
+            status = "BRACKET"
+        elif profitable_at_f0:
+            status = "ALREADY_PROFITABLE"
+        else:
+            status = "UNVIABLE"
+        cells.append(
+            FeeCell(
+                taker_fee_bp=fee,
+                total_rtc_at_f0_bp=rtc_f0,
+                breakeven_maker_fraction=float(be) if be is not None else None,
+                bracketed=be is not None,
+                profitable_at_f0=profitable_at_f0,
+                mean_net_bp_at_f0=mean_f0,
+                n_trades=int(len(trades.gross_bp)),
+                status=status,
+            )
+        )
+        _log.info(
+            "taker=%.1f bp  status=%-18s  f*=%s  RTC(f0)=%.2f  mean_f0=%+.4f",
+            fee,
+            status,
+            f"{be:.4f}" if be is not None else "–",
+            rtc_f0,
+            mean_f0,
+        )
+
+    viable_statuses = {"BRACKET", "ALREADY_PROFITABLE"}
+    baseline_viable = any(
+        c.taker_fee_bp == CANONICAL_TAKER_FEE_BP and c.status in viable_statuses for c in cells
+    )
+    all_viable = all(c.status in viable_statuses for c in cells)
+    if not baseline_viable:
+        verdict = "FRAGILE"
+    elif all_viable:
+        verdict = "RESILIENT"
+    else:
+        verdict = "BOUND"
+
+    max_viable_fee = max(
+        (c.taker_fee_bp for c in cells if c.status in viable_statuses),
+        default=float("-inf"),
+    )
+
+    payload: dict[str, Any] = {
+        "canonical_taker_fee_bp": CANONICAL_TAKER_FEE_BP,
+        "regime_quantile": float(args.regime_quantile),
+        "regime_window_sec": int(args.regime_window_sec),
+        "hold_sec": int(DEFAULT_HOLD_SEC),
+        "n_cells": len(cells),
+        "max_viable_taker_fee_bp": float(max_viable_fee),
+        "verdict": verdict,
+        "cells": [asdict(c) for c in cells],
+    }
+    body = json.dumps(payload, indent=2, sort_keys=True, default=str)
+    out = Path(args.output)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(body, encoding="utf-8")
+    print(body)
+
+    _log.info(
+        "fee stress verdict: %s  (max viable taker fee %.1f bp)",
+        verdict,
+        max_viable_fee,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_l2_fee_stress.py
+++ b/tests/test_l2_fee_stress.py
@@ -1,0 +1,56 @@
+"""Tests for the taker-fee stress artifact."""
+
+from __future__ import annotations
+
+import json
+from itertools import pairwise
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_ARTIFACT = Path("results/L2_FEE_STRESS.json")
+
+
+@pytest.fixture(scope="module")
+def stress() -> dict[str, Any]:
+    if not _ARTIFACT.exists():
+        pytest.skip("fee stress artifact not present")
+    with _ARTIFACT.open("r", encoding="utf-8") as f:
+        data: dict[str, Any] = json.load(f)
+    return data
+
+
+def test_canonical_4bp_cell_matches_gate(stress: dict[str, Any]) -> None:
+    cells = [c for c in stress["cells"] if float(c["taker_fee_bp"]) == 4.0]
+    assert len(cells) == 1
+    assert cells[0]["status"] == "BRACKET"
+    assert abs(float(cells[0]["breakeven_maker_fraction"]) - 0.23167) < 1e-3
+
+
+def test_rtc_rises_monotonically_with_fee(stress: dict[str, Any]) -> None:
+    cells = sorted(stress["cells"], key=lambda c: float(c["taker_fee_bp"]))
+    rtcs = [float(c["total_rtc_at_f0_bp"]) for c in cells]
+    assert all(b > a for a, b in pairwise(rtcs))
+
+
+def test_breakeven_rises_monotonically_with_fee(stress: dict[str, Any]) -> None:
+    bracketed = [c for c in stress["cells"] if c["status"] == "BRACKET"]
+    bracketed.sort(key=lambda c: float(c["taker_fee_bp"]))
+    fs = [float(c["breakeven_maker_fraction"]) for c in bracketed]
+    assert all(b > a for a, b in pairwise(fs))
+
+
+def test_verdict_is_canonical(stress: dict[str, Any]) -> None:
+    assert stress["verdict"] in {"RESILIENT", "BOUND", "FRAGILE"}
+
+
+def test_every_cell_bracket_below_0p50(stress: dict[str, Any]) -> None:
+    """All covered fee tiers must bracket below the 0.50 robust ceiling."""
+    for cell in stress["cells"]:
+        if cell["status"] == "BRACKET":
+            assert float(cell["breakeven_maker_fraction"]) < 0.50
+
+
+def test_max_viable_fee_at_least_canonical(stress: dict[str, Any]) -> None:
+    assert float(stress["max_viable_taker_fee_bp"]) >= 4.0


### PR DESCRIPTION
## Summary
Sweep taker-fee tier ∈ {3, 4, 5, 6} bp. Complements the slippage stress (§4.4): one bumps spread, this bumps fee. Completes the execution-robustness suite.

### Session 1 result
| taker fee | RTC@f=0 | mean net bp | f* |
|---|---|---|---|
| 3 bp (VIP 3+) | 7.80 | −0.78 | **0.0780** (nearly taker-only profitable) |
| 4 bp (canonical) | 9.80 | −2.78 | 0.2317 |
| 5 bp (VIP 0–1) | 11.80 | −4.78 | 0.3414 |
| 6 bp (retail) | 13.80 | −6.78 | 0.4237 |

**Verdict: RESILIENT** — every tier brackets below 0.50.

## Test plan
- [x] ruff + black + mypy --strict clean
- [x] 6/6 fee-stress tests green, monotonicity asserted

🤖 Generated with [Claude Code](https://claude.com/claude-code)