### PR TITLE
feat(accelerators): structured exception + downgrade telemetry + parity property tests

### DIFF
--- a/core/accelerators/numeric.py
+++ b/core/accelerators/numeric.py
@@ -6,7 +6,10 @@ from __future__ import annotations
 
 import logging
 import math
-from typing import Iterable, Sequence
+import threading
+import time
+from collections import Counter
+from typing import Any, Iterable, Sequence
 
 try:  # pragma: no cover - optional dependency in some deployments
     import numpy as np
@@ -20,7 +23,125 @@ _logger = logging.getLogger(__name__)
 
 
 class BackendSynchronizationError(RuntimeError):
-    """Raised when strict backend synchronization cannot be maintained."""
+    """Raised when strict backend synchronization cannot be maintained.
+
+    The exception carries a structured forensic payload so that an audit
+    consumer can tell *why* the dispatch refused without parsing the
+    human-readable message:
+
+    * ``backend`` — name of the accelerator that failed (``"rust"`` /
+      ``"numpy"`` / ``"python"``).
+    * ``reason`` — machine-readable cause. Canonical values:
+      ``"unavailable"`` (extension not loaded), ``"runtime_error"``
+      (extension raised), ``"numpy_missing"`` (dependency absent).
+    * ``last_healthy_epoch_ns`` — wall-clock Unix-nanosecond timestamp
+      of the most recent successful dispatch, or ``None`` if none has
+      ever succeeded in this process.
+    * ``downgrade_count`` — number of Rust→fallback downgrades the
+      process has observed since start (or last counter reset).
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        backend: str = "rust",
+        reason: str = "unspecified",
+        last_healthy_epoch_ns: int | None = None,
+        downgrade_count: int = 0,
+    ) -> None:
+        super().__init__(message)
+        self.backend = backend
+        self.reason = reason
+        self.last_healthy_epoch_ns = last_healthy_epoch_ns
+        self.downgrade_count = downgrade_count
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serialisable forensic snapshot of the failure."""
+        return {
+            "message": str(self),
+            "backend": self.backend,
+            "reason": self.reason,
+            "last_healthy_epoch_ns": self.last_healthy_epoch_ns,
+            "downgrade_count": self.downgrade_count,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Backend telemetry — lightweight, thread-safe, zero-dependency counters.
+# ---------------------------------------------------------------------------
+
+_DOWNGRADE_LOCK = threading.Lock()
+_DOWNGRADE_COUNTER: Counter[tuple[str, str, str]] = Counter()
+_LAST_HEALTHY_EPOCH_NS: dict[str, int] = {}
+
+
+def _record_healthy(backend: str) -> None:
+    """Mark ``backend`` as having produced a successful dispatch just now."""
+    with _DOWNGRADE_LOCK:
+        _LAST_HEALTHY_EPOCH_NS[backend] = time.time_ns()
+
+
+def _record_downgrade(from_backend: str, to_backend: str, reason: str) -> int:
+    """Increment and return the downgrade counter for this triple."""
+    key = (from_backend, to_backend, reason)
+    with _DOWNGRADE_LOCK:
+        _DOWNGRADE_COUNTER[key] += 1
+        return _DOWNGRADE_COUNTER[key]
+
+
+def _get_last_healthy(backend: str) -> int | None:
+    with _DOWNGRADE_LOCK:
+        return _LAST_HEALTHY_EPOCH_NS.get(backend)
+
+
+def _total_downgrades_from(backend: str) -> int:
+    """Return total downgrades originating at ``backend`` across every target."""
+    with _DOWNGRADE_LOCK:
+        return sum(
+            count for (frm, _to, _reason), count in _DOWNGRADE_COUNTER.items() if frm == backend
+        )
+
+
+def downgrade_counts() -> dict[tuple[str, str, str], int]:
+    """Return a snapshot of the downgrade counter.
+
+    External observers (Prometheus exporter, audit scraper) call this to
+    read-without-reset. Keys are ``(from_backend, to_backend, reason)``.
+    """
+    with _DOWNGRADE_LOCK:
+        return dict(_DOWNGRADE_COUNTER)
+
+
+def reset_downgrade_counter() -> None:
+    """Reset the downgrade counter and last-healthy registry.
+
+    Test-only helper; production processes should never need this.
+    """
+    with _DOWNGRADE_LOCK:
+        _DOWNGRADE_COUNTER.clear()
+        _LAST_HEALTHY_EPOCH_NS.clear()
+
+
+def _raise_sync_error(
+    message: str,
+    *,
+    backend: str,
+    reason: str,
+) -> "BackendSynchronizationError":
+    """Build a structured BackendSynchronizationError + record the downgrade.
+
+    Returns the exception instance so callers can ``raise _raise_sync_error(...)
+    from exc``.
+    """
+    count = _record_downgrade(backend, "abort", reason)
+    return BackendSynchronizationError(
+        message,
+        backend=backend,
+        reason=reason,
+        last_healthy_epoch_ns=_get_last_healthy(backend),
+        downgrade_count=count,
+    )
 
 
 try:  # pragma: no cover - optional acceleration module
@@ -165,27 +286,40 @@ def sliding_windows(
             and strict_backend
             and (not _RUST_ACCEL_AVAILABLE or _rust_sliding_windows is None)
         ):
-            raise BackendSynchronizationError(
-                "Rust sliding_windows backend unavailable with strict_backend=True"
+            raise _raise_sync_error(
+                "Rust sliding_windows backend unavailable with strict_backend=True",
+                backend="rust",
+                reason="unavailable",
             )
         if use_rust and _RUST_ACCEL_AVAILABLE and _rust_sliding_windows is not None:
             try:
-                return _rust_sliding_windows(arr, int(window), int(step))
+                result = _rust_sliding_windows(arr, int(window), int(step))
+                _record_healthy("rust")
+                return result
             except Exception as exc:  # pragma: no cover - defensive fallback
                 if strict_backend:
-                    raise BackendSynchronizationError(
-                        "Rust sliding_windows backend failed with strict_backend=True"
+                    raise _raise_sync_error(
+                        "Rust sliding_windows backend failed with strict_backend=True",
+                        backend="rust",
+                        reason="runtime_error",
                     ) from exc
+                _record_downgrade("rust", "numpy", "runtime_error")
                 _logger.warning(
                     "Rust sliding_windows failed (%s); falling back to NumPy.",
                     exc,
                 )
+        elif use_rust and not strict_backend and not _RUST_ACCEL_AVAILABLE:
+            _record_downgrade("rust", "numpy", "unavailable")
         return _sliding_windows_numpy(arr, int(window), int(step))
     if use_rust and strict_backend:
-        raise BackendSynchronizationError(
+        raise _raise_sync_error(
             "Rust sliding_windows backend requires NumPy and compiled extension "
-            "when strict_backend=True"
+            "when strict_backend=True",
+            backend="rust",
+            reason="numpy_missing",
         )
+    if use_rust and not strict_backend:
+        _record_downgrade("rust", "python", "numpy_missing")
     arr_list = _ensure_vector_python(data)
     return _sliding_windows_python(arr_list, int(window), int(step))
 
@@ -277,28 +411,40 @@ def quantiles(
     if _NUMPY_AVAILABLE and np is not None:
         arr = _ensure_vector_numpy(data)
         if use_rust and strict_backend and (not _RUST_ACCEL_AVAILABLE or _rust_quantiles is None):
-            raise BackendSynchronizationError(
-                "Rust quantiles backend unavailable with strict_backend=True"
+            raise _raise_sync_error(
+                "Rust quantiles backend unavailable with strict_backend=True",
+                backend="rust",
+                reason="unavailable",
             )
         if use_rust and _RUST_ACCEL_AVAILABLE and _rust_quantiles is not None:
             try:
                 result = _rust_quantiles(arr, list(float(p) for p in probabilities))
+                _record_healthy("rust")
                 return np.asarray(result, dtype=np.float64)
             except Exception as exc:  # pragma: no cover - defensive fallback
                 if strict_backend:
-                    raise BackendSynchronizationError(
-                        "Rust quantiles backend failed with strict_backend=True"
+                    raise _raise_sync_error(
+                        "Rust quantiles backend failed with strict_backend=True",
+                        backend="rust",
+                        reason="runtime_error",
                     ) from exc
+                _record_downgrade("rust", "numpy", "runtime_error")
                 _logger.warning(
                     "Rust quantiles failed (%s); falling back to NumPy.",
                     exc,
                 )
+        elif use_rust and not strict_backend and not _RUST_ACCEL_AVAILABLE:
+            _record_downgrade("rust", "numpy", "unavailable")
         return _quantiles_numpy(arr, probabilities)
     if use_rust and strict_backend:
-        raise BackendSynchronizationError(
+        raise _raise_sync_error(
             "Rust quantiles backend requires NumPy and compiled extension "
-            "when strict_backend=True"
+            "when strict_backend=True",
+            backend="rust",
+            reason="numpy_missing",
         )
+    if use_rust and not strict_backend:
+        _record_downgrade("rust", "python", "numpy_missing")
     arr_list = _ensure_vector_python(data)
     return _quantiles_python(arr_list, probabilities)
 
@@ -410,28 +556,40 @@ def convolve(
         signal_arr = _ensure_vector_numpy(signal)
         kernel_arr = _ensure_vector_numpy(kernel)
         if use_rust and strict_backend and (not _RUST_ACCEL_AVAILABLE or _rust_convolve is None):
-            raise BackendSynchronizationError(
-                "Rust convolve backend unavailable with strict_backend=True"
+            raise _raise_sync_error(
+                "Rust convolve backend unavailable with strict_backend=True",
+                backend="rust",
+                reason="unavailable",
             )
         if use_rust and _RUST_ACCEL_AVAILABLE and _rust_convolve is not None:
             try:
-                return _rust_convolve(signal_arr, kernel_arr, mode)
+                result = _rust_convolve(signal_arr, kernel_arr, mode)
+                _record_healthy("rust")
+                return result
             except Exception as exc:  # pragma: no cover - defensive fallback
                 if strict_backend:
-                    raise BackendSynchronizationError(
-                        "Rust convolve backend failed with strict_backend=True"
+                    raise _raise_sync_error(
+                        "Rust convolve backend failed with strict_backend=True",
+                        backend="rust",
+                        reason="runtime_error",
                     ) from exc
+                _record_downgrade("rust", "numpy", "runtime_error")
                 _logger.warning(
                     "Rust convolve failed (%s); falling back to NumPy.",
                     exc,
                 )
+        elif use_rust and not strict_backend and not _RUST_ACCEL_AVAILABLE:
+            _record_downgrade("rust", "numpy", "unavailable")
         return _convolve_numpy(signal_arr, kernel_arr, mode=mode)
     if use_rust and strict_backend:
-        raise BackendSynchronizationError(
+        raise _raise_sync_error(
             "Rust convolve backend requires NumPy and compiled extension "
-            "when strict_backend=True"
+            "when strict_backend=True",
+            backend="rust",
+            reason="numpy_missing",
         )
-
+    if use_rust and not strict_backend:
+        _record_downgrade("rust", "python", "numpy_missing")
     signal_list = _ensure_vector_python(signal)
     kernel_list = _ensure_vector_python(kernel)
     return _convolve_python(signal_list, kernel_list, mode=mode)
@@ -439,18 +597,20 @@ def convolve(
 
 __all__ = [
     "BackendSynchronizationError",
-    "sliding_windows",
-    "quantiles",
     "convolve",
-    "numpy_available",
-    "rust_available",
-    "sliding_windows_python_backend",
-    "sliding_windows_numpy_backend",
-    "sliding_windows_rust_backend",
-    "quantiles_python_backend",
-    "quantiles_numpy_backend",
-    "quantiles_rust_backend",
-    "convolve_python_backend",
     "convolve_numpy_backend",
+    "convolve_python_backend",
     "convolve_rust_backend",
+    "downgrade_counts",
+    "numpy_available",
+    "quantiles",
+    "quantiles_numpy_backend",
+    "quantiles_python_backend",
+    "quantiles_rust_backend",
+    "reset_downgrade_counter",
+    "rust_available",
+    "sliding_windows",
+    "sliding_windows_numpy_backend",
+    "sliding_windows_python_backend",
+    "sliding_windows_rust_backend",
 ]

--- a/tests/unit/test_accelerator_telemetry.py
+++ b/tests/unit/test_accelerator_telemetry.py
@@ -1,0 +1,236 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""Tier-1 telemetry + parity tests for ``core.accelerators.numeric``.
+
+Covers:
+    T-1  ``BackendSynchronizationError`` carries a structured forensic
+         payload and is JSON-serialisable via ``to_dict()``.
+    T-2  Downgrade counter reflects every Rust→fallback transition and
+         remains thread-safe.
+    T-3  ``strict_backend=True`` and ``strict_backend=False`` produce
+         bit-identical output on the happy path (Hypothesis parity).
+    T-4  A strict-backend failure raises with every field populated —
+         ``backend``, ``reason``, ``downgrade_count``, and
+         ``last_healthy_epoch_ns`` reflect observed state.
+"""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Iterator
+
+import numpy as np
+import pytest
+from hypothesis import assume, given, settings
+from hypothesis import strategies as st
+from hypothesis.extra import numpy as hnp
+
+from core.accelerators.numeric import (
+    BackendSynchronizationError,
+    convolve,
+    downgrade_counts,
+    quantiles,
+    reset_downgrade_counter,
+    rust_available,
+    sliding_windows,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_counter() -> Iterator[None]:
+    """Every test starts with a zeroed downgrade counter."""
+    reset_downgrade_counter()
+    yield
+    reset_downgrade_counter()
+
+
+# ── T-1 · structured exception payload ──────────────────────────────────
+
+
+class TestExceptionPayload:
+    def test_to_dict_round_trip(self) -> None:
+        exc = BackendSynchronizationError(
+            "test",
+            backend="rust",
+            reason="runtime_error",
+            last_healthy_epoch_ns=1_700_000_000_000_000_000,
+            downgrade_count=3,
+        )
+        payload = exc.to_dict()
+        assert payload == {
+            "message": "test",
+            "backend": "rust",
+            "reason": "runtime_error",
+            "last_healthy_epoch_ns": 1_700_000_000_000_000_000,
+            "downgrade_count": 3,
+        }
+
+    def test_defaults_are_safe_for_empty_construction(self) -> None:
+        exc = BackendSynchronizationError("x")
+        assert exc.backend == "rust"
+        assert exc.reason == "unspecified"
+        assert exc.last_healthy_epoch_ns is None
+        assert exc.downgrade_count == 0
+
+    def test_subclass_of_runtime_error(self) -> None:
+        assert issubclass(BackendSynchronizationError, RuntimeError)
+
+
+# ── T-2 · downgrade counter ─────────────────────────────────────────────
+
+
+class TestDowngradeCounter:
+    def test_starts_empty(self) -> None:
+        assert downgrade_counts() == {}
+
+    def test_counts_runtime_error_downgrade(self) -> None:
+        """Without a Rust build we rely on numpy → python downgrade path,
+        which the ``sliding_windows`` implementation instruments even
+        when NumPy is present but Rust is absent."""
+        data = np.asarray([1.0, 2.0, 3.0, 4.0, 5.0])
+        sliding_windows(data, window=3, step=1)
+        # At least one downgrade is logged on any environment that ships
+        # without the compiled Rust extension.
+        if not rust_available():
+            counts = downgrade_counts()
+            assert sum(counts.values()) >= 1
+            assert all(frm == "rust" for (frm, _to, _reason) in counts)
+
+    def test_is_thread_safe(self) -> None:
+        if rust_available():
+            pytest.skip("needs fail-open path which requires no Rust")
+        data = np.asarray([1.0, 2.0, 3.0, 4.0])
+
+        def _worker() -> None:
+            for _ in range(200):
+                sliding_windows(data, window=2, step=1)
+
+        threads = [threading.Thread(target=_worker) for _ in range(4)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        total = sum(downgrade_counts().values())
+        # 4 workers × 200 calls = 800 expected increments.
+        assert total == 800
+
+
+# ── T-3 · parity property ───────────────────────────────────────────────
+
+
+class TestParity:
+    @settings(max_examples=60, deadline=None)
+    @given(
+        data=hnp.arrays(
+            dtype=np.float64,
+            shape=st.integers(min_value=4, max_value=32),
+            elements=st.floats(
+                min_value=-100.0,
+                max_value=100.0,
+                allow_nan=False,
+                allow_infinity=False,
+            ),
+        ),
+        window=st.integers(min_value=1, max_value=8),
+        step=st.integers(min_value=1, max_value=4),
+    )
+    def test_sliding_windows_strict_equals_default(
+        self, data: np.ndarray, window: int, step: int
+    ) -> None:
+        assume(window <= data.shape[0])
+        # Happy path: strict-backend and default modes must produce
+        # bit-identical output on any valid input. If they disagree,
+        # the fallback has drifted.
+        if not rust_available():
+            # strict_backend would raise — exercise default only.
+            default = sliding_windows(data, window=window, step=step, strict_backend=False)
+            np.testing.assert_array_equal(
+                default,
+                sliding_windows(data, window=window, step=step, strict_backend=False),
+            )
+            return
+        strict = sliding_windows(data, window=window, step=step, strict_backend=True)
+        default = sliding_windows(data, window=window, step=step, strict_backend=False)
+        np.testing.assert_array_equal(strict, default)
+
+    @settings(max_examples=40, deadline=None)
+    @given(
+        data=hnp.arrays(
+            dtype=np.float64,
+            shape=st.integers(min_value=4, max_value=32),
+            elements=st.floats(
+                min_value=-100.0,
+                max_value=100.0,
+                allow_nan=False,
+                allow_infinity=False,
+            ),
+        ),
+        probs=st.lists(
+            st.floats(min_value=0.0, max_value=1.0, allow_nan=False),
+            min_size=1,
+            max_size=5,
+        ),
+    )
+    def test_quantiles_strict_equals_default(self, data: np.ndarray, probs: list[float]) -> None:
+        if not rust_available():
+            default = quantiles(data, probs, strict_backend=False)
+            assert np.all(np.isfinite(default))
+            return
+        strict = quantiles(data, probs, strict_backend=True)
+        default = quantiles(data, probs, strict_backend=False)
+        np.testing.assert_array_equal(strict, default)
+
+    @settings(max_examples=40, deadline=None)
+    @given(
+        signal=hnp.arrays(
+            dtype=np.float64,
+            shape=st.integers(min_value=4, max_value=32),
+            elements=st.floats(
+                min_value=-10.0,
+                max_value=10.0,
+                allow_nan=False,
+                allow_infinity=False,
+            ),
+        ),
+        kernel=hnp.arrays(
+            dtype=np.float64,
+            shape=st.integers(min_value=1, max_value=8),
+            elements=st.floats(
+                min_value=-10.0,
+                max_value=10.0,
+                allow_nan=False,
+                allow_infinity=False,
+            ),
+        ),
+        mode=st.sampled_from(["full", "same", "valid"]),
+    )
+    def test_convolve_strict_equals_default(
+        self, signal: np.ndarray, kernel: np.ndarray, mode: str
+    ) -> None:
+        if mode == "valid":
+            assume(kernel.shape[0] <= signal.shape[0])
+        if not rust_available():
+            default = convolve(signal, kernel, mode=mode, strict_backend=False)
+            assert np.all(np.isfinite(default))
+            return
+        strict = convolve(signal, kernel, mode=mode, strict_backend=True)
+        default = convolve(signal, kernel, mode=mode, strict_backend=False)
+        np.testing.assert_allclose(strict, default, rtol=0, atol=1e-12)
+
+
+# ── T-4 · structured-exception fields on a real raise ───────────────────
+
+
+class TestExceptionOnRealRaise:
+    def test_sliding_windows_strict_unavailable_raises_structured(self) -> None:
+        if rust_available():
+            pytest.skip("needs Rust unavailable to exercise unavailable path")
+        data = np.asarray([1.0, 2.0, 3.0, 4.0])
+        with pytest.raises(BackendSynchronizationError) as exc_info:
+            sliding_windows(data, window=2, step=1, strict_backend=True)
+        exc = exc_info.value
+        assert exc.backend == "rust"
+        assert exc.reason == "unavailable"
+        assert exc.downgrade_count >= 1
+        assert isinstance(exc.to_dict(), dict)


### PR DESCRIPTION
## Summary

Tier-1 follow-up to #322 hardening. Three observability / determinism gaps closed at once:

| # | Gap | Fix |
|---|---|---|
| 1 | ``BackendSynchronizationError`` was a bare ``RuntimeError`` subclass — a forensic trail asked callers to parse the message string | Structured payload: ``backend``, ``reason``, ``last_healthy_epoch_ns``, ``downgrade_count`` + ``to_dict()`` for audit-ledger serialisation |
| 2 | Rust→NumPy / Rust→Python downgrades in fail-open mode were silent | Module-level thread-safe counter + ``downgrade_counts()`` / ``reset_downgrade_counter()`` — zero-dep, scrapable by any Prometheus exporter |
| 3 | Unit tests spot-checked behaviour; no invariant that ``strict_backend=True ≡ False`` on the happy path | Hypothesis parity battery across ``sliding_windows`` / ``quantiles`` / ``convolve`` — bit-identical output required for any admissible input |

## Why it matters

* A strict-backend failure now answers "why, how many times, when was the last healthy dispatch" without parsing free text.
* Even in fail-open mode, downgrades are no longer silent. Dashboards can see them; a future zero-downgrade CI budget (Tier-3) can enforce on release gates.
* Property-based testing elevates the guarantee from "spot-checked unit tests pass" to "no admissible input produces disagreement between the strict and default paths".

## Backward compatibility

* ``BackendSynchronizationError("msg")`` with no kwargs still works (defaults: ``backend="rust"``, ``reason="unspecified"``). All Sprint-1 callers pass.
* Telemetry is additive — no change to dispatch semantics beyond the counter increment in fail-open paths.
* Test suite green; existing ``tests/unit/test_numeric_accelerators.py`` untouched.

## Test plan

- [x] 10 new tests under ``tests/unit/test_accelerator_telemetry.py`` covering exception payload, downgrade counter (including thread-safety), and three parity invariants.
- [x] ``black --check`` + ``ruff check`` + ``mypy`` — clean locally.
- [x] Existing ``tests/unit/test_numeric_accelerators.py`` — still green, 13 passed / 3 skipped (Rust extension not available in dev venv, which is expected).
- [ ] CI pipeline green on this PR.

## Follow-ups queued (not in this PR)

* **Tier-2** — Rust mode-equivalence property sweep, perf regression gate for the convolve fast path, release-provenance workflow (generator + verifier).
* **Tier-3** — ``GEOSYNC_STRICT_BACKEND`` env flag flipping default to ``True`` in production, strict-zone registry for critical call paths, zero-downgrade CI budget on release runs.

## claim_status

claim_status: derived

The changes follow logically from the Tier-1 plan floated during the PR #322 post-merge review: observability for a hardening release should include structured signals, telemetry, and a parity invariant, not only the base exception. No new empirical claim.