### PR TITLE
security: close 3 HIGH py/path-injection in live_server.py (CodeQL #697-699)

### DIFF
--- a/tests/security/test_live_server_path_traversal.py
+++ b/tests/security/test_live_server_path_traversal.py
@@ -1,0 +1,203 @@
+# Copyright (c) 2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""Regression tests for ``ui/dashboard/live_server._resolve_static``.
+
+Closes CodeQL alerts #697–#699 (``py/path-injection`` — "Uncontrolled data
+used in path expression") on ``ui/dashboard/live_server.py``.
+
+Pure-function tests: ``_resolve_static`` is a stateless sanitizer, so these
+run without binding a socket. Each attack vector must return ``None``; the
+single allowed happy path must return a path inside ``_WEBROOT``.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from ui.dashboard.live_server import _WEBROOT, _resolve_static  # noqa: E402
+
+
+@pytest.mark.parametrize(
+    "request_path",
+    [
+        "/../../../etc/passwd",
+        "/../..",
+        "/..",
+        "/src/../../../etc/passwd",
+        "/./../../secrets",
+        "/%2e%2e/%2e%2e/etc/passwd",
+        "/%2E%2E%2f%2E%2E%2fetc%2fpasswd",
+        "/..%2f..%2fetc%2fpasswd",
+        "/src/%2e%2e/%2e%2e/etc/passwd",
+    ],
+)
+def test_rejects_traversal(request_path: str) -> None:
+    """Directory traversal — decoded and undecoded — must never resolve."""
+    assert _resolve_static(request_path) is None
+
+
+@pytest.mark.parametrize(
+    "request_path",
+    [
+        "//etc/passwd",
+        "///etc/shadow",
+        "/%2fetc/passwd",
+    ],
+)
+def test_rejects_absolute_escape(request_path: str) -> None:
+    """Leading-slash stacking or re-encoded absolute roots must not escape."""
+    assert _resolve_static(request_path) is None
+
+
+@pytest.mark.parametrize(
+    "request_path",
+    [
+        "/demo.html\x00.png",
+        "/\x00",
+        "/src/\x00index.js",
+    ],
+)
+def test_rejects_null_byte(request_path: str) -> None:
+    """NUL-byte truncation vectors must not reach the filesystem."""
+    assert _resolve_static(request_path) is None
+
+
+def test_rejects_empty() -> None:
+    """Empty path (after strip) is rejected, not silently mapped to root."""
+    assert _resolve_static("") is None
+    assert _resolve_static("/") is None
+
+
+@pytest.mark.parametrize(
+    "request_path",
+    [
+        "/demo.html?../../etc/passwd",
+        "/demo.html#/../../etc/passwd",
+        "/src/index.js?token=../../../etc",
+    ],
+)
+def test_strips_query_and_fragment(request_path: str) -> None:
+    """Query string / fragment must not participate in path resolution.
+
+    These requests target files that exist inside _WEBROOT — they must resolve
+    to those files (proving query/fragment was stripped), not ``None``.
+    """
+    # demo.html exists at _WEBROOT/demo.html; src/index.js does not,
+    # so the src/… variant will legitimately return None. Only assert the
+    # demo.html variants which have a known-present target.
+    result = _resolve_static(request_path)
+    if request_path.startswith("/demo.html"):
+        assert result is not None
+        assert result.name == "demo.html"
+        assert result.is_relative_to(_WEBROOT)
+    else:
+        # If the src path happens to exist, containment still holds.
+        assert result is None or result.is_relative_to(_WEBROOT)
+
+
+def test_rejects_unknown_suffix(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Files with non-allow-listed extensions must return None even if real."""
+    # demo.html is allowed; create a sibling with a blocked extension.
+    blocked = _WEBROOT / "__pytest_blocked.exe"
+    blocked.write_bytes(b"MZ\x00")
+    try:
+        assert _resolve_static("/__pytest_blocked.exe") is None
+    finally:
+        blocked.unlink()
+
+
+def test_accepts_known_static_asset() -> None:
+    """Happy path: demo.html at webroot resolves and is containment-checked."""
+    target = _resolve_static("/demo.html")
+    assert target is not None
+    assert target == _WEBROOT / "demo.html"
+    assert target.is_relative_to(_WEBROOT)
+    assert target.is_file()
+
+
+def test_symlink_escape_rejected(tmp_path: Path) -> None:
+    """A symlink pointing outside _WEBROOT must not be followed.
+
+    The CodeQL sanitizer (``is_relative_to`` post-``resolve(strict=True)``)
+    catches this because ``resolve`` follows the link and produces a path
+    whose real parent chain escapes _WEBROOT.
+    """
+    outside = tmp_path / "outside_secret.js"
+    outside.write_text("// should not be served\n")
+    link = _WEBROOT / "__pytest_escape_link.js"
+    if link.exists() or link.is_symlink():
+        link.unlink()
+    try:
+        link.symlink_to(outside)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks not supported on this filesystem")
+    try:
+        assert _resolve_static("/__pytest_escape_link.js") is None
+    finally:
+        link.unlink()
+
+
+def test_rejects_nonexistent() -> None:
+    """Nonexistent paths — even inside _WEBROOT — return None (strict=True)."""
+    assert _resolve_static("/this-file-does-not-exist.js") is None
+
+
+def test_rejects_directory() -> None:
+    """Directory hits are rejected — only regular files are served."""
+    # src/ exists as a dir under _WEBROOT.
+    if (_WEBROOT / "src").is_dir():
+        assert _resolve_static("/src") is None
+        assert _resolve_static("/src/") is None
+
+
+def test_webroot_is_resolved() -> None:
+    """_WEBROOT invariant: resolved absolute path, matches the server file's parent."""
+    assert _WEBROOT.is_absolute()
+    assert _WEBROOT == Path(_WEBROOT).resolve()
+    assert _WEBROOT.name == "dashboard"
+
+
+def test_containment_holds_for_every_positive_result(tmp_path: Path) -> None:
+    """Fuzz-style: for a handful of plausible requests, every non-None result
+    sits inside _WEBROOT. This is the load-bearing invariant the CodeQL
+    sanitizer encodes.
+    """
+    candidates = [
+        "/demo.html",
+        "/src",
+        "/src/",
+        "/src/main.js",
+        "/src/styles/tokens.css",
+        "/eslint.config.js",
+        "/package.json",
+        "/nonexistent.js",
+        "/../../etc/hostname",
+    ]
+    for req in candidates:
+        resolved = _resolve_static(req)
+        if resolved is not None:
+            assert resolved.is_relative_to(
+                _WEBROOT
+            ), f"containment violated: {req!r} resolved to {resolved}"
+
+
+def test_os_environ_unused() -> None:
+    """Meta-test: the sanitizer must not depend on process env. Changing
+    CWD/HOME must not change behaviour.
+    """
+    target_before = _resolve_static("/demo.html")
+    prior_cwd = os.getcwd()
+    try:
+        os.chdir("/")
+        target_after = _resolve_static("/demo.html")
+    finally:
+        os.chdir(prior_cwd)
+    assert target_before == target_after

--- a/ui/__init__.py
+++ b/ui/__init__.py
@@ -1,0 +1,10 @@
+# Copyright (c) 2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""Namespace-package anchor for the ``ui`` tree.
+
+The ``ui/`` directory is primarily a JS/TS dashboard tree; this file exists
+only so mypy can resolve ``ui.dashboard.live_server`` as a single canonical
+module, preventing the "source file found twice under different module
+names" ambiguity that arises when CI's delta-scoped mypy scans a changed
+Python file under both its bare name and its dotted path.
+"""

--- a/ui/dashboard/__init__.py
+++ b/ui/dashboard/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""Package anchor for ``ui.dashboard`` — see ``ui/__init__.py`` rationale."""

--- a/ui/dashboard/live_server.py
+++ b/ui/dashboard/live_server.py
@@ -40,6 +40,7 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from threading import Lock
 from typing import Any, Final
+from urllib.parse import unquote, urlsplit
 
 # Enable imports of ``core.*`` from repo root when launched from anywhere.
 _HERE = Path(__file__).resolve()
@@ -50,6 +51,72 @@ if str(_REPO_ROOT) not in sys.path:
 import numpy as np  # noqa: E402 — deliberate: sys.path mutated above
 
 _LOG = logging.getLogger("geosync.dashboard")
+
+# Web-root for static-asset serving. Resolved once at import so the sanitizer
+# compares against a fixed, canonical parent. strict=True ⟹ import fails if
+# the dashboard directory is missing (fail-closed).
+_WEBROOT: Final[Path] = _HERE.parent.resolve(strict=True)
+
+# Allow-list of extensions served by the dev dashboard. Anything else — even
+# if it lives inside _WEBROOT — returns 404. Keeps the surface narrow.
+_STATIC_SUFFIXES: Final[frozenset[str]] = frozenset(
+    {
+        ".html",
+        ".css",
+        ".js",
+        ".mjs",
+        ".map",
+        ".json",
+        ".svg",
+        ".png",
+        ".ico",
+        ".webp",
+        ".woff",
+        ".woff2",
+        ".wasm",
+    }
+)
+
+
+def _resolve_static(request_path: str) -> Path | None:
+    """Resolve an HTTP request path to a file inside _WEBROOT.
+
+    Returns the validated, web-root-contained path on success, or ``None`` for
+    every rejection. Fail-closed against:
+
+    * query string / fragment injection   (``urlsplit().path``)
+    * null-byte truncation                (``"\\x00" in``)
+    * percent-encoded traversal           (``unquote`` before component check)
+    * absolute paths                      (``Path.is_absolute()``)
+    * ``..`` or empty components          (explicit rejection)
+    * symlink escape from _WEBROOT        (``resolve(strict=True) + is_relative_to``)
+    * non-regular-file targets            (``is_file()``)
+    * disallowed content types            (``suffix in _STATIC_SUFFIXES``)
+
+    The ``is_relative_to(_WEBROOT)`` call is the CodeQL-recognized sanitizer
+    barrier for ``py/path-injection``.
+    """
+    raw = urlsplit(request_path).path
+    if not raw or "\x00" in raw:
+        return None
+    rel_str = unquote(raw).lstrip("/")
+    if not rel_str:
+        return None
+    candidate = Path(rel_str)
+    if candidate.is_absolute() or any(part in ("", "..") for part in candidate.parts):
+        return None
+    try:
+        target = (_WEBROOT / candidate).resolve(strict=True)
+    except (OSError, ValueError):
+        return None
+    if not target.is_relative_to(_WEBROOT):
+        return None
+    if not target.is_file():
+        return None
+    if target.suffix.lower() not in _STATIC_SUFFIXES:
+        return None
+    return target
+
 
 # ---------------------------------------------------------------------------
 # Physics imports (guarded — fail-closed if anything is missing)
@@ -552,16 +619,16 @@ class _Handler(BaseHTTPRequestHandler):
             self._send_json(_snapshot())
             return
         if self.path in ("/", "/index.html", "/demo.html"):
-            self._send_file(_HERE.parent / "demo.html", "text/html; charset=utf-8")
+            # Literal-path sink — no user data flows into the Path.
+            self._send_file(_WEBROOT / "demo.html", "text/html; charset=utf-8")
             return
-        # static passthrough (CSS/JS/images under ui/dashboard/)
-        target = (_HERE.parent / self.path.lstrip("/")).resolve()
-        if _HERE.parent in target.parents and target.is_file():
-            ctype = mimetypes.guess_type(str(target))[0] or "application/octet-stream"
-            self._send_file(target, ctype)
+        target = _resolve_static(self.path)
+        if target is None:
+            self.send_response(404)
+            self.end_headers()
             return
-        self.send_response(404)
-        self.end_headers()
+        ctype = mimetypes.guess_type(str(target))[0] or "application/octet-stream"
+        self._send_file(target, ctype)
 
     def _send_json(self, payload: dict[str, Any]) -> None:
         body = json.dumps(payload, allow_nan=False, default=str).encode("utf-8")
@@ -574,6 +641,14 @@ class _Handler(BaseHTTPRequestHandler):
         self.wfile.write(body)
 
     def _send_file(self, path: Path, ctype: str) -> None:
+        # Belt-and-braces: CodeQL-recognized sanitizer barrier at the I/O sink.
+        # Every call site must pass a path already confined to _WEBROOT; this
+        # re-check ensures a future refactor cannot silently introduce an
+        # unsanitized path.
+        if not path.is_relative_to(_WEBROOT):
+            self.send_response(403)
+            self.end_headers()
+            return
         data = path.read_bytes()
         self.send_response(200)
         self.send_header("Content-Type", ctype)


### PR DESCRIPTION
## TL;DR

Close **3 HIGH** CodeQL `py/path-injection` alerts on `ui/dashboard/live_server.py` — alerts **#697**, **#698**, **#699** (lines 558, 559, 577). The dashboard server's static-asset pass-through previously used the `in target.parents` idiom, which is correct-ish but not a CodeQL-recognized sanitizer. Replaced with a named fail-closed helper `_resolve_static()` whose barrier is `Path.is_relative_to(_WEBROOT)` after `resolve(strict=True)` — the canonical CodeQL sanitizer.

## Before

```python
target = (_HERE.parent / self.path.lstrip("/")).resolve()
if _HERE.parent in target.parents and target.is_file():
    ctype = mimetypes.guess_type(str(target))[0] or "application/octet-stream"
    self._send_file(target, ctype)
    return
```

No query-string stripping, no percent-decoding, no null-byte rejection, no symlink-escape barrier, no extension allow-list. CodeQL flagged the unsanitized user-data-to-`read_bytes()` taint flow.

## After

```python
target = _resolve_static(self.path)
if target is None:
    self.send_response(404); self.end_headers(); return
ctype = mimetypes.guess_type(str(target))[0] or "application/octet-stream"
self._send_file(target, ctype)
```

`_resolve_static()` is fail-closed against:

| Axis | Barrier |
|---|---|
| query string / fragment | `urlsplit().path` |
| null-byte truncation | `"\x00" in rel` |
| percent-encoded traversal | `unquote()` before component check |
| absolute paths | `Path.is_absolute()` |
| `..` / empty components | explicit pre-resolve rejection |
| symlink escape | `resolve(strict=True) + Path.is_relative_to(_WEBROOT)` |
| non-regular-file targets | `Path.is_file()` |
| disallowed content types | `suffix in _STATIC_SUFFIXES` |

`is_relative_to(_WEBROOT)` is the **CodeQL-recognized barrier** for `py/path-injection`. Placed both inside the helper and **belt-and-braces at the I/O sink** in `_send_file`, so a future refactor can't silently reintroduce an unsanitized path.

The root-path handler (`/`, `/index.html`, `/demo.html`) builds from `_WEBROOT / "demo.html"` — a literal string with no user-data flow — so CodeQL's taint analysis accepts it trivially.

## Regression tests — `tests/security/test_live_server_path_traversal.py`

27 tests covering:
- 9 traversal vectors (`../`, percent-encoded, mixed)
- 3 absolute-escape vectors (leading slash stacking, `%2f`)
- 3 null-byte vectors
- 3 query/fragment-strip cases
- unknown-suffix rejection
- symlink-escape rejection
- nonexistent / directory rejection
- known-static-asset happy path
- `_WEBROOT` invariants
- containment fuzz on 9 plausible requests
- `os.environ` / CWD independence

## Local verification

| Gate | Result |
|---|---|
| `ruff check` on both files | clean |
| `black --check` on both files | clean |
| `mypy --strict ui/dashboard/live_server.py` | Success, no issues |
| `pytest tests/security/test_live_server_path_traversal.py` | **27/27 pass** (0.36s) |

## Scope

Zero runtime behaviour change for the intended use-case (`demo.html` + its `/src/*` bundle over localhost). Every rejected request was already broken or malicious. User-visible: malformed requests now return 404/403 faster and more consistently.

## Test plan

- [x] `ruff check` / `black --check` pass locally
- [x] `mypy --strict` pass locally on `ui/dashboard/live_server.py`
- [x] 27/27 regression tests pass locally
- [ ] `repo-policy` green
- [ ] `physics-invariants` green
- [ ] `python-quality` green
- [ ] `python-fast-tests` green
- [ ] `secrets-supply-chain` green
- [ ] `frontend-gate` green
- [ ] `dependency-review` green
- [ ] CodeQL next scan confirms alerts #697, #698, #699 → `fixed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)