### PR TITLE
refactor(cycle-2/7): migrate 14 scripts to l2_cli common helpers

### DIFF
--- a/scripts/run_l2_ablation_sensitivity.py
+++ b/scripts/run_l2_ablation_sensitivity.py
@@ -30,20 +30,19 @@ from pathlib import Path
 from typing import Any, Final
 
 import numpy as np
+from research.microstructure.l2_cli import (
+    SubstrateError,
+    add_common_args,
+    load_substrate,
+    setup_logging,
+)
 
 from research.microstructure.diurnal import session_start_ms_from_frames
 from research.microstructure.diurnal_filter import (
     direction_per_row,
     load_hourly_direction_map,
 )
-from research.microstructure.killtest import (
-    _load_parquets as load_parquets,
-)
-from research.microstructure.killtest import (
-    build_feature_frame,
-    cross_sectional_ricci_signal,
-)
-from research.microstructure.l2_schema import DEFAULT_SYMBOLS
+from research.microstructure.killtest import cross_sectional_ricci_signal
 from research.microstructure.pnl import (
     DEFAULT_DECISION_SEC,
     DEFAULT_HOLD_SEC,
@@ -76,8 +75,7 @@ class AblationCell:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--data-dir", type=Path, default=Path("data/binance_l2_perp"))
-    parser.add_argument("--symbols", default=",".join(DEFAULT_SYMBOLS))
+    add_common_args(parser, output_default=Path("results/L2_ABLATION_SENSITIVITY.json"))
     parser.add_argument(
         "--diurnal-filter",
         type=Path,
@@ -85,11 +83,6 @@ def main() -> int:
     )
     parser.add_argument("--diurnal-ic-gate", type=float, default=0.03)
     parser.add_argument("--diurnal-p-gate", type=float, default=0.05)
-    parser.add_argument(
-        "--output",
-        type=Path,
-        default=Path("results/L2_ABLATION_SENSITIVITY.json"),
-    )
     parser.add_argument(
         "--regime-quantiles",
         default="0.70,0.75,0.80",
@@ -100,28 +93,17 @@ def main() -> int:
         default="180,300,450",
         help="comma-separated window grid",
     )
-    parser.add_argument("--log-level", default="INFO")
     args = parser.parse_args()
 
-    logging.basicConfig(
-        level=getattr(logging, str(args.log_level).upper(), logging.INFO),
-        format="%(asctime)s %(levelname)s %(name)s %(message)s",
-    )
+    setup_logging(str(args.log_level))
 
-    symbols = tuple(s.strip().upper() for s in str(args.symbols).split(",") if s.strip())
-    data_dir = Path(args.data_dir)
-    if not data_dir.exists():
-        _log.error("data dir does not exist: %s", data_dir)
-        return 2
-    frames = load_parquets(data_dir, symbols)
-    if not frames:
-        _log.error("no parquet shards in %s", data_dir)
-        return 2
     try:
-        features = build_feature_frame(frames, symbols)
-    except ValueError as exc:
-        _log.error("insufficient overlap: %s", exc)
+        loaded = load_substrate(Path(args.data_dir), str(args.symbols))
+    except SubstrateError as exc:
+        _log.error("%s", exc)
         return 2
+    features = loaded.features
+    frames = loaded.frames
 
     signal = cross_sectional_ricci_signal(features.ofi)
     decision_idx = np.arange(0, features.n_rows, DEFAULT_DECISION_SEC, dtype=np.int64)

--- a/scripts/run_l2_attribution.py
+++ b/scripts/run_l2_attribution.py
@@ -19,6 +19,12 @@ from dataclasses import asdict
 from pathlib import Path
 
 import numpy as np
+from research.microstructure.l2_cli import (
+    SubstrateError,
+    add_common_args,
+    load_substrate,
+    setup_logging,
+)
 
 from research.microstructure.attribution import (
     LAGS_DEFAULT_SEC,
@@ -28,13 +34,8 @@ from research.microstructure.attribution import (
 )
 from research.microstructure.killtest import (
     _forward_log_return,
-    build_feature_frame,
     cross_sectional_ricci_signal,
 )
-from research.microstructure.killtest import (
-    _load_parquets as load_parquets,
-)
-from research.microstructure.l2_schema import DEFAULT_SYMBOLS
 from research.microstructure.pnl import (
     DEFAULT_DECISION_SEC,
     DEFAULT_HOLD_SEC,
@@ -47,38 +48,18 @@ _log = logging.getLogger("l2_attribution")
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--data-dir", type=Path, default=Path("data/binance_l2_perp"))
-    parser.add_argument("--symbols", default=",".join(DEFAULT_SYMBOLS))
-    parser.add_argument(
-        "--output",
-        type=Path,
-        default=Path("results/L2_IC_ATTRIBUTION.json"),
-    )
+    add_common_args(parser, output_default=Path("results/L2_IC_ATTRIBUTION.json"))
     parser.add_argument("--horizon-sec", type=int, default=DEFAULT_HOLD_SEC)
-    parser.add_argument("--log-level", default="INFO")
     args = parser.parse_args()
 
-    logging.basicConfig(
-        level=getattr(logging, str(args.log_level).upper(), logging.INFO),
-        format="%(asctime)s %(levelname)s %(name)s %(message)s",
-    )
-
-    symbols = tuple(s.strip().upper() for s in str(args.symbols).split(",") if s.strip())
-    data_dir = Path(args.data_dir)
-    if not data_dir.exists():
-        _log.error("data dir does not exist: %s", data_dir)
-        return 2
-
-    frames = load_parquets(data_dir, symbols)
-    if not frames:
-        _log.error("no parquet shards in %s", data_dir)
-        return 2
+    setup_logging(str(args.log_level))
 
     try:
-        features = build_feature_frame(frames, symbols)
-    except ValueError as exc:
-        _log.error("insufficient overlap: %s", exc)
+        loaded = load_substrate(Path(args.data_dir), str(args.symbols))
+    except SubstrateError as exc:
+        _log.error("%s", exc)
         return 2
+    features = loaded.features
 
     signal = cross_sectional_ricci_signal(features.ofi)
     target = _forward_log_return(features.mid, int(args.horizon_sec))

--- a/scripts/run_l2_conditional_te.py
+++ b/scripts/run_l2_conditional_te.py
@@ -19,6 +19,12 @@ from pathlib import Path
 from typing import Any
 
 import numpy as np
+from research.microstructure.l2_cli import (
+    SubstrateError,
+    add_common_args,
+    load_substrate,
+    setup_logging,
+)
 
 from research.microstructure.conditional_transfer_entropy import (
     DEFAULT_LAG_ROWS,
@@ -26,26 +32,13 @@ from research.microstructure.conditional_transfer_entropy import (
     DEFAULT_N_SURROGATES,
     conditional_transfer_entropy,
 )
-from research.microstructure.killtest import (
-    _load_parquets as load_parquets,
-)
-from research.microstructure.killtest import (
-    build_feature_frame,
-)
-from research.microstructure.l2_schema import DEFAULT_SYMBOLS
 
 _log = logging.getLogger("l2_conditional_te")
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--data-dir", type=Path, default=Path("data/binance_l2_perp"))
-    parser.add_argument("--symbols", default=",".join(DEFAULT_SYMBOLS))
-    parser.add_argument(
-        "--output",
-        type=Path,
-        default=Path("results/L2_CONDITIONAL_TE.json"),
-    )
+    add_common_args(parser, output_default=Path("results/L2_CONDITIONAL_TE.json"))
     parser.add_argument(
         "--conditioner",
         default="BTCUSDT",
@@ -56,29 +49,16 @@ def main() -> int:
     parser.add_argument("--lag-rows", type=int, default=DEFAULT_LAG_ROWS)
     parser.add_argument("--n-surrogates", type=int, default=DEFAULT_N_SURROGATES)
     parser.add_argument("--seed", type=int, default=42)
-    parser.add_argument("--log-level", default="INFO")
     args = parser.parse_args()
 
-    logging.basicConfig(
-        level=getattr(logging, str(args.log_level).upper(), logging.INFO),
-        format="%(asctime)s %(levelname)s %(name)s %(message)s",
-    )
+    setup_logging(str(args.log_level))
 
-    symbols = tuple(s.strip().upper() for s in str(args.symbols).split(",") if s.strip())
-    data_dir = Path(args.data_dir)
-    if not data_dir.exists():
-        _log.error("data dir does not exist: %s", data_dir)
-        return 2
-
-    frames = load_parquets(data_dir, symbols)
-    if not frames:
-        _log.error("no parquet shards in %s", data_dir)
-        return 2
     try:
-        features = build_feature_frame(frames, symbols)
-    except ValueError as exc:
-        _log.error("insufficient overlap: %s", exc)
+        loaded = load_substrate(Path(args.data_dir), str(args.symbols))
+    except SubstrateError as exc:
+        _log.error("%s", exc)
         return 2
+    features = loaded.features
 
     cond_name = str(args.conditioner).upper()
     if cond_name == "BASKET":

--- a/scripts/run_l2_fee_stress.py
+++ b/scripts/run_l2_fee_stress.py
@@ -26,20 +26,19 @@ from pathlib import Path
 from typing import Any, Final
 
 import numpy as np
+from research.microstructure.l2_cli import (
+    SubstrateError,
+    add_common_args,
+    load_substrate,
+    setup_logging,
+)
 
 from research.microstructure.diurnal import session_start_ms_from_frames
 from research.microstructure.diurnal_filter import (
     direction_per_row,
     load_hourly_direction_map,
 )
-from research.microstructure.killtest import (
-    _load_parquets as load_parquets,
-)
-from research.microstructure.killtest import (
-    build_feature_frame,
-    cross_sectional_ricci_signal,
-)
-from research.microstructure.l2_schema import DEFAULT_SYMBOLS
+from research.microstructure.killtest import cross_sectional_ricci_signal
 from research.microstructure.pnl import (
     DEFAULT_DECISION_SEC,
     DEFAULT_HOLD_SEC,
@@ -74,8 +73,7 @@ class FeeCell:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--data-dir", type=Path, default=Path("data/binance_l2_perp"))
-    parser.add_argument("--symbols", default=",".join(DEFAULT_SYMBOLS))
+    add_common_args(parser, output_default=Path("results/L2_FEE_STRESS.json"))
     parser.add_argument(
         "--diurnal-filter",
         type=Path,
@@ -84,39 +82,23 @@ def main() -> int:
     parser.add_argument("--diurnal-ic-gate", type=float, default=0.03)
     parser.add_argument("--diurnal-p-gate", type=float, default=0.05)
     parser.add_argument(
-        "--output",
-        type=Path,
-        default=Path("results/L2_FEE_STRESS.json"),
-    )
-    parser.add_argument(
         "--taker-fees-bp",
         default="3,4,5,6",
         help="comma-separated taker-fee grid in bp",
     )
     parser.add_argument("--regime-quantile", type=float, default=0.75)
     parser.add_argument("--regime-window-sec", type=int, default=300)
-    parser.add_argument("--log-level", default="INFO")
     args = parser.parse_args()
 
-    logging.basicConfig(
-        level=getattr(logging, str(args.log_level).upper(), logging.INFO),
-        format="%(asctime)s %(levelname)s %(name)s %(message)s",
-    )
+    setup_logging(str(args.log_level))
 
-    symbols = tuple(s.strip().upper() for s in str(args.symbols).split(",") if s.strip())
-    data_dir = Path(args.data_dir)
-    if not data_dir.exists():
-        _log.error("data dir does not exist: %s", data_dir)
-        return 2
-    frames = load_parquets(data_dir, symbols)
-    if not frames:
-        _log.error("no parquet shards in %s", data_dir)
-        return 2
     try:
-        features = build_feature_frame(frames, symbols)
-    except ValueError as exc:
-        _log.error("insufficient overlap: %s", exc)
+        loaded = load_substrate(Path(args.data_dir), str(args.symbols))
+    except SubstrateError as exc:
+        _log.error("%s", exc)
         return 2
+    features = loaded.features
+    frames = loaded.frames
 
     signal = cross_sectional_ricci_signal(features.ofi)
     decision_idx = np.arange(0, features.n_rows, DEFAULT_DECISION_SEC, dtype=np.int64)

--- a/scripts/run_l2_hold_ablation.py
+++ b/scripts/run_l2_hold_ablation.py
@@ -27,20 +27,19 @@ from pathlib import Path
 from typing import Any, Final
 
 import numpy as np
+from research.microstructure.l2_cli import (
+    SubstrateError,
+    add_common_args,
+    load_substrate,
+    setup_logging,
+)
 
 from research.microstructure.diurnal import session_start_ms_from_frames
 from research.microstructure.diurnal_filter import (
     direction_per_row,
     load_hourly_direction_map,
 )
-from research.microstructure.killtest import (
-    _load_parquets as load_parquets,
-)
-from research.microstructure.killtest import (
-    build_feature_frame,
-    cross_sectional_ricci_signal,
-)
-from research.microstructure.l2_schema import DEFAULT_SYMBOLS
+from research.microstructure.killtest import cross_sectional_ricci_signal
 from research.microstructure.pnl import (
     DEFAULT_DECISION_SEC,
     DEFAULT_MAKER_FRACTIONS,
@@ -74,8 +73,7 @@ class HoldCell:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--data-dir", type=Path, default=Path("data/binance_l2_perp"))
-    parser.add_argument("--symbols", default=",".join(DEFAULT_SYMBOLS))
+    add_common_args(parser, output_default=Path("results/L2_HOLD_ABLATION.json"))
     parser.add_argument(
         "--diurnal-filter",
         type=Path,
@@ -84,39 +82,23 @@ def main() -> int:
     parser.add_argument("--diurnal-ic-gate", type=float, default=0.03)
     parser.add_argument("--diurnal-p-gate", type=float, default=0.05)
     parser.add_argument(
-        "--output",
-        type=Path,
-        default=Path("results/L2_HOLD_ABLATION.json"),
-    )
-    parser.add_argument(
         "--hold-sec",
         default="60,90,180,300,600",
         help="comma-separated hold-time grid in seconds",
     )
     parser.add_argument("--regime-quantile", type=float, default=0.75)
     parser.add_argument("--regime-window-sec", type=int, default=300)
-    parser.add_argument("--log-level", default="INFO")
     args = parser.parse_args()
 
-    logging.basicConfig(
-        level=getattr(logging, str(args.log_level).upper(), logging.INFO),
-        format="%(asctime)s %(levelname)s %(name)s %(message)s",
-    )
+    setup_logging(str(args.log_level))
 
-    symbols = tuple(s.strip().upper() for s in str(args.symbols).split(",") if s.strip())
-    data_dir = Path(args.data_dir)
-    if not data_dir.exists():
-        _log.error("data dir does not exist: %s", data_dir)
-        return 2
-    frames = load_parquets(data_dir, symbols)
-    if not frames:
-        _log.error("no parquet shards in %s", data_dir)
-        return 2
     try:
-        features = build_feature_frame(frames, symbols)
-    except ValueError as exc:
-        _log.error("insufficient overlap: %s", exc)
+        loaded = load_substrate(Path(args.data_dir), str(args.symbols))
+    except SubstrateError as exc:
+        _log.error("%s", exc)
         return 2
+    features = loaded.features
+    frames = loaded.frames
 
     signal = cross_sectional_ricci_signal(features.ofi)
     decision_idx = np.arange(0, features.n_rows, DEFAULT_DECISION_SEC, dtype=np.int64)

--- a/scripts/run_l2_hurst.py
+++ b/scripts/run_l2_hurst.py
@@ -25,53 +25,33 @@ from research.microstructure.hurst import (
     DEFAULT_N_SCALES,
     dfa_hurst,
 )
-from research.microstructure.killtest import (
-    _load_parquets as load_parquets,
+from research.microstructure.killtest import cross_sectional_ricci_signal
+from research.microstructure.l2_cli import (
+    SubstrateError,
+    add_common_args,
+    load_substrate,
+    setup_logging,
 )
-from research.microstructure.killtest import (
-    build_feature_frame,
-    cross_sectional_ricci_signal,
-)
-from research.microstructure.l2_schema import DEFAULT_SYMBOLS
 
 _log = logging.getLogger("l2_hurst")
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--data-dir", type=Path, default=Path("data/binance_l2_perp"))
-    parser.add_argument("--symbols", default=",".join(DEFAULT_SYMBOLS))
-    parser.add_argument(
-        "--output",
-        type=Path,
-        default=Path("results/L2_HURST.json"),
-    )
+    add_common_args(parser, output_default=Path("results/L2_HURST.json"))
     parser.add_argument("--min-scale", type=int, default=DEFAULT_MIN_SCALE)
     parser.add_argument("--max-scale-frac", type=float, default=DEFAULT_MAX_SCALE_FRAC)
     parser.add_argument("--n-scales", type=int, default=DEFAULT_N_SCALES)
-    parser.add_argument("--log-level", default="INFO")
     args = parser.parse_args()
 
-    logging.basicConfig(
-        level=getattr(logging, str(args.log_level).upper(), logging.INFO),
-        format="%(asctime)s %(levelname)s %(name)s %(message)s",
-    )
+    setup_logging(str(args.log_level))
 
-    symbols = tuple(s.strip().upper() for s in str(args.symbols).split(",") if s.strip())
-    data_dir = Path(args.data_dir)
-    if not data_dir.exists():
-        _log.error("data dir does not exist: %s", data_dir)
-        return 2
-
-    frames = load_parquets(data_dir, symbols)
-    if not frames:
-        _log.error("no parquet shards in %s", data_dir)
-        return 2
     try:
-        features = build_feature_frame(frames, symbols)
-    except ValueError as exc:
-        _log.error("insufficient overlap: %s", exc)
+        loaded = load_substrate(Path(args.data_dir), str(args.symbols))
+    except SubstrateError as exc:
+        _log.error("%s", exc)
         return 2
+    features = loaded.features
 
     signal = cross_sectional_ricci_signal(features.ofi)
     report = dfa_hurst(

--- a/scripts/run_l2_purged_cv.py
+++ b/scripts/run_l2_purged_cv.py
@@ -16,6 +16,12 @@ from dataclasses import asdict
 from pathlib import Path
 
 import numpy as np
+from research.microstructure.l2_cli import (
+    SubstrateError,
+    add_common_args,
+    load_substrate,
+    setup_logging,
+)
 
 from research.microstructure.cv import (
     DEFAULT_EMBARGO_SEC,
@@ -24,51 +30,28 @@ from research.microstructure.cv import (
 )
 from research.microstructure.killtest import (
     _forward_log_return,
-    build_feature_frame,
     cross_sectional_ricci_signal,
 )
-from research.microstructure.killtest import (
-    _load_parquets as load_parquets,
-)
-from research.microstructure.l2_schema import DEFAULT_SYMBOLS
 
 _log = logging.getLogger("l2_purged_cv")
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--data-dir", type=Path, default=Path("data/binance_l2_perp"))
-    parser.add_argument("--symbols", default=",".join(DEFAULT_SYMBOLS))
-    parser.add_argument(
-        "--output",
-        type=Path,
-        default=Path("results/L2_PURGED_CV.json"),
-    )
+    add_common_args(parser, output_default=Path("results/L2_PURGED_CV.json"))
     parser.add_argument("--k", type=int, default=DEFAULT_K)
     parser.add_argument("--horizon-sec", type=int, default=180)
     parser.add_argument("--embargo-sec", type=int, default=DEFAULT_EMBARGO_SEC)
-    parser.add_argument("--log-level", default="INFO")
     args = parser.parse_args()
 
-    logging.basicConfig(
-        level=getattr(logging, str(args.log_level).upper(), logging.INFO),
-        format="%(asctime)s %(levelname)s %(name)s %(message)s",
-    )
+    setup_logging(str(args.log_level))
 
-    symbols = tuple(s.strip().upper() for s in str(args.symbols).split(",") if s.strip())
-    data_dir = Path(args.data_dir)
-    if not data_dir.exists():
-        _log.error("data dir does not exist: %s", data_dir)
-        return 2
-    frames = load_parquets(data_dir, symbols)
-    if not frames:
-        _log.error("no parquet shards in %s", data_dir)
-        return 2
     try:
-        features = build_feature_frame(frames, symbols)
-    except ValueError as exc:
-        _log.error("insufficient overlap: %s", exc)
+        loaded = load_substrate(Path(args.data_dir), str(args.symbols))
+    except SubstrateError as exc:
+        _log.error("%s", exc)
         return 2
+    features = loaded.features
 
     signal_1d = cross_sectional_ricci_signal(features.ofi)
     signal_panel = np.repeat(signal_1d[:, None], features.n_symbols, axis=1)

--- a/scripts/run_l2_regime_conditional_ic.py
+++ b/scripts/run_l2_regime_conditional_ic.py
@@ -30,13 +30,14 @@ import numpy as np
 from research.microstructure.killtest import (
     _forward_log_return,
     _pooled_ic,
-    build_feature_frame,
     cross_sectional_ricci_signal,
 )
-from research.microstructure.killtest import (
-    _load_parquets as load_parquets,
+from research.microstructure.l2_cli import (
+    SubstrateError,
+    add_common_args,
+    load_substrate,
+    setup_logging,
 )
-from research.microstructure.l2_schema import DEFAULT_SYMBOLS
 from research.microstructure.regime import (
     regime_mask_from_quantile,
     rolling_rv_regime,
@@ -54,38 +55,20 @@ class RegimeICCell:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--data-dir", type=Path, default=Path("data/binance_l2_perp"))
-    parser.add_argument("--symbols", default=",".join(DEFAULT_SYMBOLS))
-    parser.add_argument(
-        "--output",
-        type=Path,
-        default=Path("results/L2_REGIME_CONDITIONAL_IC.json"),
-    )
+    add_common_args(parser, output_default=Path("results/L2_REGIME_CONDITIONAL_IC.json"))
     parser.add_argument("--horizon-sec", type=int, default=180)
     parser.add_argument("--regime-quantile", type=float, default=0.75)
     parser.add_argument("--regime-window-sec", type=int, default=300)
-    parser.add_argument("--log-level", default="INFO")
     args = parser.parse_args()
 
-    logging.basicConfig(
-        level=getattr(logging, str(args.log_level).upper(), logging.INFO),
-        format="%(asctime)s %(levelname)s %(name)s %(message)s",
-    )
+    setup_logging(str(args.log_level))
 
-    symbols = tuple(s.strip().upper() for s in str(args.symbols).split(",") if s.strip())
-    data_dir = Path(args.data_dir)
-    if not data_dir.exists():
-        _log.error("data dir does not exist: %s", data_dir)
-        return 2
-    frames = load_parquets(data_dir, symbols)
-    if not frames:
-        _log.error("no parquet shards in %s", data_dir)
-        return 2
     try:
-        features = build_feature_frame(frames, symbols)
-    except ValueError as exc:
-        _log.error("insufficient overlap: %s", exc)
+        loaded = load_substrate(Path(args.data_dir), str(args.symbols))
+    except SubstrateError as exc:
+        _log.error("%s", exc)
         return 2
+    features = loaded.features
 
     signal = cross_sectional_ricci_signal(features.ofi)
     target = _forward_log_return(features.mid, int(args.horizon_sec))

--- a/scripts/run_l2_regime_markov.py
+++ b/scripts/run_l2_regime_markov.py
@@ -10,18 +10,18 @@ import sys
 from dataclasses import asdict
 from pathlib import Path
 
+from research.microstructure.l2_cli import (
+    SubstrateError,
+    add_common_args,
+    load_substrate,
+    setup_logging,
+)
+
 from research.microstructure.diurnal import session_start_ms_from_frames
 from research.microstructure.diurnal_filter import (
     direction_per_row,
     load_hourly_direction_map,
 )
-from research.microstructure.killtest import (
-    _load_parquets as load_parquets,
-)
-from research.microstructure.killtest import (
-    build_feature_frame,
-)
-from research.microstructure.l2_schema import DEFAULT_SYMBOLS
 from research.microstructure.regime import (
     regime_mask_from_quantile,
     rolling_rv_regime,
@@ -35,13 +35,7 @@ _log = logging.getLogger("l2_regime_markov")
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--data-dir", type=Path, default=Path("data/binance_l2_perp"))
-    parser.add_argument("--symbols", default=",".join(DEFAULT_SYMBOLS))
-    parser.add_argument(
-        "--output",
-        type=Path,
-        default=Path("results/L2_REGIME_MARKOV.json"),
-    )
+    add_common_args(parser, output_default=Path("results/L2_REGIME_MARKOV.json"))
     parser.add_argument(
         "--diurnal-filter",
         type=Path,
@@ -51,28 +45,17 @@ def main() -> int:
     parser.add_argument("--regime-window-sec", type=int, default=300)
     parser.add_argument("--diurnal-ic-gate", type=float, default=0.03)
     parser.add_argument("--diurnal-p-gate", type=float, default=0.05)
-    parser.add_argument("--log-level", default="INFO")
     args = parser.parse_args()
 
-    logging.basicConfig(
-        level=getattr(logging, str(args.log_level).upper(), logging.INFO),
-        format="%(asctime)s %(levelname)s %(name)s %(message)s",
-    )
+    setup_logging(str(args.log_level))
 
-    symbols = tuple(s.strip().upper() for s in str(args.symbols).split(",") if s.strip())
-    data_dir = Path(args.data_dir)
-    if not data_dir.exists():
-        _log.error("data dir does not exist: %s", data_dir)
-        return 2
-    frames = load_parquets(data_dir, symbols)
-    if not frames:
-        _log.error("no parquet shards in %s", data_dir)
-        return 2
     try:
-        features = build_feature_frame(frames, symbols)
-    except ValueError as exc:
-        _log.error("insufficient overlap: %s", exc)
+        loaded = load_substrate(Path(args.data_dir), str(args.symbols))
+    except SubstrateError as exc:
+        _log.error("%s", exc)
         return 2
+    features = loaded.features
+    frames = loaded.frames
 
     rv_score = rolling_rv_regime(features, window_rows=args.regime_window_sec)
     regime_high_mask = regime_mask_from_quantile(rv_score, quantile=args.regime_quantile)

--- a/scripts/run_l2_robustness.py
+++ b/scripts/run_l2_robustness.py
@@ -19,16 +19,17 @@ from pathlib import Path
 from typing import Any
 
 import numpy as np
+from research.microstructure.l2_cli import (
+    SubstrateError,
+    add_common_args,
+    load_substrate,
+    setup_logging,
+)
 
 from research.microstructure.killtest import (
     _forward_log_return,
-    build_feature_frame,
     cross_sectional_ricci_signal,
 )
-from research.microstructure.killtest import (
-    _load_parquets as load_parquets,
-)
-from research.microstructure.l2_schema import DEFAULT_SYMBOLS
 from research.microstructure.robustness import (
     DEFAULT_BLOCK_SIZE,
     DEFAULT_MI_BINS,
@@ -44,13 +45,7 @@ _log = logging.getLogger("l2_robustness")
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--data-dir", type=Path, default=Path("data/binance_l2_perp"))
-    parser.add_argument("--symbols", default=",".join(DEFAULT_SYMBOLS))
-    parser.add_argument(
-        "--output",
-        type=Path,
-        default=Path("results/L2_ROBUSTNESS.json"),
-    )
+    add_common_args(parser, output_default=Path("results/L2_ROBUSTNESS.json"))
     parser.add_argument("--horizon-sec", type=int, default=180)
     parser.add_argument("--block-size", type=int, default=DEFAULT_BLOCK_SIZE)
     parser.add_argument("--n-bootstraps", type=int, default=DEFAULT_N_BOOTSTRAPS)
@@ -71,29 +66,16 @@ def main() -> int:
         "REGIME_Q75+DIURNAL pnl simulation (mean_net / std_net per trade).",
     )
     parser.add_argument("--seed", type=int, default=42)
-    parser.add_argument("--log-level", default="INFO")
     args = parser.parse_args()
 
-    logging.basicConfig(
-        level=getattr(logging, str(args.log_level).upper(), logging.INFO),
-        format="%(asctime)s %(levelname)s %(name)s %(message)s",
-    )
+    setup_logging(str(args.log_level))
 
-    symbols = tuple(s.strip().upper() for s in str(args.symbols).split(",") if s.strip())
-    data_dir = Path(args.data_dir)
-    if not data_dir.exists():
-        _log.error("data dir does not exist: %s", data_dir)
-        return 2
-
-    frames = load_parquets(data_dir, symbols)
-    if not frames:
-        _log.error("no parquet shards in %s", data_dir)
-        return 2
     try:
-        features = build_feature_frame(frames, symbols)
-    except ValueError as exc:
-        _log.error("insufficient overlap: %s", exc)
+        loaded = load_substrate(Path(args.data_dir), str(args.symbols))
+    except SubstrateError as exc:
+        _log.error("%s", exc)
         return 2
+    features = loaded.features
 
     signal_1d = cross_sectional_ricci_signal(features.ofi)
     signal_panel = np.repeat(signal_1d[:, None], features.n_symbols, axis=1)

--- a/scripts/run_l2_slippage_stress.py
+++ b/scripts/run_l2_slippage_stress.py
@@ -28,20 +28,19 @@ from pathlib import Path
 from typing import Any, Final
 
 import numpy as np
+from research.microstructure.l2_cli import (
+    SubstrateError,
+    add_common_args,
+    load_substrate,
+    setup_logging,
+)
 
 from research.microstructure.diurnal import session_start_ms_from_frames
 from research.microstructure.diurnal_filter import (
     direction_per_row,
     load_hourly_direction_map,
 )
-from research.microstructure.killtest import (
-    _load_parquets as load_parquets,
-)
-from research.microstructure.killtest import (
-    build_feature_frame,
-    cross_sectional_ricci_signal,
-)
-from research.microstructure.l2_schema import DEFAULT_SYMBOLS
+from research.microstructure.killtest import cross_sectional_ricci_signal
 from research.microstructure.pnl import (
     DEFAULT_DECISION_SEC,
     DEFAULT_HOLD_SEC,
@@ -77,8 +76,7 @@ class StressCell:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--data-dir", type=Path, default=Path("data/binance_l2_perp"))
-    parser.add_argument("--symbols", default=",".join(DEFAULT_SYMBOLS))
+    add_common_args(parser, output_default=Path("results/L2_SLIPPAGE_STRESS.json"))
     parser.add_argument(
         "--diurnal-filter",
         type=Path,
@@ -87,39 +85,23 @@ def main() -> int:
     parser.add_argument("--diurnal-ic-gate", type=float, default=0.03)
     parser.add_argument("--diurnal-p-gate", type=float, default=0.05)
     parser.add_argument(
-        "--output",
-        type=Path,
-        default=Path("results/L2_SLIPPAGE_STRESS.json"),
-    )
-    parser.add_argument(
         "--slippage-bp",
         default="0,1,2,3,5",
         help="comma-separated per-side slippage grid in bp",
     )
     parser.add_argument("--regime-quantile", type=float, default=0.75)
     parser.add_argument("--regime-window-sec", type=int, default=300)
-    parser.add_argument("--log-level", default="INFO")
     args = parser.parse_args()
 
-    logging.basicConfig(
-        level=getattr(logging, str(args.log_level).upper(), logging.INFO),
-        format="%(asctime)s %(levelname)s %(name)s %(message)s",
-    )
+    setup_logging(str(args.log_level))
 
-    symbols = tuple(s.strip().upper() for s in str(args.symbols).split(",") if s.strip())
-    data_dir = Path(args.data_dir)
-    if not data_dir.exists():
-        _log.error("data dir does not exist: %s", data_dir)
-        return 2
-    frames = load_parquets(data_dir, symbols)
-    if not frames:
-        _log.error("no parquet shards in %s", data_dir)
-        return 2
     try:
-        features = build_feature_frame(frames, symbols)
-    except ValueError as exc:
-        _log.error("insufficient overlap: %s", exc)
+        loaded = load_substrate(Path(args.data_dir), str(args.symbols))
+    except SubstrateError as exc:
+        _log.error("%s", exc)
         return 2
+    features = loaded.features
+    frames = loaded.frames
 
     signal = cross_sectional_ricci_signal(features.ofi)
     decision_idx = np.arange(0, features.n_rows, DEFAULT_DECISION_SEC, dtype=np.int64)

--- a/scripts/run_l2_spectral.py
+++ b/scripts/run_l2_spectral.py
@@ -9,14 +9,13 @@ import logging
 import sys
 from pathlib import Path
 
-from research.microstructure.killtest import (
-    _load_parquets as load_parquets,
+from research.microstructure.killtest import cross_sectional_ricci_signal
+from research.microstructure.l2_cli import (
+    SubstrateError,
+    add_common_args,
+    load_substrate,
+    setup_logging,
 )
-from research.microstructure.killtest import (
-    build_feature_frame,
-    cross_sectional_ricci_signal,
-)
-from research.microstructure.l2_schema import DEFAULT_SYMBOLS
 from research.microstructure.spectral import (
     DEFAULT_SEGMENT_SEC,
     spectral_report,
@@ -27,37 +26,19 @@ _log = logging.getLogger("l2_spectral")
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--data-dir", type=Path, default=Path("data/binance_l2_perp"))
-    parser.add_argument("--symbols", default=",".join(DEFAULT_SYMBOLS))
-    parser.add_argument(
-        "--output",
-        type=Path,
-        default=Path("results/L2_SPECTRAL.json"),
-    )
+    add_common_args(parser, output_default=Path("results/L2_SPECTRAL.json"))
     parser.add_argument("--segment-sec", type=int, default=DEFAULT_SEGMENT_SEC)
     parser.add_argument("--fs-hz", type=float, default=1.0)
-    parser.add_argument("--log-level", default="INFO")
     args = parser.parse_args()
 
-    logging.basicConfig(
-        level=getattr(logging, str(args.log_level).upper(), logging.INFO),
-        format="%(asctime)s %(levelname)s %(name)s %(message)s",
-    )
+    setup_logging(str(args.log_level))
 
-    symbols = tuple(s.strip().upper() for s in str(args.symbols).split(",") if s.strip())
-    data_dir = Path(args.data_dir)
-    if not data_dir.exists():
-        _log.error("data dir does not exist: %s", data_dir)
-        return 2
-    frames = load_parquets(data_dir, symbols)
-    if not frames:
-        _log.error("no parquet shards in %s", data_dir)
-        return 2
     try:
-        features = build_feature_frame(frames, symbols)
-    except ValueError as exc:
-        _log.error("insufficient overlap: %s", exc)
+        loaded = load_substrate(Path(args.data_dir), str(args.symbols))
+    except SubstrateError as exc:
+        _log.error("%s", exc)
         return 2
+    features = loaded.features
 
     signal = cross_sectional_ricci_signal(features.ofi)
     report = spectral_report(
@@ -66,8 +47,7 @@ def main() -> int:
         segment_sec=int(args.segment_sec),
     )
 
-    # Trim the stored PSD arrays to avoid a mega-json; expose top-N
-    # highest-power bins plus the summary.
+    # Trim stored PSD arrays to avoid a mega-json; expose top-N highest-power bins.
     psd_arr = list(report.psd)
     freq_arr = list(report.frequencies_hz)
     top_n = min(32, len(psd_arr))
@@ -92,8 +72,6 @@ def main() -> int:
         "regime_verdict": report.regime_verdict,
         "top_power_bins": top_bins,
         "n_psd_bins": len(psd_arr),
-        # Full arrays omitted from the tracked JSON — too large. Recomputable
-        # by re-running this CLI against the same substrate.
     }
 
     body = json.dumps(payload, indent=2, sort_keys=True, default=str)

--- a/scripts/run_l2_symbol_ablation.py
+++ b/scripts/run_l2_symbol_ablation.py
@@ -27,17 +27,18 @@ from pathlib import Path
 from typing import Any, Final
 
 import numpy as np
+from research.microstructure.l2_cli import (
+    SubstrateError,
+    add_common_args,
+    load_substrate,
+    setup_logging,
+)
 
 from research.microstructure.killtest import (
     _forward_log_return,
     _pooled_ic,
-    build_feature_frame,
     cross_sectional_ricci_signal,
 )
-from research.microstructure.killtest import (
-    _load_parquets as load_parquets,
-)
-from research.microstructure.l2_schema import DEFAULT_SYMBOLS
 
 _log = logging.getLogger("l2_symbol_ablation")
 
@@ -55,36 +56,18 @@ class LeaveOneOutCell:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--data-dir", type=Path, default=Path("data/binance_l2_perp"))
-    parser.add_argument("--symbols", default=",".join(DEFAULT_SYMBOLS))
-    parser.add_argument(
-        "--output",
-        type=Path,
-        default=Path("results/L2_SYMBOL_ABLATION.json"),
-    )
+    add_common_args(parser, output_default=Path("results/L2_SYMBOL_ABLATION.json"))
     parser.add_argument("--horizon-sec", type=int, default=180)
-    parser.add_argument("--log-level", default="INFO")
     args = parser.parse_args()
 
-    logging.basicConfig(
-        level=getattr(logging, str(args.log_level).upper(), logging.INFO),
-        format="%(asctime)s %(levelname)s %(name)s %(message)s",
-    )
+    setup_logging(str(args.log_level))
 
-    symbols = tuple(s.strip().upper() for s in str(args.symbols).split(",") if s.strip())
-    data_dir = Path(args.data_dir)
-    if not data_dir.exists():
-        _log.error("data dir does not exist: %s", data_dir)
-        return 2
-    frames = load_parquets(data_dir, symbols)
-    if not frames:
-        _log.error("no parquet shards in %s", data_dir)
-        return 2
     try:
-        features = build_feature_frame(frames, symbols)
-    except ValueError as exc:
-        _log.error("insufficient overlap: %s", exc)
+        loaded = load_substrate(Path(args.data_dir), str(args.symbols))
+    except SubstrateError as exc:
+        _log.error("%s", exc)
         return 2
+    features = loaded.features
 
     horizon = int(args.horizon_sec)
 

--- a/scripts/run_l2_transfer_entropy.py
+++ b/scripts/run_l2_transfer_entropy.py
@@ -22,13 +22,13 @@ from dataclasses import asdict
 from pathlib import Path
 from typing import Any
 
-from research.microstructure.killtest import (
-    _load_parquets as load_parquets,
+from research.microstructure.l2_cli import (
+    SubstrateError,
+    add_common_args,
+    load_substrate,
+    setup_logging,
 )
-from research.microstructure.killtest import (
-    build_feature_frame,
-)
-from research.microstructure.l2_schema import DEFAULT_SYMBOLS
+
 from research.microstructure.transfer_entropy import (
     DEFAULT_LAG_ROWS,
     DEFAULT_N_BINS,
@@ -41,40 +41,21 @@ _log = logging.getLogger("l2_transfer_entropy")
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--data-dir", type=Path, default=Path("data/binance_l2_perp"))
-    parser.add_argument("--symbols", default=",".join(DEFAULT_SYMBOLS))
-    parser.add_argument(
-        "--output",
-        type=Path,
-        default=Path("results/L2_TRANSFER_ENTROPY.json"),
-    )
+    add_common_args(parser, output_default=Path("results/L2_TRANSFER_ENTROPY.json"))
     parser.add_argument("--n-bins", type=int, default=DEFAULT_N_BINS)
     parser.add_argument("--lag-rows", type=int, default=DEFAULT_LAG_ROWS)
     parser.add_argument("--n-surrogates", type=int, default=DEFAULT_N_SURROGATES)
     parser.add_argument("--seed", type=int, default=42)
-    parser.add_argument("--log-level", default="INFO")
     args = parser.parse_args()
 
-    logging.basicConfig(
-        level=getattr(logging, str(args.log_level).upper(), logging.INFO),
-        format="%(asctime)s %(levelname)s %(name)s %(message)s",
-    )
+    setup_logging(str(args.log_level))
 
-    symbols = tuple(s.strip().upper() for s in str(args.symbols).split(",") if s.strip())
-    data_dir = Path(args.data_dir)
-    if not data_dir.exists():
-        _log.error("data dir does not exist: %s", data_dir)
-        return 2
-
-    frames = load_parquets(data_dir, symbols)
-    if not frames:
-        _log.error("no parquet shards in %s", data_dir)
-        return 2
     try:
-        features = build_feature_frame(frames, symbols)
-    except ValueError as exc:
-        _log.error("insufficient overlap: %s", exc)
+        loaded = load_substrate(Path(args.data_dir), str(args.symbols))
+    except SubstrateError as exc:
+        _log.error("%s", exc)
         return 2
+    features = loaded.features
 
     pairs: list[dict[str, Any]] = []
     for i, sym_a in enumerate(features.symbols):


### PR DESCRIPTION
## Summary
Cycle 2 of the 7-cycle tech-debt elimination loop. Eliminates 258 lines of duplicated preamble across 14 scripts by routing them through the shared \`research.microstructure.l2_cli\` helpers introduced in PR #314.

### Diff shape
14 files, −436 deletions, +178 insertions = **−258 LoC net**.

### Verification
- 57 CLI-related tests green (\`test_l2_cli_common\` + \`test_l2_coherence_cli_discoverability\`)
- End-to-end bit-match: refactored \`run_l2_hurst\` produces identical H=1.0139539571 vs committed baseline
- ruff + black + mypy --strict clean on every modified file

### Left untouched (on purpose)
- \`run_l2_killtest.py\` — dual train/test substrate via \`--test-dir\`
- \`run_l2_diurnal_profile.py\` — multi-session \`--data-dir\` append
- \`run_l2_pnl.py\` — more custom flags
- \`scripts/l2_*.py\` (archived analysis)

🤖 Generated with [Claude Code](https://claude.com/claude-code)