### PR TITLE
docs(l2): session CHANGELOG + Makefile integrity tests

### DIFF
--- a/research/microstructure/CHANGELOG.L2.md
+++ b/research/microstructure/CHANGELOG.L2.md
@@ -1,0 +1,78 @@
+# CHANGELOG — L2 Ricci cross-sectional edge
+
+Chronological record of every PR that shaped the 10-axis + 5-ablation
+Ricci research stack on Binance USDT-M perp L2 substrate.
+
+---
+
+## 2026-04-18 · Demo-readiness session
+
+End-to-end integration from 8-axis narrative to canonical, self-verifying,
+demo-shippable package.
+
+### Validation layer — 10 orthogonal axes
+
+- **PR #268** · `feat(robustness)` — Politis-Romano block bootstrap 95% CI +
+  Lopez-de-Prado deflated Sharpe + Augmented Dickey-Fuller + mutual
+  information (4 axes in one module: `research/microstructure/robustness.py`)
+- **PR #270** · `feat(cv)` — purged & embargoed K-fold CV (AFML Ch. 7);
+  5/5 folds positive, mean IC = 0.122
+- **PR #271** · `feat(spectral)` — Welch PSD, redness slope β = 1.80
+- **PR #272** · `feat(regime-markov)` — 6-state transition matrix,
+  mean diagonal = 0.832
+- **PR #273** · `feat(hurst)` — DFA-1 Hurst, H = 1.014, R² = 0.982
+- **PR #274** · `feat(te)` — pairwise Transfer Entropy, 45/45 BIDIRECTIONAL
+- **PR #276** · `feat(cte)` — Conditional Transfer Entropy (BTC-conditioned),
+  33/36 PRIVATE_FLOW — rules out common-factor artifact
+- **PR #280** · `feat(walk-forward)` — rolling temporal-stability summary,
+  82.1% windows positive, STABLE_POSITIVE verdict
+
+### Execution layer
+
+- **PR #266** · `feat(diurnal-filter)` — sign-aware per-row direction filter
+- **PR #269** · `feat(pnl)` — cost sweep + break-even for REGIME_Q75+DIURNAL,
+  f* = 0.23167 (canonical gate fixture)
+
+### Synthesis + demo artifacts
+
+- **PR #275** · `docs(findings)` — 8-axis consolidated narrative
+- **PR #278** · `feat(demo)` — three canonical figures + manifest + runner
+- **PR #279** · `docs(readme)` — L2 microstructure section
+- **PR #281** · `feat(visualize)` — fig4_stability walk-forward panel
+- **PR #282** · `feat(visualize)` — fig0_cover single-page demo poster
+- **PR #297** · `feat(demo)` — self-contained HTML dashboard (7.2 KB)
+- **PR #300** · `feat(make)` — pro-max ergonomic Makefile targets
+
+### Ablation / stress layer — 5 axes
+
+- **PR #290** · `feat(ablation)` — hyperparameter (regime-q × window) sweep →
+  **SENSITIVE** (f* drifts ±60%, but all 9 cells below production ceiling)
+- **PR #293** · `feat(ablation)` — leave-one-symbol-out → **MIXED**
+  (BTC removal drops IC 43%; all 10 cells still positive)
+- **PR #295** · `feat(ablation)` — hold-time (60–600 s) → **ROBUST**
+  (3/5 cells already profitable at f = 0)
+- **PR #296** · `feat(stress)` — slippage stress (±bp/side) → **BOUND**
+  (max viable +3 bp/side; typical prod +0.5–1.5 bp)
+- **PR #298** · `feat(stress)` — fee-tier sensitivity → **RESILIENT**
+  (all 4 VIP tiers bracket below 0.50)
+
+### Coherence / integrity gates
+
+- **PR #286** · `test(coherence)` — 7 independent gate suites
+  (deterministic replay, doc-data, per-axis invariants, schema registry,
+  CLI discoverability, performance budget, E2E demo smoke)
+- **PR #288** · `test(property-based)` — Hypothesis coverage for
+  DFA Hurst, TE, CTE, walk-forward
+
+### Final state
+
+- **10 validation axes**, all green on Session 1
+- **5 ablation / stress axes** with honest verdicts (SENSITIVE / MIXED /
+  ROBUST / BOUND / RESILIENT)
+- **5 canonical figures** + HTML dashboard
+- **1 one-command runner** + SHA-256 manifest (81 s end-to-end)
+- **300+ L2 tests** passing
+- **Deterministic replay** confirmed bit-exact across two runs
+
+Canonical entry point: `make l2-demo`
+Synthesis document: `research/microstructure/FINDINGS.md`

--- a/tests/test_l2_makefile_targets.py
+++ b/tests/test_l2_makefile_targets.py
@@ -1,0 +1,133 @@
+"""Tests for the Makefile L2 demo targets.
+
+Verifies each `l2-*` target is declared as PHONY, has a docstring
+(`## l2-xxx: …`), and `make l2-help` lists every one. Prevents silent
+drift between the target set, the help output, and the CHANGELOG.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_MAKEFILE = Path("Makefile")
+
+_EXPECTED_TARGETS: frozenset[str] = frozenset(
+    {
+        "l2-help",
+        "l2-demo",
+        "l2-figures",
+        "l2-dashboard",
+        "l2-smoke",
+        "l2-deterministic",
+        "l2-ablations",
+        "l2-test",
+    }
+)
+
+
+@pytest.fixture(scope="module")
+def makefile_text() -> str:
+    if not _MAKEFILE.exists():
+        pytest.skip("Makefile not present in CWD")
+    return _MAKEFILE.read_text(encoding="utf-8")
+
+
+def test_every_expected_l2_target_is_phony(makefile_text: str) -> None:
+    # Gather every .PHONY line and extract target names.
+    phony_targets: set[str] = set()
+    for m in re.finditer(r"^\.PHONY:\s*(.+)$", makefile_text, re.MULTILINE):
+        phony_targets.update(m.group(1).split())
+    missing = _EXPECTED_TARGETS - phony_targets
+    assert not missing, f"Missing from .PHONY declarations: {sorted(missing)}"
+
+
+def test_every_expected_l2_target_has_docstring(makefile_text: str) -> None:
+    for target in _EXPECTED_TARGETS:
+        # Match the ## <target>: ... convention used by l2-help
+        pat = re.compile(rf"^##\s+{re.escape(target)}:\s+.+$", re.MULTILINE)
+        assert pat.search(makefile_text), f"target {target} missing '## {target}: ...' docstring"
+
+
+def test_l2_help_lists_every_target() -> None:
+    proc = subprocess.run(
+        ["make", "--no-print-directory", "l2-help"],
+        capture_output=True,
+        text=True,
+        env={"NO_COLOR": "1", "PATH": "/usr/bin:/bin:/usr/local/bin"},
+        timeout=30,
+    )
+    if proc.returncode != 0:
+        pytest.skip(f"make l2-help not runnable in this environment: {proc.stderr[:200]}")
+    stdout = proc.stdout
+    missing = [t for t in _EXPECTED_TARGETS if t not in stdout]
+    assert not missing, f"make l2-help output missing: {missing}"
+
+
+def test_l2_help_exits_zero() -> None:
+    proc = subprocess.run(
+        ["make", "--no-print-directory", "l2-help"],
+        capture_output=True,
+        text=True,
+        env={"NO_COLOR": "1", "PATH": "/usr/bin:/bin:/usr/local/bin"},
+        timeout=30,
+    )
+    if proc.returncode == 127:
+        pytest.skip("make not available in PATH")
+    assert proc.returncode == 0, f"make l2-help exited {proc.returncode}: {proc.stderr[:200]}"
+
+
+def test_makefile_references_existing_scripts(makefile_text: str) -> None:
+    """Every scripts/ path mentioned in the L2 section must exist on disk."""
+    l2_section_start = makefile_text.find("# L2 Ricci cross-sectional edge")
+    if l2_section_start < 0:
+        pytest.skip("L2 section not found")
+    l2_section = makefile_text[l2_section_start:]
+    script_paths = re.findall(r"scripts/[A-Za-z0-9_./-]+\.py", l2_section)
+    missing = [p for p in set(script_paths) if not Path(p).exists()]
+    assert not missing, f"Makefile references missing scripts: {missing}"
+
+
+def test_changelog_lists_all_nineteen_session_prs() -> None:
+    path = Path("research/microstructure/CHANGELOG.L2.md")
+    if not path.exists():
+        pytest.skip("CHANGELOG.L2.md not present")
+    text = path.read_text(encoding="utf-8")
+    # Expect every merged PR number that shipped L2 work in the session
+    expected_prs = {
+        "#266",
+        "#268",
+        "#269",
+        "#270",
+        "#271",
+        "#272",
+        "#273",
+        "#274",
+        "#275",
+        "#276",
+        "#278",
+        "#279",
+        "#280",
+        "#281",
+        "#282",
+        "#286",
+        "#288",
+        "#290",
+        "#293",
+        "#295",
+        "#296",
+        "#297",
+        "#298",
+        "#300",
+    }
+    missing = [pr for pr in expected_prs if pr not in text]
+    assert not missing, f"CHANGELOG missing PR refs: {missing}"
+
+
+def test_sys_python_available_for_make_targets() -> None:
+    """Sanity: the python interpreter exists and is the one we expect."""
+    assert Path(sys.executable).exists()


### PR DESCRIPTION
## Summary
Seals the demo-readiness session with two provenance artifacts:

### 1. \`research/microstructure/CHANGELOG.L2.md\`
Chronological record of every PR that built the 10-axis + 5-ablation L2 stack. Grouped by layer:
- **Validation** (10 orthogonal axes, all green)
- **Execution** (diurnal filter + cost sweep → f* = 0.232)
- **Synthesis** (FINDINGS, figures, HTML dashboard, README, Makefile)
- **Ablations** (5 axes: SENSITIVE / MIXED / ROBUST / BOUND / RESILIENT)
- **Coherence gates** (7 integrity suites + property-based)

### 2. \`tests/test_l2_makefile_targets.py\`
Seven integrity checks that catch drift between Makefile, help output, CHANGELOG, and on-disk script paths:
- every \`l2-*\` target declared \`.PHONY\`
- every target has a \`## <name>: …\` docstring
- \`make l2-help\` runs and lists every target
- \`make l2-help\` exits 0
- every scripts/ path referenced exists on disk
- CHANGELOG lists all 24 session PRs
- system python reachable

## Test plan
- [x] 7/7 Makefile audit tests green
- [x] CHANGELOG lists 24 PRs by layer

🤖 Generated with [Claude Code](https://claude.com/claude-code)