### PR TITLE
fix(typing): clean up 12 mypy errors on core/

### DIFF
--- a/core/interfaces.py
+++ b/core/interfaces.py
@@ -37,9 +37,12 @@ if TYPE_CHECKING:
     pass
 
 # Type variables for generic interfaces
+# DataT / EventT use variance markers to satisfy Protocol position rules:
+# DataT is covariant (appears only in return positions, e.g. Iterable[DataT] from DataSource.fetch).
+# EventT is contravariant (appears only in input positions, e.g. payload: EventT on EventBus.publish).
 T = TypeVar("T")
-EventT = TypeVar("EventT")
-DataT = TypeVar("DataT")
+EventT = TypeVar("EventT", contravariant=True)
+DataT = TypeVar("DataT", covariant=True)
 FeatureT = TypeVar("FeatureT")
 
 

--- a/core/io/parquet_compat.py
+++ b/core/io/parquet_compat.py
@@ -5,8 +5,11 @@ from __future__ import annotations
 import importlib.util
 from functools import lru_cache
 from pathlib import Path
+from typing import Literal, cast
 
 import pandas as pd
+
+ParquetEngine = Literal["auto", "pyarrow", "fastparquet"]
 
 
 class ParquetEngineUnavailable(RuntimeError):
@@ -36,7 +39,7 @@ def read_parquet_compat(path: Path) -> pd.DataFrame:
     last_err: Exception | None = None
     for engine in engines:
         try:
-            return pd.read_parquet(path, engine=engine)
+            return pd.read_parquet(path, engine=cast(ParquetEngine, engine))
         except Exception as exc:  # pragma: no cover - backend-specific
             last_err = exc
 

--- a/core/telemetry.py
+++ b/core/telemetry.py
@@ -179,9 +179,9 @@ class PrometheusBackend:
             registry: Prometheus registry (uses default if None)
         """
         self._registry = registry
-        self._counters: dict[str, Any] = {}
-        self._gauges: dict[str, Any] = {}
-        self._histograms: dict[str, Any] = {}
+        self._counters: dict[tuple[str, tuple[str, ...]], Any] = {}
+        self._gauges: dict[tuple[str, tuple[str, ...]], Any] = {}
+        self._histograms: dict[tuple[str, tuple[str, ...]], Any] = {}
         self._prometheus_available = self._check_prometheus()
 
     def _check_prometheus(self) -> bool:
@@ -194,9 +194,7 @@ class PrometheusBackend:
             LOGGER.warning("prometheus_client not installed, metrics disabled")
             return False
 
-    def _get_or_create_counter(
-        self, name: str, tags: Mapping[str, str] | None
-    ) -> Any:
+    def _get_or_create_counter(self, name: str, tags: Mapping[str, str] | None) -> Any:
         """Get or create a counter metric."""
         if not self._prometheus_available:
             return None
@@ -215,9 +213,7 @@ class PrometheusBackend:
             )
         return self._counters[key]
 
-    def _get_or_create_gauge(
-        self, name: str, tags: Mapping[str, str] | None
-    ) -> Any:
+    def _get_or_create_gauge(self, name: str, tags: Mapping[str, str] | None) -> Any:
         """Get or create a gauge metric."""
         if not self._prometheus_available:
             return None
@@ -236,9 +232,7 @@ class PrometheusBackend:
             )
         return self._gauges[key]
 
-    def _get_or_create_histogram(
-        self, name: str, tags: Mapping[str, str] | None
-    ) -> Any:
+    def _get_or_create_histogram(self, name: str, tags: Mapping[str, str] | None) -> Any:
         """Get or create a histogram metric."""
         if not self._prometheus_available:
             return None


### PR DESCRIPTION
## Summary

Audit 2026-04-20 found that `python -m mypy core` reported **12 errors in 3 files** on `origin/main` @ SHA `0863d8b`. This PR brings that to `0`.

Zero physics changes, zero runtime behavior changes — only type annotations and one `cast`.

### Breakdown

| File | Errors | Root cause | Fix |
|---|---|---|---|
| `core/interfaces.py` | 2 | `DataT` invariant used in covariant return; `EventT` invariant used in contravariant input — disallowed inside `Protocol[T]` | add `covariant=True` / `contravariant=True` markers on the two `TypeVar` declarations |
| `core/telemetry.py` | 9 | `self._counters: dict[str, Any]` but key is actually `tuple[str, tuple[str, ...]]` — every `key in dict` and `dict[key]` mypy-failed | widen attribute type to `dict[tuple[str, tuple[str, ...]], Any]` |
| `core/io/parquet_compat.py` | 1 | `pd.read_parquet(engine=...)` wants `Literal['auto','pyarrow','fastparquet']`, got plain `str` from `available_engines()` | add `ParquetEngine` Literal alias + `cast(ParquetEngine, engine)` at the single call site |

## Verification

On fresh clone at SHA `0863d8b`:

```
$ python -m mypy core
Success: no issues found in 321 source files

$ python -m ruff check core
All checks passed!

$ python -m black --check core/telemetry.py core/interfaces.py core/io/parquet_compat.py
3 files would be left unchanged.
```

## Scope notes

- This PR fixes the 12 errors visible under plain `mypy core`. A later `mypy --strict core` still shows 29 other (separate) issues across 15 files; those are pre-existing and out of scope here.
- No invariant test changed. `physics_contracts/`, `core/kuramoto/`, `core/neuro/` untouched.

Audit basis: `~/audit-2026-04-20T17-36-14Z/measured/GeoSync.yaml` (resume claim `mypy_errors: 0` was inflation vs measured 12).

## Test plan

- [x] `mypy core` → clean
- [x] `ruff check core` → clean
- [x] `black --check` on 3 edited files → clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)