### PR TITLE
fix(contracts): escape brackets in DRO-ARA catalog entries (unblock CI)

### DIFF
--- a/physics_contracts/catalog.yaml
+++ b/physics_contracts/catalog.yaml
@@ -303,7 +303,9 @@ laws:
     module: dro_ara
     statement: "The risk scalar is bounded in [0, 1] and Lipschitz-1 in γ."
     formula: "rs(γ) = max(0, 1 − |γ − 1|)"
-    variables: {gamma: derived scaling exponent, rs: risk scalar ∈ [0, 1]}
+    variables:
+      gamma: "derived scaling exponent"
+      rs: "risk scalar in [0, 1]"
     tolerance: "strict; violation is a bug, not a numerical artefact"
     validity: "all real γ"
     source: "core/dro_ara/engine.py::risk_scalar"
@@ -322,8 +324,10 @@ laws:
   - id: dro_ara.long_signal_gate
     module: dro_ara
     statement: "A LONG signal requires CRITICAL regime, rs above threshold, and a converging/stable trend."
-    formula: "signal == LONG  ⇒  regime == CRITICAL ∧ rs > RS_LONG_THRESH ∧ trend ∈ {CONVERGING, STABLE}"
-    variables: {RS_LONG_THRESH: 0.33, trend: ARA trajectory classification}
+    formula: "signal == LONG  =>  regime == CRITICAL AND rs > RS_LONG_THRESH AND trend in (CONVERGING, STABLE)"
+    variables:
+      RS_LONG_THRESH: 0.33
+      trend: "ARA trajectory classification"
     tolerance: "strict logical conjunction; all three must hold"
     validity: "geosync_observe output dict"
     source: "core/dro_ara/engine.py::geosync_observe"


### PR DESCRIPTION
## Summary

`physics_contracts/catalog.yaml` (merged in PR #294) contained inline flow mappings with unquoted square/curly brackets — e.g. `{rs: risk scalar ∈ [0, 1]}`. YAML parses `[0, 1]` as a nested list inside the flow mapping, raising `yaml.parser.ParserError` in `tests/physics_contracts/test_witness_examples.py` and blocking every open PR.

## Fix

- Rewrite the two affected `variables:` mappings in **block** style with **quoted** string values.
- Replace the set/bracket notation in the `long_signal_gate` formula with ASCII (`AND`, `in (CONVERGING, STABLE)`) to avoid the same trap.

All 5 DRO-ARA entries remain semantically identical.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('physics_contracts/catalog.yaml'))"` clean
- [x] `pytest tests/physics_contracts/test_witness_examples.py` 3/3 pass
- [x] No other entries touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)