### PR TITLE
security: close 4 HIGH CodeQL in validate_i18n.js (#702-#705)

### DIFF
--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -5,14 +5,16 @@ on:
     paths:
       - "ui/dashboard/demo.html"
       - "ui/dashboard/src/i18n/**"
-      - "ui/dashboard/scripts/validate_i18n.js"
+      - "ui/dashboard/scripts/**"
+      - "ui/dashboard/tests/html_strip.test.js"
       - ".github/workflows/i18n.yml"
   push:
     branches: [main]
     paths:
       - "ui/dashboard/demo.html"
       - "ui/dashboard/src/i18n/**"
-      - "ui/dashboard/scripts/validate_i18n.js"
+      - "ui/dashboard/scripts/**"
+      - "ui/dashboard/tests/html_strip.test.js"
 
 permissions:
   contents: read
@@ -27,5 +29,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "24"
+      - name: HTML-strip sanitizer unit tests
+        run: node --test ui/dashboard/tests/html_strip.test.js
       - name: Validate i18n
         run: node ui/dashboard/scripts/validate_i18n.js

--- a/ui/dashboard/scripts/html_strip.js
+++ b/ui/dashboard/scripts/html_strip.js
@@ -1,0 +1,58 @@
+// Copyright (c) 2026 Yaroslav Vasylenko (neuron7xLab)
+// SPDX-License-Identifier: MIT
+//
+// Minimal HTML-strip helpers used by the i18n validator. Kept in a separate
+// module so unit tests can exercise the sanitizer without running the full
+// validator's top-level side effects (demo.html read, strings.js import).
+//
+// The strip regexes close CodeQL alerts #702–#705 (js/incomplete-multi-
+// character-sanitization, js/bad-tag-filter) on
+// ``ui/dashboard/scripts/validate_i18n.js``. The post-strip barrier
+// ``dangerousLexemesIn`` is the explicit fail-closed check CodeQL recognises:
+// if any dangerous lexeme survives the regex, the caller must treat the
+// input as unsafe rather than scan the garbage.
+
+/**
+ * Strip <script>, <style>, HTML comments, and data-i18n[-placeholder]-bound
+ * elements from a fragment of HTML.
+ *
+ * The regexes tolerate:
+ *   * case-insensitive tag names (`i` flag)
+ *   * attributes on the opening tag
+ *   * whitespace-padded end tags ("</script >", "</style >") — HTML5-valid,
+ *     which the previous patterns missed
+ *   * `\b` prevents <scriptx>/<stylex> collisions
+ *
+ * @param {string} html Raw HTML (may be empty/null — treated as "").
+ * @returns {string} Stripped HTML.
+ */
+export function stripHtmlBlocks(html) {
+  return (html || "")
+    .replace(/<script\b[\s\S]*?<\/script\s*>/gi, "")
+    .replace(/<style\b[\s\S]*?<\/style\s*>/gi, "")
+    .replace(/<!--[\s\S]*?-->/g, "")
+    .replace(
+      /<([A-Za-z][A-Za-z0-9]*)[^>]*\sdata-i18n(?:-placeholder)?="[^"]*"[^>]*>[\s\S]*?<\/\1\s*>/g,
+      "",
+    );
+}
+
+/**
+ * Return the list of dangerous lexemes still present in `stripped`.
+ * Empty list = strip succeeded. Non-empty = regex bypass — callers must
+ * treat the input as unsafe.
+ *
+ * This is the fail-closed barrier that CodeQL recognises as a complete
+ * sanitizer for `js/incomplete-multi-character-sanitization`.
+ *
+ * @param {string} stripped Output of ``stripHtmlBlocks``.
+ * @returns {string[]} Lexemes still present, in order of discovery.
+ */
+export function dangerousLexemesIn(stripped) {
+  const lowered = stripped.toLowerCase();
+  const found = [];
+  for (const lexeme of ["<script", "<style", "<!--"]) {
+    if (lowered.includes(lexeme)) found.push(lexeme);
+  }
+  return found;
+}

--- a/ui/dashboard/scripts/validate_i18n.js
+++ b/ui/dashboard/scripts/validate_i18n.js
@@ -20,6 +20,8 @@ import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
+import { dangerousLexemesIn, stripHtmlBlocks } from "./html_strip.js";
+
 const __here = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__here, "..");
 
@@ -94,11 +96,16 @@ try {
 // Strip <script>, <style>, comments, AND every element carrying data-i18n /
 // data-i18n-placeholder — the fallback text inside such elements is bound at
 // page load and therefore not a hard-coded literal.
-const stripped = (demoRaw || "")
-  .replace(/<script[\s\S]*?<\/script>/gi, "")
-  .replace(/<style[\s\S]*?<\/style>/gi, "")
-  .replace(/<!--[\s\S]*?-->/g, "")
-  .replace(/<([A-Za-z][A-Za-z0-9]*)[^>]*\sdata-i18n(?:-placeholder)?="[^"]*"[^>]*>[\s\S]*?<\/\1>/g, "");
+//
+// Sanitizer + fail-closed barrier live in ./html_strip.js. See CodeQL alerts
+// #702–#705 for the bypass vectors the previous inline regex missed.
+const stripped = stripHtmlBlocks(demoRaw);
+for (const lexeme of dangerousLexemesIn(stripped)) {
+  errors.push(
+    `[C] strip regex bypass: stripped HTML still contains "${lexeme}" — ` +
+      `fix ui/dashboard/scripts/html_strip.js before proceeding.`,
+  );
+}
 
 // Words on canon list OR inline-approved (numbers, symbols, units).
 const allowlist = new Set([

--- a/ui/dashboard/tests/html_strip.test.js
+++ b/ui/dashboard/tests/html_strip.test.js
@@ -1,0 +1,165 @@
+// Copyright (c) 2026 Yaroslav Vasylenko (neuron7xLab)
+// SPDX-License-Identifier: MIT
+//
+// Regression tests for ui/dashboard/scripts/html_strip.js. Closes CodeQL
+// alerts #702–#705 (js/incomplete-multi-character-sanitization,
+// js/bad-tag-filter) on ui/dashboard/scripts/validate_i18n.js.
+//
+// Uses node:test (built-in, no dependency). Run: `node --test tests/html_strip.test.js`.
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { dangerousLexemesIn, stripHtmlBlocks } from "../scripts/html_strip.js";
+
+describe("stripHtmlBlocks — script tag variants", () => {
+  const variants = [
+    { html: "<script>alert(1)</script>", label: "plain" },
+    { html: "<script >alert(1)</script >", label: "padded start + end" },
+    { html: "<script\n>alert(1)</script\n>", label: "newline-padded tags" },
+    { html: "<script\ttype=module>alert(1)</script\t>", label: "tab-separated" },
+    { html: '<script type="module">alert(1)</script>', label: "attrs on opener" },
+    { html: "<SCRIPT>alert(1)</SCRIPT>", label: "uppercase" },
+    { html: "<ScRiPt>alert(1)</sCrIpT>", label: "mixed case" },
+    { html: "<script>a</script><script>b</script>", label: "two scripts" },
+    { html: "before<script>x</script>after", label: "surrounded by text" },
+  ];
+  for (const { html, label } of variants) {
+    it(`removes <script> (${label})`, () => {
+      const stripped = stripHtmlBlocks(html);
+      assert.equal(dangerousLexemesIn(stripped).length, 0, `bypass: ${stripped}`);
+      assert.equal(/script/i.test(stripped), false);
+    });
+  }
+});
+
+describe("stripHtmlBlocks — style tag variants", () => {
+  const variants = [
+    "<style>body{color:red}</style>",
+    "<style >body{}</style >",
+    '<style type="text/css">body{}</style>',
+    "<STYLE>body{}</STYLE>",
+    "<style\nmedia=screen>body{}</style\n>",
+  ];
+  for (const html of variants) {
+    it(`removes <style> in ${JSON.stringify(html).slice(0, 40)}…`, () => {
+      const stripped = stripHtmlBlocks(html);
+      assert.equal(dangerousLexemesIn(stripped).length, 0);
+      assert.equal(/style/i.test(stripped), false);
+    });
+  }
+});
+
+describe("stripHtmlBlocks — HTML comments", () => {
+  const variants = [
+    "<!-- normal -->",
+    "<!-- multi\nline\ncomment -->",
+    "before<!-- c -->middle<!-- d -->after",
+    "<!---->",
+    "<!-- contains <script> inside -->",
+  ];
+  for (const html of variants) {
+    it(`removes comment in ${JSON.stringify(html).slice(0, 40)}…`, () => {
+      const stripped = stripHtmlBlocks(html);
+      assert.equal(dangerousLexemesIn(stripped).length, 0);
+    });
+  }
+});
+
+describe("stripHtmlBlocks — data-i18n bound elements", () => {
+  it('removes <span data-i18n="x">...</span>', () => {
+    const html = '<span data-i18n="foo.bar">fallback text</span>';
+    assert.equal(stripHtmlBlocks(html), "");
+  });
+  it('removes <label data-i18n-placeholder="x">...</label>', () => {
+    const html = '<label data-i18n-placeholder="placeholder">fallback</label>';
+    assert.equal(stripHtmlBlocks(html), "");
+  });
+  it("preserves elements WITHOUT data-i18n", () => {
+    const html = "<span>visible text</span>";
+    assert.equal(stripHtmlBlocks(html), html);
+  });
+});
+
+describe("dangerousLexemesIn — barrier detection", () => {
+  it("empty on clean stripped output", () => {
+    assert.deepEqual(dangerousLexemesIn("<p>hello</p>"), []);
+  });
+  it("detects leftover <script (case-insensitive)", () => {
+    assert.deepEqual(dangerousLexemesIn("<Script ooops"), ["<script"]);
+  });
+  it("detects leftover <style", () => {
+    assert.deepEqual(dangerousLexemesIn("<STYLE"), ["<style"]);
+  });
+  it("detects leftover <!--", () => {
+    assert.deepEqual(dangerousLexemesIn("text <!-- unclosed"), ["<!--"]);
+  });
+  it("returns all three when all three leaked", () => {
+    const leak = "<script <style <!-- here";
+    assert.deepEqual(
+      new Set(dangerousLexemesIn(leak)),
+      new Set(["<script", "<style", "<!--"]),
+    );
+  });
+});
+
+describe("stripHtmlBlocks — prefix-collision guard (\\b anchor)", () => {
+  it("does NOT strip tags whose name only starts with 'script'", () => {
+    // <scriptx> is not a real script tag. The \b anchor prevents a false match.
+    const html = "<scriptx>keep me</scriptx>";
+    assert.equal(stripHtmlBlocks(html), html);
+  });
+  it("does NOT strip tags whose name only starts with 'style'", () => {
+    const html = "<stylex>keep me</stylex>";
+    assert.equal(stripHtmlBlocks(html), html);
+  });
+});
+
+describe("stripHtmlBlocks — empty / null / absurd input", () => {
+  it("handles empty string", () => {
+    assert.equal(stripHtmlBlocks(""), "");
+  });
+  it("handles null / undefined as empty", () => {
+    assert.equal(stripHtmlBlocks(null), "");
+    assert.equal(stripHtmlBlocks(undefined), "");
+  });
+  it("leaves pure text untouched", () => {
+    assert.equal(stripHtmlBlocks("hello world"), "hello world");
+  });
+});
+
+describe("stripHtmlBlocks — barrier catches pathological interleaving", () => {
+  // Regex-based stripping cannot possibly handle every interleaving of
+  // comments containing fake script tags etc. — that's why the barrier
+  // exists. Two complementary tests:
+  //   1. Clean per-vector inputs: strip is complete, barrier finds nothing.
+  //   2. Pathological interleaved input: strip may leave a comment fragment
+  //      (a <script> inside a real <!-- … --> comment causes the script
+  //      regex to eat across the comment), and the barrier MUST catch it.
+  it("stripping is complete on clean inputs (barrier empty)", () => {
+    const clean = [
+      "<script >pwn()</script >",
+      "<style\n>body{}</style\n>",
+      "<!-- just a comment -->",
+      "<SCRIPT>alert(1)</SCRIPT><style>x</style>",
+      '<script type="module" src="x.js"></script>',
+    ].join("\n");
+    assert.deepEqual(dangerousLexemesIn(stripHtmlBlocks(clean)), []);
+  });
+  it("barrier detects leak when an unterminated <script> is inside a comment", () => {
+    // The non-greedy script regex, faced with a <script> that has no </script>
+    // inside the comment, extends beyond the comment to the next </script> on
+    // a later line, leaving the "<!-- bypass " fragment dangling. This is a
+    // known limitation of any regex-based HTML strip — the barrier MUST
+    // surface it rather than silently emit garbage.
+    const pathological =
+      "<!-- bypass <script> -->intermediate\n" +
+      "<SCRIPT>alert(1)</SCRIPT>";
+    const stripped = stripHtmlBlocks(pathological);
+    assert.ok(
+      dangerousLexemesIn(stripped).length > 0,
+      "barrier must fire on pathological interleaving; stripped=" +
+        JSON.stringify(stripped),
+    );
+  });
+});


### PR DESCRIPTION
## TL;DR

Close **4 HIGH** CodeQL alerts on `ui/dashboard/scripts/validate_i18n.js`:

| Alert | Rule | Line | Issue |
|---|---|---|---|
| #702 | js/incomplete-multi-character-sanitization | 100 | string may still contain `<!--` |
| #703 | js/incomplete-multi-character-sanitization | 99 | string may still contain `<style` |
| #704 | js/incomplete-multi-character-sanitization | 98 | string may still contain `<script` |
| #705 | js/bad-tag-filter | 98 | regex misses `</script >` (HTML5-valid) |

Root cause: three latent defects in the inline strip regex. Pattern missed whitespace-padded HTML5 end tags, lacked word-boundary anchors, and had no post-strip fail-closed barrier — so any regex bypass would silently feed garbage into the downstream text-node scanner.

## Fix

Extracted two pure helpers into a new module `ui/dashboard/scripts/html_strip.js`:

- `stripHtmlBlocks(html)` — tightened regex:
  - `<\/script\s*>` / `<\/style\s*>` match whitespace-padded end tags
  - `\b` anchor prevents `<scriptx>` over-match
  - same case-insensitive `gi` flags as before
- `dangerousLexemesIn(stripped)` — the **fail-closed barrier**. Returns any of `<script`, `<style`, `<!--` still present in the strip output. Non-empty → validator emits a hard linter error rather than scanning garbage. This is the CodeQL-recognized sanitizer completeness check.

`validate_i18n.js` now imports both helpers. Inline regex gone. Runtime behaviour on `demo.html` unchanged (demo.html has no whitespace-padded end tags to begin with).

## Regression tests — `ui/dashboard/tests/html_strip.test.js`

**34 tests, 8 suites, zero fail.** Uses `node:test` (built-in — no added dependency). Coverage:

- 9 `<script>` variants: plain, padded start+end, newline-padded, tab-separated, attrs, uppercase, mixed-case, multi, surrounded
- 5 `<style>` variants including whitespace-padded end
- 5 HTML-comment variants including multi-line and containing `<script>` inside
- `data-i18n` / `data-i18n-placeholder` element stripping
- `<scriptx>` / `<stylex>` **prefix-collision guard** (`\b` anchor)
- barrier detection: all three lexemes, case-insensitive
- empty / null / undefined input
- **pathological interleaving**: a `<script>` inside a comment whose `</script>` is on a later line causes the non-greedy regex to eat across comment boundaries — the barrier correctly surfaces the leak. This is the fail-closed guarantee in action.

## CI wiring

`.github/workflows/i18n.yml` extended:
- trigger paths widened: `scripts/validate_i18n.js` → `scripts/**` (picks up the new `html_strip.js`) + `tests/html_strip.test.js`
- new step `HTML-strip sanitizer unit tests` runs `node --test ui/dashboard/tests/html_strip.test.js` before the canon linter; both must pass

## Local verification

- `node --test ui/dashboard/tests/html_strip.test.js` → **34/34 pass**
- `node ui/dashboard/scripts/validate_i18n.js` → **PASS** (147 keys, 64 canon tokens)

## Test plan

- [x] `node --test` suite passes locally
- [x] Validator still passes end-to-end locally
- [ ] `repo-policy` green
- [ ] `physics-invariants` green
- [ ] `canon + parity linter` green (from i18n.yml — runs both the unit tests and the validator)
- [ ] `python-quality` green
- [ ] `secrets-supply-chain` green
- [ ] `dependency-review` green
- [ ] CodeQL next scan confirms alerts #702–#705 → `fixed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)