### PR TITLE
docs(cycle-5/7): fix 6-ablation typo + strengthen coherence gates

### DIFF
--- a/research/microstructure/headline_metrics.py
+++ b/research/microstructure/headline_metrics.py
@@ -2,7 +2,7 @@
 
 Downstream tooling (dashboards, warehouses, external review) needs one
 ingestion-friendly JSON file with every key number from the 10-axis +
-6-ablation/stress stack — not 16 variable-structure artifacts.
+5-ablation/stress stack — not 16 variable-structure artifacts.
 
 This module reads the existing results/L2_*.json files and emits a
 single flat dictionary with snake_case keys. Every top-level key is

--- a/tests/test_l2_coherence_doc_data.py
+++ b/tests/test_l2_coherence_doc_data.py
@@ -118,3 +118,27 @@ def test_readme_purged_cv_mean_and_5of5() -> None:
     assert f"{mean_ic:.3f}" == "0.122"
     assert positive_count == 5
     assert "5/5 folds positive" in section
+
+
+def test_findings_ablation_count_consistency() -> None:
+    """FINDINGS.md, SESSION_STATE.md, CHANGELOG.L2.md must agree on axis counts."""
+    findings = Path("research/microstructure/FINDINGS.md").read_text(encoding="utf-8")
+    session = Path("research/microstructure/SESSION_STATE.md")
+    changelog = Path("research/microstructure/CHANGELOG.L2.md")
+    # Axis count — 10
+    assert "10 independent methodologies" in findings
+    # Ablation count — 5
+    if session.exists():
+        assert "10-axis + 5-ablation" in session.read_text(encoding="utf-8")
+    if changelog.exists():
+        assert "10-axis + 5-ablation" in changelog.read_text(encoding="utf-8")
+
+
+def test_findings_regime_conditional_numbers_match() -> None:
+    """FINDINGS §4.3b numbers must match L2_REGIME_CONDITIONAL_IC.json."""
+    findings = Path("research/microstructure/FINDINGS.md").read_text(encoding="utf-8")
+    cond = _load("L2_REGIME_CONDITIONAL_IC.json")
+    ratio = float(cond["abs_ratio_high_over_low"])
+    verdict = str(cond["verdict"])
+    assert f"{ratio:.2f}×" in findings or f"{ratio:.2f} ×" in findings
+    assert verdict in findings


### PR DESCRIPTION
## Summary
Cycle 5 of the 7-cycle tech-debt loop. Systematic cross-check of numerical and axis-count references across README / FINDINGS / SESSION_STATE / CHANGELOG / headline_metrics docstring.

### Contradiction found + fixed
\`headline_metrics.py\` docstring said **\"6-ablation/stress stack\"** while every other doc says 5. Corrected to 5-ablation.

### New coherence gates
- \`test_findings_ablation_count_consistency\` — all three narrative docs must use \"10-axis + 5-ablation\"
- \`test_findings_regime_conditional_numbers_match\` — FINDINGS §4.3b ratio + verdict must match \`L2_REGIME_CONDITIONAL_IC.json\`

### Bit-exact verified
ic_pooled · hurst_exponent · spectral_beta · n_rows — all match source JSON

## Test plan
- [x] 10/10 doc-data consistency tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)