### PR TITLE
harden(agent_coordinator): entropy contract A + fail-closed halt + full audit trail

### DIFF
--- a/modules/agent_coordinator.py
+++ b/modules/agent_coordinator.py
@@ -2,21 +2,75 @@
 # SPDX-License-Identifier: MIT
 """
 Agent Coordinator Module
+========================
 
 Модуль для координації між різними агентами в системі GeoSync,
 включаючи TACL, ризик-менеджер, та торгові агенти.
 
-Features:
-- Централізована координація агентів
-- Розподіл ресурсів між агентами
-- Синхронізація станів
-- Вирішення конфліктів
+Canonical contracts shipped in this revision
+--------------------------------------------
+
+1. UTC timestamp contract.
+   ``utc_now()`` is the single source of timezone-aware ``datetime``
+   values in this module. Every default factory and every live
+   ``datetime`` assignment routes through it. Naive ``datetime.now()``
+   calls are forbidden.
+
+2. Entropy contract (Variant A — derived).
+   ``SubjectiveState.entropy`` is derived from the ``coherence_score``
+   as ``entropy = 1.0 - coherence_score`` inside
+   ``_evaluate_subjective_state``. The equality check
+   ``abs(entropy - (1.0 - coherence_score)) <= 1e-9`` in
+   ``hidden_contradiction`` is therefore a **sanity guard** against
+   externally constructed invalid states (tests, subclasses,
+   deserialisation paths), not a diagnostic of production drift.
+   In production the equality holds by construction.
+
+3. Fail-closed halt contract.
+   When ``_detect_hidden_contradiction`` returns ``True`` the
+   coordinator enters a halted state. While halted, every mutating /
+   executing operation raises ``ContradictionHaltError``.
+   The only allowed operations are read-only introspection:
+
+   * ``get_agent_info``
+   * ``get_system_health``
+   * ``get_coordination_summary``
+
+   …and the explicit recovery call ``reset_halt`` which requires a
+   human-supplied reason and an authorising identity. Both halt and
+   reset events are appended to the ``_halt_history`` audit trail
+   with a reproducible ``state_hash`` of the
+   ``SubjectiveState`` payload.
+
+4. State classification contract.
+   ``SubjectiveState.state_class`` partitions every observable
+   coordinator state into one of three disjoint classes:
+
+   * ``healthy``          — fully coherent (coherence≈1, entropy≈0).
+   * ``degraded_valid``   — coherent but below healthy perfection.
+   * ``impossible``       — contradictory or out-of-range invariants.
 """
 
-from dataclasses import dataclass, field
-from datetime import datetime
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, Callable, Dict, List, Optional, Set
+
+
+def utc_now() -> datetime:
+    """Return a timezone-aware UTC ``datetime`` — the module's only clock.
+
+    All timestamps produced inside this module (agent metadata, task
+    lifecycle, decisions, synthesis cycle reports, halt/reset audit
+    events) route through this function. The function is deliberately
+    tiny and free of side effects so that callers can monkey-patch it
+    in deterministic replay tests.
+    """
+    return datetime.now(timezone.utc)
 
 
 class AgentType(str, Enum):
@@ -65,8 +119,8 @@ class AgentMetadata:
     priority: Priority = Priority.NORMAL
     capabilities: Set[str] = field(default_factory=set)
     dependencies: Set[str] = field(default_factory=set)
-    registered_at: datetime = field(default_factory=datetime.now)
-    last_active: datetime = field(default_factory=datetime.now)
+    registered_at: datetime = field(default_factory=utc_now)
+    last_active: datetime = field(default_factory=utc_now)
     task_count: int = 0
     error_count: int = 0
 
@@ -80,8 +134,8 @@ class AgentTask:
     task_type: str
     priority: Priority
     payload: Dict[str, Any]
-    callback: Optional[Callable] = None
-    created_at: datetime = field(default_factory=datetime.now)
+    callback: Optional[Callable[..., Any]] = None
+    created_at: datetime = field(default_factory=utc_now)
     started_at: Optional[datetime] = None
     completed_at: Optional[datetime] = None
     result: Optional[Any] = None
@@ -97,7 +151,7 @@ class CoordinationDecision:
     action: str
     reason: str
     priority: Priority
-    timestamp: datetime = field(default_factory=datetime.now)
+    timestamp: datetime = field(default_factory=utc_now)
     metadata: Dict[str, Any] = field(default_factory=dict)
 
 
@@ -113,6 +167,123 @@ class ConflictDescriptor:
     details: Dict[str, Any] = field(default_factory=dict)
 
 
+@dataclass(frozen=True)
+class CoherenceAxes:
+    """П'ять осей цілісності для суб'єктивного стану.
+
+    Every axis is a score in ``[0.0, 1.0]`` where ``1.0`` is ideal.
+    ``all_above(threshold)`` is used by ``SubjectiveState.truth``.
+    """
+
+    structural_integrity: float
+    temporal_stability: float
+    verification_honesty: float
+    dependency_coherence: float
+    recovery_readiness: float
+
+    def all_above(self, threshold: float) -> bool:
+        return (
+            self.structural_integrity >= threshold
+            and self.temporal_stability >= threshold
+            and self.verification_honesty >= threshold
+            and self.dependency_coherence >= threshold
+            and self.recovery_readiness >= threshold
+        )
+
+
+@dataclass(frozen=True)
+class SubjectiveState:
+    """Структурований стан когерентності (замість неструктурованого Dict).
+
+    Invariants (documented contract, enforced via
+    :meth:`hidden_contradiction`):
+
+    * ``0.0 <= coherence_score <= 1.0``
+    * ``0.0 <= entropy <= 1.0``
+    * ``abs(entropy - (1.0 - coherence_score)) <= 1e-9``
+    * every axis in ``[0.0, 1.0]``
+
+    Production invariant: ``_evaluate_subjective_state`` always sets
+    ``entropy = 1.0 - coherence_score`` explicitly, so
+    ``hidden_contradiction`` can only fire for externally constructed
+    states (tests, subclasses, deserialisation). Such states are
+    classified as ``state_class == "impossible"`` and trigger the
+    fail-closed halt contract inside the coordinator.
+    """
+
+    axes: CoherenceAxes
+    coherence_score: float
+    entropy: float
+
+    @property
+    def truth(self) -> bool:
+        """Canonical truth predicate.
+
+        An artefact is *true* iff every axis is ≥ 0.8, the aggregate
+        coherence is ≥ 0.8, entropy is ≤ 0.2, **and** the entropy
+        equation is consistent with the coherence score.
+        """
+        return (
+            self.axes.all_above(0.8)
+            and self.coherence_score >= 0.8
+            and self.entropy <= 0.2
+            and abs(self.entropy - (1.0 - self.coherence_score)) <= 1e-9
+        )
+
+    @property
+    def hidden_contradiction(self) -> bool:
+        """Sanity guard against externally-constructed invalid states.
+
+        Returns ``True`` iff the state violates at least one of the
+        documented ``SubjectiveState`` invariants:
+
+        * ``coherence_score`` outside ``[0.0, 1.0]``
+        * ``entropy`` outside ``[0.0, 1.0]``
+        * entropy is not the derived complement of coherence
+          (``|entropy - (1 - coherence_score)| > 1e-9``)
+        * any axis outside ``[0.0, 1.0]``
+
+        In production this is a dead branch — the only way to reach it
+        is to construct a ``SubjectiveState`` directly with inconsistent
+        values. The sanity guard exists so that tests, subclasses,
+        and deserialisation paths cannot smuggle impossible states
+        past the halt gate.
+        """
+        if not (0.0 <= self.coherence_score <= 1.0):
+            return True
+        if not (0.0 <= self.entropy <= 1.0):
+            return True
+        if abs(self.entropy - (1.0 - self.coherence_score)) > 1e-9:
+            return True
+
+        return any(
+            not (0.0 <= axis_value <= 1.0)
+            for axis_value in (
+                self.axes.structural_integrity,
+                self.axes.temporal_stability,
+                self.axes.verification_honesty,
+                self.axes.dependency_coherence,
+                self.axes.recovery_readiness,
+            )
+        )
+
+    @property
+    def state_class(self) -> str:
+        """Canonical state classification — one of three disjoint classes.
+
+        * ``impossible``     — violates a structural invariant
+          (see :meth:`hidden_contradiction`).
+        * ``healthy``        — fully coherent
+          (coherence ≥ 1 − ε, entropy ≤ ε, and ``truth`` holds).
+        * ``degraded_valid`` — coherent but below healthy perfection.
+        """
+        if self.hidden_contradiction:
+            return "impossible"
+        if self.coherence_score >= (1.0 - 1e-9) and self.entropy <= 1e-9 and self.truth:
+            return "healthy"
+        return "degraded_valid"
+
+
 @dataclass
 class SynthesisCycleReport:
     """Звіт детермінованого циклу синтезу."""
@@ -125,6 +296,47 @@ class SynthesisCycleReport:
     verification_results: Dict[str, bool]
     recovered_agents: List[str]
     coherence_score: float
+    subjective_state: SubjectiveState
+    hidden_contradiction_detected: bool
+    halted: bool
+
+
+class ContradictionHaltError(RuntimeError):
+    """Raised when a mutating operation is attempted while the
+    coordinator is halted because of a hidden contradiction.
+
+    See the module docstring (section *Fail-closed halt contract*)
+    for the set of allowed read-only operations and the explicit
+    recovery path via :meth:`AgentCoordinator.reset_halt`.
+    """
+
+
+# Mutating / executing operations blocked while halted.
+# The set is part of the module contract and is also used by the test
+# suite to prove that every mutating path is gated.
+_HALT_GATED_OPS: frozenset[str] = frozenset(
+    {
+        "register_agent",
+        "unregister_agent",
+        "submit_task",
+        "register_protocol",
+        "register_validator",
+        "process_tasks",
+        "make_decision",
+        "update_agent_status",
+        "run_deterministic_synthesis_cycle",
+    }
+)
+
+# Read-only operations that remain callable while halted.
+_HALT_ALLOWED_OPS: frozenset[str] = frozenset(
+    {
+        "get_agent_info",
+        "get_system_health",
+        "get_coordination_summary",
+        "reset_halt",
+    }
+)
 
 
 class AgentCoordinator:
@@ -137,7 +349,7 @@ class AgentCoordinator:
 
     def __init__(
         self, max_concurrent_tasks: int = 10, enable_conflict_resolution: bool = True
-    ):
+    ) -> None:
         """
         Ініціалізація координатора
 
@@ -172,6 +384,22 @@ class AgentCoordinator:
         self._protocol_handlers: Dict[str, Callable[[Dict[str, Any]], Any]] = {}
         self._validators: Dict[str, Callable[["AgentCoordinator"], bool]] = {}
 
+        # Fail-closed halt state
+        self._halted_due_to_contradiction: bool = False
+        self._last_subjective_state: Optional[SubjectiveState] = None
+        self._halted_state_snapshot: Optional[SubjectiveState] = None
+        self._halt_history: List[Dict[str, Any]] = []
+
+    def _assert_not_halted(self, operation: str) -> None:
+        """System-wide fail-closed contract for mutating/execution operations."""
+        if self._halted_due_to_contradiction:
+            raise ContradictionHaltError(
+                f"Operation '{operation}' is blocked: coordinator is halted "
+                "due to hidden contradiction. Allowed operations: "
+                + ", ".join(sorted(_HALT_ALLOWED_OPS))
+                + "."
+            )
+
     def register_agent(
         self,
         agent_id: str,
@@ -199,6 +427,7 @@ class AgentCoordinator:
         Returns:
             AgentMetadata
         """
+        self._assert_not_halted("register_agent")
         if agent_id in self._agents:
             raise ValueError(f"Agent {agent_id} already registered")
 
@@ -227,12 +456,11 @@ class AgentCoordinator:
         Args:
             agent_id: Ідентифікатор агента
         """
+        self._assert_not_halted("unregister_agent")
         if agent_id in self._agents:
             # Скасувати всі активні задачі агента
             tasks_to_remove = [
-                task_id
-                for task_id, task in self._active_tasks.items()
-                if task.agent_id == agent_id
+                task_id for task_id, task in self._active_tasks.items() if task.agent_id == agent_id
             ]
             for task_id in tasks_to_remove:
                 del self._active_tasks[task_id]
@@ -249,7 +477,7 @@ class AgentCoordinator:
         task_type: str,
         payload: Dict[str, Any],
         priority: Priority = Priority.NORMAL,
-        callback: Optional[Callable] = None,
+        callback: Optional[Callable[..., Any]] = None,
     ) -> str:
         """
         Додавання задачі до черги
@@ -264,6 +492,7 @@ class AgentCoordinator:
         Returns:
             Ідентифікатор задачі
         """
+        self._assert_not_halted("submit_task")
         if agent_id not in self._agents:
             raise ValueError(f"Agent {agent_id} not registered")
 
@@ -293,6 +522,7 @@ class AgentCoordinator:
         """
         Реєструє універсальний протокол взаємодії (IoC).
         """
+        self._assert_not_halted("register_protocol")
         self._protocol_handlers[protocol_name] = handler
 
     def register_validator(
@@ -301,6 +531,7 @@ class AgentCoordinator:
         """
         Реєструє валідатор для рекурсивної верифікації системи.
         """
+        self._assert_not_halted("register_validator")
         self._validators[validator_name] = validator
 
     def process_tasks(self) -> List[str]:
@@ -310,6 +541,7 @@ class AgentCoordinator:
         Returns:
             Список ID оброблених задач
         """
+        self._assert_not_halted("process_tasks")
         processed: List[str] = []
 
         # Обмежуємо кількість одночасних задач
@@ -333,17 +565,17 @@ class AgentCoordinator:
 
                 # Оновлюємо статус
                 self._agents[task.agent_id].status = AgentStatus.BUSY
-                self._agents[task.agent_id].last_active = datetime.now()
+                self._agents[task.agent_id].last_active = utc_now()
                 self._agents[task.agent_id].task_count += 1
 
-                task.started_at = datetime.now()
+                task.started_at = utc_now()
                 self._active_tasks[task.task_id] = task
 
                 # Виконуємо задачу (в реальності це буде async)
                 handler = self._agent_handlers[task.agent_id]
                 result = self._execute_task(handler, task)
 
-                task.completed_at = datetime.now()
+                task.completed_at = utc_now()
                 task.result = result
 
                 # Викликаємо callback якщо є
@@ -414,9 +646,7 @@ class AgentCoordinator:
             "task_type": task.task_type,
         }
 
-    def make_decision(
-        self, decision_type: str, context: Dict[str, Any]
-    ) -> CoordinationDecision:
+    def make_decision(self, decision_type: str, context: Dict[str, Any]) -> CoordinationDecision:
         """
         Прийняття координаційного рішення
 
@@ -427,7 +657,8 @@ class AgentCoordinator:
         Returns:
             CoordinationDecision
         """
-        affected_agents = []
+        self._assert_not_halted("make_decision")
+        affected_agents: List[str] = []
         action = "no_action"
         reason = "default"
         priority = Priority.NORMAL
@@ -504,13 +735,14 @@ class AgentCoordinator:
             agent_id: Ідентифікатор агента
             status: Новий статус
         """
+        self._assert_not_halted("update_agent_status")
         if agent_id in self._agents:
             self._agents[agent_id].status = status
-            self._agents[agent_id].last_active = datetime.now()
+            self._agents[agent_id].last_active = utc_now()
 
-    def get_agent_info(self, agent_id: str) -> Optional[Dict]:
+    def get_agent_info(self, agent_id: str) -> Optional[Dict[str, Any]]:
         """
-        Отримання інформації про агента
+        Отримання інформації про агента (read-only — дозволено під час halt).
 
         Args:
             agent_id: Ідентифікатор агента
@@ -536,9 +768,9 @@ class AgentCoordinator:
             "last_active": agent.last_active.isoformat(),
         }
 
-    def get_system_health(self) -> Dict:
+    def get_system_health(self) -> Dict[str, Any]:
         """
-        Отримання стану системи
+        Отримання стану системи (read-only — дозволено під час halt).
 
         Returns:
             Словник зі станом здоров'я системи
@@ -549,17 +781,13 @@ class AgentCoordinator:
             for a in self._agents.values()
             if a.status == AgentStatus.ACTIVE or a.status == AgentStatus.BUSY
         )
-        error_agents = sum(
-            1 for a in self._agents.values() if a.status == AgentStatus.ERROR
-        )
+        error_agents = sum(1 for a in self._agents.values() if a.status == AgentStatus.ERROR)
 
         # Обчислюємо health score
         health_score = 100.0
         if total_agents > 0:
             health_score -= (error_agents / total_agents) * 50
-            health_score -= (
-                len(self._task_queue) / max(self.max_concurrent_tasks, 1)
-            ) * 25
+            health_score -= (len(self._task_queue) / max(self.max_concurrent_tasks, 1)) * 25
 
         health_score = max(0.0, min(100.0, health_score))
 
@@ -567,9 +795,7 @@ class AgentCoordinator:
             "health_score": f"{health_score:.1f}",
             "total_agents": total_agents,
             "active_agents": active_agents,
-            "idle_agents": sum(
-                1 for a in self._agents.values() if a.status == AgentStatus.IDLE
-            ),
+            "idle_agents": sum(1 for a in self._agents.values() if a.status == AgentStatus.IDLE),
             "error_agents": error_agents,
             "queued_tasks": len(self._task_queue),
             "active_tasks": len(self._active_tasks),
@@ -577,9 +803,9 @@ class AgentCoordinator:
             "recent_decisions": len(self._decisions[-10:]),
         }
 
-    def get_coordination_summary(self) -> Dict:
+    def get_coordination_summary(self) -> Dict[str, Any]:
         """
-        Отримання загального звіту координації
+        Отримання загального звіту координації (read-only — дозволено під час halt).
 
         Returns:
             Словник зі звітом
@@ -593,16 +819,21 @@ class AgentCoordinator:
             "active_tasks": len(self._active_tasks),
             "decisions_made": len(self._decisions),
             "system_health": self.get_system_health(),
+            "halted": self._halted_due_to_contradiction,
         }
 
     def run_deterministic_synthesis_cycle(self) -> SynthesisCycleReport:
         """
         Детермінований цикл синтезу:
-        1) Декомпозиція ентропії
-        2) Алгоритмічна синхронізація
-        3) Рекурсивна верифікація та самовідновлення
+
+        1) Декомпозиція ентропії.
+        2) Алгоритмічна синхронізація.
+        3) Рекурсивна верифікація та самовідновлення.
+        4) Побудова канонічного ``SubjectiveState`` і перевірка
+           ``hidden_contradiction`` як fail-closed gate.
         """
-        started_at = datetime.now()
+        self._assert_not_halted("run_deterministic_synthesis_cycle")
+        started_at = utc_now()
         self._synthesis_cycle_counter += 1
         cycle_id = f"cycle_{self._synthesis_cycle_counter}"
 
@@ -611,8 +842,26 @@ class AgentCoordinator:
         verification = self._recursive_verify()
         recovered_agents = self._recover_from_conflicts(conflicts)
         coherence_score = self._calculate_coherence_score(conflicts, verification)
+        subjective_state = self._evaluate_subjective_state(
+            conflicts=conflicts,
+            synchronized_agents=synchronized_agents,
+            verification_results=verification,
+            recovered_agents=recovered_agents,
+            coherence_score=coherence_score,
+        )
+        hidden_contradiction_detected = self._detect_hidden_contradiction(
+            subjective_state=subjective_state
+        )
+        if hidden_contradiction_detected:
+            self._halted_due_to_contradiction = True
+            self._halted_state_snapshot = subjective_state
+            self._record_halt_event(
+                cycle_id=cycle_id,
+                reason="hidden_contradiction_detected",
+                subjective_state=subjective_state,
+            )
 
-        completed_at = datetime.now()
+        completed_at = utc_now()
         return SynthesisCycleReport(
             cycle_id=cycle_id,
             started_at=started_at,
@@ -622,6 +871,38 @@ class AgentCoordinator:
             verification_results=verification,
             recovered_agents=recovered_agents,
             coherence_score=coherence_score,
+            subjective_state=subjective_state,
+            hidden_contradiction_detected=hidden_contradiction_detected,
+            halted=self._halted_due_to_contradiction,
+        )
+
+    @staticmethod
+    def _state_payload_hash(payload: Optional[Dict[str, Any]]) -> Optional[str]:
+        """Deterministic sha256 of an ``asdict``-ified ``SubjectiveState``.
+
+        Returns ``None`` when the payload is ``None`` so that reset
+        events that had no snapshot still produce a well-formed audit
+        record.
+        """
+        if payload is None:
+            return None
+        serialised = json.dumps(payload, sort_keys=True).encode("utf-8")
+        return hashlib.sha256(serialised).hexdigest()
+
+    def _record_halt_event(
+        self, cycle_id: str, reason: str, subjective_state: SubjectiveState
+    ) -> None:
+        state_payload = asdict(subjective_state)
+        state_hash = self._state_payload_hash(state_payload)
+        self._halt_history.append(
+            {
+                "event_type": "halt",
+                "halt_at": utc_now(),
+                "reason": reason,
+                "subjective_state": state_payload,
+                "state_hash": state_hash,
+                "cycle_id": cycle_id,
+            }
         )
 
     def _decompose_entropy(self) -> List[ConflictDescriptor]:
@@ -637,9 +918,7 @@ class AgentCoordinator:
                             agent_id=agent_id,
                             conflict_type="missing_dependency",
                             severity=Priority.HIGH,
-                            function_expression=(
-                                f"f_missing_dep({agent_id},{dep_id})=1"
-                            ),
+                            function_expression=(f"f_missing_dep({agent_id},{dep_id})=1"),
                             details={"dependency": dep_id},
                         )
                     )
@@ -667,9 +946,7 @@ class AgentCoordinator:
                         agent_id="system",
                         conflict_type="throughput_pressure",
                         severity=Priority.HIGH,
-                        function_expression=(
-                            "f_queue=max(0, queued/max_concurrent_tasks - 1)"
-                        ),
+                        function_expression=("f_queue=max(0, queued/max_concurrent_tasks - 1)"),
                         details={"queue_pressure": queue_pressure},
                     )
                 )
@@ -696,9 +973,7 @@ class AgentCoordinator:
             results["dependency_integrity"] = all(
                 self._check_dependencies(agent) for agent in self._agents.values()
             )
-            results["health_above_floor"] = (
-                float(self.get_system_health()["health_score"]) >= 50.0
-            )
+            results["health_above_floor"] = float(self.get_system_health()["health_score"]) >= 50.0
             return results
 
         for validator_name, validator in self._validators.items():
@@ -708,10 +983,9 @@ class AgentCoordinator:
                 results[validator_name] = False
         return results
 
-    def _recover_from_conflicts(
-        self, conflicts: List[ConflictDescriptor]
-    ) -> List[str]:
-        """Самовідновлення: переводить конфліктні агенти в PAUSED для контрольованого деградування."""
+    def _recover_from_conflicts(self, conflicts: List[ConflictDescriptor]) -> List[str]:
+        """Самовідновлення: переводить конфліктні агенти в PAUSED
+        для контрольованого деградування."""
         recovered: List[str] = []
         conflicted_agents = {
             c.agent_id for c in conflicts if c.agent_id != "system" and c.agent_id in self._agents
@@ -725,7 +999,9 @@ class AgentCoordinator:
         return recovered
 
     def _calculate_coherence_score(
-        self, conflicts: List[ConflictDescriptor], verification_results: Dict[str, bool]
+        self,
+        conflicts: List[ConflictDescriptor],
+        verification_results: Dict[str, bool],
     ) -> float:
         """Оцінює когерентність системи в діапазоні [0, 1]."""
         base = 1.0
@@ -735,3 +1011,114 @@ class AgentCoordinator:
 
         score = base - conflict_penalty - verification_penalty
         return max(0.0, min(1.0, score))
+
+    def _evaluate_subjective_state(
+        self,
+        conflicts: List[ConflictDescriptor],
+        synchronized_agents: List[str],
+        verification_results: Dict[str, bool],
+        recovered_agents: List[str],
+        coherence_score: float,
+    ) -> SubjectiveState:
+        """
+        Оцінює "цифровий суб'єктивізм" по п'яти осях цілісності.
+
+        Осі:
+        1) ``structural_integrity``  — 1 − conflict density per agent.
+        2) ``temporal_stability``    — weighted mix of coherence and
+           synchronisation ratio.
+        3) ``verification_honesty``  — ratio of passing validators.
+        4) ``dependency_coherence``  — 1 − dep-related-conflict density.
+        5) ``recovery_readiness``    — penalised by recent recoveries.
+
+        Production contract (Variant A): ``entropy`` is set to
+        ``1.0 - coherence_score`` by construction. This keeps the
+        sanity-guard in :meth:`SubjectiveState.hidden_contradiction`
+        a **dead branch** in production; it only fires for externally
+        constructed states.
+        """
+        total_agents = max(len(self._agents), 1)
+        conflicts_count = len(conflicts)
+        active_conflicts_ratio = min(conflicts_count / total_agents, 1.0)
+        synchronized_ratio = min(len(synchronized_agents) / total_agents, 1.0)
+
+        structural_integrity = max(0.0, 1.0 - active_conflicts_ratio)
+        temporal_stability = max(0.0, min(1.0, 0.6 * coherence_score + 0.4 * synchronized_ratio))
+
+        verification_total = max(len(verification_results), 1)
+        verification_pass_ratio = (
+            sum(1 for ok in verification_results.values() if ok) / verification_total
+        )
+        verification_honesty = verification_pass_ratio
+
+        dependency_coherence = max(
+            0.0,
+            1.0
+            - min(
+                sum(
+                    1
+                    for c in conflicts
+                    if c.conflict_type in {"missing_dependency", "error_dependency"}
+                )
+                / total_agents,
+                1.0,
+            ),
+        )
+        recovery_readiness = max(
+            0.0,
+            min(1.0, 1.0 - (len(recovered_agents) / total_agents) * 0.5),
+        )
+
+        axes = CoherenceAxes(
+            structural_integrity=structural_integrity,
+            temporal_stability=temporal_stability,
+            verification_honesty=verification_honesty,
+            dependency_coherence=dependency_coherence,
+            recovery_readiness=recovery_readiness,
+        )
+        entropy = 1.0 - coherence_score
+        state = SubjectiveState(axes=axes, coherence_score=coherence_score, entropy=entropy)
+        self._last_subjective_state = state
+        return state
+
+    def _detect_hidden_contradiction(self, subjective_state: SubjectiveState) -> bool:
+        """``HiddenContradiction(S)``: виявляє внутрішню брехню між
+        ``truth`` і фактичною когерентністю.
+
+        In production this is a dead branch (see the module docstring,
+        *Entropy contract (Variant A — derived)*). The coordinator
+        still routes every synthesis cycle through it so that any
+        future regression that breaks the entropy derivation trips
+        the halt gate immediately rather than silently corrupting
+        downstream decisions.
+        """
+        return subjective_state.hidden_contradiction
+
+    def reset_halt(self, reason: str, authorized_by: str) -> None:
+        """Явне розблокування halt-стану через авторизовану дію.
+
+        Always appends a ``reset`` event to ``_halt_history`` when the
+        coordinator is halted, including an ``authorized_by`` identity
+        and the sha256 of the snapshot that the reset supersedes.
+        When called without an active halt, the method is a no-op and
+        the audit trail is not mutated.
+        """
+        if not self._halted_due_to_contradiction:
+            return
+        state_payload = (
+            asdict(self._halted_state_snapshot) if self._halted_state_snapshot is not None else None
+        )
+        state_hash = self._state_payload_hash(state_payload)
+        self._halt_history.append(
+            {
+                "event_type": "reset",
+                "reset_at": utc_now(),
+                "reason": reason,
+                "authorized_by": authorized_by,
+                "subjective_state": state_payload,
+                "state_hash": state_hash,
+                "cycle_id": None,
+            }
+        )
+        self._halted_due_to_contradiction = False
+        self._halted_state_snapshot = None

--- a/tests/unit/modules/test_agent_coordinator.py
+++ b/tests/unit/modules/test_agent_coordinator.py
@@ -1,44 +1,85 @@
 # Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
 # SPDX-License-Identifier: MIT
 """
-Tests for Agent Coordinator Module
+Tests for Agent Coordinator Module.
+
+The suite covers — in addition to the original registration / scheduling /
+decision paths — the full fail-closed halt contract, the ``SubjectiveState``
+state-class partition, the halt/reset audit schema (with reproducible
+``state_hash``), the UTC timestamp contract, and an exhaustive sweep of
+every mutating operation gated by ``_assert_not_halted``.
 """
+
+from __future__ import annotations
 
 import pytest
 
 from modules.agent_coordinator import (
+    _HALT_ALLOWED_OPS,
+    _HALT_GATED_OPS,
     AgentCoordinator,
     AgentMetadata,
     AgentStatus,
     AgentType,
+    CoherenceAxes,
+    ContradictionHaltError,
     Priority,
+    SubjectiveState,
 )
 
 
 class MockAgentHandler:
     """Mock agent handler for testing"""
 
-    def __init__(self, name):
+    def __init__(self, name: str) -> None:
         self.name = name
         self.call_count = 0
 
-    def process(self, task):
+    def process(self, task: object) -> dict[str, str]:
         self.call_count += 1
         return {"status": "success", "handler": self.name}
+
+
+def _healthy_state() -> SubjectiveState:
+    return SubjectiveState(
+        axes=CoherenceAxes(1.0, 1.0, 1.0, 1.0, 1.0),
+        coherence_score=1.0,
+        entropy=0.0,
+    )
+
+
+def _degraded_state() -> SubjectiveState:
+    return SubjectiveState(
+        axes=CoherenceAxes(0.95, 0.91, 0.89, 0.92, 0.86),
+        coherence_score=0.9,
+        entropy=0.1,
+    )
+
+
+def _impossible_state_entropy_drift() -> SubjectiveState:
+    # coherence=0.9 demands entropy=0.1 under Variant A; 0.3 breaks the
+    # equation → sanity guard fires.
+    return SubjectiveState(
+        axes=CoherenceAxes(0.95, 0.91, 0.89, 0.92, 0.86),
+        coherence_score=0.9,
+        entropy=0.3,
+    )
 
 
 class TestAgentCoordinator:
     """Test suite for AgentCoordinator"""
 
-    def test_initialization(self):
+    def test_initialization(self) -> None:
         """Test coordinator initialization"""
         coordinator = AgentCoordinator(max_concurrent_tasks=10)
 
         assert coordinator.max_concurrent_tasks == 10
         assert len(coordinator._agents) == 0
         assert len(coordinator._task_queue) == 0
+        assert coordinator._halted_due_to_contradiction is False
+        assert coordinator._halt_history == []
 
-    def test_register_agent(self):
+    def test_register_agent(self) -> None:
         """Test agent registration"""
         coordinator = AgentCoordinator()
         handler = MockAgentHandler("test_agent")
@@ -59,41 +100,35 @@ class TestAgentCoordinator:
         assert metadata.priority == Priority.HIGH
         assert "trade" in metadata.capabilities
 
-    def test_register_duplicate_agent(self):
+    def test_register_duplicate_agent(self) -> None:
         """Test duplicate agent registration fails"""
         coordinator = AgentCoordinator()
         handler = MockAgentHandler("test_agent")
 
-        coordinator.register_agent(
-            "agent_1", AgentType.TRADING, "Agent 1", "Description", handler
-        )
+        coordinator.register_agent("agent_1", AgentType.TRADING, "Agent 1", "Description", handler)
 
         with pytest.raises(ValueError):
             coordinator.register_agent(
                 "agent_1", AgentType.TRADING, "Agent 1 Duplicate", "Desc", handler
             )
 
-    def test_unregister_agent(self):
+    def test_unregister_agent(self) -> None:
         """Test agent unregistration"""
         coordinator = AgentCoordinator()
         handler = MockAgentHandler("test_agent")
 
-        coordinator.register_agent(
-            "agent_1", AgentType.TRADING, "Agent 1", "Description", handler
-        )
+        coordinator.register_agent("agent_1", AgentType.TRADING, "Agent 1", "Description", handler)
         assert "agent_1" in coordinator._agents
 
         coordinator.unregister_agent("agent_1")
         assert "agent_1" not in coordinator._agents
 
-    def test_submit_task(self):
+    def test_submit_task(self) -> None:
         """Test task submission"""
         coordinator = AgentCoordinator()
         handler = MockAgentHandler("test_agent")
 
-        coordinator.register_agent(
-            "agent_1", AgentType.TRADING, "Agent 1", "Description", handler
-        )
+        coordinator.register_agent("agent_1", AgentType.TRADING, "Agent 1", "Description", handler)
 
         task_id = coordinator.submit_task(
             agent_id="agent_1",
@@ -105,33 +140,27 @@ class TestAgentCoordinator:
         assert task_id.startswith("task_")
         assert len(coordinator._task_queue) == 1
 
-    def test_submit_task_unregistered_agent(self):
+    def test_submit_task_unregistered_agent(self) -> None:
         """Test task submission for unregistered agent fails"""
         coordinator = AgentCoordinator()
 
         with pytest.raises(ValueError):
-            coordinator.submit_task(
-                agent_id="nonexistent", task_type="test", payload={}
-            )
+            coordinator.submit_task(agent_id="nonexistent", task_type="test", payload={})
 
-    def test_task_priority_ordering(self):
+    def test_task_priority_ordering(self) -> None:
         """Test tasks are ordered by priority"""
         coordinator = AgentCoordinator()
         handler = MockAgentHandler("test_agent")
 
-        coordinator.register_agent(
-            "agent_1", AgentType.TRADING, "Agent 1", "Description", handler
-        )
+        coordinator.register_agent("agent_1", AgentType.TRADING, "Agent 1", "Description", handler)
 
-        # Submit tasks with different priorities
         coordinator.submit_task("agent_1", "task_low", {}, Priority.LOW)
         coordinator.submit_task("agent_1", "task_high", {}, Priority.HIGH)
         coordinator.submit_task("agent_1", "task_normal", {}, Priority.NORMAL)
 
-        # High priority should be first
         assert coordinator._task_queue[0].priority == Priority.HIGH
 
-    def test_make_decision_resource_allocation(self):
+    def test_make_decision_resource_allocation(self) -> None:
         """Test resource allocation decision"""
         coordinator = AgentCoordinator()
         handler1 = MockAgentHandler("agent1")
@@ -154,24 +183,18 @@ class TestAgentCoordinator:
             priority=Priority.NORMAL,
         )
 
-        decision = coordinator.make_decision(
-            decision_type="resource_allocation", context={}
-        )
+        decision = coordinator.make_decision(decision_type="resource_allocation", context={})
 
         assert decision.decision_type == "resource_allocation"
         assert len(decision.affected_agents) == 2
-
-        # Check resources were allocated
         assert sum(coordinator._resource_allocation.values()) > 0
 
-    def test_make_decision_emergency_stop(self):
+    def test_make_decision_emergency_stop(self) -> None:
         """Test emergency stop decision"""
         coordinator = AgentCoordinator()
         handler = MockAgentHandler("test_agent")
 
-        coordinator.register_agent(
-            "agent_1", AgentType.TRADING, "Agent 1", "Description", handler
-        )
+        coordinator.register_agent("agent_1", AgentType.TRADING, "Agent 1", "Description", handler)
 
         decision = coordinator.make_decision(
             decision_type="emergency_stop", context={"reason": "critical_error"}
@@ -179,23 +202,19 @@ class TestAgentCoordinator:
 
         assert decision.priority == Priority.EMERGENCY
         assert decision.action == "stop_all"
-
-        # All agents should be stopped
         assert coordinator._agents["agent_1"].status == AgentStatus.STOPPED
 
-    def test_update_agent_status(self):
+    def test_update_agent_status(self) -> None:
         """Test agent status update"""
         coordinator = AgentCoordinator()
         handler = MockAgentHandler("test_agent")
 
-        coordinator.register_agent(
-            "agent_1", AgentType.TRADING, "Agent 1", "Description", handler
-        )
+        coordinator.register_agent("agent_1", AgentType.TRADING, "Agent 1", "Description", handler)
 
         coordinator.update_agent_status("agent_1", AgentStatus.ACTIVE)
         assert coordinator._agents["agent_1"].status == AgentStatus.ACTIVE
 
-    def test_get_agent_info(self):
+    def test_get_agent_info(self) -> None:
         """Test getting agent information"""
         coordinator = AgentCoordinator()
         handler = MockAgentHandler("test_agent")
@@ -216,24 +235,20 @@ class TestAgentCoordinator:
         assert info["type"] == AgentType.TRADING.value
         assert "trade" in info["capabilities"]
 
-    def test_get_agent_info_nonexistent(self):
+    def test_get_agent_info_nonexistent(self) -> None:
         """Test getting info for nonexistent agent"""
         coordinator = AgentCoordinator()
 
         info = coordinator.get_agent_info("nonexistent")
         assert info is None
 
-    def test_get_system_health(self):
+    def test_get_system_health(self) -> None:
         """Test system health calculation"""
         coordinator = AgentCoordinator()
         handler = MockAgentHandler("test_agent")
 
-        coordinator.register_agent(
-            "agent_1", AgentType.TRADING, "Agent 1", "Desc", handler
-        )
-        coordinator.register_agent(
-            "agent_2", AgentType.RISK_MANAGER, "Agent 2", "Desc", handler
-        )
+        coordinator.register_agent("agent_1", AgentType.TRADING, "Agent 1", "Desc", handler)
+        coordinator.register_agent("agent_2", AgentType.RISK_MANAGER, "Agent 2", "Desc", handler)
 
         health = coordinator.get_system_health()
 
@@ -241,44 +256,41 @@ class TestAgentCoordinator:
         assert "total_agents" in health
         assert health["total_agents"] == 2
 
-    def test_get_coordination_summary(self):
+    def test_get_coordination_summary(self) -> None:
         """Test coordination summary"""
         coordinator = AgentCoordinator()
         handler = MockAgentHandler("test_agent")
 
-        coordinator.register_agent(
-            "agent_1", AgentType.TRADING, "Agent 1", "Desc", handler
-        )
+        coordinator.register_agent("agent_1", AgentType.TRADING, "Agent 1", "Desc", handler)
 
         summary = coordinator.get_coordination_summary()
 
         assert "registered_agents" in summary
         assert "system_health" in summary
         assert summary["registered_agents"] == 1
+        assert summary["halted"] is False
 
-    def test_process_task_uses_handler_process_method(self):
+    def test_process_task_uses_handler_process_method(self) -> None:
         """Task processing should call handler.process when available."""
         coordinator = AgentCoordinator(max_concurrent_tasks=1)
         handler = MockAgentHandler("exec_agent")
 
-        coordinator.register_agent(
-            "agent_1", AgentType.TRADING, "Agent 1", "Desc", handler
-        )
+        coordinator.register_agent("agent_1", AgentType.TRADING, "Agent 1", "Desc", handler)
         coordinator.submit_task("agent_1", "execute", {"symbol": "ETHUSD"})
 
         processed = coordinator.process_tasks()
 
         assert len(processed) == 1
         assert handler.call_count == 1
-        assert coordinator._completed_tasks[0].result["handler"] == "exec_agent"
+        result = coordinator._completed_tasks[0].result
+        assert isinstance(result, dict)
+        assert result["handler"] == "exec_agent"
 
-    def test_protocol_inversion_of_control(self):
+    def test_protocol_inversion_of_control(self) -> None:
         """Registered protocol should execute instead of direct handler invocation."""
         coordinator = AgentCoordinator(max_concurrent_tasks=1)
         handler = MockAgentHandler("fallback_agent")
-        coordinator.register_agent(
-            "agent_1", AgentType.STRATEGY, "Strategy Agent", "Desc", handler
-        )
+        coordinator.register_agent("agent_1", AgentType.STRATEGY, "Strategy Agent", "Desc", handler)
 
         coordinator.register_protocol(
             "shared_protocol",
@@ -293,11 +305,12 @@ class TestAgentCoordinator:
 
         coordinator.process_tasks()
         result = coordinator._completed_tasks[0].result
+        assert isinstance(result, dict)
         assert result["status"] == "protocol_ok"
         assert result["payload"] == 42
         assert handler.call_count == 0
 
-    def test_deterministic_synthesis_cycle_detects_and_recovers(self):
+    def test_deterministic_synthesis_cycle_detects_and_recovers(self) -> None:
         """Deterministic synthesis cycle should isolate conflicts and recover errored agents."""
         coordinator = AgentCoordinator()
         handler = MockAgentHandler("test_agent")
@@ -324,12 +337,316 @@ class TestAgentCoordinator:
 
         assert report.cycle_id.startswith("cycle_")
         assert any(
-            conflict.conflict_type == "error_dependency"
-            for conflict in report.decomposed_conflicts
+            conflict.conflict_type == "error_dependency" for conflict in report.decomposed_conflicts
         )
         assert "agent_1" in report.recovered_agents
         assert coordinator._agents["agent_1"].status == AgentStatus.PAUSED
         assert 0.0 <= report.coherence_score <= 1.0
+        assert report.hidden_contradiction_detected is False
+        assert report.halted is False
+        assert report.subjective_state.truth in {False, True}
+        assert report.subjective_state.axes.recovery_readiness >= 0.0
+
+
+class TestSubjectiveStateContract:
+    """Variant-A entropy contract: derived in production; sanity-only on injection."""
+
+    def test_healthy_state_class(self) -> None:
+        s = _healthy_state()
+        assert s.state_class == "healthy"
+        assert s.hidden_contradiction is False
+        assert s.truth is True
+
+    def test_degraded_state_class(self) -> None:
+        s = _degraded_state()
+        assert s.state_class == "degraded_valid"
+        assert s.hidden_contradiction is False
+        assert s.truth is True  # axes ≥ 0.8, coherence ≥ 0.8, entropy consistent
+
+    def test_impossible_state_entropy_drift(self) -> None:
+        s = _impossible_state_entropy_drift()
+        assert s.state_class == "impossible"
+        assert s.hidden_contradiction is True
+        assert s.truth is False
+
+    def test_impossible_state_out_of_range_coherence(self) -> None:
+        """Externally-injected invalid state (sanity guard test)."""
+        s = SubjectiveState(
+            axes=CoherenceAxes(1.0, 1.0, 1.0, 1.0, 1.0),
+            coherence_score=1.5,
+            entropy=-0.5,
+        )
+        assert s.hidden_contradiction is True
+        assert s.state_class == "impossible"
+
+    def test_impossible_state_out_of_range_axis(self) -> None:
+        """Axis outside [0,1] must trip the sanity guard."""
+        s = SubjectiveState(
+            axes=CoherenceAxes(1.0, 1.0, 1.0, 1.0, 1.5),
+            coherence_score=1.0,
+            entropy=0.0,
+        )
+        assert s.hidden_contradiction is True
+        assert s.state_class == "impossible"
+
+    def test_state_class_partition_is_exhaustive(self) -> None:
+        """The classifier only emits one of three canonical labels."""
+        labels = {
+            _healthy_state().state_class,
+            _degraded_state().state_class,
+            _impossible_state_entropy_drift().state_class,
+        }
+        assert labels <= {"healthy", "degraded_valid", "impossible"}
+        assert labels == {"healthy", "degraded_valid", "impossible"}
+
+
+class TestHaltContract:
+    """System-wide fail-closed halt contract."""
+
+    def test_healthy_state_no_halt(self) -> None:
+        coordinator = AgentCoordinator()
+        assert coordinator._detect_hidden_contradiction(_healthy_state()) is False
+
+    def test_degraded_state_no_halt(self) -> None:
+        coordinator = AgentCoordinator()
+        assert coordinator._detect_hidden_contradiction(_degraded_state()) is False
+
+    def test_impossible_state_triggers_halt(self) -> None:
+        coordinator = AgentCoordinator()
+        s = _impossible_state_entropy_drift()
+        coordinator._halted_due_to_contradiction = coordinator._detect_hidden_contradiction(s)
+        assert coordinator._halted_due_to_contradiction is True
+
+    def test_fail_closed_blocks_next_cycle_until_explicit_reset(self) -> None:
+        coordinator = AgentCoordinator()
+        coordinator._halted_due_to_contradiction = True
+        with pytest.raises(ContradictionHaltError):
+            coordinator.run_deterministic_synthesis_cycle()
+
+    def test_reset_allows_reentry_after_halt(self) -> None:
+        coordinator = AgentCoordinator()
+        handler = MockAgentHandler("agent")
+        coordinator.register_agent("agent_1", AgentType.TRADING, "A", "D", handler)
+        coordinator._halted_due_to_contradiction = True
+        coordinator._halted_state_snapshot = _impossible_state_entropy_drift()
+
+        coordinator.reset_halt("manual clear", "ops")
+
+        report = coordinator.run_deterministic_synthesis_cycle()
+        assert report.halted is False
+        assert coordinator._halted_state_snapshot is None
+
+    def test_halt_blocks_submit_and_process_paths(self) -> None:
+        coordinator = AgentCoordinator()
+        handler = MockAgentHandler("agent")
+        coordinator.register_agent("agent_1", AgentType.TRADING, "A", "D", handler)
+        coordinator._halted_due_to_contradiction = True
+
+        with pytest.raises(ContradictionHaltError):
+            coordinator.submit_task("agent_1", "sync", {})
+        with pytest.raises(ContradictionHaltError):
+            coordinator.process_tasks()
+
+    def test_halt_blocks_every_gated_mutating_operation(self) -> None:
+        """Exhaustive coverage of every op inside ``_HALT_GATED_OPS``."""
+        coordinator = AgentCoordinator()
+        handler = MockAgentHandler("agent")
+        coordinator.register_agent("agent_1", AgentType.TRADING, "A", "D", handler)
+        # Go halted only after initial setup so the probes below can assume
+        # the registered agent exists.
+        coordinator._halted_due_to_contradiction = True
+
+        def _probe(op: str) -> None:
+            if op == "register_agent":
+                coordinator.register_agent("new_agent", AgentType.TRADING, "N", "D", handler)
+            elif op == "unregister_agent":
+                coordinator.unregister_agent("agent_1")
+            elif op == "submit_task":
+                coordinator.submit_task("agent_1", "t", {})
+            elif op == "register_protocol":
+                coordinator.register_protocol("p", lambda _p: None)
+            elif op == "register_validator":
+                coordinator.register_validator("v", lambda _c: True)
+            elif op == "process_tasks":
+                coordinator.process_tasks()
+            elif op == "make_decision":
+                coordinator.make_decision("agent_coordination", {})
+            elif op == "update_agent_status":
+                coordinator.update_agent_status("agent_1", AgentStatus.ACTIVE)
+            elif op == "run_deterministic_synthesis_cycle":
+                coordinator.run_deterministic_synthesis_cycle()
+            else:
+                raise AssertionError(f"unmapped gated op: {op}")
+
+        for op in _HALT_GATED_OPS:
+            with pytest.raises(ContradictionHaltError) as exc:
+                _probe(op)
+            assert op in str(exc.value)
+
+    def test_halt_permits_every_allowed_readonly_operation(self) -> None:
+        """Read-only introspection + reset_halt remain callable under halt."""
+        coordinator = AgentCoordinator()
+        handler = MockAgentHandler("agent")
+        coordinator.register_agent("agent_1", AgentType.TRADING, "A", "D", handler)
+        coordinator._halted_due_to_contradiction = True
+        coordinator._halted_state_snapshot = _impossible_state_entropy_drift()
+
+        # get_agent_info
+        assert coordinator.get_agent_info("agent_1") is not None
+        # get_system_health
+        assert "health_score" in coordinator.get_system_health()
+        # get_coordination_summary
+        summary = coordinator.get_coordination_summary()
+        assert summary["halted"] is True
+        # reset_halt (explicit recovery)
+        coordinator.reset_halt("ok", "ops")
+        assert coordinator._halted_due_to_contradiction is False
+
+    def test_allowed_and_gated_op_sets_are_disjoint(self) -> None:
+        """Contract invariant: no op appears in both sets."""
+        assert _HALT_GATED_OPS.isdisjoint(_HALT_ALLOWED_OPS)
+
+    def test_last_subjective_state_matches_report_state(self) -> None:
+        coordinator = AgentCoordinator()
+        handler = MockAgentHandler("agent")
+        coordinator.register_agent("agent_1", AgentType.TRADING, "A", "D", handler)
+
+        report = coordinator.run_deterministic_synthesis_cycle()
+        assert coordinator._last_subjective_state == report.subjective_state
+        assert coordinator._halted_state_snapshot is None
+
+
+class TestAuditTrail:
+    """Halt/reset audit schema, reproducible state_hash."""
+
+    def test_halt_event_schema_and_cycle_id(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Production path through halt records the full event schema."""
+        coordinator = AgentCoordinator()
+        handler = MockAgentHandler("agent")
+        coordinator.register_agent("agent_1", AgentType.TRADING, "A", "D", handler)
+
+        # Force the production path to emit an impossible state without
+        # editing its mathematics: monkey-patch the evaluator.
+        monkeypatch.setattr(
+            AgentCoordinator,
+            "_evaluate_subjective_state",
+            lambda _self, **_kw: _impossible_state_entropy_drift(),
+        )
+
+        report = coordinator.run_deterministic_synthesis_cycle()
+        assert report.hidden_contradiction_detected is True
+        assert report.halted is True
+        assert coordinator._halted_due_to_contradiction is True
+
+        # Event schema
+        assert len(coordinator._halt_history) == 1
+        event = coordinator._halt_history[0]
+        assert event["event_type"] == "halt"
+        assert event["reason"] == "hidden_contradiction_detected"
+        assert event["cycle_id"] == report.cycle_id
+        assert event["state_hash"] is not None
+        assert event["subjective_state"] is not None
+        assert event["halt_at"].tzinfo is not None
+
+    def test_reset_halt_schema_and_authorized_by(self) -> None:
+        coordinator = AgentCoordinator()
+        coordinator._halted_due_to_contradiction = True
+        coordinator._halted_state_snapshot = _impossible_state_entropy_drift()
+
+        coordinator.reset_halt(reason="manual review", authorized_by="chief_risk")
+
+        assert coordinator._halted_due_to_contradiction is False
+        assert len(coordinator._halt_history) == 1
+        event = coordinator._halt_history[0]
+        assert event["event_type"] == "reset"
+        assert event["reason"] == "manual review"
+        assert event["authorized_by"] == "chief_risk"
+        assert event["state_hash"] is not None
+        assert event["cycle_id"] is None
+        assert event["reset_at"].tzinfo is not None
+        assert coordinator._halted_state_snapshot is None
+
+    def test_reset_without_halt_is_noop(self) -> None:
+        coordinator = AgentCoordinator()
+        assert coordinator._halt_history == []
+        coordinator.reset_halt(reason="noop", authorized_by="ops")
+        assert coordinator._halt_history == []
+        assert coordinator._halted_due_to_contradiction is False
+
+    def test_state_hash_is_deterministic_for_same_payload(self) -> None:
+        """Identical SubjectiveState → identical state_hash."""
+        from dataclasses import asdict
+
+        coordinator = AgentCoordinator()
+        s = _impossible_state_entropy_drift()
+        h1 = coordinator._state_payload_hash(asdict(s))
+        h2 = coordinator._state_payload_hash(asdict(s))
+        assert h1 is not None
+        assert h1 == h2
+
+    def test_state_hash_diverges_when_any_axis_changes(self) -> None:
+        """Changing any axis must perturb the hash."""
+        from dataclasses import asdict
+
+        coordinator = AgentCoordinator()
+        s = _impossible_state_entropy_drift()
+        s_perturbed = SubjectiveState(
+            axes=CoherenceAxes(
+                structural_integrity=s.axes.structural_integrity + 0.01,
+                temporal_stability=s.axes.temporal_stability,
+                verification_honesty=s.axes.verification_honesty,
+                dependency_coherence=s.axes.dependency_coherence,
+                recovery_readiness=s.axes.recovery_readiness,
+            ),
+            coherence_score=s.coherence_score,
+            entropy=s.entropy,
+        )
+        h1 = coordinator._state_payload_hash(asdict(s))
+        h2 = coordinator._state_payload_hash(asdict(s_perturbed))
+        assert h1 != h2
+
+    def test_state_hash_of_none_is_none(self) -> None:
+        coordinator = AgentCoordinator()
+        assert coordinator._state_payload_hash(None) is None
+
+
+class TestUTCContract:
+    """Every coordinator-produced timestamp must be timezone-aware UTC."""
+
+    def test_utc_aware_timestamps_on_all_surfaces(self) -> None:
+        coordinator = AgentCoordinator()
+        handler = MockAgentHandler("agent")
+        metadata = coordinator.register_agent("agent_1", AgentType.TRADING, "A", "D", handler)
+        coordinator.submit_task("agent_1", "t", {})
+        coordinator.process_tasks()
+        report = coordinator.run_deterministic_synthesis_cycle()
+        decision = coordinator.make_decision("agent_coordination", {"agents": ["agent_1"]})
+
+        assert metadata.registered_at.tzinfo is not None
+        assert metadata.last_active.tzinfo is not None
+        assert report.started_at.tzinfo is not None
+        assert report.completed_at.tzinfo is not None
+        assert decision.timestamp.tzinfo is not None
+        task = coordinator._completed_tasks[0]
+        assert task.created_at.tzinfo is not None
+        assert task.started_at is not None and task.started_at.tzinfo is not None
+        assert task.completed_at is not None and task.completed_at.tzinfo is not None
+
+    def test_halt_and_reset_events_are_utc_aware(self) -> None:
+        coordinator = AgentCoordinator()
+        coordinator._halted_due_to_contradiction = True
+        coordinator._halted_state_snapshot = _impossible_state_entropy_drift()
+        # Seed a halt event to exercise halt_at path.
+        coordinator._record_halt_event(
+            cycle_id="cycle_test",
+            reason="hidden_contradiction_detected",
+            subjective_state=_impossible_state_entropy_drift(),
+        )
+        coordinator.reset_halt("ok", "ops")
+
+        halt_event, reset_event = coordinator._halt_history
+        assert halt_event["halt_at"].tzinfo is not None
+        assert reset_event["reset_at"].tzinfo is not None
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Closes the official merge-gate protocol for ``modules/agent_coordinator.py``. Every phase of the protocol has an explicit, named contract in the module docstring and a dedicated test in the suite. No hidden contradiction survives.

### Phase I — Identification separation
PR #238 (AE-reduce CLI/pnl compression) is unrelated; this diff is reviewed standalone. No cross-claim.

### Phase II — Entropy contract: **Variant A (derived)**
\`entropy = 1.0 - coherence_score\` is set by construction in \`_evaluate_subjective_state\`. The equation check in \`hidden_contradiction\` is therefore a **sanity guard** for externally-constructed states (tests, subclasses, deserialisation), not a runtime diagnostic of production drift. Decision is documented inline in the module docstring and in the \`hidden_contradiction\` / \`_detect_hidden_contradiction\` docstrings.

### Phase III — Fail-closed halt contract
- \`_assert_not_halted(op)\` raises \`ContradictionHaltError\` (with the list of allowed ops).
- Gated ops exported as \`_HALT_GATED_OPS\`: \`register_agent, unregister_agent, submit_task, register_protocol, register_validator, process_tasks, make_decision, update_agent_status, run_deterministic_synthesis_cycle\`.
- Allowed read-only ops exported as \`_HALT_ALLOWED_OPS\`: \`get_agent_info, get_system_health, get_coordination_summary, reset_halt\`.
- Disjointness asserted by a test.

### Phase IV — UTC contract
- Single clock \`utc_now() -> datetime.now(timezone.utc)\`.
- Every default_factory and every assignment routes through it — covered by \`test_utc_aware_timestamps_on_all_surfaces\` and \`test_halt_and_reset_events_are_utc_aware\`.

### Phase V — Tests (41, all green locally)
- full \`SubjectiveState\` partition: healthy / degraded_valid / impossible (entropy drift, out-of-range coherence, out-of-range axis);
- exhaustive halt gate: every op in \`_HALT_GATED_OPS\` probed;
- halt permits every op in \`_HALT_ALLOWED_OPS\` (incl. \`reset_halt\`);
- production path contradiction via monkey-patched evaluator → halt event carries \`cycle_id\`;
- reset_halt schema, authorized_by, no-op-without-halt;
- \`state_hash\` deterministic for same payload, diverges on any axis, \`None\` for \`None\` payload;
- allowed/gated sets are disjoint (structural invariant).

### Phase VI — Audit trail schema
| Event  | Fields |
|--------|--------|
| halt   | event_type='halt', halt_at (UTC), reason, subjective_state, state_hash, cycle_id |
| reset  | event_type='reset', reset_at (UTC), reason, authorized_by, subjective_state, state_hash, cycle_id=None |

\`state_hash = sha256(json.dumps(asdict(state), sort_keys=True))\`, via shared \`_state_payload_hash\` helper.

### Phase VII — Network invariants
- ranges on coherence_score, entropy, axes enforced via \`hidden_contradiction\`;
- \`truth\` and \`state_class\` documented as part of the module contract;
- \`hidden_contradiction\` is explicitly documented as a dead branch in production — kept only as a sanity guard.

### Phase VIII — Documentation
Module docstring ships a single canonical contract block covering UTC / entropy / halt / state-class. Every contract-bearing method carries a docstring pointing back at that block.

## Local quality gates

- \`black --check\` — clean
- \`ruff check\` — clean
- \`mypy --strict\` — clean on both files
- \`pytest tests/unit/modules/test_agent_coordinator.py\` — **41 passed**

## Test plan

- [ ] python-quality (3.11 + 3.12) green
- [ ] python-fast-tests / python-heavy-tests green
- [ ] physics-invariants green
- [ ] secrets-supply-chain green
- [ ] repo-policy / dependency-review / go-workspace-integrity / frontend-gate green

🤖 Generated with [Claude Code](https://claude.com/claude-code)