### PR TITLE
harden(ci/formal-verification): pin tla2tools.jar v1.7.4 + sha256 + explicit TLC rc

### DIFF
--- a/.github/workflows/formal-verification.yml
+++ b/.github/workflows/formal-verification.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Fetch TLA+ tools (pinned v1.7.4)
         env:
           TLA_TOOLS_VERSION: v1.7.4
-          TLA_TOOLS_SHA256: 936a262061c914694dfd669a543be24573c45d5aa0ff20a8b96b23d01e050e88
+          TLA_TOOLS_SHA256: 936a262061c914694dfd669a543be24573c45d5aa0ff20a8b96b23d01e050e88  # pragma: allowlist secret — sha256 of an upstream release jar, not a credential
         run: |
           curl -fsSL -o /tmp/tla2tools.jar \
             "https://github.com/tlaplus/tlaplus/releases/download/${TLA_TOOLS_VERSION}/tla2tools.jar"

--- a/.github/workflows/formal-verification.yml
+++ b/.github/workflows/formal-verification.yml
@@ -35,21 +35,31 @@ jobs:
       - name: Install JRE
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends default-jre-headless
 
-      - name: Fetch TLA+ tools
+      - name: Fetch TLA+ tools (pinned v1.7.4)
+        env:
+          TLA_TOOLS_VERSION: v1.7.4
+          TLA_TOOLS_SHA256: 936a262061c914694dfd669a543be24573c45d5aa0ff20a8b96b23d01e050e88
         run: |
           curl -fsSL -o /tmp/tla2tools.jar \
-            https://github.com/tlaplus/tlaplus/releases/latest/download/tla2tools.jar
+            "https://github.com/tlaplus/tlaplus/releases/download/${TLA_TOOLS_VERSION}/tla2tools.jar"
           test -s /tmp/tla2tools.jar
+          echo "${TLA_TOOLS_SHA256}  /tmp/tla2tools.jar" | sha256sum --check --strict
 
       - name: Run TLC
         working-directory: formal/tla
         run: |
+          set +e
           OUTPUT="$(java -cp /tmp/tla2tools.jar tlc2.TLC -config MC.cfg AdmissionGate.tla 2>&1)"
+          TLC_RC=$?
+          set -e
           echo "$OUTPUT"
+          echo "TLC exit code: ${TLC_RC}"
           echo "$OUTPUT" | grep -q "Model checking completed. No error has been found" \
             || (echo "::error::TLC did not report clean completion"; exit 1)
           echo "$OUTPUT" | grep -q "853 states generated, 547 distinct states found" \
             || (echo "::error::TLC state-space diverged from pinned expectation (853/547)"; exit 1)
+          test "${TLC_RC}" -eq 0 \
+            || (echo "::error::TLC exited non-zero (${TLC_RC}) despite producing the pinned summary"; exit 1)
 
   manifest:
     name: reproducibility sha256 manifest


### PR DESCRIPTION
## Summary

Root-cause follow-up to PR #329. The prior workflow fetched \`releases/latest/download/tla2tools.jar\` — i.e. **unpinned** — so any new TLC release could silently change behaviour and nuke CI (which is exactly what happened). This PR closes that time-axis leak.

## Changes

- **Pin the tool** to \`v1.7.4\` via env \`TLA_TOOLS_VERSION\`; URL is explicit.
- **Verify the jar sha256** (\`936a262061c914694dfd669a543be24573c45d5aa0ff20a8b96b23d01e050e88\`) with \`sha256sum --check --strict\` before TLC is invoked.
- **Surface TLC's own exit code.** The old wrapper ran \`OUTPUT=\$(java …)\` under \`bash -e\`, which terminated the step *before* the diagnostic output was ever echoed. Now the rc is captured, the output is always printed, and a non-zero rc accompanied by the pinned summary is reported explicitly.

## Verification

Locally reproduced against the pinned jar:

\`\`\`
Model checking completed. No error has been found.
853 states generated, 547 distinct states found, 0 states left on queue.
The depth of the complete state graph search is 9.
\`\`\`

State-space shape unchanged.

## Test plan

- [ ] \`TLC admission-gate model check\` passes against the pinned jar.
- [ ] \`reproducibility sha256 manifest\` still passes (no artefact touched).
- [ ] A deliberate bad hash causes the workflow to fail cleanly on the sha256 step (sanity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)