### PR TITLE
chore(ci): kill Node20 deprecation — pin all actions to Node24 SHAs

### DIFF
--- a/.github/workflows/formal-verification.yml
+++ b/.github/workflows/formal-verification.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Install JRE
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends default-jre-headless
@@ -66,6 +66,6 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: Verify manifest
         run: sha256sum --check --strict reproducibility/manifest.sha256

--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -25,8 +25,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "24"
       - name: HTML-strip sanitizer unit tests

--- a/.github/workflows/l2-demo-gate.yml
+++ b/.github/workflows/l2-demo-gate.yml
@@ -45,7 +45,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.12"
           cache: pip
@@ -72,7 +72,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.12"
           cache: pip
@@ -99,7 +99,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.12"
           cache: pip

--- a/.github/workflows/main-validation.yml
+++ b/.github/workflows/main-validation.yml
@@ -76,7 +76,7 @@ jobs:
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '24'
           cache: npm

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -340,7 +340,7 @@ jobs:
 
       - name: Setup Node.js
         if: steps.changes.outputs.frontend_changed == 'true'
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '24'
           cache: npm

--- a/INVENTORY.json
+++ b/INVENTORY.json
@@ -11,7 +11,7 @@
   "files": [
     {
       "path": ".github/workflows/pr-gate.yml",
-      "sha256": "a454d2ccd1d9d22c1a7220259c80167a08f196eef93fff7750c9352c2f1ddd5f"
+      "sha256": "61ffad694a85402b12c918a18fe86c989c830ff9f7b201882affb8614d734c35"
     },
     {
       "path": "scripts/ci/check_central_files_touched.py",


### PR DESCRIPTION
## Summary
- Eliminates Node.js 20 deprecation warnings in GitHub Actions (GitHub forces Node 24 from **2026-06-02**, Node 20 runners removed **2026-09-16**).
- Upgrades five action references to Node 24 SHAs; SHA-pins three previously unpinned actions (supply-chain hygiene — matches rest of repo).
- Closes the Node-20 warning surfaced by the historical failure run [23947699387](https://github.com/neuron7xLab/GeoSync/actions/runs/23947699387) for both [`python-full-validation`](https://github.com/neuron7xLab/GeoSync/actions/runs/23947699387/job/69847468929) and [`frontend-build-smoke`](https://github.com/neuron7xLab/GeoSync/actions/runs/23947699387/job/69847468950). The Python 48-test GABA/coverage failures from that run were already fixed in `623a02d`; the eslint peer-dep conflict was fixed in `6efe159`.

## Changes
| File | Before | After |
|------|--------|-------|
| `main-validation.yml` | `setup-node@49933ea5 # v4` (Node 20) | `setup-node@48b55a01 # v6.4.0` (Node 24) |
| `pr-gate.yml` | `setup-node@49933ea5 # v4` (Node 20) | `setup-node@48b55a01 # v6.4.0` (Node 24) |
| `l2-demo-gate.yml` ×3 | `setup-python@a26af69b # v5.6.0` (Node 20) | `setup-python@a309ff8b # v6` (Node 24) |
| `i18n.yml` | `checkout@v4` + `setup-node@v4` (unpinned, Node 20) | `checkout@93cb6efe # v5` + `setup-node@48b55a01 # v6.4.0` |
| `formal-verification.yml` ×2 | `checkout@v5` (unpinned) | `checkout@93cb6efe # v5` |

Transitively fixes the Node-20 `actions/cache@0057852b` warning — that binary ships inside `setup-node@v4`. `v6.4.0` bundles a Node-24 cache.

## Security docs audit
`docs/security/` reviewed during this pass:
- `2025-10-penetration-review.md` — 3 findings (StrategyEngine, metrics, P2Quantile) all **remediated** in code (assert → explicit raise). No open items.
- `hardening.md`, `security-tests-2025-10-21.md`, `SECURITY_OPERATIONS_GUIDE.md` — remediation references are process-level, not open tickets.
- No FIXME/TODO/pending outside of standard operational language.

## Test plan
- [ ] CI Main Validation green on merge PR
- [ ] CI PR Gate green on this PR
- [ ] CodeQL green on this PR
- [ ] Physics Invariants + Physics Kernel Gate green
- [ ] No `Node.js 20 actions are deprecated` annotations on any job in this run

🤖 Generated with [Claude Code](https://claude.com/claude-code)