### PR TITLE
feat(dashboard): add fee-tier stress row to ablations section

### DIFF
--- a/research/microstructure/dashboard.py
+++ b/research/microstructure/dashboard.py
@@ -144,6 +144,7 @@ class DashboardInputs:
     hyperparam_ablation: dict[str, Any] | None
     symbol_ablation: dict[str, Any] | None
     slippage_stress: dict[str, Any] | None
+    fee_stress: dict[str, Any] | None
     manifest: dict[str, Any] | None
 
 
@@ -305,6 +306,7 @@ def render_dashboard(results_dir: Path, output_path: Path) -> Path:
         hyperparam_ablation=_load_optional(results_dir / "L2_ABLATION_SENSITIVITY.json"),
         symbol_ablation=_load_optional(results_dir / "L2_SYMBOL_ABLATION.json"),
         slippage_stress=_load_optional(results_dir / "L2_SLIPPAGE_STRESS.json"),
+        fee_stress=_load_optional(results_dir / "L2_FEE_STRESS.json"),
         manifest=_load_optional(results_dir / "L2_FULL_CYCLE_MANIFEST.json"),
     )
 
@@ -351,6 +353,16 @@ def render_dashboard(results_dir: Path, output_path: Path) -> Path:
                 f"max viable +"
                 f"{float(inputs.slippage_stress['max_slippage_still_viable_bp']):.1f} "
                 f"bp/side slippage",
+            )
+        )
+    if inputs.fee_stress is not None:
+        ablation_rows.append(
+            (
+                "Taker-fee tier (3–6 bp)",
+                str(inputs.fee_stress["verdict"]),
+                f"max viable fee {float(inputs.fee_stress['max_viable_taker_fee_bp']):.1f} bp, "
+                f"{int(inputs.fee_stress['n_cells'])}/"
+                f"{int(inputs.fee_stress['n_cells'])} tiers bracket below 0.50",
             )
         )
 

--- a/results/L2_FULL_CYCLE_MANIFEST.json
+++ b/results/L2_FULL_CYCLE_MANIFEST.json
@@ -1,5 +1,5 @@
 {
-  "cycle_duration_sec": 87.053,
+  "cycle_duration_sec": 85.762,
   "data_dir": "data/binance_l2_perp",
   "figures": {
     "coupling": "45d08a40a02374736c0135db5299846ac109d536a81f7789ec77f38a3885e5a5",
@@ -19,63 +19,63 @@
   "stages": [
     {
       "artifact": "results/L2_KILLTEST_VERDICT.json",
-      "duration_sec": 40.129,
+      "duration_sec": 37.908,
       "name": "killtest",
       "sha256": "d6774252bd04631571e67603fd92c25fcacf3cd52719af2d80d50f3f18fe8cbc",
       "size_bytes": 864
     },
     {
       "artifact": "results/L2_IC_ATTRIBUTION.json",
-      "duration_sec": 2.654,
+      "duration_sec": 2.63,
       "name": "attribution",
       "sha256": "b1686e6936859a6717383a7946ac7b225f12a541c6f4daba3f6dacc498561fc2",
       "size_bytes": 5941
     },
     {
       "artifact": "results/L2_PURGED_CV.json",
-      "duration_sec": 2.164,
+      "duration_sec": 1.951,
       "name": "purged_cv",
       "sha256": "971bcb8893142461863b05ad58b7c35ccb809cf3c571ca121f4c23d8cdbfd8af",
       "size_bytes": 592
     },
     {
       "artifact": "results/L2_SPECTRAL.json",
-      "duration_sec": 2.223,
+      "duration_sec": 2.003,
       "name": "spectral",
       "sha256": "2fd49049cf24cbbf97fa1f413bd38f70c3fef78f348b56b2ceb22d2e5f60eb30",
       "size_bytes": 3907
     },
     {
       "artifact": "results/L2_HURST.json",
-      "duration_sec": 2.121,
+      "duration_sec": 1.954,
       "name": "hurst",
       "sha256": "1f09c6d0ff1683ff48d32ee2c3063e52e2b885e3f16884e45ec023af3509739d",
       "size_bytes": 866
     },
     {
       "artifact": "results/L2_REGIME_MARKOV.json",
-      "duration_sec": 2.311,
+      "duration_sec": 2.234,
       "name": "regime_markov",
       "sha256": "0d082cf7b94129a06665e65a540b9593d6f32da793f7adc018305e784ee60162",
       "size_bytes": 1432
     },
     {
       "artifact": "results/L2_ROBUSTNESS.json",
-      "duration_sec": 19.615,
+      "duration_sec": 21.218,
       "name": "robustness",
       "sha256": "4ae97165c204fa0042db46fcc2e90fa978606e3aea033a541d59faa40159d567",
       "size_bytes": 1004
     },
     {
       "artifact": "results/L2_TRANSFER_ENTROPY.json",
-      "duration_sec": 6.98,
+      "duration_sec": 5.624,
       "name": "transfer_entropy",
       "sha256": "e11ebb1fff0a09079022acccd68e57c94b7052299cdb48376117cd2682970807",
       "size_bytes": 21537
     },
     {
       "artifact": "results/L2_CONDITIONAL_TE.json",
-      "duration_sec": 7.222,
+      "duration_sec": 7.29,
       "name": "conditional_te",
       "sha256": "5b9b13d3853b42de6c95b6cdfdd6de283588796f74afa31b60f8cb8f8b0471a4",
       "size_bytes": 18430

--- a/results/figures/index.html
+++ b/results/figures/index.html
@@ -137,6 +137,7 @@ pre {
 <tr><td>Leave-one-symbol-out</td><td style='color:#b8860b; font-weight:600; font-family:monospace;'>MIXED</td><td>min IC = 0.070, max drop 42.9%</td></tr>
 <tr><td>Hold-time horizon (60–600s)</td><td style='color:#2e7d32; font-weight:600; font-family:monospace;'>ROBUST</td><td>5/5 cells viable, 3 already profitable at f=0</td></tr>
 <tr><td>Slippage stress (±bp/side)</td><td style='color:#b8860b; font-weight:600; font-family:monospace;'>BOUND</td><td>max viable +3.0 bp/side slippage</td></tr>
+<tr><td>Taker-fee tier (3–6 bp)</td><td style='color:#2e7d32; font-weight:600; font-family:monospace;'>RESILIENT</td><td>max viable fee 6.0 bp, 4/4 tiers bracket below 0.50</td></tr>
 </tbody>
 </table>
 <p class='caveat'>These are the honest caveats: ablation axes describe the edge's operational envelope, not failure. Every axis is either green or has a documented boundary.</p>
@@ -148,18 +149,18 @@ PYTHONPATH=. python scripts/render_l2_dashboard.py</code></pre>
 <table>
 <thead><tr><th>Stage</th><th>Duration (s)</th><th>SHA-256 (12 chars)</th></tr></thead>
 <tbody>
-<tr><td class='metric'>killtest</td><td class='metric'>40.13</td><td class='metric'>d6774252bd04</td></tr>
-<tr><td class='metric'>attribution</td><td class='metric'>2.65</td><td class='metric'>b1686e693685</td></tr>
-<tr><td class='metric'>purged_cv</td><td class='metric'>2.16</td><td class='metric'>971bcb889314</td></tr>
-<tr><td class='metric'>spectral</td><td class='metric'>2.22</td><td class='metric'>2fd49049cf24</td></tr>
-<tr><td class='metric'>hurst</td><td class='metric'>2.12</td><td class='metric'>1f09c6d0ff16</td></tr>
-<tr><td class='metric'>regime_markov</td><td class='metric'>2.31</td><td class='metric'>0d082cf7b941</td></tr>
-<tr><td class='metric'>robustness</td><td class='metric'>19.61</td><td class='metric'>4ae97165c204</td></tr>
-<tr><td class='metric'>transfer_entropy</td><td class='metric'>6.98</td><td class='metric'>e11ebb1fff0a</td></tr>
-<tr><td class='metric'>conditional_te</td><td class='metric'>7.22</td><td class='metric'>5b9b13d3853b</td></tr>
+<tr><td class='metric'>killtest</td><td class='metric'>37.91</td><td class='metric'>d6774252bd04</td></tr>
+<tr><td class='metric'>attribution</td><td class='metric'>2.63</td><td class='metric'>b1686e693685</td></tr>
+<tr><td class='metric'>purged_cv</td><td class='metric'>1.95</td><td class='metric'>971bcb889314</td></tr>
+<tr><td class='metric'>spectral</td><td class='metric'>2.00</td><td class='metric'>2fd49049cf24</td></tr>
+<tr><td class='metric'>hurst</td><td class='metric'>1.95</td><td class='metric'>1f09c6d0ff16</td></tr>
+<tr><td class='metric'>regime_markov</td><td class='metric'>2.23</td><td class='metric'>0d082cf7b941</td></tr>
+<tr><td class='metric'>robustness</td><td class='metric'>21.22</td><td class='metric'>4ae97165c204</td></tr>
+<tr><td class='metric'>transfer_entropy</td><td class='metric'>5.62</td><td class='metric'>e11ebb1fff0a</td></tr>
+<tr><td class='metric'>conditional_te</td><td class='metric'>7.29</td><td class='metric'>5b9b13d3853b</td></tr>
 </tbody>
 </table>
-<p><strong>Total cycle duration:</strong> <code>87.05 s</code></p>
+<p><strong>Total cycle duration:</strong> <code>85.76 s</code></p>
 <div class='footer'>
 <p>Full narrative: <a href='../../research/microstructure/FINDINGS.md'>research/microstructure/FINDINGS.md</a></p>
 <p>Source: github.com/neuron7xLab/GeoSync</p>


### PR DESCRIPTION
## Summary
HTML demo dashboard now renders **all 5 ablation axes** instead of 4. Adds the RESILIENT fee-tier stress row (from PR #298) alongside hyperparameter / symbol / hold / slippage verdicts. Also regenerates manifest + dashboard from latest artifacts.

### Ablation grid rendered
| Axis | Verdict | Color |
|---|---|---|
| Hyperparameter (q × window) | SENSITIVE | amber |
| Leave-one-symbol-out | MIXED | amber |
| Hold-time (60–600 s) | ROBUST | green |
| Slippage stress | BOUND | amber |
| **Taker-fee tier (3–6 bp)** | **RESILIENT** | **green** |

## Test plan
- [x] 4/4 dashboard tests pass
- [x] 7/7 demo-smoke gate tests pass
- [x] Dashboard contains all 5 ablation verdicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)