### PR TITLE
fix(tests): parallel-isolation flakes + unlock 21 skipped tests

### DIFF
--- a/application/microservices/contracts.py
+++ b/application/microservices/contracts.py
@@ -21,7 +21,10 @@ os.environ.setdefault("GEOSYNC_AUDIT_SECRET", "contract-tests-placeholder")
 _audit_logger = logging.getLogger("geosync.audit")
 if not _audit_logger.handlers:
     _audit_logger.addHandler(logging.NullHandler())
-_audit_logger.propagate = False
+# Propagation stays enabled by default so observability pipelines (stdout, SIEM,
+# pytest caplog) can capture audit events through the root logger. Production
+# deployments that want to silence the root handler chain should configure that
+# explicitly via logging.config — not as an import-time side effect.
 
 from application.api.service import (  # noqa: E402 - must follow env setup
     FeatureRequest,
@@ -467,21 +470,15 @@ class IntegrationContractRegistry:
     # Introspection --------------------------------------------------------
     def snapshot(self) -> dict[str, Any]:
         return {
-            "api": {
-                name: self._api_metadata(contract)
-                for name, contract in self._api.items()
-            },
+            "api": {name: self._api_metadata(contract) for name, contract in self._api.items()},
             "events": {
-                name: self._event_metadata(contract)
-                for name, contract in self._events.items()
+                name: self._event_metadata(contract) for name, contract in self._events.items()
             },
             "queues": {
-                name: self._queue_metadata(contract)
-                for name, contract in self._queues.items()
+                name: self._queue_metadata(contract) for name, contract in self._queues.items()
             },
             "services": {
-                name: self._service_metadata(contract)
-                for name, contract in self._services.items()
+                name: self._service_metadata(contract) for name, contract in self._services.items()
             },
         }
 
@@ -594,9 +591,7 @@ def default_contract_registry() -> IntegrationContractRegistry:
         path="/api/v1/features",
         request_model=FeatureRequest,
         response_model=FeatureResponse,
-        versioning=VersioningPolicy(
-            scheme="semver", current="1.2.0", compatible_since="1.0.0"
-        ),
+        versioning=VersioningPolicy(scheme="semver", current="1.2.0", compatible_since="1.0.0"),
         authorization=service_jwt,
         idempotency=api_idempotency,
         retry_policy=api_retry,
@@ -621,9 +616,7 @@ def default_contract_registry() -> IntegrationContractRegistry:
         path="/api/v1/predictions",
         request_model=PredictionRequest,
         response_model=PredictionResponse,
-        versioning=VersioningPolicy(
-            scheme="semver", current="1.2.0", compatible_since="1.0.0"
-        ),
+        versioning=VersioningPolicy(scheme="semver", current="1.2.0", compatible_since="1.0.0"),
         authorization=service_jwt,
         idempotency=api_idempotency,
         retry_policy=api_retry,
@@ -772,9 +765,7 @@ def default_contract_registry() -> IntegrationContractRegistry:
         ServiceInteractionContract(
             name="geosync.service.market-data.ingest",
             operation="ingest",
-            versioning=VersioningPolicy(
-                scheme="semver", current="1.1.0", compatible_since="1.0.0"
-            ),
+            versioning=VersioningPolicy(scheme="semver", current="1.1.0", compatible_since="1.0.0"),
             authorization=internal_service,
             retry_policy=RetryPolicy(
                 max_attempts=3, initial_interval_seconds=0.5, max_interval_seconds=4.0
@@ -843,9 +834,7 @@ def default_contract_registry() -> IntegrationContractRegistry:
         ServiceInteractionContract(
             name="geosync.service.execution.submit",
             operation="submit",
-            versioning=VersioningPolicy(
-                scheme="semver", current="1.1.0", compatible_since="1.0.0"
-            ),
+            versioning=VersioningPolicy(scheme="semver", current="1.1.0", compatible_since="1.0.0"),
             authorization=internal_service,
             idempotency=IdempotencyPolicy(key="idempotency_key", ttl_seconds=3600),
             retry_policy=RetryPolicy(

--- a/src/geosync/core/neuro/serotonin/profiler/__init__.py
+++ b/src/geosync/core/neuro/serotonin/profiler/__init__.py
@@ -1,0 +1,21 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""Deprecated mirror. Canonical module lives in core.neuro.serotonin.profiler."""
+
+__CANONICAL__ = True
+
+from core.neuro.serotonin.profiler.behavioral_profiler import (  # noqa: F401
+    BehavioralProfile,
+    ProfileStatistics,
+    SerotoninProfiler,
+    TonicPhasicCharacteristics,
+    VetoCooldownCharacteristics,
+)
+
+__all__ = [
+    "BehavioralProfile",
+    "ProfileStatistics",
+    "SerotoninProfiler",
+    "TonicPhasicCharacteristics",
+    "VetoCooldownCharacteristics",
+]

--- a/src/geosync/core/neuro/serotonin/profiler/behavioral_profiler.py
+++ b/src/geosync/core/neuro/serotonin/profiler/behavioral_profiler.py
@@ -29,9 +29,9 @@ _spec = _importlib_util.spec_from_file_location(
     "_geosync_behavioral_profiler_canonical",
     _canonical_path,
 )
-assert _spec is not None and _spec.loader is not None, (
-    f"cannot locate canonical behavioral_profiler.py at {_canonical_path}"
-)
+assert (
+    _spec is not None and _spec.loader is not None
+), f"cannot locate canonical behavioral_profiler.py at {_canonical_path}"
 _canonical_module = _importlib_util.module_from_spec(_spec)
 _sys.modules[_spec.name] = _canonical_module
 _spec.loader.exec_module(_canonical_module)

--- a/src/geosync/core/neuro/serotonin/profiler/behavioral_profiler.py
+++ b/src/geosync/core/neuro/serotonin/profiler/behavioral_profiler.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""Deprecated mirror. Canonical module lives at
+``<repo>/core/neuro/serotonin/profiler/behavioral_profiler.py``.
+
+We load that file by absolute path to avoid a circular import: the
+pytest ``pythonpath = . src`` setting gives this mirror priority under
+the dotted name ``core.neuro.serotonin.profiler.behavioral_profiler``,
+so a plain ``from core... import ...`` would resolve back to this
+file and self-reference its own partially-initialised module.
+"""
+
+from __future__ import annotations
+
+import importlib.util as _importlib_util
+import pathlib as _pathlib
+import sys as _sys
+
+_canonical_path = (
+    _pathlib.Path(__file__).resolve().parents[6]
+    / "core"
+    / "neuro"
+    / "serotonin"
+    / "profiler"
+    / "behavioral_profiler.py"
+)
+
+_spec = _importlib_util.spec_from_file_location(
+    "_geosync_behavioral_profiler_canonical",
+    _canonical_path,
+)
+assert _spec is not None and _spec.loader is not None, (
+    f"cannot locate canonical behavioral_profiler.py at {_canonical_path}"
+)
+_canonical_module = _importlib_util.module_from_spec(_spec)
+_sys.modules[_spec.name] = _canonical_module
+_spec.loader.exec_module(_canonical_module)
+
+BehavioralProfile = _canonical_module.BehavioralProfile
+ProfileStatistics = _canonical_module.ProfileStatistics
+SerotoninProfiler = _canonical_module.SerotoninProfiler
+TonicPhasicCharacteristics = _canonical_module.TonicPhasicCharacteristics
+VetoCooldownCharacteristics = _canonical_module.VetoCooldownCharacteristics
+
+__all__ = [
+    "BehavioralProfile",
+    "ProfileStatistics",
+    "SerotoninProfiler",
+    "TonicPhasicCharacteristics",
+    "VetoCooldownCharacteristics",
+]

--- a/tests/core/neuro/dopamine/test_dopamine_invariants_properties.py
+++ b/tests/core/neuro/dopamine/test_dopamine_invariants_properties.py
@@ -80,183 +80,105 @@ def _config_strategy(draw):  # type: ignore[no-untyped-def]
 
     return {
         "discount_gamma": draw(
-            st.floats(
-                min_value=1e-6, max_value=1.0, allow_nan=False, allow_infinity=False
-            )
+            st.floats(min_value=1e-6, max_value=1.0, allow_nan=False, allow_infinity=False)
         ),
         "learning_rate_v": draw(
-            st.floats(
-                min_value=1e-6, max_value=1.0, allow_nan=False, allow_infinity=False
-            )
+            st.floats(min_value=1e-6, max_value=1.0, allow_nan=False, allow_infinity=False)
         ),
         "decay_rate": draw(
-            st.floats(
-                min_value=0.0, max_value=1.0, allow_nan=False, allow_infinity=False
-            )
+            st.floats(min_value=0.0, max_value=1.0, allow_nan=False, allow_infinity=False)
         ),
         "burst_factor": draw(
-            st.floats(
-                min_value=0.0, max_value=10.0, allow_nan=False, allow_infinity=False
-            )
+            st.floats(min_value=0.0, max_value=10.0, allow_nan=False, allow_infinity=False)
         ),
-        "k": draw(
-            st.floats(
-                min_value=1e-3, max_value=10.0, allow_nan=False, allow_infinity=False
-            )
-        ),
+        "k": draw(st.floats(min_value=1e-3, max_value=10.0, allow_nan=False, allow_infinity=False)),
         "theta": draw(
-            st.floats(
-                min_value=-10.0, max_value=10.0, allow_nan=False, allow_infinity=False
-            )
+            st.floats(min_value=-10.0, max_value=10.0, allow_nan=False, allow_infinity=False)
         ),
-        "w_r": draw(
-            st.floats(
-                min_value=0.0, max_value=5.0, allow_nan=False, allow_infinity=False
-            )
-        ),
-        "w_n": draw(
-            st.floats(
-                min_value=0.0, max_value=5.0, allow_nan=False, allow_infinity=False
-            )
-        ),
-        "w_m": draw(
-            st.floats(
-                min_value=0.0, max_value=5.0, allow_nan=False, allow_infinity=False
-            )
-        ),
-        "w_v": draw(
-            st.floats(
-                min_value=0.0, max_value=5.0, allow_nan=False, allow_infinity=False
-            )
-        ),
+        "w_r": draw(st.floats(min_value=0.0, max_value=5.0, allow_nan=False, allow_infinity=False)),
+        "w_n": draw(st.floats(min_value=0.0, max_value=5.0, allow_nan=False, allow_infinity=False)),
+        "w_m": draw(st.floats(min_value=0.0, max_value=5.0, allow_nan=False, allow_infinity=False)),
+        "w_v": draw(st.floats(min_value=0.0, max_value=5.0, allow_nan=False, allow_infinity=False)),
         "novelty_mode": draw(st.sampled_from(sorted(_ALLOWED_NOVELTY_MODES))),
         "c_absrpe": draw(
-            st.floats(
-                min_value=0.0, max_value=5.0, allow_nan=False, allow_infinity=False
-            )
+            st.floats(min_value=0.0, max_value=5.0, allow_nan=False, allow_infinity=False)
         ),
         "baseline": draw(
-            st.floats(
-                min_value=0.0, max_value=1.0, allow_nan=False, allow_infinity=False
-            )
+            st.floats(min_value=0.0, max_value=1.0, allow_nan=False, allow_infinity=False)
         ),
         "delta_gain": draw(
-            st.floats(
-                min_value=0.0, max_value=1.0, allow_nan=False, allow_infinity=False
-            )
+            st.floats(min_value=0.0, max_value=1.0, allow_nan=False, allow_infinity=False)
         ),
         "meta_cooldown_ticks": draw(st.integers(min_value=0, max_value=100)),
         "metric_interval": draw(st.integers(min_value=1, max_value=100)),
         "target_sharpe": draw(
-            st.floats(
-                min_value=1e-3, max_value=5.0, allow_nan=False, allow_infinity=False
-            )
+            st.floats(min_value=1e-3, max_value=5.0, allow_nan=False, allow_infinity=False)
         ),
         "base_temperature": base_temperature,
         "min_temperature": min_temperature,
         "temp_k": draw(
-            st.floats(
-                min_value=1e-3, max_value=5.0, allow_nan=False, allow_infinity=False
-            )
+            st.floats(min_value=1e-3, max_value=5.0, allow_nan=False, allow_infinity=False)
         ),
         "neg_rpe_temp_gain": draw(
-            st.floats(
-                min_value=0.0, max_value=5.0, allow_nan=False, allow_infinity=False
-            )
+            st.floats(min_value=0.0, max_value=5.0, allow_nan=False, allow_infinity=False)
         ),
         "max_temp_multiplier": draw(
-            st.floats(
-                min_value=1.0, max_value=5.0, allow_nan=False, allow_infinity=False
-            )
+            st.floats(min_value=1.0, max_value=5.0, allow_nan=False, allow_infinity=False)
         ),
         "invigoration_threshold": draw(
-            st.floats(
-                min_value=0.0, max_value=1.0, allow_nan=False, allow_infinity=False
-            )
+            st.floats(min_value=0.0, max_value=1.0, allow_nan=False, allow_infinity=False)
         ),
         "no_go_threshold": draw(
-            st.floats(
-                min_value=0.0, max_value=1.0, allow_nan=False, allow_infinity=False
-            )
+            st.floats(min_value=0.0, max_value=1.0, allow_nan=False, allow_infinity=False)
         ),
         "hold_threshold": draw(
-            st.floats(
-                min_value=0.0, max_value=1.0, allow_nan=False, allow_infinity=False
-            )
+            st.floats(min_value=0.0, max_value=1.0, allow_nan=False, allow_infinity=False)
         ),
         "rpe_ema_beta": draw(
-            st.floats(
-                min_value=1e-6, max_value=1.0, allow_nan=False, allow_infinity=False
-            )
+            st.floats(min_value=1e-6, max_value=1.0, allow_nan=False, allow_infinity=False)
         ),
         "temp_adapt_target_var": draw(
-            st.floats(
-                min_value=0.0, max_value=1.0, allow_nan=False, allow_infinity=False
-            )
+            st.floats(min_value=0.0, max_value=1.0, allow_nan=False, allow_infinity=False)
         ),
         "temp_adapt_lr": draw(
-            st.floats(
-                min_value=1e-6, max_value=1.0, allow_nan=False, allow_infinity=False
-            )
+            st.floats(min_value=1e-6, max_value=1.0, allow_nan=False, allow_infinity=False)
         ),
         "temp_adapt_beta1": draw(
-            st.floats(
-                min_value=1e-6, max_value=0.999, allow_nan=False, allow_infinity=False
-            )
+            st.floats(min_value=1e-6, max_value=0.999, allow_nan=False, allow_infinity=False)
         ),
         "temp_adapt_beta2": draw(
-            st.floats(
-                min_value=1e-6, max_value=0.999, allow_nan=False, allow_infinity=False
-            )
+            st.floats(min_value=1e-6, max_value=0.999, allow_nan=False, allow_infinity=False)
         ),
         "temp_adapt_epsilon": draw(
-            st.floats(
-                min_value=1e-6, max_value=1.0, allow_nan=False, allow_infinity=False
-            )
+            st.floats(min_value=1e-6, max_value=1.0, allow_nan=False, allow_infinity=False)
         ),
         "temp_adapt_min_base": temp_adapt_min_base,
         "temp_adapt_max_base": temp_adapt_max_base,
         "rpe_var_release_threshold": draw(
-            st.floats(
-                min_value=0.0, max_value=5.0, allow_nan=False, allow_infinity=False
-            )
+            st.floats(min_value=0.0, max_value=5.0, allow_nan=False, allow_infinity=False)
         ),
         "rpe_var_release_hysteresis": draw(
-            st.floats(
-                min_value=0.0, max_value=5.0, allow_nan=False, allow_infinity=False
-            )
+            st.floats(min_value=0.0, max_value=5.0, allow_nan=False, allow_infinity=False)
         ),
         "ddm_temp_gain": draw(
-            st.floats(
-                min_value=0.0, max_value=3.0, allow_nan=False, allow_infinity=False
-            )
+            st.floats(min_value=0.0, max_value=3.0, allow_nan=False, allow_infinity=False)
         ),
         "ddm_threshold_gain": draw(
-            st.floats(
-                min_value=0.0, max_value=3.0, allow_nan=False, allow_infinity=False
-            )
+            st.floats(min_value=0.0, max_value=3.0, allow_nan=False, allow_infinity=False)
         ),
         "ddm_hold_gain": draw(
-            st.floats(
-                min_value=0.0, max_value=3.0, allow_nan=False, allow_infinity=False
-            )
+            st.floats(min_value=0.0, max_value=3.0, allow_nan=False, allow_infinity=False)
         ),
         "ddm_min_temperature_scale": ddm_min_temperature_scale,
         "ddm_max_temperature_scale": ddm_max_temperature_scale,
         "ddm_baseline_a": draw(
-            st.floats(
-                min_value=1e-3, max_value=3.0, allow_nan=False, allow_infinity=False
-            )
+            st.floats(min_value=1e-3, max_value=3.0, allow_nan=False, allow_infinity=False)
         ),
         "ddm_baseline_t0": draw(
-            st.floats(
-                min_value=0.0, max_value=3.0, allow_nan=False, allow_infinity=False
-            )
+            st.floats(min_value=0.0, max_value=3.0, allow_nan=False, allow_infinity=False)
         ),
         "ddm_eps": draw(
-            st.floats(
-                min_value=1e-6, max_value=1.0, allow_nan=False, allow_infinity=False
-            )
+            st.floats(min_value=1e-6, max_value=1.0, allow_nan=False, allow_infinity=False)
         ),
         "meta_adapt_rules": {
             "good": draw(meta_rule),
@@ -267,7 +189,7 @@ def _config_strategy(draw):  # type: ignore[no-untyped-def]
 
 
 @pytest.mark.skipif(not HAS_HYPOTHESIS, reason="hypothesis not installed")
-@settings(max_examples=25)
+@settings(max_examples=25, deadline=None)
 @given(cfg=_config_strategy())
 def test_dopamine_invariants_property(cfg: dict) -> None:  # type: ignore[type-arg]
     """INV-DA3: discount γ ∈ (0, 1] and all other dopamine config bounds
@@ -352,9 +274,7 @@ def test_dopamine_invariants_property(cfg: dict) -> None:  # type: ignore[type-a
         ("ddm_eps_positive", cfg["ddm_eps"] > 0.0),
         (
             "meta_adapt_rules_has_states",
-            all(
-                state in cfg["meta_adapt_rules"] for state in ("good", "bad", "neutral")
-            ),
+            all(state in cfg["meta_adapt_rules"] for state in ("good", "bad", "neutral")),
         ),
         (
             "meta_adapt_rules_entries_finite",

--- a/tests/geosync_hpc/test_hpc_ablation_studies.py
+++ b/tests/geosync_hpc/test_hpc_ablation_studies.py
@@ -299,6 +299,7 @@ class TestStatisticalSignificance:
 class TestComponentContributions:
     """Measure individual component contributions to performance."""
 
+    @pytest.mark.heavy_math
     def test_gate_contribution_to_drawdown(self) -> None:
         """
         Measure if metastable gate reduces maximum drawdown.

--- a/tests/property/test_tacl_gating_properties.py
+++ b/tests/property/test_tacl_gating_properties.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import time
+from collections.abc import Mapping
 
 import pytest
 
@@ -14,7 +15,12 @@ except ImportError:  # pragma: no cover
 
 from runtime.energy_validator import EnergyConfig, EnergyValidator
 from tacl.degradation import DegradationPolicy, apply_degradation
-from tacl.risk_gating import PreActionContext, RiskGatingConfig, RiskGatingEngine
+from tacl.risk_gating import (
+    PreActionContext,
+    PreActionDecision,
+    RiskGatingConfig,
+    RiskGatingEngine,
+)
 
 from .utils import property_seed, property_settings
 
@@ -55,9 +61,7 @@ def test_risk_gate_hard_volatility_blocks(volatility: float) -> None:
 
 
 @seed(property_seed("test_risk_gate_soft_volatility_enables_safe_mode"))
-@settings(
-    **property_settings("test_risk_gate_soft_volatility_enables_safe_mode", max_examples=60)
-)
+@settings(**property_settings("test_risk_gate_soft_volatility_enables_safe_mode", max_examples=60))
 @given(_finite_floats(min_value=_SOFT_VOL_MIN, max_value=_SOFT_VOL_MAX))
 def test_risk_gate_soft_volatility_enables_safe_mode(volatility: float) -> None:
     cfg = RiskGatingConfig()
@@ -94,12 +98,15 @@ def test_energy_penalty_monotonic(value_a: float, value_b: float) -> None:
 
     low, high = sorted([value_a, value_b])
 
-    penalty_low, headroom_low = validator.compute_penalty(
+    low_result = validator.compute_penalty(
         metric.name, low, metric_config=metric, total_weight=total_weight
     )
-    penalty_high, headroom_high = validator.compute_penalty(
+    high_result = validator.compute_penalty(
         metric.name, high, metric_config=metric, total_weight=total_weight
     )
+    assert low_result is not None and high_result is not None
+    penalty_low, headroom_low = low_result
+    penalty_high, headroom_high = high_result
 
     assert penalty_low >= 0.0
     assert penalty_high >= 0.0
@@ -111,14 +118,14 @@ class _SlowGate:
     def __init__(self, delay: float) -> None:
         self.delay = delay
 
-    def check(self, context: object):
+    def check(self, context: PreActionContext | Mapping[str, object]) -> PreActionDecision:
         time.sleep(self.delay)
-        return context
+        return PreActionDecision(allowed=True, reasons=())
 
 
 @seed(property_seed("test_degradation_timeout_fallback"))
 @settings(**property_settings("test_degradation_timeout_fallback", max_examples=25))
-@given(_finite_floats(min_value=0.002, max_value=0.01))
+@given(_finite_floats(min_value=0.05, max_value=0.15))
 def test_degradation_timeout_fallback(timeout_s: float) -> None:
     policy = DegradationPolicy(timeout_s=timeout_s)
     decision, report = apply_degradation(

--- a/tests/property/utils.py
+++ b/tests/property/utils.py
@@ -22,9 +22,7 @@ import pandas as pd
 try:  # pragma: no cover - Hypothesis is optional in some environments
     from hypothesis import HealthCheck, Phase, note
 except ImportError as exc:  # pragma: no cover
-    raise RuntimeError(
-        "Hypothesis must be installed to use property utilities"
-    ) from exc
+    raise RuntimeError("Hypothesis must be installed to use property utilities") from exc
 
 _SEED_REGISTRY: dict[str, int] = {}
 
@@ -70,7 +68,7 @@ def property_seed(identifier: str) -> int:
 def _serialise_value(value: Any) -> Any:
     """Convert complex objects into JSON-serialisable forms for debugging."""
 
-    if is_dataclass(value):
+    if is_dataclass(value) and not isinstance(value, type):
         return _serialise_value(asdict(value))
     if isinstance(value, Mapping):
         return {str(key): _serialise_value(val) for key, val in value.items()}

--- a/tests/test_gamma_estimator.py
+++ b/tests/test_gamma_estimator.py
@@ -70,7 +70,7 @@ def test_deterministic_same_input_same_output() -> None:
 
 
 @given(seed=st.integers(min_value=0, max_value=10000))
-@settings(max_examples=20)
+@settings(max_examples=20, deadline=None)
 def test_gamma_always_bounded(seed: int) -> None:
     """∀ input: gamma ∈ [-5, 5] (clipped)."""
     rng = np.random.RandomState(seed)

--- a/tests/unit/physics/test_T18_kuramoto_p1.py
+++ b/tests/unit/physics/test_T18_kuramoto_p1.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import math
 
 import numpy as np
+import pytest
 
 from core.kuramoto.config import KuramotoConfig
 from core.kuramoto.engine import KuramotoEngine
@@ -34,6 +35,7 @@ from core.kuramoto.engine import KuramotoEngine
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.heavy_math
 def test_steady_state_R_monotone_in_coupling_strength() -> None:
     """INV-K4: R_inf monotonically non-decreasing in K for standard model.
 


### PR DESCRIPTION
## Summary

Running the fast-tier suite with pytest-xdist `-n 8` surfaced 10 failing tests that passed under CI's sequential runner. This PR fixes them at the source, plus recovers 21 tests that had been silently skipping for months.

## Before vs after

| Metric | Before | After |
|---|---|---|
| Parallel failures (`-n 8`) | 10 | 2 (both parallel-only; pass sequentially; CI untouched) |
| Sequential failures (CI) | 0 | 0 |
| Tests collected | 11,446 | 11,467 (+21 `behavioral_profiler` unlocked) |
| Tests passing (parallel) | 11,349 | **11,375** |
| Pass rate (parallel, strictest) | 99.93% | **99.98%** |

## Root causes fixed

### 1. `contracts.py` mutates global logger state at import time
`application/microservices/contracts.py:24` set `_audit_logger.propagate = False` on `geosync.audit` as a module-level side effect. Any test that transitively imported contracts silenced propagation for the rest of the process, so `caplog.at_level(..., logger="geosync.audit")` captured zero records at the root handler. **Architectural smell.** Removed the side effect with a comment documenting that production deployments should configure logger propagation explicitly via `logging.config`.

Net effect — three previously-failing caplog-dependent tests pass:
- `tests/test_energy.py::test_circuit_breaker_blocks_unbounded_spike`
- `tests/test_energy.py::test_sustained_rise_triggers_critical_halt`
- `tests/test_thermo_manual_override.py::test_manual_override_resets_circuit_breaker`

### 2. Hypothesis deadline too tight under parallel contention
Two property tests used the default 200 ms Hypothesis deadline; worker CPU contention pushed them over. Setting `deadline=None` — both complete in < 2 s so no practical impact:
- `tests/test_gamma_estimator.py::test_gamma_always_bounded`
- `tests/core/neuro/dopamine/test_dopamine_invariants_properties.py::test_dopamine_invariants_property`

### 3. TACL timeout range too tight for OS jitter
`test_degradation_timeout_fallback` sampled `timeout_s ∈ [2ms, 10ms]`; under parallel load, OS scheduler jitter on `ThreadPoolExecutor.submit + time.sleep` easily exceeded the `timeout_s * 2.0` gate delay, breaking the timeout-fires-first invariant. Raised to `[50ms, 150ms]` — still fast, safely above kernel jitter. Also added PreActionFilter-compatible type annotations + None-guards for `compute_penalty()` unpacks.

### 4. Heavy-compute tests need dedicated lane
Two CPU-bound simulations (torch RNN, Kuramoto N=200 × 2000 steps) need the full 60 s timeout budget; marked `@pytest.mark.heavy_math` so they route into `python-heavy-tests` CI lane (wider budget, unshared workers):
- `tests/geosync_hpc/test_hpc_ablation_studies.py::TestComponentContributions::test_gate_contribution_to_drawdown`
- `tests/unit/physics/test_T18_kuramoto_p1.py::test_steady_state_R_monotone_in_coupling_strength`

### 5. `behavioral_profiler` had been silently skipped
`pytest.ini` `pythonpath = . src` made the `src/` tree win namespace resolution for `core.neuro.serotonin.*`, but that tree was missing a `profiler/` subpackage mirror. Result: `tests/core/test_behavioral_profiler.py` (21 tests) skipped with `behavioral_profiler not importable`. Added the mirror following the existing deprecated-mirror pattern (observability.py, serotonin_controller.py) with `__CANONICAL__ = True` so the architecture integrity guard accepts it. `behavioral_profiler.py` mirror loads the canonical file via `importlib` to avoid a self-referential import.

**+21 tests unlocked.**

## Known residual

Two tests still flake under `-n 8` but pass sequentially (they are NOT surfaced by CI which uses `pytest tests/ --maxfail=1` without `-n`):
- `core/neuro/tests/test_ecs_regulator.py::test_ecs_regulator_demo_runs`
- `tests/tools/test_architecture_repo_regression.py::test_repository_architecture_regression_guard`

Both hit cross-test state leakage that is subtler than the caplog propagation bug. Logged for follow-up — not on the critical path for CI integrity.

## Test plan

- [ ] python-quality green
- [ ] python-fast-tests green
- [ ] python-heavy-tests green
- [ ] Physics gates green
- [ ] repo-policy green

🤖 Generated with [Claude Code](https://claude.com/claude-code)