### PR TITLE
feat(hpc): session lifecycle FSM — eight states, explicit transitions

### DIFF
--- a/geosync_hpc/session_fsm.py
+++ b/geosync_hpc/session_fsm.py
@@ -1,0 +1,181 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""BacktesterCAL lifecycle — explicit finite-state machine.
+
+A backtest session moves through a small number of qualitatively
+different states (untrained model, fitted quantiles, calibrated
+conformal, running loop, checkpointed, restored, completed, failed).
+The existing ``BacktesterCAL`` encodes these phases implicitly: a
+caller who invokes ``run`` before ``calibrate_conformal`` gets a
+cryptic ``KeyError`` deep in the loop; one who invokes ``calibrate``
+before ``fit_quantiles`` fits on ``None``; a restore that lands the
+session into an impossible state (``COMPLETED → RUNNING``) fails
+silently.
+
+This module makes the lifecycle explicit, testable, and snapshotable.
+It does *not* replace ``BacktesterCAL`` — it sits next to it as a
+companion state machine that the harness will route every public
+operation through in a follow-up PR. Keeping the FSM isolated lets
+it fail-close on its own invariant tests first.
+
+Design choices:
+
+* **Eight states, ten transitions.** The full transition table is a
+  single public constant (:data:`TRANSITIONS`); unit tests enumerate
+  every cell.
+* **Terminal states are absorbing.** ``COMPLETED`` and ``FAILED``
+  accept no further transitions — attempting one raises
+  :class:`InvalidTransitionError` with a helpful message.
+* **Failure is first-class.** ``fail`` is a valid action from every
+  non-terminal state; observability matters more than aesthetic purity.
+* **Serialisable.** ``SessionLifecycle.to_dict`` / ``from_dict`` round-
+  trip cleanly into a :mod:`geosync_hpc.runtime_state` envelope
+  payload without losing information.
+
+Rejecting heavier formal-methods machinery (TLA+, Alloy) is intentional
+for this scope. A property test that exercises every transition cell
+is sufficient evidence at the Task 5 scope; a model-checker becomes
+worthwhile when the transition graph grows non-trivial branching.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from enum import Enum
+from typing import Any, Final, Mapping
+
+
+class SessionState(str, Enum):
+    """Lifecycle state of a backtest session.
+
+    Inherits from ``str`` so that JSON encoding of the envelope payload
+    yields readable labels without a custom encoder.
+    """
+
+    UNINITIALIZED = "uninitialized"
+    FITTED = "fitted"
+    CALIBRATED = "calibrated"
+    RUNNING = "running"
+    CHECKPOINTED = "checkpointed"
+    RESTORED = "restored"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+# Actions are plain strings — avoids a second enum that would have to
+# be kept synchronised with a string vocabulary at the envelope edge.
+FIT: Final[str] = "fit"
+CALIBRATE: Final[str] = "calibrate"
+RUN: Final[str] = "run"
+CHECKPOINT: Final[str] = "checkpoint"
+RESTORE: Final[str] = "restore"
+RESUME: Final[str] = "resume"
+COMPLETE: Final[str] = "complete"
+FAIL: Final[str] = "fail"
+
+ACTIONS: Final[frozenset[str]] = frozenset(
+    {FIT, CALIBRATE, RUN, CHECKPOINT, RESTORE, RESUME, COMPLETE, FAIL}
+)
+
+TERMINAL_STATES: Final[frozenset[SessionState]] = frozenset(
+    {SessionState.COMPLETED, SessionState.FAILED}
+)
+
+TRANSITIONS: Final[dict[tuple[SessionState, str], SessionState]] = {
+    # Happy path:
+    (SessionState.UNINITIALIZED, FIT): SessionState.FITTED,
+    (SessionState.FITTED, CALIBRATE): SessionState.CALIBRATED,
+    (SessionState.CALIBRATED, RUN): SessionState.RUNNING,
+    (SessionState.RUNNING, COMPLETE): SessionState.COMPLETED,
+    # Checkpoint / restore branch:
+    (SessionState.RUNNING, CHECKPOINT): SessionState.CHECKPOINTED,
+    (SessionState.CHECKPOINTED, RESTORE): SessionState.RESTORED,
+    (SessionState.RESTORED, RESUME): SessionState.RUNNING,
+    # Failure is admissible from any non-terminal state:
+    (SessionState.FITTED, FAIL): SessionState.FAILED,
+    (SessionState.CALIBRATED, FAIL): SessionState.FAILED,
+    (SessionState.RUNNING, FAIL): SessionState.FAILED,
+    (SessionState.CHECKPOINTED, FAIL): SessionState.FAILED,
+    (SessionState.RESTORED, FAIL): SessionState.FAILED,
+    (SessionState.UNINITIALIZED, FAIL): SessionState.FAILED,
+}
+
+
+class InvalidTransitionError(Exception):
+    """Attempted action is not admissible from the current state."""
+
+
+@dataclass(frozen=True)
+class SessionLifecycle:
+    """Immutable lifecycle snapshot.
+
+    Evolve by calling :meth:`transition`, which returns a new instance
+    (the old instance is unchanged). This keeps rollback trivial and
+    matches the ``runtime_state`` envelope's "dump every field"
+    contract.
+    """
+
+    state: SessionState = SessionState.UNINITIALIZED
+
+    def can(self, action: str) -> bool:
+        """Return True if ``action`` is admissible from the current
+        state. Unknown actions return False (not raise)."""
+        return (self.state, action) in TRANSITIONS
+
+    def transition(self, action: str) -> SessionLifecycle:
+        """Return a new lifecycle after applying ``action``.
+
+        Raises
+        ------
+        InvalidTransitionError
+            The action is unknown, or not admissible from the current
+            state (including all attempts to leave a terminal state).
+        """
+        if action not in ACTIONS:
+            raise InvalidTransitionError(
+                f"unknown action {action!r}; valid actions: {sorted(ACTIONS)}"
+            )
+        if self.state in TERMINAL_STATES:
+            raise InvalidTransitionError(
+                f"cannot transition from terminal state {self.state.value!r}; "
+                f"attempted action {action!r}"
+            )
+        key = (self.state, action)
+        if key not in TRANSITIONS:
+            allowed = [a for (s, a) in TRANSITIONS if s == self.state]
+            raise InvalidTransitionError(
+                f"action {action!r} not admissible from {self.state.value!r}; "
+                f"allowed: {sorted(allowed)}"
+            )
+        return replace(self, state=TRANSITIONS[key])
+
+    def is_terminal(self) -> bool:
+        return self.state in TERMINAL_STATES
+
+    # --- envelope serialisation ------------------------------------------
+
+    def to_dict(self) -> dict[str, Any]:
+        """Canonical JSON-safe dict, pairable with
+        :mod:`geosync_hpc.runtime_state`."""
+        return {"state": self.state.value}
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> SessionLifecycle:
+        """Inverse of :meth:`to_dict`.
+
+        Raises
+        ------
+        ValueError
+            ``state`` missing, not a string, or not a recognised
+            :class:`SessionState` label.
+        """
+        if "state" not in payload:
+            raise ValueError(f"payload missing 'state': {payload!r}")
+        raw = payload["state"]
+        if not isinstance(raw, str):
+            raise ValueError(f"'state' must be a string, got {type(raw).__name__}")
+        try:
+            state = SessionState(raw)
+        except ValueError as exc:
+            raise ValueError(f"unknown SessionState label {raw!r}") from exc
+        return cls(state=state)

--- a/tests/geosync_hpc/test_session_fsm.py
+++ b/tests/geosync_hpc/test_session_fsm.py
@@ -1,0 +1,265 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""Session lifecycle FSM — invariants and enumerated transitions.
+
+Guards the four properties that justify a first-class lifecycle:
+
+1. **Enumerated transitions.** Every cell of the transition table is
+   exercised; unknown / inadmissible / terminal transitions all raise
+   :class:`InvalidTransitionError`.
+2. **Happy path reachability.** The canonical sequence
+   ``fit → calibrate → run → complete`` reaches ``COMPLETED``.
+3. **Checkpoint / restore branch.** ``run → checkpoint → restore →
+   resume → complete`` reaches ``COMPLETED``; intermediate states are
+   as declared.
+4. **Terminal absorption.** Once in ``COMPLETED`` or ``FAILED``, every
+   subsequent transition raises.
+
+Plus envelope round-trip through :func:`to_dict` / :func:`from_dict`
+and a Hypothesis property test that any randomly-generated legal
+action sequence ends at a declared :class:`SessionState`.
+"""
+
+from __future__ import annotations
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from geosync_hpc.session_fsm import (
+    ACTIONS,
+    CALIBRATE,
+    CHECKPOINT,
+    COMPLETE,
+    FAIL,
+    FIT,
+    RESTORE,
+    RESUME,
+    RUN,
+    TERMINAL_STATES,
+    TRANSITIONS,
+    InvalidTransitionError,
+    SessionLifecycle,
+    SessionState,
+)
+
+# ---------------------------------------------------------------------------
+# Construction + invariants
+# ---------------------------------------------------------------------------
+
+
+def test_default_state_is_uninitialized() -> None:
+    s = SessionLifecycle()
+    assert s.state is SessionState.UNINITIALIZED
+
+
+def test_lifecycle_is_frozen() -> None:
+    s = SessionLifecycle()
+    with pytest.raises(Exception):  # FrozenInstanceError
+        s.state = SessionState.FITTED  # type: ignore[misc]
+
+
+def test_actions_constant_matches_transition_table() -> None:
+    """Defence in depth: every action referenced in TRANSITIONS must
+    appear in ACTIONS. Catches a future rename that drifts one but
+    not the other."""
+    used = {a for (_, a) in TRANSITIONS}
+    assert used <= ACTIONS
+
+
+def test_terminal_states_have_no_outgoing_transitions() -> None:
+    for terminal in TERMINAL_STATES:
+        outgoing = [(s, a) for (s, a) in TRANSITIONS if s is terminal]
+        assert outgoing == [], f"terminal state {terminal} has outgoing: {outgoing}"
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_canonical_happy_path_reaches_completed() -> None:
+    s = SessionLifecycle()
+    s = s.transition(FIT)
+    assert s.state is SessionState.FITTED
+    s = s.transition(CALIBRATE)
+    assert s.state is SessionState.CALIBRATED
+    s = s.transition(RUN)
+    assert s.state is SessionState.RUNNING
+    s = s.transition(COMPLETE)
+    assert s.state is SessionState.COMPLETED
+    assert s.is_terminal()
+
+
+def test_checkpoint_restore_branch_reaches_completed() -> None:
+    s = SessionLifecycle()
+    for action in (FIT, CALIBRATE, RUN, CHECKPOINT, RESTORE, RESUME, COMPLETE):
+        s = s.transition(action)
+    assert s.state is SessionState.COMPLETED
+
+
+# ---------------------------------------------------------------------------
+# Failure
+# ---------------------------------------------------------------------------
+
+
+def test_fail_from_every_non_terminal_state() -> None:
+    """Failure must be admissible from every non-terminal state."""
+    for state in SessionState:
+        if state in TERMINAL_STATES:
+            continue
+        s = SessionLifecycle(state=state)
+        s_fail = s.transition(FAIL)
+        assert s_fail.state is SessionState.FAILED
+
+
+def test_failed_is_terminal() -> None:
+    s = SessionLifecycle(state=SessionState.FAILED)
+    with pytest.raises(InvalidTransitionError):
+        s.transition(FIT)
+    with pytest.raises(InvalidTransitionError):
+        s.transition(FAIL)
+
+
+def test_completed_is_terminal() -> None:
+    s = SessionLifecycle(state=SessionState.COMPLETED)
+    with pytest.raises(InvalidTransitionError):
+        s.transition(RUN)
+    with pytest.raises(InvalidTransitionError):
+        s.transition(FAIL)
+
+
+# ---------------------------------------------------------------------------
+# Invalid transitions — every state × every forbidden action
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_action_raises() -> None:
+    s = SessionLifecycle()
+    with pytest.raises(InvalidTransitionError):
+        s.transition("nonsense")
+
+
+def test_admissible_actions_match_can() -> None:
+    """``can`` and ``transition`` must agree on admissibility for every
+    (state, action) pair."""
+    for state in SessionState:
+        for action in ACTIONS:
+            s = SessionLifecycle(state=state)
+            admissible = s.can(action)
+            if admissible:
+                s.transition(action)  # must not raise
+            else:
+                with pytest.raises(InvalidTransitionError):
+                    s.transition(action)
+
+
+def test_run_before_calibrate_is_invalid() -> None:
+    s = SessionLifecycle().transition(FIT)
+    with pytest.raises(InvalidTransitionError):
+        s.transition(RUN)
+
+
+def test_calibrate_before_fit_is_invalid() -> None:
+    s = SessionLifecycle()
+    with pytest.raises(InvalidTransitionError):
+        s.transition(CALIBRATE)
+
+
+def test_checkpoint_from_calibrated_is_invalid() -> None:
+    s = SessionLifecycle().transition(FIT).transition(CALIBRATE)
+    with pytest.raises(InvalidTransitionError):
+        s.transition(CHECKPOINT)
+
+
+def test_resume_without_restore_is_invalid() -> None:
+    s = (
+        SessionLifecycle()
+        .transition(FIT)
+        .transition(CALIBRATE)
+        .transition(RUN)
+        .transition(CHECKPOINT)
+    )
+    with pytest.raises(InvalidTransitionError):
+        s.transition(RESUME)
+
+
+# ---------------------------------------------------------------------------
+# Envelope serialisation
+# ---------------------------------------------------------------------------
+
+
+def test_to_dict_and_from_dict_roundtrip_every_state() -> None:
+    for state in SessionState:
+        s = SessionLifecycle(state=state)
+        restored = SessionLifecycle.from_dict(s.to_dict())
+        assert restored == s
+
+
+def test_from_dict_rejects_missing_state() -> None:
+    with pytest.raises(ValueError):
+        SessionLifecycle.from_dict({})
+
+
+def test_from_dict_rejects_non_string_state() -> None:
+    with pytest.raises(ValueError):
+        SessionLifecycle.from_dict({"state": 1})
+
+
+def test_from_dict_rejects_unknown_label() -> None:
+    with pytest.raises(ValueError):
+        SessionLifecycle.from_dict({"state": "not_a_state"})
+
+
+def test_to_dict_emits_canonical_labels() -> None:
+    assert SessionLifecycle().to_dict() == {"state": "uninitialized"}
+    assert SessionLifecycle(state=SessionState.COMPLETED).to_dict() == {"state": "completed"}
+
+
+# ---------------------------------------------------------------------------
+# Property: any legal sequence ends at a declared SessionState
+# ---------------------------------------------------------------------------
+
+
+@given(st.lists(st.sampled_from(sorted(ACTIONS)), min_size=0, max_size=20))
+@settings(max_examples=300, deadline=None)
+def test_random_action_sequences_preserve_invariants(actions: list[str]) -> None:
+    """Any action sequence — legal or not — either completes without
+    raising and lands in a declared state, or raises InvalidTransitionError
+    on the first illegal step. Invariant: the FSM never silently
+    produces an undeclared state."""
+    s = SessionLifecycle()
+    for action in actions:
+        try:
+            s = s.transition(action)
+        except InvalidTransitionError:
+            break
+        assert isinstance(s.state, SessionState)
+
+
+# ---------------------------------------------------------------------------
+# Transition-table surface audit
+# ---------------------------------------------------------------------------
+
+
+def test_transition_table_has_no_self_loops() -> None:
+    for (src, action), dst in TRANSITIONS.items():
+        assert src is not dst, f"self-loop at ({src}, {action}); lifecycle must record progress"
+
+
+def test_every_non_terminal_state_reachable_from_default() -> None:
+    """Every non-terminal state must be reachable via the canonical
+    happy path + checkpoint branch. Dead states are a design smell."""
+    reachable = {SessionState.UNINITIALIZED}
+    # Forward flood from the default start.
+    frontier = {SessionState.UNINITIALIZED}
+    while frontier:
+        new_frontier: set[SessionState] = set()
+        for state in frontier:
+            for (src, _), dst in TRANSITIONS.items():
+                if src is state and dst not in reachable:
+                    new_frontier.add(dst)
+                    reachable.add(dst)
+        frontier = new_frontier
+    expected = set(SessionState)
+    assert reachable == expected, f"unreachable states: {expected - reachable}"


### PR DESCRIPTION
## Why

Task 5 of the post-2026-04-23 audit sequence. The backtest session implicitly moves through several qualitatively different phases; ``BacktesterCAL`` encodes them by method invocation order. ``run()`` before ``calibrate_conformal()`` raises a cryptic KeyError deep in the loop; ``calibrate()`` before ``fit_quantiles()`` fits on ``None``; a restore that lands the session in an impossible state (e.g. ``COMPLETED → RUNNING``) fails silently.

This PR makes the lifecycle explicit, testable, and envelope-serialisable.

## What ships

### ``geosync_hpc/session_fsm.py`` (new primitive module)

- **8 ``SessionState`` values** — UNINITIALIZED / FITTED / CALIBRATED / RUNNING / CHECKPOINTED / RESTORED / COMPLETED / FAILED. Inherits from ``str`` so the envelope payload uses readable labels.
- **8 action constants** — ``FIT``, ``CALIBRATE``, ``RUN``, ``CHECKPOINT``, ``RESTORE``, ``RESUME``, ``COMPLETE``, ``FAIL``.
- **13 transitions in one public dict** ``TRANSITIONS``:
  * Happy path: `UNINIT → fit → FITTED → calibrate → CALIBRATED → run → RUNNING → complete → COMPLETED`
  * Checkpoint branch: `RUNNING → checkpoint → CHECKPOINTED → restore → RESTORED → resume → RUNNING`
  * Failure admissible from every non-terminal state
- **Terminal absorption** — ``COMPLETED`` / ``FAILED`` accept no further transitions; attempts raise ``InvalidTransitionError``.
- Frozen ``SessionLifecycle`` dataclass with ``transition(action)``, ``can(action)``, ``is_terminal()``, ``to_dict()``, ``from_dict()``.
- Round-trips cleanly into a :mod:`geosync_hpc.runtime_state` envelope payload.

**Design rejection:** TLA+ / Alloy is explicit non-goal. Property test over random action sequences + enumerated transition-cell tests is sufficient evidence for this surface.

### ``tests/geosync_hpc/test_session_fsm.py`` (23 new)

| Axis | Count | Sample |
|------|------:|--------|
| Construction + invariants | 4 | default UNINITIALIZED; frozen; ACTIONS ⊇ table; no outgoing from terminal |
| Happy path | 2 | canonical + checkpoint branch both reach COMPLETED |
| Failure | 3 | fail admissible from every non-terminal; COMPLETED / FAILED absorb |
| Invalid transitions | 5 | unknown action; ``can`` matches ``transition``; run-before-calibrate; calibrate-before-fit; checkpoint-from-calibrated; resume-without-restore |
| Envelope serialisation | 5 | to_dict/from_dict round-trip every state; rejects missing / non-string / unknown labels; canonical lowercase |
| **Property test** | 1 | 300 Hypothesis-generated random action sequences (length 0–20) — FSM never silently produces an undeclared state |
| Surface audit | 2 | no self-loops; every state reachable from UNINITIALIZED |

## Quality

- 23 / 23 FSM tests pass in 0.41 s.
- 190 / 190 full HPC suite pass — 23 new + 167 existing. Zero regression.
- mypy --strict, ruff, black clean on both files.

## What this PR is NOT

- **Not a BacktesterCAL integration.** Wiring every public operation through ``SessionLifecycle.transition`` is a follow-up; the primitives (seal + ledger + indexed RNG + envelope + FSM) land in isolation so each can gate on its own invariant tests before the integration PR.

## Readiness delta (2026-04-23 rubric)

Determinism + Execution Rigor: + lifecycle primitive (Task 5 scope).

## Canonical sequence status

- ✅ Task 1 (Seal Runtime State) — merged `4419140`
- ✅ Task 2 (Fixed-point Ledger) — merged `556cadb`
- ✅ Task 3 (Indexed RNG) — merged `d1941a5`
- ✅ Task 4 (RuntimeState envelope) — merged `d749068`
- 🟡 **Task 5 (FSM lifecycle) — this PR**
- ⏳ Task 6 (Claim/evidence gate) — final primitive

## Test plan
- [ ] PR Gate + Main Validation green
- [ ] CodeQL, physics-invariants, physics-kernel-gate, repo-policy green

🤖 Generated with [Claude Code](https://claude.com/claude-code)