### PR TITLE
docs(l2): final doc sync — CHANGELOG + SESSION_STATE + README

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,6 +434,14 @@ emits `results/L2_FULL_CYCLE_MANIFEST.json` with SHA-256 replay hashes,
 and generates a self-contained HTML dashboard at
 `results/figures/index.html`.
 
+Downstream-friendly flat metrics:
+`results/L2_HEADLINE_METRICS.json` — 44 primitive keys covering every
+axis + ablation + verdict. Ingestion-ready for dashboards and
+warehouses without parsing variable-structure artifacts.
+
+Protection: `.github/workflows/l2-demo-gate.yml` runs full test suite
++ demo-smoke gate on every PR that touches the L2 surface.
+
 | Axis | Finding | Artifact |
 |---|---|---|
 | 1. Kill test | IC = 0.122 at p = 0.002 | `L2_KILLTEST_VERDICT.json` |

--- a/research/microstructure/CHANGELOG.L2.md
+++ b/research/microstructure/CHANGELOG.L2.md
@@ -64,15 +64,33 @@ demo-shippable package.
 - **PR #288** · `test(property-based)` — Hypothesis coverage for
   DFA Hurst, TE, CTE, walk-forward
 
+### Additional polish PRs
+
+- **PR #297** · `feat(demo)` — HTML dashboard (7.5 KB self-contained)
+- **PR #298** · `feat(stress)` — taker-fee tier sensitivity → RESILIENT
+- **PR #300** · `feat(make)` — pro-max ergonomic Makefile targets
+- **PR #301** · `docs(l2)` — CHANGELOG + Makefile integrity tests
+- **PR #303** · `feat(dashboard)` — fee-tier row in ablations section
+- **PR #304** · `feat(make)` — `l2-open` + frozen SESSION_STATE.md
+- **PR #306** · `ci(l2-demo)` — dedicated GitHub Actions gate
+- **PR #308** · `test(fail-closed)` — 17 adversarial input tests
+- **PR #309** · `feat(regime-cond)` — VOL_DRIVEN (3.16× high/low ratio)
+- **PR #312** · `feat(metrics)` — flat headline metrics JSON (44 keys)
+
 ### Final state
 
 - **10 validation axes**, all green on Session 1
 - **5 ablation / stress axes** with honest verdicts (SENSITIVE / MIXED /
   ROBUST / BOUND / RESILIENT)
-- **5 canonical figures** + HTML dashboard
+- **1 regime-conditional decomposition** (VOL_DRIVEN, 3.16× high/low)
+- **5 canonical figures** + self-contained HTML dashboard
 - **1 one-command runner** + SHA-256 manifest (81 s end-to-end)
-- **300+ L2 tests** passing
+- **1 flat headline metrics JSON** for downstream ingestion (44 keys)
+- **345+ L2 tests** passing (coherence + property-based + fail-closed)
 - **Deterministic replay** confirmed bit-exact across two runs
+- **CI gate workflow** protects canonical state under branch-protection
 
 Canonical entry point: `make l2-demo`
 Synthesis document: `research/microstructure/FINDINGS.md`
+Demo landing page: `results/figures/index.html`
+Headline metrics: `results/L2_HEADLINE_METRICS.json`

--- a/research/microstructure/SESSION_STATE.md
+++ b/research/microstructure/SESSION_STATE.md
@@ -13,10 +13,13 @@
 | Edge verdict | **PROCEED** |
 | Validation axes passed | **10 / 10** |
 | Ablation / stress axes | **5 / 5** bounded and documented |
-| Test base | **317 passed, 1 opt-in skip** |
+| Regime-conditional decomposition | **VOL_DRIVEN** (3.16× high/low) |
+| Test base | **345 passed, 1 opt-in skip** |
 | Deterministic replay | confirmed bit-exact across two runs |
+| CI protection | `.github/workflows/l2-demo-gate.yml` |
 | One-command demo | `make l2-demo` (~85 s) |
 | Dashboard | `results/figures/index.html` (self-contained 7.5 KB) |
+| Flat headline metrics | `results/L2_HEADLINE_METRICS.json` (44 keys) |
 
 ---
 
@@ -80,6 +83,9 @@ make l2-deterministic   # bit-identical replay audit (~170 s)
 make l2-ablations       # run all 5 ablation axes
 make l2-test            # every tests/test_l2_*.py
 ```
+
+Protection: `.github/workflows/l2-demo-gate.yml` runs `l2-test` +
+`l2-smoke` + Makefile audit on every PR touching the L2 surface.
 
 Override substrate: `L2_DATA_DIR=/path/to/parquets make l2-demo`
 

--- a/tests/test_l2_makefile_targets.py
+++ b/tests/test_l2_makefile_targets.py
@@ -124,6 +124,13 @@ def test_changelog_lists_all_nineteen_session_prs() -> None:
         "#297",
         "#298",
         "#300",
+        "#301",
+        "#303",
+        "#304",
+        "#306",
+        "#308",
+        "#309",
+        "#312",
     }
     missing = [pr for pr in expected_prs if pr not in text]
     assert not missing, f"CHANGELOG missing PR refs: {missing}"


### PR DESCRIPTION
## Summary
Brings the three narrative documents in sync with PRs #301 → #312: headline metrics, regime-conditional IC, fail-closed tests, CI gate, l2-open target, dashboard fee row.

### Updated
- **CHANGELOG.L2.md** — new \"Additional polish PRs\" section (10 entries), final state counters updated
- **SESSION_STATE.md** — headline table now shows 345 tests, VOL_DRIVEN, CI protection, headline metrics JSON
- **README.md** — L2 section references \`L2_HEADLINE_METRICS.json\` + CI gate workflow
- **tests/test_l2_makefile_targets.py** — expected_prs extended with 7 new PR refs

## Test plan
- [x] 7/7 Makefile audit tests green (CHANGELOG lists all 31 session PRs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)