### PR TITLE
Introduce UTC helper and unify timezone-aware now across codebase

### DIFF
--- a/core/compat.py
+++ b/core/compat.py
@@ -1,0 +1,15 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""Cross-version compatibility helpers for core runtime modules."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+UTC = timezone.utc
+
+
+def utc_now() -> datetime:
+    """Return a timezone-aware UTC timestamp."""
+    return datetime.now(UTC)
+

--- a/core/events/sourcing.py
+++ b/core/events/sourcing.py
@@ -16,7 +16,7 @@ import json
 import logging
 from contextlib import contextmanager
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import datetime
 from typing import (
     Any,
     ClassVar,
@@ -51,6 +51,7 @@ from sqlalchemy.engine import Engine
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session, sessionmaker
 
+from core.compat import UTC, utc_now
 from domain.order import OrderSide, OrderStatus, OrderType
 
 LOGGER = logging.getLogger(__name__)
@@ -103,7 +104,7 @@ class DomainEvent(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     event_id: UUID = Field(default_factory=uuid4)
-    occurred_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    occurred_at: datetime = Field(default_factory=utc_now)
     # ``stream_version`` is injected during hydration and excluded from persistence.
     stream_version: int | None = Field(default=None, exclude=True)
 
@@ -1131,7 +1132,7 @@ def take_snapshot(aggregate: AggregateRoot) -> AggregateSnapshot:
         aggregate_type=aggregate.aggregate_type,
         version=aggregate.version,
         state=dict(aggregate.snapshot_state()),
-        taken_at=datetime.now(UTC),
+        taken_at=utc_now(),
     )
 
 

--- a/cortex_service/tests/test_property.py
+++ b/cortex_service/tests/test_property.py
@@ -4,6 +4,10 @@
 
 from __future__ import annotations
 
+from datetime import datetime
+
+from core.compat import UTC
+
 from hypothesis import given
 from hypothesis import strategies as st
 
@@ -82,8 +86,6 @@ def test_regime_valence_always_clipped(valence, min_valence, max_valence):
     )
     modulator = RegimeModulator(settings)
 
-    from datetime import UTC, datetime
-
     state = modulator.update(None, valence, 0.1, datetime.now(UTC))
     assert min_valence <= state.valence <= max_valence
 
@@ -103,8 +105,6 @@ def test_regime_confidence_bounds(feedback, volatility, decay):
         confidence_floor=confidence_floor,
     )
     modulator = RegimeModulator(settings)
-
-    from datetime import UTC, datetime
 
     state = modulator.update(None, feedback, volatility, datetime.now(UTC))
     assert confidence_floor <= state.confidence <= 1.0

--- a/cortex_service/tests/test_signals.py
+++ b/cortex_service/tests/test_signals.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import os
-from datetime import UTC, datetime
+from datetime import datetime
+
+from core.compat import UTC
 
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine

--- a/scripts/localization/sync_translations.py
+++ b/scripts/localization/sync_translations.py
@@ -16,6 +16,8 @@ from typing import Any, Dict, Iterable, Mapping, Set
 import yaml
 from jsonschema import Draft202012Validator
 
+from core.compat import utc_now
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_LOCALES_YAML = REPO_ROOT / "configs" / "localization" / "locales.yaml"
 TRANSLATIONS_DIR = REPO_ROOT / "ui" / "dashboard" / "src" / "i18n" / "locales"
@@ -300,9 +302,7 @@ def main(argv: Iterable[str]) -> int:
 
     write_translations(translations, args.translations_dir, check=False)
     dump_json(args.metadata_output, metadata_payload)
-    from datetime import UTC, datetime
-
-    coverage["generatedAt"] = datetime.now(UTC).isoformat().replace("+00:00", "Z")
+    coverage["generatedAt"] = utc_now().isoformat().replace("+00:00", "Z")
     dump_json(args.coverage_report, coverage)
 
     if issues:

--- a/src/geosync/core/compat.py
+++ b/src/geosync/core/compat.py
@@ -1,0 +1,15 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""Cross-version compatibility helpers for GeoSync core packages."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+UTC = timezone.utc
+
+
+def utc_now() -> datetime:
+    """Return a timezone-aware UTC timestamp."""
+    return datetime.now(UTC)
+

--- a/src/geosync/core/security/audit.py
+++ b/src/geosync/core/security/audit.py
@@ -6,10 +6,10 @@ from __future__ import annotations
 
 import json
 import logging
-from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+from src.geosync.core.compat import utc_now
 
 class AuditLogger:
     """Simple JSON audit logger."""
@@ -40,7 +40,7 @@ class AuditLogger:
         **kwargs: Any,
     ) -> None:
         entry = {
-            "timestamp": datetime.now(UTC).isoformat(),
+            "timestamp": utc_now().isoformat(),
             "event": event,
             "user": user,
             "resource": resource,

--- a/src/geosync/core/security/incident.py
+++ b/src/geosync/core/security/incident.py
@@ -7,9 +7,10 @@ from __future__ import annotations
 import logging
 import os
 import smtplib
-from datetime import UTC, datetime
 from email.mime.text import MIMEText
 from typing import Any, Callable
+
+from src.geosync.core.compat import utc_now
 
 logger = logging.getLogger(__name__)
 
@@ -29,7 +30,7 @@ class IncidentResponse:
             raise ValueError(f"Unknown severity '{severity}'")
         incident = {
             "id": self._next_id,
-            "timestamp": datetime.now(UTC).isoformat(),
+            "timestamp": utc_now().isoformat(),
             "severity": severity,
             "event": event,
             "details": details,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.util
+import importlib.metadata
 import logging
 import os
 import sys
@@ -11,12 +12,22 @@ from functools import lru_cache
 from pathlib import Path, PurePosixPath
 from typing import Iterable, Iterator, Sequence
 
-import pandas as pd
 import pytest
 import yaml  # type: ignore[import-untyped]
 
-if not hasattr(pd, "_pandas_datetime_CAPI"):  # pragma: no cover - import-time guard
-    pd._pandas_datetime_CAPI = None
+LOGGER = logging.getLogger("tests.bootstrap")
+
+try:
+    import pandas as pd
+    pd.Timestamp.now(tz="UTC")
+    pandas_version = importlib.metadata.version("pandas")
+    LOGGER.info("Pandas compatibility gate passed (pandas=%s)", pandas_version)
+except Exception as exc:  # pragma: no cover - environment compatibility gate
+    LOGGER.exception("Pandas compatibility gate failed")
+    raise pytest.UsageError(
+        "Pandas compatibility gate failed. "
+        "Install/repair a compatible pandas build before running tests."
+    ) from exc
 
 _audit_trail_path = Path("observability/audit/trail.py")
 _audit_spec = importlib.util.spec_from_file_location(
@@ -33,15 +44,7 @@ get_system_audit_trail = _audit_module.get_system_audit_trail
 os.environ.setdefault("GEOSYNC_TWO_FACTOR_SECRET", "JBSWY3DPEHPK3PXP")
 os.environ.setdefault("THERMO_DUAL_SECRET", "test-secret")
 
-_fixture_path = Path(__file__).parent / "fixtures" / "conftest.py"
-spec = importlib.util.spec_from_file_location("geosync_tests_fixtures", _fixture_path)
-if spec is None or spec.loader is None:
-    raise ImportError(f"Unable to load fixtures from {_fixture_path}")
-module = importlib.util.module_from_spec(spec)
-sys.modules[spec.name] = module
-spec.loader.exec_module(module)
-
-globals().update({name: getattr(module, name) for name in dir(module) if not name.startswith("__")})
+pytest_plugins = ("tests.fixtures.conftest",)
 
 
 _LEVEL_DESCRIPTIONS: dict[str, str] = {

--- a/tests/core/test_compliance_modules.py
+++ b/tests/core/test_compliance_modules.py
@@ -5,7 +5,9 @@
 from __future__ import annotations
 
 import json
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta
+
+from core.compat import UTC
 
 import pytest
 

--- a/tests/integration/test_backfill_gap_fill.py
+++ b/tests/integration/test_backfill_gap_fill.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
 # SPDX-License-Identifier: MIT
-from datetime import UTC
+from core.compat import UTC
 
 import pandas as pd
 

--- a/tests/integration/test_ingestion_feature_signal_pipeline.py
+++ b/tests/integration/test_ingestion_feature_signal_pipeline.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import csv
-from datetime import UTC
+from core.compat import UTC
 from pathlib import Path
 
 import numpy as np

--- a/tests/unit/altdata/test_social_listening.py
+++ b/tests/unit/altdata/test_social_listening.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import asyncio
 import json
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta
+
+from core.compat import UTC
 
 import pytest
 

--- a/tests/unit/compliance/test_mifid2.py
+++ b/tests/unit/compliance/test_mifid2.py
@@ -5,7 +5,9 @@
 from __future__ import annotations
 
 import json
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta
+
+from core.compat import UTC
 from pathlib import Path
 
 import pytest

--- a/tests/unit/indicators/test_cache_extended.py
+++ b/tests/unit/indicators/test_cache_extended.py
@@ -4,7 +4,9 @@
 from __future__ import annotations
 
 import tempfile
-from datetime import UTC, datetime
+from datetime import datetime
+
+from core.compat import UTC
 from pathlib import Path
 
 import numpy as np


### PR DESCRIPTION
### Motivation

- Provide a single compatibility helper for UTC timestamps to avoid repeated timezone handling and small inconsistencies across modules.
- Replace ad-hoc `datetime.now(UTC)` usages with a single `utc_now()` helper to make timestamp creation clearer and easier to test.
- Harden test bootstrapping by gating on a compatible `pandas` installation early to avoid obscure runtime failures.

### Description

- Added `core/compat.py` and `src/geosync/core/compat.py` which expose `UTC` and `utc_now()` for timezone-aware UTC timestamps.
- Replaced direct uses of `datetime.now(UTC)` with `utc_now()` in multiple modules including `core/events/sourcing.py`, `src/geosync/core/security/audit.py`, `src/geosync/core/security/incident.py`, and the localization sync script `scripts/localization/sync_translations.py`.
- Updated numerous tests to import `UTC` from `core.compat` instead of importing `UTC` directly from `datetime` locations and adjusted test bootstrapping in `tests/conftest.py` to add a `pandas` compatibility gate and use `pytest_plugins` for fixtures.
- Minor test infrastructure cleanup to log and fail fast when `pandas` is missing or incompatible.

### Testing

- Ran unit and integration tests using `pytest` across the modified suites (`tests/unit` and `tests/integration`) and they completed successfully.
- Executed the test bootstrap which verifies `pandas` compatibility and the suite initialization step, and it passed in the tested environment.
- Verified localization script execution path that emits `generatedAt` now uses `utc_now()` and writes expected coverage output during the run of the script-related tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3c38520c88324b5c0daff2c38e22b)