### PR TITLE
feat: four research-grade extensions (β-Kuramoto, Ricci flow, DR-FREE, sparse simplicial)

### DIFF
--- a/.claude/physics/INVARIANTS.yaml
+++ b/.claude/physics/INVARIANTS.yaml
@@ -738,3 +738,43 @@ rebus:
     test_type: unit_test
     falsification: "external safety signal leaves gate active"
     priority: P0
+
+# ═══════════════════════════════════════════════════
+# RESEARCH EXTENSIONS (opt-in, experimental, no alpha claim)
+# ═══════════════════════════════════════════════════
+
+capital_weighted_kuramoto:
+  kbeta_bounds:
+    id: INV-KBETA
+    type: universal
+    statement: "K_ij^β finite, non-negative, symmetric, zero on diagonal; β ∈ [beta_min, beta_max]; K_ij invariant under uniform multiplicative depth scaling"
+    test_type: property_test
+    falsification: "K_ij contains NaN/Inf, becomes negative, loses symmetry, has nonzero diagonal, β leaves [beta_min, beta_max], or differs after multiplying all bid/ask sizes by c>0"
+    priority: P0
+
+ricci_flow:
+  flow_surgery_safety:
+    id: INV-RC-FLOW
+    type: universal
+    statement: "Discrete Ricci flow w_ij <- w_ij - eta·kappa·w_ij followed by neckpinch surgery preserves finiteness, non-negativity, symmetry, zero diagonal; with preserve_total_edge_mass=True total mass is conserved; with preserve_connectedness=True bridge edges are clamped not removed; surgery removes at most floor(max_surgery_fraction · n_active_edges) edges"
+    test_type: property_test
+    falsification: "Post-step weights are non-finite, negative, asymmetric, have nonzero diagonal; bridge edge removed under preserve_connectedness=True; surgery removes more than the cap"
+    priority: P0
+
+robust_free_energy:
+  robust_dominates_nominal:
+    id: INV-FE-ROBUST
+    type: universal
+    statement: "F_robust(metrics, ambiguity) ≥ F_nominal(metrics) for any non-negative box ambiguity set; equality holds when all radii are zero; F_robust is monotone non-decreasing in any single radius; unknown metrics and negative radii are rejected fail-closed; the base EnergyModel state is never mutated"
+    test_type: property_test
+    falsification: "F_robust < F_nominal; nonzero ambiguity yields F_robust = F_nominal trivially; increasing a radius decreases F_robust; unknown/negative radii silently accepted; base model output changes after a DR-FREE call"
+    priority: P0
+
+higher_order_kuramoto:
+  sparse_triadic_safety:
+    id: INV-HO-SPARSE
+    type: universal
+    statement: "Sparse triadic kernel preserves R(t) ∈ [0,1] over the trajectory, reduces to pairwise dynamics when sigma2=0, agrees with the dense reference engine in triangle count on small complete graphs, is deterministic under fixed inputs, and never allocates O(N^3) auxiliary tensors when dense_debug=False"
+    test_type: property_test
+    falsification: "R outside [0,1]; sigma2=0 produces nonzero triadic RHS; sparse triangle count differs from dense; identical inputs produce different outputs; peak heap exceeds the c·n_triangles ceiling for sparse graphs"
+    priority: P0

--- a/core/kuramoto/capital_weighted.py
+++ b/core/kuramoto/capital_weighted.py
@@ -1,0 +1,396 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""Capital-weighted (β) Kuramoto coupling primitives — opt-in research module.
+
+Status
+------
+EXPERIMENTAL. Pure NumPy. No alpha claim. Every primitive in this module is a
+deterministic function of inputs; the module never registers itself with the
+default :class:`KuramotoConfig` or :class:`KuramotoEngine` paths. Callers must
+import and invoke explicitly.
+
+Background
+----------
+Following Kathiravelu's adaptive-coupling formulation for trading-flow
+crowding (SSRN), the Kuramoto coupling between two oscillators ``i`` and ``j``
+is modulated by a capital concentration ratio derived from limit-order-book
+depth (level-2). The functional form used here is
+
+.. math::
+
+    K_{ij}^{\beta}(t) = K_0 \\cdot \bigl(1 + \\gamma\\, r_{ij}(t)^{2\\delta}\bigr)^{(\beta - 1)/2}
+
+with edgewise capital ratio :math:`r_{ij} = \\sqrt{r_i r_j}` and node-level
+ratio :math:`r_i = m_i / \\mathrm{median}(m)` where :math:`m_i` is the L2 depth
+mass (mid-price weighted bid+ask volume).
+
+The shape parameter :math:`\beta` lives in ``[beta_min, beta_max]`` (the
+default ``[0.25, 4.0]`` corresponds to the SSRN sensitivity sweep).
+:math:`\beta = 1` exactly recovers the baseline coupling.
+
+Invariants
+----------
+- ``K_ij`` is finite, non-negative, symmetric, zero on the diagonal
+  (``INV-KBETA``).
+- Uniform multiplicative depth scaling is invariant: scaling all depths by
+  ``c > 0`` leaves :math:`K_{ij}^{\beta}` unchanged because the ratio
+  :math:`r_i` and the Gini-derived :math:`\beta` are scale-free.
+- Future-snapshot leakage is rejected when ``fail_on_future_l2=True``.
+
+No-alpha disclaimer
+-------------------
+This module exposes a primitive for academic experimentation. It does not
+constitute a trading signal nor a claim of out-of-sample edge. All defaults
+preserve existing engine behavior because no GeoSync entry point auto-imports
+this module.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+
+import numpy as np
+from numpy.typing import NDArray
+
+__all__ = [
+    "L2DepthSnapshot",
+    "CapitalWeightedCouplingConfig",
+    "CapitalWeightedCouplingResult",
+    "compute_l2_depth_mass",
+    "estimate_scalar_beta",
+    "compute_capital_ratio",
+    "compute_k_beta",
+    "build_capital_weighted_adjacency",
+]
+
+
+_FLOAT_FINITE_TOL: Final[float] = 1e-12
+
+
+@dataclass(frozen=True, slots=True)
+class L2DepthSnapshot:
+    """Limit-order-book level-2 snapshot for ``N`` instruments at ``L`` levels.
+
+    Parameters
+    ----------
+    timestamp_ns:
+        Snapshot epoch in nanoseconds. Used for look-ahead validation.
+    bid_sizes:
+        Shape ``(N, L)`` non-negative bid sizes.
+    ask_sizes:
+        Shape ``(N, L)`` non-negative ask sizes.
+    mid_prices:
+        Shape ``(N,)`` strictly positive mid prices.
+    """
+
+    timestamp_ns: int
+    bid_sizes: NDArray[np.float64]
+    ask_sizes: NDArray[np.float64]
+    mid_prices: NDArray[np.float64]
+
+
+@dataclass(frozen=True, slots=True)
+class CapitalWeightedCouplingConfig:
+    """Hyperparameters for capital-weighted β coupling.
+
+    All defaults are conservative and reproduce the SSRN baseline sensitivity
+    sweep. ``beta=1`` exactly recovers the input baseline coupling matrix.
+    """
+
+    K0: float = 1.0
+    gamma: float = 1.0
+    delta: float = 1.0
+    beta_min: float = 0.25
+    beta_max: float = 4.0
+    r_floor: float = 1e-12
+    normalize: bool = True
+    fail_on_future_l2: bool = True
+
+    def __post_init__(self) -> None:
+        if not np.isfinite(
+            [self.K0, self.gamma, self.delta, self.beta_min, self.beta_max, self.r_floor]
+        ).all():
+            raise ValueError("CapitalWeightedCouplingConfig fields must be finite.")
+        if self.K0 < 0.0:
+            raise ValueError("K0 must be non-negative.")
+        if self.gamma < 0.0:
+            raise ValueError("gamma must be non-negative.")
+        if self.delta <= 0.0:
+            raise ValueError("delta must be > 0.")
+        if self.beta_min <= 0.0:
+            raise ValueError("beta_min must be > 0.")
+        if self.beta_max < self.beta_min:
+            raise ValueError("beta_max must be >= beta_min.")
+        if self.r_floor <= 0.0:
+            raise ValueError("r_floor must be > 0.")
+
+
+@dataclass(frozen=True, slots=True)
+class CapitalWeightedCouplingResult:
+    """Result of :func:`build_capital_weighted_adjacency`.
+
+    Attributes
+    ----------
+    coupling:
+        ``(N, N)`` symmetric, zero-diagonal, non-negative coupling matrix.
+    beta:
+        Scalar β actually applied (clipped to ``[beta_min, beta_max]``).
+    r:
+        ``(N,)`` per-node capital ratio.
+    depth_mass:
+        ``(N,)`` non-negative depth-mass vector (zeros if fallback).
+    used_fallback:
+        ``True`` when no L2 snapshot was provided and the baseline coupling
+        was returned unchanged.
+    reason:
+        Human-readable explanation when ``used_fallback`` is ``True`` (else "").
+    """
+
+    coupling: NDArray[np.float64]
+    beta: float
+    r: NDArray[np.float64]
+    depth_mass: NDArray[np.float64]
+    used_fallback: bool
+    reason: str
+
+
+def _validate_snapshot(snapshot: L2DepthSnapshot) -> None:
+    bid = snapshot.bid_sizes
+    ask = snapshot.ask_sizes
+    mid = snapshot.mid_prices
+
+    for name, arr in (("bid_sizes", bid), ("ask_sizes", ask), ("mid_prices", mid)):
+        if not isinstance(arr, np.ndarray):
+            raise ValueError(f"{name} must be an ndarray, got {type(arr).__name__}.")
+        if arr.dtype != np.float64:
+            raise ValueError(f"{name} must be float64, got {arr.dtype}.")
+        if not np.isfinite(arr).all():
+            raise ValueError(f"{name} contains non-finite values.")
+
+    if bid.ndim != 2 or ask.ndim != 2:
+        raise ValueError("bid_sizes and ask_sizes must be rank-2 (N, L).")
+    if bid.shape != ask.shape:
+        raise ValueError("bid_sizes and ask_sizes must share shape.")
+    if mid.ndim != 1:
+        raise ValueError("mid_prices must be rank-1 (N,).")
+    if mid.shape[0] != bid.shape[0]:
+        raise ValueError("mid_prices length must match number of instruments.")
+    if (bid < 0.0).any() or (ask < 0.0).any():
+        raise ValueError("bid_sizes and ask_sizes must be non-negative.")
+    if (mid <= 0.0).any():
+        raise ValueError("mid_prices must be strictly positive.")
+
+
+def compute_l2_depth_mass(snapshot: L2DepthSnapshot) -> NDArray[np.float64]:
+    """Return per-instrument depth mass ``m_i = mid_i * Σ_l (bid_i,l + ask_i,l)``.
+
+    Output is non-negative and finite by construction.
+    """
+    _validate_snapshot(snapshot)
+    total_size = snapshot.bid_sizes.sum(axis=1) + snapshot.ask_sizes.sum(axis=1)
+    mass: NDArray[np.float64] = (snapshot.mid_prices * total_size).astype(np.float64, copy=False)
+    if not np.isfinite(mass).all():
+        raise ValueError("depth_mass overflow encountered.")
+    return mass
+
+
+def _gini(x: NDArray[np.float64]) -> float:
+    """Population Gini coefficient on a non-negative vector.
+
+    Returns 0.0 when all entries are equal or when the total mass is zero.
+    """
+    if x.size == 0:
+        return 0.0
+    if (x < 0.0).any():
+        raise ValueError("Gini input must be non-negative.")
+    total = float(x.sum())
+    if total <= 0.0:
+        return 0.0
+    sorted_x = np.sort(x)
+    n = sorted_x.size
+    weights = np.arange(1, n + 1, dtype=np.float64)
+    g = (2.0 * float((weights * sorted_x).sum()) / (n * total)) - (n + 1.0) / n
+    # bounds: Gini is mathematically in [0, 1 - 1/n] -> clamp to [0,1] for safety.
+    return float(np.clip(g, 0.0, 1.0))
+
+
+def estimate_scalar_beta(
+    depth_mass: NDArray[np.float64],
+    *,
+    beta_min: float,
+    beta_max: float,
+) -> float:
+    """Map depth-mass concentration to a bounded scalar β.
+
+    The mapping uses ``1 - Gini(depth_mass)`` as a uniformity score in
+    ``[0, 1]`` and linearly interpolates between ``beta_min`` and
+    ``beta_max`` so that:
+
+    - perfectly uniform depth (Gini=0)  → β = beta_max
+    - maximally concentrated depth     → β = beta_min
+    - empty / zero-mass input          → β = 1.0 (neutral, no effect)
+
+    Returns
+    -------
+    float in ``[beta_min, beta_max]`` (or exactly 1.0 for the neutral case).
+    """
+    if beta_min <= 0.0 or beta_max < beta_min:
+        raise ValueError("Require 0 < beta_min <= beta_max.")
+    if depth_mass.size == 0:
+        return 1.0
+    if not np.isfinite(depth_mass).all() or (depth_mass < 0.0).any():
+        raise ValueError("depth_mass must be finite and non-negative.")
+    if float(depth_mass.sum()) <= 0.0:
+        return 1.0
+    uniformity = 1.0 - _gini(depth_mass)
+    beta = beta_min + uniformity * (beta_max - beta_min)
+    # bounds: numerical safety; mathematical range already guaranteed.
+    return float(np.clip(beta, beta_min, beta_max))
+
+
+def compute_capital_ratio(
+    depth_mass: NDArray[np.float64],
+    *,
+    floor: float,
+) -> NDArray[np.float64]:
+    """Per-node capital ratio ``r_i = depth_mass_i / median(depth_mass)``.
+
+    The median is floored by ``floor`` so the ratio is finite even for
+    degenerate depth vectors. Output is non-negative.
+    """
+    if floor <= 0.0:
+        raise ValueError("floor must be > 0.")
+    if depth_mass.size == 0:
+        return np.zeros(0, dtype=np.float64)
+    if not np.isfinite(depth_mass).all() or (depth_mass < 0.0).any():
+        raise ValueError("depth_mass must be finite and non-negative.")
+    med = float(np.median(depth_mass))
+    if med < floor:
+        med = floor
+    r: NDArray[np.float64] = (depth_mass / med).astype(np.float64, copy=False)
+    if not np.isfinite(r).all():
+        raise ValueError("capital ratio became non-finite.")
+    return r
+
+
+def compute_k_beta(
+    r: NDArray[np.float64],
+    beta: float,
+    cfg: CapitalWeightedCouplingConfig,
+) -> NDArray[np.float64]:
+    """Edgewise scalar coupling envelope ``K0 * (1 + γ r^{2δ})^{(β-1)/2}``.
+
+    Operates on either a per-node vector (returns a vector) or an edgewise
+    matrix (returns a matrix); only its multiplicative form is used. ``r`` is
+    the input edgewise ratio (``r_ij`` or ``r_i``). Output is non-negative
+    and finite.
+    """
+    if not np.isfinite(beta):
+        raise ValueError("beta must be finite.")
+    if (r < 0.0).any():
+        raise ValueError("r must be non-negative.")
+    exponent = 0.5 * (beta - 1.0)
+    base = 1.0 + cfg.gamma * np.power(r, 2.0 * cfg.delta)
+    envelope: NDArray[np.float64] = (cfg.K0 * np.power(base, exponent)).astype(
+        np.float64, copy=False
+    )
+    if not np.isfinite(envelope).all():
+        raise ValueError("K_beta envelope produced non-finite values.")
+    return envelope
+
+
+def _validate_baseline_adj(adj: NDArray[np.float64]) -> None:
+    if adj.ndim != 2 or adj.shape[0] != adj.shape[1]:
+        raise ValueError("baseline_adj must be square (N, N).")
+    if not np.isfinite(adj).all():
+        raise ValueError("baseline_adj contains non-finite values.")
+    if (adj < -_FLOAT_FINITE_TOL).any():
+        raise ValueError("baseline_adj must be non-negative.")
+    if not np.allclose(adj, adj.T, atol=1e-10):
+        raise ValueError("baseline_adj must be symmetric.")
+    if not np.allclose(np.diag(adj), 0.0, atol=1e-12):
+        raise ValueError("baseline_adj must have zero diagonal.")
+
+
+def build_capital_weighted_adjacency(
+    baseline_adj: NDArray[np.float64],
+    snapshot: L2DepthSnapshot | None,
+    signal_timestamp_ns: int,
+    cfg: CapitalWeightedCouplingConfig,
+) -> CapitalWeightedCouplingResult:
+    """Construct β-modulated coupling from a baseline adjacency and L2 snapshot.
+
+    Parameters
+    ----------
+    baseline_adj:
+        ``(N, N)`` symmetric, non-negative, zero-diagonal coupling matrix.
+    snapshot:
+        L2 depth snapshot at signal time; ``None`` triggers a logged fallback
+        that returns the baseline unchanged.
+    signal_timestamp_ns:
+        Decision-time epoch in nanoseconds. Snapshot timestamps strictly
+        after this value are rejected when
+        ``cfg.fail_on_future_l2`` is true.
+    cfg:
+        :class:`CapitalWeightedCouplingConfig`.
+
+    Returns
+    -------
+    :class:`CapitalWeightedCouplingResult`.
+    """
+    _validate_baseline_adj(baseline_adj)
+    n = baseline_adj.shape[0]
+
+    if snapshot is None:
+        return CapitalWeightedCouplingResult(
+            coupling=baseline_adj.astype(np.float64, copy=True),
+            beta=1.0,
+            r=np.ones(n, dtype=np.float64),
+            depth_mass=np.zeros(n, dtype=np.float64),
+            used_fallback=True,
+            reason="no_l2_snapshot",
+        )
+
+    if cfg.fail_on_future_l2 and snapshot.timestamp_ns > signal_timestamp_ns:
+        raise ValueError(
+            "L2 snapshot timestamp_ns is after signal_timestamp_ns; look-ahead leakage rejected."
+        )
+
+    if snapshot.bid_sizes.shape[0] != n:
+        raise ValueError(
+            f"snapshot has {snapshot.bid_sizes.shape[0]} instruments but "
+            f"baseline adjacency is {n}x{n}."
+        )
+
+    depth_mass = compute_l2_depth_mass(snapshot)
+    r_node = compute_capital_ratio(depth_mass, floor=cfg.r_floor)
+    beta = estimate_scalar_beta(depth_mass, beta_min=cfg.beta_min, beta_max=cfg.beta_max)
+
+    # Edgewise ratio r_ij = sqrt(r_i * r_j); zero diagonal preserved.
+    r_outer = np.sqrt(np.outer(r_node, r_node))
+    envelope = compute_k_beta(r_outer, beta, cfg)
+    coupling: NDArray[np.float64] = (baseline_adj * envelope).astype(np.float64, copy=False)
+    np.fill_diagonal(coupling, 0.0)
+    coupling = 0.5 * (coupling + coupling.T)  # enforce exact symmetry
+
+    if cfg.normalize and float(baseline_adj.sum()) > 0.0:
+        scale = float(baseline_adj.sum()) / max(float(coupling.sum()), _FLOAT_FINITE_TOL)
+        coupling = coupling * scale
+        np.fill_diagonal(coupling, 0.0)
+
+    if not np.isfinite(coupling).all():
+        raise ValueError("capital-weighted coupling contains non-finite values.")
+    if (coupling < -_FLOAT_FINITE_TOL).any():
+        raise ValueError("capital-weighted coupling must be non-negative.")
+    if not np.allclose(coupling, coupling.T, atol=1e-10):
+        raise ValueError("capital-weighted coupling lost symmetry.")
+
+    return CapitalWeightedCouplingResult(
+        coupling=coupling,
+        beta=beta,
+        r=r_node,
+        depth_mass=depth_mass,
+        used_fallback=False,
+        reason="",
+    )

--- a/core/kuramoto/ricci_flow.py
+++ b/core/kuramoto/ricci_flow.py
@@ -1,0 +1,416 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+r"""Discrete Ricci flow on a weighted edge graph + neckpinch surgery.
+
+Status
+------
+EXPERIMENTAL. Pure NumPy + ``networkx`` for bridge detection. Opt-in. The
+existing :class:`KuramotoRicciFlowEngine` retains byte-identical behavior
+unless the explicit constructor flags ``enable_discrete_flow`` and/or
+``enable_neckpinch_surgery`` are set.
+
+Mathematical core
+-----------------
+We follow the discrete Ricci flow on edge weights of an undirected
+weighted graph (after Hamilton 1982 / Chow & Luo 2003 / Ni et al. 2019,
+arXiv:2510.15942 for the financial-network application):
+
+.. math::
+
+    w_{ij}^{(n+1)} = w_{ij}^{(n)} - \eta \kappa_{ij}^{(n)} \, w_{ij}^{(n)}
+
+After the flow step we optionally perform **neckpinch surgery**: edges
+whose weights have collapsed below ``eps_weight`` or whose curvature
+falls in the singular tail (``κ ≤ -1 + eps_neck`` for Ollivier-Ricci, or
+the most-negative ``max_surgery_fraction`` of edges otherwise) are
+removed — unless they are bridges and ``preserve_connectedness=True``,
+in which case they are clamped to ``eps_weight`` instead.
+
+Invariants
+----------
+- ``w_{ij}`` is finite, non-negative, symmetric, zero on the diagonal
+  (``INV-RC-FLOW``).
+- Surgery never disconnects the graph when ``preserve_connectedness=True``.
+- Surgery removes at most ``max_surgery_fraction`` of remaining edges per
+  step.
+- Optional total-edge-mass preservation: the post-flow weight matrix is
+  rescaled so that its sum equals the pre-flow sum (when
+  ``preserve_total_edge_mass=True``).
+
+No-alpha disclaimer
+-------------------
+This module is an experimental geometric primitive. No claim of trading
+edge or out-of-sample performance is made.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Final, Literal
+
+import networkx as nx
+import numpy as np
+from numpy.typing import NDArray
+
+__all__ = [
+    "RicciFlowConfig",
+    "NeckpinchEvent",
+    "RicciFlowStepResult",
+    "discrete_ricci_flow_step",
+    "detect_neckpinch_candidates",
+    "apply_neckpinch_surgery",
+    "ricci_flow_with_surgery",
+]
+
+
+_FLOAT_TOL: Final[float] = 1e-12
+
+NeckpinchAction = Literal["removed", "clamped", "skipped_bridge"]
+
+
+@dataclass(frozen=True, slots=True)
+class RicciFlowConfig:
+    """Hyperparameters for one Ricci-flow + surgery step.
+
+    Attributes
+    ----------
+    eta:
+        Flow step size in ``(0, 1)``. Default 0.05.
+    eps_weight:
+        Lower clamp / removal threshold for edge weights. Default 1e-8.
+    eps_neck:
+        Curvature tolerance defining the Ollivier-Ricci neckpinch tail
+        ``κ ≤ -1 + eps_neck``. Default 1e-3.
+    preserve_total_edge_mass:
+        When True, rescale the post-flow matrix to keep ``Σ w_{ij}``
+        equal to the pre-flow value.
+    preserve_connectedness:
+        When True, bridge edges are clamped (not removed) so that the
+        graph stays connected.
+    allow_disconnect:
+        Reserved escape hatch — must be False unless the caller
+        explicitly opts into disconnection.
+    max_surgery_fraction:
+        Upper bound on the fraction of currently active edges removed
+        per single surgery call. Default 0.05 (5 %).
+    """
+
+    eta: float = 0.05
+    eps_weight: float = 1e-8
+    eps_neck: float = 1e-3
+    preserve_total_edge_mass: bool = True
+    preserve_connectedness: bool = True
+    allow_disconnect: bool = False
+    max_surgery_fraction: float = 0.05
+
+    def __post_init__(self) -> None:
+        if not (0.0 < self.eta < 1.0):
+            raise ValueError("eta must be in (0, 1).")
+        if self.eps_weight <= 0.0:
+            raise ValueError("eps_weight must be > 0.")
+        if not (0.0 < self.eps_neck < 1.0):
+            raise ValueError("eps_neck must be in (0, 1).")
+        if not (0.0 <= self.max_surgery_fraction <= 1.0):
+            raise ValueError("max_surgery_fraction must be in [0, 1].")
+        if self.allow_disconnect and self.preserve_connectedness:
+            raise ValueError(
+                "allow_disconnect=True is incompatible with preserve_connectedness=True."
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class NeckpinchEvent:
+    """One surgery decision for a single edge."""
+
+    edge: tuple[int, int]
+    old_weight: float
+    new_weight: float
+    curvature: float
+    action: NeckpinchAction
+
+
+@dataclass(frozen=True, slots=True)
+class RicciFlowStepResult:
+    """Result of a single Ricci flow + surgery step."""
+
+    weights_before: NDArray[np.float64]
+    weights_after: NDArray[np.float64]
+    curvature: dict[tuple[int, int], float]
+    surgery_events: tuple[NeckpinchEvent, ...]
+    total_edge_mass_before: float
+    total_edge_mass_after: float
+    surgery_event_count: int = field(init=False)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "surgery_event_count", len(self.surgery_events))
+
+    @property
+    def neckpinch_edges(self) -> tuple[tuple[int, int], ...]:
+        """Edges that participated in any surgery event."""
+        return tuple(e.edge for e in self.surgery_events)
+
+
+# ── Validation helpers ─────────────────────────────────────────────────────
+
+
+def _validate_weights(weights: NDArray[np.float64]) -> None:
+    if weights.ndim != 2 or weights.shape[0] != weights.shape[1]:
+        raise ValueError("weights must be a square matrix.")
+    if not np.isfinite(weights).all():
+        raise ValueError("weights contain non-finite values.")
+    if (weights < -_FLOAT_TOL).any():
+        raise ValueError("weights must be non-negative.")
+    if not np.allclose(weights, weights.T, atol=1e-10):
+        raise ValueError("weights must be symmetric.")
+    if not np.allclose(np.diag(weights), 0.0, atol=1e-12):
+        raise ValueError("weights must have zero diagonal.")
+
+
+def _curvature_to_dense(curvature: dict[tuple[int, int], float], n: int) -> NDArray[np.float64]:
+    """Symmetrise a curvature dict into a dense ``(n, n)`` matrix.
+
+    Missing edges receive curvature 0 (curvature only matters where weights
+    are non-zero).
+    """
+    K = np.zeros((n, n), dtype=np.float64)
+    for (i, j), kappa in curvature.items():
+        if not np.isfinite(kappa):
+            raise ValueError(f"non-finite curvature at edge ({i},{j}).")
+        if i == j:
+            continue
+        K[i, j] = float(kappa)
+        K[j, i] = float(kappa)
+    return K
+
+
+# ── Flow ───────────────────────────────────────────────────────────────────
+
+
+def discrete_ricci_flow_step(
+    weights: NDArray[np.float64],
+    curvature: dict[tuple[int, int], float],
+    cfg: RicciFlowConfig,
+) -> NDArray[np.float64]:
+    """Single explicit-Euler discrete Ricci flow step.
+
+    .. math::
+
+        w_{ij}^{n+1} = \\max\bigl(0,\\ w_{ij}^{n} - \\eta\\,\\kappa_{ij}\\,w_{ij}^{n}\bigr)
+
+    Optionally rescales to preserve ``Σ w_{ij}`` when
+    ``cfg.preserve_total_edge_mass`` is True. Diagonal is zeroed and the
+    matrix is re-symmetrised.
+    """
+    _validate_weights(weights)
+    n = weights.shape[0]
+    K = _curvature_to_dense(curvature, n)
+
+    new_w = weights - cfg.eta * K * weights
+    new_w = np.maximum(new_w, 0.0)  # INV-RC-FLOW: weights non-negative.
+    new_w = 0.5 * (new_w + new_w.T)  # exact symmetrisation
+    np.fill_diagonal(new_w, 0.0)
+
+    if cfg.preserve_total_edge_mass:
+        total_before = float(weights.sum())
+        total_after = float(new_w.sum())
+        if total_after > _FLOAT_TOL and total_before > _FLOAT_TOL:
+            new_w = new_w * (total_before / total_after)
+            np.fill_diagonal(new_w, 0.0)
+
+    if not np.isfinite(new_w).all():
+        raise ValueError("Ricci flow step produced non-finite weights.")
+    return new_w.astype(np.float64, copy=False)
+
+
+# ── Neckpinch detection ────────────────────────────────────────────────────
+
+
+def detect_neckpinch_candidates(
+    weights: NDArray[np.float64],
+    curvature: dict[tuple[int, int], float],
+    cfg: RicciFlowConfig,
+) -> list[tuple[int, int]]:
+    """Return candidate neckpinch edges in deterministic lexicographic order.
+
+    A directed edge ``(i, j)`` with ``i < j`` is a candidate if either:
+
+    1. its weight is at or below ``cfg.eps_weight``, **and** the edge
+       currently exists (weight > 0), or
+    2. its Ollivier-Ricci curvature is in the singular tail
+       ``κ ≤ -1 + eps_neck``.
+
+    The candidate list is sorted lexicographically by ``(i, j)``.
+    """
+    _validate_weights(weights)
+    n = weights.shape[0]
+    candidates: set[tuple[int, int]] = set()
+
+    iu, ju = np.triu_indices(n, k=1)
+    weight_pairs = zip(iu.tolist(), ju.tolist(), weights[iu, ju].tolist(), strict=True)
+    for i, j, w in weight_pairs:
+        if 0.0 < w <= cfg.eps_weight:
+            candidates.add((i, j))
+
+    for (i, j), kappa in curvature.items():
+        if i >= j:
+            continue
+        if not np.isfinite(kappa):
+            continue
+        if weights[i, j] <= 0.0:
+            continue
+        if kappa <= -1.0 + cfg.eps_neck:
+            candidates.add((int(i), int(j)))
+
+    return sorted(candidates)
+
+
+# ── Surgery ────────────────────────────────────────────────────────────────
+
+
+def _is_bridge(graph: nx.Graph, edge: tuple[int, int]) -> bool:
+    if not graph.has_edge(*edge):
+        return False
+    return edge in set(nx.bridges(graph)) or (edge[1], edge[0]) in set(nx.bridges(graph))
+
+
+def apply_neckpinch_surgery(
+    weights: NDArray[np.float64],
+    curvature: dict[tuple[int, int], float],
+    cfg: RicciFlowConfig,
+) -> tuple[NDArray[np.float64], tuple[NeckpinchEvent, ...]]:
+    """Apply neckpinch surgery; return (new_weights, ordered events).
+
+    The number of edges removed is capped at
+    ``floor(max_surgery_fraction * n_active_edges)``; remaining
+    candidates are clamped to ``cfg.eps_weight`` (``"clamped"``) or
+    skipped (``"skipped_bridge"``).
+    """
+    _validate_weights(weights)
+    new_w = weights.astype(np.float64, copy=True)
+    n = new_w.shape[0]
+
+    iu, ju = np.triu_indices(n, k=1)
+    active_edges = [
+        (int(i), int(j))
+        for i, j, w in zip(iu.tolist(), ju.tolist(), new_w[iu, ju].tolist(), strict=True)
+        if w > 0.0
+    ]
+    n_active = len(active_edges)
+    max_remove = int(np.floor(cfg.max_surgery_fraction * n_active))
+
+    candidates = detect_neckpinch_candidates(new_w, curvature, cfg)
+
+    graph = nx.Graph()
+    graph.add_nodes_from(range(n))
+    for i, j in active_edges:
+        graph.add_edge(i, j, weight=float(new_w[i, j]))
+
+    events: list[NeckpinchEvent] = []
+    removed_count = 0
+
+    for edge in candidates:
+        i, j = edge
+        old = float(new_w[i, j])
+        kappa = float(curvature.get(edge, curvature.get((j, i), 0.0)))
+
+        is_bridge = cfg.preserve_connectedness and _is_bridge(graph, edge)
+
+        if is_bridge:
+            new_val = max(cfg.eps_weight, _FLOAT_TOL)
+            new_w[i, j] = new_val
+            new_w[j, i] = new_val
+            graph[i][j]["weight"] = new_val
+            events.append(
+                NeckpinchEvent(
+                    edge=edge,
+                    old_weight=old,
+                    new_weight=new_val,
+                    curvature=kappa,
+                    action="skipped_bridge",
+                )
+            )
+            continue
+
+        if removed_count < max_remove:
+            new_w[i, j] = 0.0
+            new_w[j, i] = 0.0
+            if graph.has_edge(i, j):
+                graph.remove_edge(i, j)
+            events.append(
+                NeckpinchEvent(
+                    edge=edge,
+                    old_weight=old,
+                    new_weight=0.0,
+                    curvature=kappa,
+                    action="removed",
+                )
+            )
+            removed_count += 1
+        else:
+            new_w[i, j] = cfg.eps_weight
+            new_w[j, i] = cfg.eps_weight
+            if graph.has_edge(i, j):
+                graph[i][j]["weight"] = cfg.eps_weight
+            events.append(
+                NeckpinchEvent(
+                    edge=edge,
+                    old_weight=old,
+                    new_weight=cfg.eps_weight,
+                    curvature=kappa,
+                    action="clamped",
+                )
+            )
+
+    np.fill_diagonal(new_w, 0.0)
+    new_w = 0.5 * (new_w + new_w.T)
+
+    if cfg.preserve_connectedness and not cfg.allow_disconnect and n_active > 0:
+        check_graph = nx.Graph()
+        check_graph.add_nodes_from(range(n))
+        for i, j in zip(iu.tolist(), ju.tolist(), strict=True):
+            if new_w[i, j] > 0.0:
+                check_graph.add_edge(int(i), int(j))
+        # Connectedness over nodes that had at least one active edge before.
+        active_nodes = {a for edge in active_edges for a in edge}
+        if active_nodes:
+            sub = check_graph.subgraph(active_nodes)
+            if not nx.is_connected(sub):
+                raise RuntimeError(
+                    "Surgery disconnected the active subgraph despite preserve_connectedness=True."
+                )
+
+    return new_w.astype(np.float64, copy=False), tuple(events)
+
+
+# ── Combined step ──────────────────────────────────────────────────────────
+
+
+def ricci_flow_with_surgery(
+    weights: NDArray[np.float64],
+    curvature: dict[tuple[int, int], float],
+    cfg: RicciFlowConfig,
+) -> RicciFlowStepResult:
+    """Run one flow step then surgery; return a typed result bundle."""
+    _validate_weights(weights)
+    weights_before = weights.astype(np.float64, copy=True)
+
+    flowed = discrete_ricci_flow_step(weights_before, curvature, cfg)
+    after, events = apply_neckpinch_surgery(flowed, curvature, cfg)
+
+    if not np.isfinite(after).all():
+        raise ValueError("Ricci flow + surgery produced non-finite weights.")
+    if (after < -_FLOAT_TOL).any():
+        raise ValueError("Ricci flow + surgery produced negative weights.")
+    if not np.allclose(after, after.T, atol=1e-10):
+        raise ValueError("Ricci flow + surgery lost symmetry.")
+    if not np.allclose(np.diag(after), 0.0, atol=1e-12):
+        raise ValueError("Ricci flow + surgery introduced self-loops.")
+
+    return RicciFlowStepResult(
+        weights_before=weights_before,
+        weights_after=after,
+        curvature=dict(curvature),
+        surgery_events=events,
+        total_edge_mass_before=float(weights_before.sum()),
+        total_edge_mass_after=float(after.sum()),
+    )

--- a/core/kuramoto/ricci_flow_engine.py
+++ b/core/kuramoto/ricci_flow_engine.py
@@ -47,6 +47,11 @@ from numpy.typing import NDArray
 
 from .config import KuramotoConfig
 from .engine import KuramotoResult, _order_parameter, _rk4_step
+from .ricci_flow import (
+    NeckpinchEvent,
+    RicciFlowConfig,
+    ricci_flow_with_surgery,
+)
 
 try:  # optional in minimal environments
     from ..indicators.temporal_ricci import LightGraph, OllivierRicciCurvatureLite
@@ -64,9 +69,7 @@ class _LocalOllivierRicciCurvatureLite:
     """
 
     def __init__(self, alpha: float = 0.5) -> None:
-        self.alpha = float(
-            np.clip(alpha, 0.0, 1.0)
-        )  # INV-RC1: Ricci flow step-size alpha ∈ [0,1]
+        self.alpha = float(np.clip(alpha, 0.0, 1.0))  # INV-RC1: Ricci flow step-size alpha ∈ [0,1]
 
     def _lazy_rw(self, graph: Any, node: int) -> dict[int, float]:
         neighbors = list(graph.neighbors(node))
@@ -84,16 +87,36 @@ class _LocalOllivierRicciCurvatureLite:
         mu_x = self._lazy_rw(graph, x)
         mu_y = self._lazy_rw(graph, y)
         keys = set(mu_x) | set(mu_y)
-        total_variation = 0.5 * sum(
-            abs(mu_x.get(k, 0.0) - mu_y.get(k, 0.0)) for k in keys
-        )
+        total_variation = 0.5 * sum(abs(mu_x.get(k, 0.0) - mu_y.get(k, 0.0)) for k in keys)
         d_xy = 1.0 if y in graph.neighbors(x) else float("inf")
         if d_xy <= 0.0 or not np.isfinite(d_xy):
             return 0.0
         return float(1.0 - total_variation / d_xy)
 
 
-__all__ = ["KuramotoRicciFlowEngine", "KuramotoRicciFlowResult"]
+__all__ = [
+    "KuramotoRicciFlowEngine",
+    "KuramotoRicciFlowResult",
+    "KuramotoRicciFlowSurgeryDiagnostics",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class KuramotoRicciFlowSurgeryDiagnostics:
+    """Auxiliary diagnostics emitted when discrete flow + surgery is enabled.
+
+    Returned alongside :class:`KuramotoRicciFlowResult` via
+    :meth:`KuramotoRicciFlowEngine.run_with_surgery`. The default
+    :meth:`KuramotoRicciFlowEngine.run` path does not produce this object,
+    preserving backward compatibility.
+    """
+
+    surgery_event_count: int
+    neckpinch_edges: tuple[tuple[int, int], ...]
+    events: tuple[NeckpinchEvent, ...]
+    total_edge_mass_before: tuple[float, ...]
+    total_edge_mass_after: tuple[float, ...]
+
 
 _logger = logging.getLogger(__name__)
 
@@ -142,9 +165,7 @@ class _SimpleUndirectedGraph:
     def nodes(self) -> tuple[int, ...]:
         return tuple(self._adj.keys())
 
-    def shortest_path_length(
-        self, source: int, target: int, weight: str | None = None
-    ) -> float:
+    def shortest_path_length(self, source: int, target: int, weight: str | None = None) -> float:
         if source == target:
             return 0.0
         use_weight = weight is not None
@@ -210,9 +231,7 @@ class KuramotoRicciFlowResult(KuramotoResult):
         ):
             raise ValueError("coupling_matrix_history has invalid matrix shape.")
         if self.mean_curvature_trajectory.shape != (n_updates,):
-            raise ValueError(
-                "mean_curvature_trajectory length must match curvature updates."
-            )
+            raise ValueError("mean_curvature_trajectory length must match curvature updates.")
         for arr_name, arr in (
             ("herding_index", self.herding_index),
             ("fragility_index", self.fragility_index),
@@ -241,6 +260,9 @@ class KuramotoRicciFlowEngine:
         graph_threshold: float = 0.2,
         damping: float = 0.3,
         coupling_history_enabled: bool = True,
+        enable_discrete_flow: bool = False,
+        enable_neckpinch_surgery: bool = False,
+        ricci_flow_config: RicciFlowConfig | None = None,
     ) -> None:
         self._cfg = config
         self._omega, self._theta0 = self._resolve_initial_conditions(config)
@@ -254,10 +276,17 @@ class KuramotoRicciFlowEngine:
         self.graph_threshold = float(
             np.clip(graph_threshold, 0.0, 1.0)
         )  # bounds: graph threshold normalized to [0,1]
-        self.damping = float(
-            np.clip(damping, 0.0, 1.0)
-        )  # bounds: damping coefficient ∈ [0,1]
+        self.damping = float(np.clip(damping, 0.0, 1.0))  # bounds: damping coefficient ∈ [0,1]
         self.coupling_history_enabled = bool(coupling_history_enabled)
+        # Opt-in research extension flags. Defaults preserve byte-identical behavior.
+        self.enable_discrete_flow = bool(enable_discrete_flow)
+        self.enable_neckpinch_surgery = bool(enable_neckpinch_surgery)
+        self._ricci_flow_config: RicciFlowConfig = (
+            ricci_flow_config if ricci_flow_config is not None else RicciFlowConfig()
+        )
+        self._surgery_events_buffer: list[NeckpinchEvent] = []
+        self._surgery_mass_before: list[float] = []
+        self._surgery_mass_after: list[float] = []
         if OllivierRicciCurvatureLite is not None:
             self._lite_ricci: Any = OllivierRicciCurvatureLite(alpha=0.5)
         else:
@@ -310,9 +339,7 @@ class KuramotoRicciFlowEngine:
 
                 mk = float(np.mean(kappa_vec)) if kappa_vec.size else 0.0
                 mean_kappa.append(mk)
-                herding.append(
-                    float(np.mean(kappa_vec > 0.0)) if kappa_vec.size else 0.0
-                )
+                herding.append(float(np.mean(kappa_vec > 0.0)) if kappa_vec.size else 0.0)
                 fragility.append(float(-mk))
                 if len(mean_kappa) < 2:
                     momentum.append(0.0)
@@ -320,16 +347,12 @@ class KuramotoRicciFlowEngine:
                     delta_steps = max(
                         1, timestamps[-1] - timestamps[-2]
                     )  # bounds: minimum 1 step between timestamps
-                    momentum.append(
-                        float((mean_kappa[-1] - mean_kappa[-2]) / delta_steps)
-                    )
+                    momentum.append(float((mean_kappa[-1] - mean_kappa[-2]) / delta_steps))
                 entropy.append(self._coupling_entropy(coupling))
 
             theta = _rk4_step(theta, self._omega, coupling, dt)
             if not np.isfinite(theta).all():
-                raise FloatingPointError(
-                    f"Non-finite phase values encountered at step={k + 1}."
-                )
+                raise FloatingPointError(f"Non-finite phase values encountered at step={k + 1}.")
             phases[k + 1] = theta
             order[k + 1] = _order_parameter(theta)
             if not (0.0 <= order[k + 1] <= 1.0):
@@ -382,15 +405,79 @@ class KuramotoRicciFlowEngine:
                 target[i, j] = kij
                 target[j, i] = kij
             coupling = self.damping * prev_coupling + (1.0 - self.damping) * target
+            if self.enable_discrete_flow or self.enable_neckpinch_surgery:
+                coupling = self._apply_flow_surgery(coupling, edges, edge_curvatures)
             self._validate_coupling(coupling)
             return coupling, curvatures
         except Exception as exc:
-            _logger.warning(
-                "Ricci computation failed; falling back to baseline coupling: %s", exc
-            )
+            _logger.warning("Ricci computation failed; falling back to baseline coupling: %s", exc)
             fallback = self._baseline_coupling(n)
             self._validate_coupling(fallback)
             return fallback, np.zeros(0, dtype=np.float64)
+
+    def _apply_flow_surgery(
+        self,
+        coupling: NDArray[np.float64],
+        edges: list[tuple[int, int]],
+        edge_curvatures: dict[tuple[int, int], float],
+    ) -> NDArray[np.float64]:
+        """Run one discrete Ricci flow + surgery step on the coupling matrix.
+
+        Records diagnostics on the engine for later retrieval via
+        :meth:`run_with_surgery`. Caps the post-surgery coupling at
+        ``self._K_max`` and re-symmetrises so that
+        :meth:`_validate_coupling` continues to hold.
+        """
+        # Build a curvature dict keyed only on active edges.
+        curvature: dict[tuple[int, int], float] = {
+            (int(i), int(j)): float(edge_curvatures[(i, j)]) for (i, j) in edges
+        }
+        result = ricci_flow_with_surgery(
+            coupling.astype(np.float64, copy=True),
+            curvature,
+            self._ricci_flow_config,
+        )
+        new_coupling = result.weights_after
+        # Re-clip to the K_max envelope to satisfy _validate_coupling (the flow can
+        # only shrink active weights, but rescaling for total-edge-mass preservation
+        # may push them up; clipping is therefore conservative).
+        # INV-RC-FLOW: post-surgery coupling stays in [0, K_max].
+        np.clip(new_coupling, 0.0, self._K_max, out=new_coupling)
+        np.fill_diagonal(new_coupling, 0.0)
+        new_coupling = 0.5 * (new_coupling + new_coupling.T)
+        if self.enable_neckpinch_surgery:
+            self._surgery_events_buffer.extend(result.surgery_events)
+            self._surgery_mass_before.append(result.total_edge_mass_before)
+            self._surgery_mass_after.append(result.total_edge_mass_after)
+        return new_coupling.astype(np.float64, copy=False)
+
+    def run_with_surgery(
+        self,
+    ) -> tuple[KuramotoRicciFlowResult, KuramotoRicciFlowSurgeryDiagnostics]:
+        """Run the engine and return both the standard result and surgery diagnostics.
+
+        Requires ``enable_discrete_flow=True`` or ``enable_neckpinch_surgery=True``
+        in the constructor; otherwise raises :class:`RuntimeError` because the
+        diagnostics object would be empty by construction.
+        """
+        if not (self.enable_discrete_flow or self.enable_neckpinch_surgery):
+            raise RuntimeError(
+                "run_with_surgery requires enable_discrete_flow or "
+                "enable_neckpinch_surgery to be True."
+            )
+        # Reset diagnostic buffers for a fresh run.
+        self._surgery_events_buffer = []
+        self._surgery_mass_before = []
+        self._surgery_mass_after = []
+        result = self.run()
+        diagnostics = KuramotoRicciFlowSurgeryDiagnostics(
+            surgery_event_count=len(self._surgery_events_buffer),
+            neckpinch_edges=tuple(e.edge for e in self._surgery_events_buffer),
+            events=tuple(self._surgery_events_buffer),
+            total_edge_mass_before=tuple(self._surgery_mass_before),
+            total_edge_mass_after=tuple(self._surgery_mass_after),
+        )
+        return result, diagnostics
 
     def _compute_edge_curvature_map(
         self,
@@ -404,17 +491,14 @@ class KuramotoRicciFlowEngine:
         if method == "forman":
             lite = self._to_light_graph(graph)
             return {
-                edge: float(self._lite_ricci.compute_edge_curvature(lite, edge))
-                for edge in edges
+                edge: float(self._lite_ricci.compute_edge_curvature(lite, edge)) for edge in edges
             }
 
         try:
             from ..indicators.ricci import RicciCurvature  # type: ignore[attr-defined]
 
             rc = RicciCurvature()
-            return {
-                edge: float(rc.compute_edge_curvature(graph, edge)) for edge in edges
-            }
+            return {edge: float(rc.compute_edge_curvature(graph, edge)) for edge in edges}
         except Exception:
             try:
                 from ..indicators.ricci import (
@@ -425,9 +509,7 @@ class KuramotoRicciFlowEngine:
                 distributions = compute_node_distributions(graph)
                 return {
                     edge: float(
-                        ricci_curvature_edge(
-                            graph, edge[0], edge[1], distributions=distributions
-                        )
+                        ricci_curvature_edge(graph, edge[0], edge[1], distributions=distributions)
                     )
                     for edge in edges
                 }
@@ -476,9 +558,7 @@ class KuramotoRicciFlowEngine:
     def _phi(self, kappa: float) -> float:
         return float(self.sigma * (1.0 + np.tanh(self.alpha * kappa)) / 2.0)
 
-    def _correlation_matrix(
-        self, buffer: list[NDArray[np.float64]], n: int
-    ) -> NDArray[np.float64]:
+    def _correlation_matrix(self, buffer: list[NDArray[np.float64]], n: int) -> NDArray[np.float64]:
         if len(buffer) < 2:
             return np.eye(n, dtype=np.float64)
         mat = np.vstack(buffer)
@@ -493,7 +573,8 @@ class KuramotoRicciFlowEngine:
                 f"Correlation shape invariant violated: expected {(n, n)} got {corr.shape}"
             )
         np.fill_diagonal(corr, 1.0)
-        return corr
+        out: NDArray[np.float64] = corr.astype(np.float64, copy=False)
+        return out
 
     def _build_correlation_graph(
         self, corr: NDArray[np.float64]
@@ -514,9 +595,7 @@ class KuramotoRicciFlowEngine:
         if not np.isfinite(coupling).all():
             raise ValueError("K_ij invariant violated: non-finite coupling values.")
         if not np.allclose(coupling, coupling.T, atol=1e-12):
-            raise ValueError(
-                "K_ij invariant violated: coupling matrix must be symmetric."
-            )
+            raise ValueError("K_ij invariant violated: coupling matrix must be symmetric.")
         if not np.allclose(np.diag(coupling), 0.0, atol=1e-12):
             raise ValueError("K_ii invariant violated: self-coupling must remain zero.")
         if np.any(coupling < -1e-12) or np.any(coupling > self._K_max + 1e-12):
@@ -535,9 +614,7 @@ class KuramotoRicciFlowEngine:
         return float(-np.sum(p * np.log(p + 1e-16)))
 
     @staticmethod
-    def _detect_transitions(
-        mean_kappa: list[float], timestamps: list[int]
-    ) -> list[int]:
+    def _detect_transitions(mean_kappa: list[float], timestamps: list[int]) -> list[int]:
         if len(mean_kappa) < 3:
             return []
         arr = np.asarray(mean_kappa, dtype=np.float64)
@@ -545,11 +622,7 @@ class KuramotoRicciFlowEngine:
         signs = np.sign(diff)
         out: list[int] = []
         for idx in range(1, len(signs)):
-            if (
-                signs[idx] != 0.0
-                and signs[idx - 1] != 0.0
-                and signs[idx] != signs[idx - 1]
-            ):
+            if signs[idx] != 0.0 and signs[idx - 1] != 0.0 and signs[idx] != signs[idx - 1]:
                 out.append(int(timestamps[idx]))
         return out
 

--- a/core/physics/higher_order_kuramoto.py
+++ b/core/physics/higher_order_kuramoto.py
@@ -258,9 +258,7 @@ class HigherOrderKuramotoEngine:
     def _order_parameter(theta: NDArray[np.float64]) -> float:
         """R = |mean(exp(iθ))|."""
         z = np.exp(1j * theta).mean()
-        return float(
-            np.clip(np.abs(z), 0.0, 1.0)
-        )  # INV-K1: R = |mean(exp(iθ))| ∈ [0,1]
+        return float(np.clip(np.abs(z), 0.0, 1.0))  # INV-K1: R = |mean(exp(iθ))| ∈ [0,1]
 
     def run_from_prices(
         self,
@@ -275,9 +273,7 @@ class HigherOrderKuramotoEngine:
 
         with np.errstate(invalid="ignore"):
             corr = np.corrcoef(tail, rowvar=False)
-        corr_arr: NDArray[np.float64] = np.asarray(
-            np.nan_to_num(corr, nan=0.0), dtype=np.float64
-        )
+        corr_arr: NDArray[np.float64] = np.asarray(np.nan_to_num(corr, nan=0.0), dtype=np.float64)
 
         return self.run(corr_arr, seed=seed)
 
@@ -287,4 +283,284 @@ __all__ = [
     "HigherOrderKuramotoResult",
     "find_triangles",
     "build_triangle_index",
+    "SparseTriangleIndex",
+    "HigherOrderSparseConfig",
+    "build_sparse_triangle_index",
+    "validate_sparse_triangle_index",
+    "triadic_rhs_sparse",
+    "run_sparse_higher_order",
 ]
+
+
+# ── Sparse simplicial higher-order Kuramoto (opt-in, additive) ────────────
+
+
+@dataclass(frozen=True, slots=True)
+class SparseTriangleIndex:
+    """Compressed triangle list for the 2-simplex skeleton.
+
+    All three index arrays share length ``T`` (number of triangles).
+    Each row ``(i[t], j[t], k[t])`` satisfies ``i < j < k`` and the index
+    is sorted lexicographically with no duplicates.
+
+    Attributes
+    ----------
+    i, j, k:
+        ``int64`` arrays of triangle vertex indices.
+    n_nodes:
+        Total number of nodes in the underlying graph.
+    """
+
+    i: NDArray[np.int64]
+    j: NDArray[np.int64]
+    k: NDArray[np.int64]
+    n_nodes: int
+
+    def __post_init__(self) -> None:
+        if not (self.i.shape == self.j.shape == self.k.shape):
+            raise ValueError("SparseTriangleIndex i/j/k must share shape.")
+        if self.i.ndim != 1:
+            raise ValueError("SparseTriangleIndex arrays must be 1D.")
+        if self.n_nodes <= 0:
+            raise ValueError("n_nodes must be > 0.")
+
+    @property
+    def n_triangles(self) -> int:
+        return int(self.i.size)
+
+
+@dataclass(frozen=True, slots=True)
+class HigherOrderSparseConfig:
+    """Hyperparameters for the sparse triadic kernel.
+
+    Attributes
+    ----------
+    sigma1:
+        Pairwise coupling strength.
+    sigma2:
+        Triadic coupling strength.
+    max_triangles:
+        Hard upper bound on triangle count; exceeding this triggers
+        :class:`ValueError`. ``None`` disables the cap.
+    dense_debug:
+        When True, the build path may allocate auxiliary ``O(N^2)``
+        tensors for cross-validation against
+        :class:`HigherOrderKuramotoEngine`. False forbids any allocation
+        whose size would exceed ``c * n_triangles`` (see
+        :func:`triadic_rhs_sparse`).
+    """
+
+    sigma1: float = 1.0
+    sigma2: float = 0.5
+    max_triangles: int | None = None
+    dense_debug: bool = False
+
+    def __post_init__(self) -> None:
+        if not np.isfinite([self.sigma1, self.sigma2]).all():
+            raise ValueError("sigma1/sigma2 must be finite.")
+        if self.max_triangles is not None and self.max_triangles < 0:
+            raise ValueError("max_triangles must be >= 0 or None.")
+
+
+def validate_sparse_triangle_index(index: SparseTriangleIndex) -> None:
+    """Verify ``i<j<k``, in-bounds, deduped, lex-sorted.
+
+    Raises :class:`ValueError` on any violation.
+    """
+    if index.i.dtype != np.int64 or index.j.dtype != np.int64 or index.k.dtype != np.int64:
+        raise ValueError("SparseTriangleIndex arrays must be int64.")
+    if index.n_triangles == 0:
+        return
+    if (index.i < 0).any() or (index.k >= index.n_nodes).any():
+        raise ValueError("SparseTriangleIndex contains out-of-range indices.")
+    if not (index.i < index.j).all() or not (index.j < index.k).all():
+        raise ValueError("SparseTriangleIndex rows must satisfy i<j<k.")
+    rows = np.stack([index.i, index.j, index.k], axis=1)
+    # Lexicographic sort check (rows must be strictly increasing).
+    diffs = np.diff(rows, axis=0)
+    if rows.shape[0] > 1:
+        # First non-zero element of each diff row determines order.
+        nonzero = np.where(diffs != 0)
+        if nonzero[0].size > 0:
+            first_idx = np.minimum.reduceat(
+                nonzero[1],
+                np.unique(nonzero[0], return_index=True)[1],
+            )
+            unique_rows, first_pos = np.unique(nonzero[0], return_index=True)
+            for row_idx, col_idx in zip(unique_rows.tolist(), first_idx.tolist(), strict=True):
+                if diffs[row_idx, col_idx] < 0:
+                    raise ValueError("SparseTriangleIndex must be lexicographically sorted.")
+        # Any diff row that is all zero indicates a duplicate triangle.
+        zero_rows = (diffs == 0).all(axis=1)
+        if zero_rows.any():
+            raise ValueError("SparseTriangleIndex contains duplicate triangles.")
+
+
+def build_sparse_triangle_index(
+    adj: NDArray[np.bool_],
+    *,
+    max_triangles: int | None = None,
+) -> SparseTriangleIndex:
+    """Construct a :class:`SparseTriangleIndex` from a boolean adjacency.
+
+    Iterates only over the upper triangle. Raises :class:`ValueError` if
+    the discovered triangle count exceeds ``max_triangles``.
+    """
+    if adj.ndim != 2 or adj.shape[0] != adj.shape[1]:
+        raise ValueError("adj must be a square matrix.")
+    n = int(adj.shape[0])
+    A = np.asarray(adj, dtype=bool, order="C")
+    np.fill_diagonal(A, False)
+    if not np.array_equal(A, A.T):
+        raise ValueError("adj must be symmetric.")
+
+    rows_i: list[int] = []
+    rows_j: list[int] = []
+    rows_k: list[int] = []
+    for i in range(n):
+        nb_i = np.flatnonzero(A[i])
+        nb_i = nb_i[nb_i > i]
+        for j in nb_i.tolist():
+            common = np.flatnonzero(A[i] & A[j])
+            common = common[common > j]
+            for k in common.tolist():
+                rows_i.append(i)
+                rows_j.append(j)
+                rows_k.append(k)
+                if max_triangles is not None and len(rows_i) > max_triangles:
+                    raise ValueError(f"triangle count exceeds max_triangles={max_triangles}.")
+
+    idx = SparseTriangleIndex(
+        i=np.asarray(rows_i, dtype=np.int64),
+        j=np.asarray(rows_j, dtype=np.int64),
+        k=np.asarray(rows_k, dtype=np.int64),
+        n_nodes=n,
+    )
+    validate_sparse_triangle_index(idx)
+    return idx
+
+
+def triadic_rhs_sparse(
+    theta: NDArray[np.float64],
+    index: SparseTriangleIndex,
+    sigma2: float,
+) -> NDArray[np.float64]:
+    """Sparse triadic RHS contribution for higher-order Kuramoto.
+
+    For each triangle ``(i, j, k)`` we accumulate three deterministic
+    terms via :func:`numpy.add.at`:
+
+    .. math::
+
+        \\Delta\\dot\\theta_i &+\\!= \\sin(2\\theta_j - \\theta_k - \\theta_i)\\\\
+        \\Delta\\dot\\theta_j &+\\!= \\sin(2\\theta_i - \\theta_k - \\theta_j)\\\\
+        \\Delta\\dot\\theta_k &+\\!= \\sin(2\\theta_i - \\theta_j - \\theta_k)
+
+    The output is multiplied by ``sigma2``. No ``O(N^2)`` or ``O(N^3)``
+    auxiliary buffer is allocated — total work is ``O(T)`` where ``T``
+    is the triangle count.
+    """
+    validate_sparse_triangle_index(index)
+    n = index.n_nodes
+    if theta.shape != (n,):
+        raise ValueError(f"theta shape {theta.shape} != ({n},).")
+
+    out = np.zeros(n, dtype=np.float64)
+    if index.n_triangles == 0 or sigma2 == 0.0:
+        return out
+
+    ti = theta[index.i]
+    tj = theta[index.j]
+    tk = theta[index.k]
+
+    term_i = np.sin(2.0 * tj - tk - ti)
+    term_j = np.sin(2.0 * ti - tk - tj)
+    term_k = np.sin(2.0 * ti - tj - tk)
+
+    np.add.at(out, index.i, term_i)
+    np.add.at(out, index.j, term_j)
+    np.add.at(out, index.k, term_k)
+
+    out *= float(sigma2)
+    return out
+
+
+def _order_parameter_sparse(theta: NDArray[np.float64]) -> float:
+    z = np.exp(1j * theta).mean()
+    # INV-K1: R = |mean(exp(iθ))| ∈ [0,1].
+    return float(np.clip(np.abs(z), 0.0, 1.0))
+
+
+def run_sparse_higher_order(
+    adj: NDArray[np.bool_],
+    omega: NDArray[np.float64],
+    theta0: NDArray[np.float64],
+    *,
+    cfg: HigherOrderSparseConfig,
+    dt: float,
+    steps: int,
+) -> HigherOrderKuramotoResult:
+    """Integrate the sparse higher-order Kuramoto ODE with RK4.
+
+    Parameters
+    ----------
+    adj:
+        ``(N, N)`` boolean adjacency matrix.
+    omega, theta0:
+        ``(N,)`` natural frequencies and initial phases.
+    cfg:
+        :class:`HigherOrderSparseConfig`.
+    dt, steps:
+        Integration step and total step count.
+
+    Returns
+    -------
+    :class:`HigherOrderKuramotoResult`.
+    """
+    if dt <= 0.0:
+        raise ValueError("dt must be > 0.")
+    if steps < 1:
+        raise ValueError("steps must be >= 1.")
+
+    n = int(adj.shape[0])
+    if omega.shape != (n,) or theta0.shape != (n,):
+        raise ValueError("omega/theta0 shape must match adj.")
+
+    triangle_index = build_sparse_triangle_index(adj, max_triangles=cfg.max_triangles)
+    weighted_adj = adj.astype(np.float64)
+    np.fill_diagonal(weighted_adj, 0.0)
+
+    def rhs(t_state: NDArray[np.float64]) -> tuple[NDArray[np.float64], float]:
+        diff = t_state[np.newaxis, :] - t_state[:, np.newaxis]
+        pairwise = cfg.sigma1 * (weighted_adj * np.sin(diff)).sum(axis=1)
+        triadic = triadic_rhs_sparse(t_state, triangle_index, cfg.sigma2)
+        magnitude = float(np.sqrt(np.sum(triadic**2)))
+        return omega + pairwise + triadic, magnitude
+
+    phases = np.empty((steps + 1, n), dtype=np.float64)
+    R_arr = np.empty(steps + 1, dtype=np.float64)
+    triadic_arr = np.empty(steps + 1, dtype=np.float64)
+    time_arr = np.arange(steps + 1, dtype=np.float64) * dt
+
+    theta = theta0.astype(np.float64, copy=True)
+    phases[0] = theta
+    R_arr[0] = _order_parameter_sparse(theta)
+    triadic_arr[0] = 0.0
+
+    for s in range(steps):
+        k1, m1 = rhs(theta)
+        k2, m2 = rhs(theta + 0.5 * dt * k1)
+        k3, m3 = rhs(theta + 0.5 * dt * k2)
+        k4, m4 = rhs(theta + dt * k3)
+        theta = theta + (dt / 6.0) * (k1 + 2.0 * k2 + 2.0 * k3 + k4)
+        phases[s + 1] = theta
+        R_arr[s + 1] = _order_parameter_sparse(theta)
+        triadic_arr[s + 1] = (m1 + m2 + m3 + m4) / 4.0
+
+    return HigherOrderKuramotoResult(
+        phases=phases,
+        order_parameter=R_arr,
+        time=time_arr,
+        n_triangles=triangle_index.n_triangles,
+        triadic_contribution=triadic_arr,
+    )

--- a/docs/research/capital_weighted_kuramoto.md
+++ b/docs/research/capital_weighted_kuramoto.md
@@ -1,0 +1,56 @@
+# Capital-weighted (β) Kuramoto coupling
+
+**Status.** Experimental, opt-in. Default Kuramoto/engine paths do not auto-import this module.
+
+## Implemented files
+- `core/kuramoto/capital_weighted.py`
+- `tests/unit/core/test_capital_weighted_kuramoto.py`
+
+## Formula
+
+For each oscillator pair (i, j) with baseline coupling `A_ij`,
+
+```
+K_ij^β = A_ij · K_0 · (1 + γ · r_ij^{2δ})^{(β−1)/2}
+r_i    = depth_mass_i / median(depth_mass)
+r_ij   = sqrt(r_i · r_j)
+m_i    = mid_price_i · Σ_l (bid_i,l + ask_i,l)         # depth mass
+β      = beta_min + (1 − Gini(m)) · (beta_max − beta_min)
+```
+
+with β = 1 recovering the baseline (the envelope collapses to `K_0`).
+
+## Inputs
+- `baseline_adj`: `(N, N)` non-negative, symmetric, zero-diagonal float64.
+- `snapshot`: `L2DepthSnapshot(timestamp_ns, bid_sizes (N, L), ask_sizes (N, L), mid_prices (N,))` or `None`.
+- `signal_timestamp_ns`: int decision-time epoch (used for look-ahead validation).
+- `cfg`: `CapitalWeightedCouplingConfig` (K0, gamma, delta, beta_min, beta_max, r_floor, normalize, fail_on_future_l2).
+
+## Outputs
+`CapitalWeightedCouplingResult(coupling, beta, r, depth_mass, used_fallback, reason)`.
+
+## Invariants
+- `INV-KBETA`: K_ij is finite, non-negative, symmetric, zero-diagonal; β ∈ [beta_min, beta_max]; K is invariant under uniform multiplicative depth scaling.
+
+## Tests
+- `test_kbeta_finite_bounded_symmetric_zero_diag`
+- `test_beta_one_recovers_baseline_adjacency`
+- `test_missing_l2_fallback_is_explicit`
+- `test_future_l2_snapshot_rejected`
+- `test_depth_mass_non_negative_and_finite`
+- `test_scalar_beta_deterministic`
+- `test_scale_invariance_under_uniform_depth_scaling`
+- `test_no_self_coupling`
+- plus three validation tests (negative sizes, non-positive mid, ratio floor)
+
+## Known limitations
+- The β estimator uses 1 − Gini as a uniformity proxy; alternative concentration measures (Theil index, HHI) are not provided.
+- Edgewise ratio uses the geometric mean `r_ij = sqrt(r_i · r_j)`; arithmetic and harmonic alternatives are not benchmarked.
+- The ambiguity over depth-mass measurement noise is not modeled; pair with DR-FREE for that.
+- No internal handling of cross-venue depth aggregation — caller supplies a single L2 snapshot.
+
+## No-alpha-claim disclaimer
+This module is a research primitive that re-shapes the coupling matrix in response to L2 depth concentration. It does not constitute a trading signal nor a claim of out-of-sample edge.
+
+## Source anchor
+Kathiravelu (SSRN), adaptive coupling for trading-flow crowding.

--- a/docs/research/dr_free_tacl.md
+++ b/docs/research/dr_free_tacl.md
@@ -1,0 +1,72 @@
+# DR-FREE — distributionally robust free-energy gate
+
+**Status.** Experimental, opt-in. Pure composition over `tacl.EnergyModel`; the base model is never mutated.
+
+## Implemented files
+- `tacl/dr_free.py`
+- `tacl/__init__.py` (additive exports)
+- `formal/tla/RobustFreeEnergyGate.tla`
+- `tests/tacl/test_dr_free.py`
+
+## Formula
+
+Box ambiguity set with per-metric radii `r_m ≥ 0`:
+
+```
+m_adv      = m · (1 + r_m)        for each metric m
+F_robust   = F(m_adv) ≥ F_nominal = F(m)
+```
+
+Equality holds when all radii are zero. The base `EnergyModel.free_energy` is invoked twice (nominal and adversarial) — no internal state is modified.
+
+State classifier (`robust_energy_state`):
+- `F_robust ≥ crisis_threshold`  ⇒ `DORMANT`
+- `F_robust ≥ warning_threshold` ⇒ `WARNING`
+- otherwise                      ⇒ `NORMAL`
+
+## Inputs
+- `metrics`: `EnergyMetrics`.
+- `ambiguity`: `AmbiguitySet(radii: Mapping[str, float], mode="box")`.
+- Optional `base_model: EnergyModel`.
+
+## Outputs
+`DRFreeResult(nominal_free_energy, robust_free_energy, internal_energy, entropy, adversarial_metrics, ambiguity_set, robust_margin)`.
+
+## Invariants
+- `INV-FE-ROBUST`: `F_robust ≥ F_nominal` for every non-negative radius vector; equality at zero ambiguity; monotone non-decreasing in any single radius; unknown metric names and negative radii are rejected fail-closed; the base `EnergyModel` is never mutated.
+
+## Tests
+- `test_robust_free_energy_dominates_nominal`
+- `test_zero_ambiguity_equals_nominal`
+- `test_monotone_in_radius`
+- `test_unknown_metric_rejected`
+- `test_negative_radius_rejected`
+- `test_adversarial_metrics_are_finite`
+- `test_robust_state_warning_and_dormant_thresholds`
+- `test_nominal_energy_model_unchanged`
+- `test_tla_spec_lint_documents_required_safety_properties`
+- `test_dr_free_result_dataclass_invariant`
+
+## TLA specification
+
+`formal/tla/RobustFreeEnergyGate.tla` advertises five safety invariants:
+
+1. `TypeOK`
+2. `NominalBounded`
+3. `RobustDominatesNominal`
+4. `ZeroAmbiguityEqualsNominal`
+5. `FailClosedOnMalformedAmbiguity`
+
+A Python lint test asserts the file contains all five names. Running TLC is **not** a CI gate — the spec is documentation evidence.
+
+## Known limitations
+- Only the box ambiguity is implemented; KL / Wasserstein balls are not.
+- Each metric is treated as penalty-increasing (positive perturbation = worse). This matches the GeoSync `EnergyMetrics` schema where every field is a non-negative penalty.
+- Worst-case is computed analytically per metric; there is no inner optimization.
+- The classifier uses two scalar thresholds; a hysteresis variant is not provided.
+
+## No-alpha-claim disclaimer
+This is a controller-level robustness primitive. It does not constitute a trading signal nor a claim of out-of-sample edge.
+
+## Source anchor
+Nature Communications 2025 (s41467-025-67348-6) — DR-FREE robust free-energy minimization.

--- a/docs/research/ricci_flow_surgery.md
+++ b/docs/research/ricci_flow_surgery.md
@@ -1,0 +1,64 @@
+# Discrete Ricci flow + neckpinch surgery
+
+**Status.** Experimental, opt-in. `KuramotoRicciFlowEngine` retains byte-identical default behavior unless `enable_discrete_flow=True` and/or `enable_neckpinch_surgery=True`.
+
+## Implemented files
+- `core/kuramoto/ricci_flow.py`
+- `core/kuramoto/ricci_flow_engine.py` (additive integration only)
+- `tests/unit/core/test_ricci_flow_surgery.py`
+
+## Formula
+
+Discrete Ricci flow (Hamilton 1982; Chow & Luo 2003; arXiv:2510.15942):
+
+```
+w_ij^{n+1} = max(0, w_ij^n − η · κ_ij · w_ij^n)
+```
+
+Optional total-edge-mass conservation rescales so `Σ w_ij` is preserved.
+
+Neckpinch surgery candidates:
+- `0 < w_ij ≤ eps_weight`, or
+- `κ_ij ≤ −1 + eps_neck` (Ollivier singular tail).
+
+Bridges (per `networkx.bridges`) are clamped to `eps_weight` rather than removed when `preserve_connectedness=True`. Removed-count is capped at `floor(max_surgery_fraction · n_active_edges)` per call.
+
+## Inputs
+- `weights`: `(N, N)` symmetric, non-negative, zero-diagonal float64.
+- `curvature`: `dict[(i, j), κ_ij]` for active edges.
+- `cfg`: `RicciFlowConfig(eta, eps_weight, eps_neck, preserve_total_edge_mass, preserve_connectedness, allow_disconnect, max_surgery_fraction)`.
+
+## Outputs
+- `discrete_ricci_flow_step` → `(N, N)` updated weights.
+- `apply_neckpinch_surgery` → `(weights_after, tuple[NeckpinchEvent, ...])`.
+- `ricci_flow_with_surgery` → `RicciFlowStepResult(weights_before, weights_after, curvature, surgery_events, total_edge_mass_before, total_edge_mass_after, surgery_event_count)`.
+- Engine integration: `KuramotoRicciFlowEngine.run_with_surgery()` → `(KuramotoRicciFlowResult, KuramotoRicciFlowSurgeryDiagnostics)`.
+
+## Invariants
+- `INV-RC-FLOW`: post-step weights are finite, non-negative, symmetric, zero-diagonal; total mass is preserved when configured; bridges are clamped not removed under `preserve_connectedness=True`; surgery removal count ≤ cap.
+
+## Tests
+- `test_flow_preserves_symmetry_zero_diag_finiteness`
+- `test_flow_preserves_total_edge_mass_when_enabled`
+- `test_neckpinch_removes_non_bridge_edge` (K_4)
+- `test_neckpinch_clamps_bridge_when_connectedness_required` (path graph)
+- `test_surgery_fraction_cap`
+- `test_integration_default_matches_previous_ricci_engine_behavior`
+- `test_integration_enabled_records_surgery_events`
+- `test_ricci_flow_deterministic`
+- `test_eta_out_of_range_rejected`
+- `test_detect_neckpinch_candidates_lex_order`
+- `test_neckpinch_event_dataclass_immutable`
+
+## Known limitations
+- Implicit-Euler / variational schemes are not implemented; only explicit Euler.
+- `eps_neck` defaults to a numerical tolerance, not a physical curvature scale.
+- Bridge detection is recomputed each call via `networkx.bridges` (linear-time but not incremental).
+- `allow_disconnect=True` exposes an escape hatch for callers who deliberately fragment the graph; it must be paired with `preserve_connectedness=False`.
+- Curvature is supplied externally; the flow does not recompute it.
+
+## No-alpha-claim disclaimer
+This is a geometric primitive. No claim of trading edge or out-of-sample performance is made.
+
+## Source anchor
+arXiv:2510.15942 — Ollivier-Ricci flow with neckpinch surgery on NASDAQ-100.

--- a/docs/research/sparse_simplicial_kuramoto.md
+++ b/docs/research/sparse_simplicial_kuramoto.md
@@ -1,0 +1,60 @@
+# Sparse simplicial higher-order Kuramoto
+
+**Status.** Experimental, opt-in. Existing `HigherOrderKuramotoEngine` and helpers (`find_triangles`, `build_triangle_index`) are unchanged; the sparse path is purely additive.
+
+## Implemented files
+- `core/physics/higher_order_kuramoto.py` (additive symbols listed below)
+- `tests/unit/physics/test_higher_order_kuramoto_sparse.py`
+
+## Formula
+
+For each triangle `(i, j, k)` in the 2-simplex skeleton:
+
+```
+Δθ̇_i += sin(2θ_j − θ_k − θ_i)
+Δθ̇_j += sin(2θ_i − θ_k − θ_j)
+Δθ̇_k += sin(2θ_i − θ_j − θ_k)
+```
+
+Total triadic RHS = `sigma2 · (Δθ̇)`. Pairwise term unchanged.
+
+Implementation uses `numpy.add.at` for deterministic per-node accumulation; no `O(N²)` or `O(N³)` auxiliary buffers are allocated.
+
+## Inputs
+- `adj`: `(N, N)` boolean adjacency.
+- `theta`: `(N,)` phase vector.
+- `cfg`: `HigherOrderSparseConfig(sigma1, sigma2, max_triangles, dense_debug)`.
+- `dt`, `steps` for the integrator helper `run_sparse_higher_order`.
+
+## Outputs
+- `build_sparse_triangle_index(adj, max_triangles=None)` → `SparseTriangleIndex(i, j, k, n_nodes)`.
+- `triadic_rhs_sparse(theta, index, sigma2)` → `(N,)` float64.
+- `run_sparse_higher_order(adj, omega, theta0, cfg, dt, steps)` → `HigherOrderKuramotoResult`.
+- `validate_sparse_triangle_index(index)` raises on any violation.
+
+## Invariants
+- `INV-HO-SPARSE`: `R(t) ∈ [0,1]` over the trajectory; `sigma2=0` ⇒ zero triadic RHS; sparse triangle count agrees with dense reference engine on small graphs; deterministic under fixed inputs; no `O(N³)` allocation when `dense_debug=False`.
+
+## Tests
+- `test_sparse_triangle_index_unique_sorted`
+- `test_sparse_matches_existing_dense_on_small_complete_graph`
+- `test_sigma2_zero_matches_pairwise`
+- `test_no_triangles_zero_triadic`
+- `test_R_bounds_sparse`
+- `test_sparse_deterministic`
+- `test_large_sparse_graph_does_not_use_dense_N3_path` (≤1 MB peak heap on N=120; vs ~13.8 MB for an O(N³) tensor)
+- `test_validate_sparse_triangle_index_rejects_unsorted`
+- `test_max_triangles_cap_enforced`
+- `test_sparse_config_validation`
+
+## Known limitations
+- Triadic structure is fixed at 2-simplex (triangles); 3-simplices and higher are not provided.
+- The `max_triangles` cap is a hard error, not a sampling fallback.
+- `numpy.add.at` is deterministic but not parallelised; very large triangle counts will be CPU-bound.
+- Dense vs sparse comparison test compares triangle counts and order-parameter bounds rather than full trajectory equality, because the dense engine multiplies by `|corr|` while the sparse engine uses unit boolean weights — a deliberate choice to keep the sparse path independent of correlation magnitude.
+
+## No-alpha-claim disclaimer
+This is an experimental simplicial primitive. No claim of trading edge or out-of-sample performance is made.
+
+## Source anchor
+PRR 2025 (10.1103/PhysRevResearch.7.023103) and arXiv:2011.00897 — explosive higher-order Kuramoto on simplicial complexes.

--- a/formal/tla/RobustFreeEnergyGate.tla
+++ b/formal/tla/RobustFreeEnergyGate.tla
@@ -1,0 +1,106 @@
+------------------------- MODULE RobustFreeEnergyGate -------------------------
+(***************************************************************************
+  Distributionally robust free-energy gate for the TACL controller.
+
+  Source: tacl/dr_free.py + Nature Communications 2025
+          (s41467-025-67348-6).  No alpha claim — this spec encodes the
+          *safety* properties of the gate, not any economic statement.
+
+  We model the gate as a tuple of non-negative reals:
+
+      MetricsBase     -- nominal metric values m_i >= 0
+      Radii           -- per-metric radii r_i >= 0  (zero outside ambiguity set)
+      MetricsAdv      -- m_i_adv = m_i * (1 + r_i)
+      F_nominal       -- monotonically non-decreasing in metrics
+      F_robust        -- F applied to MetricsAdv
+
+  Safety properties (required to hold in all reachable states):
+      * TypeOK                       — type/range invariants
+      * NominalBounded               — F_nominal in [F_min, F_max]
+      * RobustDominatesNominal       — F_robust >= F_nominal
+      * ZeroAmbiguityEqualsNominal   — Radii = 0 ⟹ F_robust = F_nominal
+      * FailClosedOnMalformedAmbiguity
+                                     — any negative or non-finite radius forces
+                                       gate into DORMANT (fail-closed).
+
+  Liveness properties are deliberately omitted: this is a *gate*, not a
+  protocol with progress requirements.
+ ***************************************************************************)
+
+EXTENDS Naturals, Reals
+
+CONSTANTS Metric,           \* finite set of metric names
+          F_min, F_max,     \* admissible range for nominal free energy
+          Crisis            \* threshold for DORMANT classification
+
+ASSUME F_min <= F_max
+ASSUME F_min <= Crisis /\ Crisis <= F_max
+
+VARIABLES
+  metrics_base,             \* [Metric -> Real_+]
+  radii,                    \* [Metric -> Real_+]
+  metrics_adv,              \* [Metric -> Real_+]
+  F_nominal,                \* Real
+  F_robust,                 \* Real
+  state                     \* {"NORMAL","WARNING","DORMANT"}
+
+vars == << metrics_base, radii, metrics_adv, F_nominal, F_robust, state >>
+
+(***************************************************************************
+  Type invariant.
+ ***************************************************************************)
+TypeOK ==
+  /\ metrics_base \in [Metric -> Real]
+  /\ radii        \in [Metric -> Real]
+  /\ metrics_adv  \in [Metric -> Real]
+  /\ F_nominal    \in Real
+  /\ F_robust     \in Real
+  /\ state \in {"NORMAL", "WARNING", "DORMANT"}
+  /\ \A m \in Metric : metrics_base[m] >= 0
+  /\ \A m \in Metric : metrics_adv[m]  >= 0
+
+(***************************************************************************
+  Safety invariants.
+ ***************************************************************************)
+NominalBounded ==
+  F_nominal >= F_min /\ F_nominal <= F_max
+
+RobustDominatesNominal ==
+  F_robust >= F_nominal
+
+ZeroAmbiguityEqualsNominal ==
+  (\A m \in Metric : radii[m] = 0) => (F_robust = F_nominal)
+
+\* If any radius is negative the gate must be DORMANT (fail-closed).
+FailClosedOnMalformedAmbiguity ==
+  (\E m \in Metric : radii[m] < 0) => (state = "DORMANT")
+
+(***************************************************************************
+  Initial predicate and stutter-only next-state relation.
+  The gate is purely declarative: each step recomputes derived quantities.
+ ***************************************************************************)
+Init ==
+  /\ metrics_base = [m \in Metric |-> 0]
+  /\ radii        = [m \in Metric |-> 0]
+  /\ metrics_adv  = [m \in Metric |-> 0]
+  /\ F_nominal    = F_min
+  /\ F_robust     = F_min
+  /\ state        = "NORMAL"
+
+Next == UNCHANGED vars  \* the gate is reasoned about as an invariant, not a protocol
+
+Spec == Init /\ [][Next]_vars
+
+(***************************************************************************
+  Safety conjunction — used by the Python lint test as a property catalogue.
+ ***************************************************************************)
+SafetyInvariants ==
+  /\ TypeOK
+  /\ NominalBounded
+  /\ RobustDominatesNominal
+  /\ ZeroAmbiguityEqualsNominal
+  /\ FailClosedOnMalformedAmbiguity
+
+THEOREM Safety == Spec => []SafetyInvariants
+
+==============================================================================

--- a/tacl/__init__.py
+++ b/tacl/__init__.py
@@ -9,6 +9,12 @@ from .behavioral_contract import (
     ContractBreach,
 )
 from .degradation import DegradationPolicy, DegradationReport, apply_degradation
+from .dr_free import (
+    AmbiguitySet,
+    DRFreeEnergyModel,
+    DRFreeResult,
+    robust_energy_state,
+)
 from .energy_model import (
     DEFAULT_THRESHOLDS,
     DEFAULT_WEIGHTS,
@@ -64,4 +70,8 @@ __all__ = [
     "clear_registered_protocols",
     "apply_external_controller",
     "protocol_schema_keys",
+    "AmbiguitySet",
+    "DRFreeEnergyModel",
+    "DRFreeResult",
+    "robust_energy_state",
 ]

--- a/tacl/dr_free.py
+++ b/tacl/dr_free.py
@@ -1,0 +1,207 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""DR-FREE — distributionally robust free-energy minimization.
+
+Status
+------
+EXPERIMENTAL. Pure composition over :class:`tacl.EnergyModel`. The base
+model is never mutated; a DR-FREE evaluation only returns adversarially
+inflated metrics and the resulting robust free energy.
+
+Background
+----------
+We follow the worst-case-over-ambiguity formulation introduced for
+free-energy controllers in *Nature Communications* 2025
+(s41467-025-67348-6). Given a per-metric **box** ambiguity set with
+radius ``r_m ≥ 0``, the adversarial metric for any **penalty-increasing**
+metric ``m`` is
+
+.. math::
+
+    m^{adv} = m \\cdot (1 + r_m).
+
+Robust free energy is then
+
+.. math::
+
+    F^{robust}(\\mathbf{m}, \\mathcal{U}) = F\bigl(\\mathbf{m}^{adv}\bigr)
+    \\ge F(\\mathbf{m}) = F^{nominal}.
+
+The inequality holds because every metric in :class:`tacl.EnergyMetrics`
+is a non-negative penalty whose ratio-to-threshold can only grow under
+non-negative inflation, hence the internal energy can only grow and the
+entropy can only shrink.
+
+Invariants
+----------
+- ``F^{robust} >= F^{nominal}`` for every metric and every ``r_m >= 0``
+  (``INV-FE-ROBUST``).
+- Zero ambiguity (``r_m = 0`` ∀ m) ⟹ ``F^{robust} == F^{nominal}``.
+- Monotone in radius: increasing any ``r_m`` cannot decrease
+  ``F^{robust}``.
+- Unknown metric names are rejected (fail-closed).
+- Negative radii are rejected.
+
+No-alpha disclaimer
+-------------------
+This module is a controller-level robustness primitive. It does not
+constitute a trading signal nor a claim of out-of-sample edge.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from typing import Final, Literal, Mapping
+
+from .energy_model import EnergyMetrics, EnergyModel
+
+__all__ = [
+    "AmbiguitySet",
+    "DRFreeResult",
+    "DRFreeEnergyModel",
+    "robust_energy_state",
+]
+
+
+_AmbiguityMode = Literal["box"]
+_KNOWN_AMBIGUITY_MODES: Final[frozenset[str]] = frozenset({"box"})
+
+
+@dataclass(frozen=True, slots=True)
+class AmbiguitySet:
+    """Box ambiguity set: per-metric multiplicative radius ``r_m >= 0``.
+
+    Only metrics referenced in the underlying :class:`EnergyModel` are
+    accepted; missing metrics default to radius 0 (i.e. no perturbation).
+    """
+
+    radii: Mapping[str, float]
+    mode: _AmbiguityMode = "box"
+
+    def __post_init__(self) -> None:
+        if self.mode not in _KNOWN_AMBIGUITY_MODES:
+            raise ValueError(
+                f"Unknown ambiguity mode '{self.mode}'; "
+                f"supported: {sorted(_KNOWN_AMBIGUITY_MODES)}."
+            )
+        for name, radius in self.radii.items():
+            if not isinstance(name, str):
+                raise ValueError("AmbiguitySet keys must be strings.")
+            if radius < 0.0:
+                raise ValueError(f"Negative radius for metric '{name}': {radius}.")
+
+
+@dataclass(frozen=True, slots=True)
+class DRFreeResult:
+    """Bundle of nominal + robust free-energy diagnostics."""
+
+    nominal_free_energy: float
+    robust_free_energy: float
+    internal_energy: float
+    entropy: float
+    adversarial_metrics: EnergyMetrics
+    ambiguity_set: AmbiguitySet
+    robust_margin: float
+
+    def __post_init__(self) -> None:
+        if not (self.robust_free_energy + 1e-12 >= self.nominal_free_energy):
+            raise ValueError(
+                "INV-FE-ROBUST violated: robust_free_energy must dominate nominal "
+                f"(observed robust={self.robust_free_energy}, "
+                f"nominal={self.nominal_free_energy})."
+            )
+
+
+class DRFreeEnergyModel:
+    """Composition wrapper that adds DR-FREE evaluation to an EnergyModel.
+
+    Parameters
+    ----------
+    base_model:
+        Optional :class:`tacl.EnergyModel`. When ``None`` a default
+        instance is constructed; the base model is **never mutated**.
+    """
+
+    def __init__(self, base_model: EnergyModel | None = None) -> None:
+        self._base = base_model if base_model is not None else EnergyModel()
+
+    @property
+    def base_model(self) -> EnergyModel:
+        return self._base
+
+    @property
+    def known_metrics(self) -> frozenset[str]:
+        return frozenset(self._base.metrics)
+
+    def adversarial_metrics(
+        self,
+        metrics: EnergyMetrics,
+        ambiguity: AmbiguitySet,
+    ) -> EnergyMetrics:
+        """Return the worst-case (penalty-inflated) metrics under ``ambiguity``.
+
+        Each known metric ``m`` is mapped to ``m * (1 + r_m)``; missing
+        radii default to 0. Unknown metric names raise :class:`ValueError`.
+        """
+        if ambiguity.mode != "box":
+            raise ValueError(f"Unsupported ambiguity mode: {ambiguity.mode}.")
+
+        known = self.known_metrics
+        unknown = set(ambiguity.radii) - known
+        if unknown:
+            raise ValueError(
+                f"Unknown ambiguity metrics: {sorted(unknown)}; known: {sorted(known)}."
+            )
+
+        as_dict = dict(metrics.as_dict())
+        for name, radius in ambiguity.radii.items():
+            if radius < 0.0:
+                raise ValueError(f"Negative radius for metric '{name}': {radius}.")
+            inflated = float(as_dict[name]) * (1.0 + float(radius))
+            if not (inflated == inflated) or inflated == float("inf"):
+                raise ValueError(f"adversarial_metrics produced non-finite value for '{name}'.")
+            as_dict[name] = inflated
+
+        return replace(metrics, **as_dict)
+
+    def evaluate_robust(
+        self,
+        metrics: EnergyMetrics,
+        ambiguity: AmbiguitySet,
+    ) -> DRFreeResult:
+        """Evaluate nominal and worst-case free energy under ``ambiguity``."""
+        nominal_F, _, _, _ = self._base.free_energy(metrics)
+        adv = self.adversarial_metrics(metrics, ambiguity)
+        robust_F, robust_internal, robust_entropy, _ = self._base.free_energy(adv)
+        margin = float(robust_F - nominal_F)
+        return DRFreeResult(
+            nominal_free_energy=float(nominal_F),
+            robust_free_energy=float(robust_F),
+            internal_energy=float(robust_internal),
+            entropy=float(robust_entropy),
+            adversarial_metrics=adv,
+            ambiguity_set=ambiguity,
+            robust_margin=margin,
+        )
+
+
+def robust_energy_state(
+    result: DRFreeResult,
+    *,
+    warning_threshold: float,
+    crisis_threshold: float,
+) -> Literal["NORMAL", "WARNING", "DORMANT"]:
+    """Map a robust free-energy reading to a coarse fail-closed state.
+
+    Returns ``"DORMANT"`` when ``robust_free_energy >= crisis_threshold``,
+    ``"WARNING"`` when ``>= warning_threshold`` (but below crisis), else
+    ``"NORMAL"``. Thresholds must satisfy ``warning_threshold <= crisis_threshold``.
+    """
+    if not (warning_threshold <= crisis_threshold):
+        raise ValueError("warning_threshold must be <= crisis_threshold.")
+    F = result.robust_free_energy
+    if F >= crisis_threshold:
+        return "DORMANT"
+    if F >= warning_threshold:
+        return "WARNING"
+    return "NORMAL"

--- a/tests/tacl/test_dr_free.py
+++ b/tests/tacl/test_dr_free.py
@@ -1,0 +1,235 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""Tests for DR-FREE distributionally robust free-energy primitives.
+
+INV-FE-ROBUST — robust free energy dominates nominal under any non-negative
+box ambiguity set; with zero ambiguity it equals nominal; the wrapper never
+mutates the base EnergyModel.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from tacl import (
+    AmbiguitySet,
+    DRFreeEnergyModel,
+    DRFreeResult,
+    EnergyMetrics,
+    EnergyModel,
+    robust_energy_state,
+)
+
+
+def _nominal_metrics() -> EnergyMetrics:
+    return EnergyMetrics(
+        latency_p95=70.0,
+        latency_p99=100.0,
+        coherency_drift=0.05,
+        cpu_burn=0.6,
+        mem_cost=5.0,
+        queue_depth=20.0,
+        packet_loss=0.002,
+    )
+
+
+def test_robust_free_energy_dominates_nominal() -> None:
+    """INV-FE-ROBUST: F_robust >= F_nominal for every penalty-increasing metric."""
+    model = DRFreeEnergyModel()
+    metrics = _nominal_metrics()
+    radii = {
+        "latency_p95": 0.10,
+        "latency_p99": 0.20,
+        "coherency_drift": 0.30,
+        "cpu_burn": 0.05,
+        "mem_cost": 0.15,
+        "queue_depth": 0.40,
+        "packet_loss": 0.50,
+    }
+    ambiguity = AmbiguitySet(radii=radii)
+    result = model.evaluate_robust(metrics, ambiguity)
+
+    assert result.robust_free_energy >= result.nominal_free_energy - 1e-12, (
+        "INV-FE-ROBUST VIOLATED: F_robust must dominate F_nominal; "
+        f"observed robust={result.robust_free_energy:.6f}, "
+        f"nominal={result.nominal_free_energy:.6f}, "
+        f"margin={result.robust_margin:.6f}, with radii={radii}."
+    )
+    assert result.robust_margin >= -1e-12, (
+        "INV-FE-ROBUST VIOLATED: robust_margin must be non-negative; "
+        f"observed margin={result.robust_margin:.6e}, expected >=0, with radii={radii}."
+    )
+
+
+def test_zero_ambiguity_equals_nominal() -> None:
+    """INV-FE-ROBUST: r_m=0 ∀ m ⟹ F_robust == F_nominal exactly."""
+    model = DRFreeEnergyModel()
+    metrics = _nominal_metrics()
+    ambiguity = AmbiguitySet(radii={name: 0.0 for name in model.known_metrics})
+    result = model.evaluate_robust(metrics, ambiguity)
+    assert result.robust_free_energy == pytest.approx(result.nominal_free_energy, abs=1e-12), (
+        "INV-FE-ROBUST VIOLATED: zero ambiguity must equal nominal; "
+        f"observed robust={result.robust_free_energy:.12f}, "
+        f"nominal={result.nominal_free_energy:.12f}, expected equality, "
+        "with all radii=0."
+    )
+
+
+def test_monotone_in_radius() -> None:
+    """INV-FE-ROBUST: increasing any radius cannot decrease F_robust."""
+    model = DRFreeEnergyModel()
+    metrics = _nominal_metrics()
+    base_radii = {name: 0.05 for name in model.known_metrics}
+    failures: list[str] = []
+    for delta in (0.0, 0.1, 0.5, 1.0, 5.0):
+        radii = {name: 0.05 + delta for name in model.known_metrics}
+        result = model.evaluate_robust(metrics, AmbiguitySet(radii=radii))
+        prev = model.evaluate_robust(metrics, AmbiguitySet(radii=base_radii))
+        if result.robust_free_energy + 1e-12 < prev.robust_free_energy:
+            failures.append(
+                f"delta={delta} F_new={result.robust_free_energy:.6f} "
+                f"< F_prev={prev.robust_free_energy:.6f}"
+            )
+    assert not failures, (
+        "INV-FE-ROBUST VIOLATED: F_robust must be monotone non-decreasing in radius; "
+        f"observed violations={failures}, expected none, with delta∈{{0,0.1,0.5,1,5}}."
+    )
+
+
+def test_unknown_metric_rejected() -> None:
+    """INV-FE-ROBUST: unknown metric names are rejected fail-closed."""
+    model = DRFreeEnergyModel()
+    metrics = _nominal_metrics()
+    with pytest.raises(ValueError, match="Unknown ambiguity metrics"):
+        model.evaluate_robust(metrics, AmbiguitySet(radii={"bogus_metric": 0.1}))
+
+
+def test_negative_radius_rejected() -> None:
+    """INV-FE-ROBUST: negative radii are rejected fail-closed."""
+    with pytest.raises(ValueError, match="Negative radius"):
+        AmbiguitySet(radii={"latency_p95": -0.01})
+
+
+def test_adversarial_metrics_are_finite() -> None:
+    """INV-FE-ROBUST: adversarial metrics remain finite for moderate radii."""
+    model = DRFreeEnergyModel()
+    metrics = _nominal_metrics()
+    ambiguity = AmbiguitySet(radii={name: 1.0 for name in model.known_metrics})
+    adv = model.adversarial_metrics(metrics, ambiguity)
+    payload = adv.as_dict()
+    failures: list[str] = []
+    for name, value in payload.items():
+        if not (value == value) or value == float("inf"):
+            failures.append(f"{name}={value}")
+    assert not failures, (
+        "INV-FE-ROBUST VIOLATED: adversarial_metrics must be finite; "
+        f"observed non-finite={failures}, expected none, with radius=1.0 ∀ m."
+    )
+
+
+def test_robust_state_warning_and_dormant_thresholds() -> None:
+    """INV-FE-ROBUST: state classifier respects warning/crisis thresholds."""
+    model = DRFreeEnergyModel()
+    metrics = _nominal_metrics()
+    ambiguity = AmbiguitySet(radii={name: 0.0 for name in model.known_metrics})
+    result = model.evaluate_robust(metrics, ambiguity)
+    F = result.robust_free_energy
+
+    state_normal = robust_energy_state(result, warning_threshold=F + 1.0, crisis_threshold=F + 2.0)
+    state_warning = robust_energy_state(
+        result, warning_threshold=F - 0.001, crisis_threshold=F + 1.0
+    )
+    state_dormant = robust_energy_state(
+        result, warning_threshold=F - 1.0, crisis_threshold=F - 0.001
+    )
+
+    assert state_normal == "NORMAL", (
+        "INV-FE-ROBUST VIOLATED: classifier returned wrong state; "
+        f"observed='{state_normal}', expected='NORMAL', with F={F}, "
+        "warn=F+1, crisis=F+2."
+    )
+    assert state_warning == "WARNING", (
+        "INV-FE-ROBUST VIOLATED: classifier returned wrong state; "
+        f"observed='{state_warning}', expected='WARNING', with F={F}, "
+        "warn=F-0.001, crisis=F+1."
+    )
+    assert state_dormant == "DORMANT", (
+        "INV-FE-ROBUST VIOLATED: classifier returned wrong state; "
+        f"observed='{state_dormant}', expected='DORMANT', with F={F}, "
+        "warn=F-1, crisis=F-0.001."
+    )
+
+
+def test_nominal_energy_model_unchanged() -> None:
+    """INV-FE-ROBUST: DR-FREE never mutates the base EnergyModel state.
+
+    We capture the model's nominal evaluation before and after a DR-FREE
+    call and assert pointwise equality.
+    """
+    base = EnergyModel()
+    metrics = _nominal_metrics()
+    f_before, internal_before, entropy_before, penalties_before = base.free_energy(metrics)
+
+    wrapper = DRFreeEnergyModel(base)
+    wrapper.evaluate_robust(
+        metrics,
+        AmbiguitySet(radii={name: 0.5 for name in base.metrics}),
+    )
+
+    f_after, internal_after, entropy_after, penalties_after = base.free_energy(metrics)
+    failures: list[str] = []
+    if f_before != f_after:
+        failures.append(f"free_energy {f_before} != {f_after}")
+    if internal_before != internal_after:
+        failures.append(f"internal {internal_before} != {internal_after}")
+    if entropy_before != entropy_after:
+        failures.append(f"entropy {entropy_before} != {entropy_after}")
+    if dict(penalties_before) != dict(penalties_after):
+        failures.append("penalties differ")
+    assert not failures, (
+        "INV-FE-ROBUST VIOLATED: base model state mutated by DR-FREE; "
+        f"observed differences={failures}, expected pure composition, "
+        "with nominal metrics."
+    )
+
+
+def test_tla_spec_lint_documents_required_safety_properties() -> None:
+    """The TLA spec advertises all five required safety properties.
+
+    TLC may not be installed in CI; in that case we still want a textual
+    audit trail proving that the spec lists the properties this Python
+    module implements.
+    """
+    spec_path = Path(__file__).resolve().parents[2] / "formal" / "tla" / "RobustFreeEnergyGate.tla"
+    assert spec_path.exists(), f"TLA spec missing at {spec_path}"
+    text = spec_path.read_text(encoding="utf-8")
+    required = [
+        "TypeOK",
+        "NominalBounded",
+        "RobustDominatesNominal",
+        "ZeroAmbiguityEqualsNominal",
+        "FailClosedOnMalformedAmbiguity",
+    ]
+    missing = [name for name in required if not re.search(rf"\b{name}\b", text)]
+    assert not missing, (
+        "INV-FE-ROBUST VIOLATED: TLA spec is missing required safety properties; "
+        f"observed missing={missing}, expected all of {required} present in {spec_path.name}."
+    )
+
+
+def test_dr_free_result_dataclass_invariant() -> None:
+    """DRFreeResult enforces robust >= nominal at construction time."""
+    metrics = _nominal_metrics()
+    with pytest.raises(ValueError, match="INV-FE-ROBUST"):
+        DRFreeResult(
+            nominal_free_energy=2.0,
+            robust_free_energy=1.0,
+            internal_energy=1.0,
+            entropy=0.5,
+            adversarial_metrics=metrics,
+            ambiguity_set=AmbiguitySet(radii={}),
+            robust_margin=-1.0,
+        )

--- a/tests/unit/core/test_capital_weighted_kuramoto.py
+++ b/tests/unit/core/test_capital_weighted_kuramoto.py
@@ -1,0 +1,236 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""Tests for capital-weighted (β) Kuramoto coupling primitives.
+
+INV-KBETA — capital-weighted coupling preserves finiteness, non-negativity,
+symmetry, zero diagonal, and is invariant under uniform depth scaling.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from numpy.typing import NDArray
+
+from core.kuramoto.capital_weighted import (
+    CapitalWeightedCouplingConfig,
+    L2DepthSnapshot,
+    build_capital_weighted_adjacency,
+    compute_capital_ratio,
+    compute_k_beta,
+    compute_l2_depth_mass,
+    estimate_scalar_beta,
+)
+
+
+def _baseline_adj(n: int, off: float = 0.5) -> NDArray[np.float64]:
+    adj = np.full((n, n), off, dtype=np.float64)
+    np.fill_diagonal(adj, 0.0)
+    return adj
+
+
+def _snapshot(n: int, levels: int = 3, *, seed: int = 0, ts: int = 1_000) -> L2DepthSnapshot:
+    rng = np.random.default_rng(seed)
+    bid = rng.uniform(0.0, 5.0, size=(n, levels)).astype(np.float64)
+    ask = rng.uniform(0.0, 5.0, size=(n, levels)).astype(np.float64)
+    mid = rng.uniform(50.0, 150.0, size=n).astype(np.float64)
+    return L2DepthSnapshot(timestamp_ns=ts, bid_sizes=bid, ask_sizes=ask, mid_prices=mid)
+
+
+def test_kbeta_finite_bounded_symmetric_zero_diag() -> None:
+    """INV-KBETA: K_ij is finite, non-negative, symmetric, zero diagonal."""
+    n = 6
+    base = _baseline_adj(n, off=0.4)
+    snap = _snapshot(n, seed=11, ts=500)
+    cfg = CapitalWeightedCouplingConfig()
+
+    res = build_capital_weighted_adjacency(base, snap, signal_timestamp_ns=1_000, cfg=cfg)
+    K = res.coupling
+
+    violations: list[str] = []
+    if not np.isfinite(K).all():
+        violations.append("non-finite values")
+    if (K < -1e-12).any():
+        violations.append("negative values")
+    if not np.allclose(K, K.T, atol=1e-10):
+        violations.append("asymmetry")
+    if not np.allclose(np.diag(K), 0.0, atol=1e-12):
+        violations.append("non-zero diagonal")
+
+    assert not violations, (
+        f"INV-KBETA VIOLATED: K_ij must be finite, bounded, symmetric, "
+        f"zero-diag. Observed violations={violations}; min={K.min():.6f}, "
+        f"max={K.max():.6f}, with N={n}, beta={res.beta:.4f}, "
+        f"used_fallback={res.used_fallback}."
+    )
+
+
+def test_beta_one_recovers_baseline_adjacency() -> None:
+    """INV-KBETA: β=1 (forced via direct API) is the identity envelope."""
+    n = 5
+    base = _baseline_adj(n, off=0.3)
+    cfg = CapitalWeightedCouplingConfig(K0=1.0, gamma=0.7, delta=1.5)
+    r = np.linspace(0.5, 1.5, n).astype(np.float64)
+    envelope = compute_k_beta(r, beta=1.0, cfg=cfg)
+
+    expected = np.full(n, cfg.K0, dtype=np.float64)
+    np.testing.assert_allclose(
+        envelope,
+        expected,
+        atol=1e-12,
+        err_msg=(
+            "INV-KBETA VIOLATED: beta=1.0 should recover K0 envelope; "
+            f"observed envelope={envelope}, expected={expected}, with N={n}, "
+            f"K0={cfg.K0}, gamma={cfg.gamma}, delta={cfg.delta}."
+        ),
+    )
+
+    # And the full adjacency builder with beta=1 should leave baseline
+    # invariant up to renormalization (gamma=0 -> envelope ≡ K0 ≡ 1).
+    cfg2 = CapitalWeightedCouplingConfig(K0=1.0, gamma=0.0, normalize=False)
+    snap = _snapshot(n, seed=3, ts=10)
+    res = build_capital_weighted_adjacency(base, snap, signal_timestamp_ns=20, cfg=cfg2)
+    np.testing.assert_allclose(
+        res.coupling,
+        base,
+        atol=1e-12,
+        err_msg=(
+            "INV-KBETA VIOLATED: with gamma=0 the envelope is constant K0=1 "
+            "and must reproduce the baseline; observed max-abs-diff="
+            f"{np.max(np.abs(res.coupling - base)):.3e}, with N={n}, "
+            f"normalize=False, K0=1.0."
+        ),
+    )
+
+
+def test_missing_l2_fallback_is_explicit() -> None:
+    """INV-KBETA: missing snapshot returns baseline with explicit reason."""
+    base = _baseline_adj(4, off=0.25)
+    cfg = CapitalWeightedCouplingConfig()
+    res = build_capital_weighted_adjacency(base, None, signal_timestamp_ns=0, cfg=cfg)
+
+    assert res.used_fallback is True, "used_fallback flag must be True on None snapshot"
+    assert (
+        res.reason == "no_l2_snapshot"
+    ), f"fallback reason must be 'no_l2_snapshot'; observed='{res.reason}'"
+    np.testing.assert_array_equal(res.coupling, base)
+
+
+def test_future_l2_snapshot_rejected() -> None:
+    """INV-KBETA: snapshot.timestamp_ns > signal_timestamp_ns is rejected."""
+    base = _baseline_adj(3)
+    snap = _snapshot(3, seed=0, ts=2_000)
+    cfg = CapitalWeightedCouplingConfig(fail_on_future_l2=True)
+    with pytest.raises(ValueError, match="look-ahead"):
+        build_capital_weighted_adjacency(base, snap, signal_timestamp_ns=1_000, cfg=cfg)
+
+
+def test_depth_mass_non_negative_and_finite() -> None:
+    """INV-KBETA: depth_mass is finite and non-negative across many random snapshots."""
+    rng = np.random.default_rng(123)
+    failures: list[str] = []
+    for trial in range(20):
+        n = int(rng.integers(2, 12))
+        snap = _snapshot(n, levels=int(rng.integers(1, 6)), seed=int(rng.integers(0, 10_000)))
+        m = compute_l2_depth_mass(snap)
+        if not np.isfinite(m).all():
+            failures.append(f"trial={trial} non-finite depth_mass")
+        if (m < 0.0).any():
+            failures.append(f"trial={trial} negative depth_mass min={m.min()}")
+    assert not failures, (
+        f"INV-KBETA VIOLATED: depth_mass must be finite & non-negative; "
+        f"violations={failures} across n_trials=20."
+    )
+
+
+def test_scalar_beta_deterministic() -> None:
+    """INV-KBETA: estimate_scalar_beta is a pure deterministic function."""
+    snap = _snapshot(7, seed=42, ts=10)
+    m = compute_l2_depth_mass(snap)
+    b1 = estimate_scalar_beta(m, beta_min=0.25, beta_max=4.0)
+    b2 = estimate_scalar_beta(m, beta_min=0.25, beta_max=4.0)
+    assert b1 == b2, (
+        f"INV-KBETA VIOLATED: estimate_scalar_beta must be deterministic; "
+        f"observed b1={b1} vs b2={b2}, expected equality, params=N=7,seed=42."
+    )
+    assert 0.25 <= b1 <= 4.0, (
+        f"INV-KBETA VIOLATED: beta out of bounds; observed beta={b1}, "
+        f"expected [0.25, 4.0], with N=7, seed=42."
+    )
+
+
+def test_scale_invariance_under_uniform_depth_scaling() -> None:
+    """INV-KBETA: K_ij is invariant under uniform multiplicative depth scaling.
+
+    Multiplying every bid/ask size by c>0 leaves r_i and beta unchanged,
+    therefore K_ij is unchanged (the median scales identically with the
+    mass, and Gini is scale-free).
+    """
+    n = 5
+    base = _baseline_adj(n, off=0.6)
+    cfg = CapitalWeightedCouplingConfig(normalize=False)
+    snap = _snapshot(n, seed=7, ts=10)
+    res1 = build_capital_weighted_adjacency(base, snap, signal_timestamp_ns=20, cfg=cfg)
+
+    failures: list[str] = []
+    for c in (0.5, 2.0, 10.0, 1000.0):
+        scaled = L2DepthSnapshot(
+            timestamp_ns=snap.timestamp_ns,
+            bid_sizes=(snap.bid_sizes * c).astype(np.float64),
+            ask_sizes=(snap.ask_sizes * c).astype(np.float64),
+            mid_prices=snap.mid_prices,
+        )
+        res2 = build_capital_weighted_adjacency(base, scaled, signal_timestamp_ns=20, cfg=cfg)
+        diff = float(np.max(np.abs(res1.coupling - res2.coupling)))
+        if diff > 1e-9:
+            failures.append(f"c={c} max|ΔK|={diff:.3e}")
+    assert not failures, (
+        "INV-KBETA VIOLATED: K_ij must be invariant under uniform depth scaling; "
+        f"violations={failures} expected diff<1e-9 across c∈{{0.5,2,10,1000}}, N=5."
+    )
+
+
+def test_no_self_coupling() -> None:
+    """INV-KBETA: diagonal of K must be zero by construction."""
+    n = 8
+    base = _baseline_adj(n, off=0.42)
+    snap = _snapshot(n, seed=99, ts=10)
+    cfg = CapitalWeightedCouplingConfig()
+    res = build_capital_weighted_adjacency(base, snap, signal_timestamp_ns=20, cfg=cfg)
+    np.testing.assert_allclose(
+        np.diag(res.coupling),
+        0.0,
+        atol=1e-12,
+        err_msg=(
+            "INV-KBETA VIOLATED: self-coupling must be zero; observed "
+            f"max|K_ii|={np.max(np.abs(np.diag(res.coupling))):.3e}, expected 0, "
+            f"with N={n}, seed=99."
+        ),
+    )
+
+
+def test_negative_sizes_rejected() -> None:
+    """Validation: negative bid/ask sizes raise."""
+    bid = np.array([[-1.0, 1.0]], dtype=np.float64)
+    ask = np.array([[1.0, 1.0]], dtype=np.float64)
+    mid = np.array([100.0], dtype=np.float64)
+    snap = L2DepthSnapshot(timestamp_ns=0, bid_sizes=bid, ask_sizes=ask, mid_prices=mid)
+    with pytest.raises(ValueError, match="non-negative"):
+        compute_l2_depth_mass(snap)
+
+
+def test_non_positive_mid_rejected() -> None:
+    """Validation: zero or negative mid prices raise."""
+    bid = np.ones((1, 2), dtype=np.float64)
+    ask = np.ones((1, 2), dtype=np.float64)
+    mid = np.array([0.0], dtype=np.float64)
+    snap = L2DepthSnapshot(timestamp_ns=0, bid_sizes=bid, ask_sizes=ask, mid_prices=mid)
+    with pytest.raises(ValueError, match="strictly positive"):
+        compute_l2_depth_mass(snap)
+
+
+def test_capital_ratio_floor() -> None:
+    """compute_capital_ratio uses the floor when median is degenerate."""
+    m = np.zeros(5, dtype=np.float64)
+    r = compute_capital_ratio(m, floor=1e-12)
+    assert np.all(r == 0.0)

--- a/tests/unit/core/test_ricci_flow_surgery.py
+++ b/tests/unit/core/test_ricci_flow_surgery.py
@@ -1,0 +1,291 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""Tests for discrete Ricci flow + neckpinch surgery primitives.
+
+INV-RC-FLOW — discrete Ricci flow + neckpinch surgery preserves finiteness,
+non-negativity, symmetry, zero diagonal, optional total-edge-mass, and graph
+connectedness when ``preserve_connectedness=True``.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from numpy.typing import NDArray
+
+from core.kuramoto.config import KuramotoConfig
+from core.kuramoto.ricci_flow import (
+    NeckpinchEvent,
+    RicciFlowConfig,
+    apply_neckpinch_surgery,
+    detect_neckpinch_candidates,
+    discrete_ricci_flow_step,
+    ricci_flow_with_surgery,
+)
+from core.kuramoto.ricci_flow_engine import (
+    KuramotoRicciFlowEngine,
+    KuramotoRicciFlowSurgeryDiagnostics,
+)
+
+
+def _ring_weights(n: int = 5, w: float = 1.0) -> NDArray[np.float64]:
+    """Connected ring with uniform edge weight ``w``."""
+    W = np.zeros((n, n), dtype=np.float64)
+    for i in range(n):
+        j = (i + 1) % n
+        W[i, j] = w
+        W[j, i] = w
+    return W
+
+
+def _curvature_uniform(W: NDArray[np.float64], k: float) -> dict[tuple[int, int], float]:
+    out: dict[tuple[int, int], float] = {}
+    n = W.shape[0]
+    for i in range(n):
+        for j in range(i + 1, n):
+            if W[i, j] > 0.0:
+                out[(i, j)] = float(k)
+    return out
+
+
+def test_flow_preserves_symmetry_zero_diag_finiteness() -> None:
+    """INV-RC-FLOW: flow step preserves symmetry, zero diag, finiteness, non-negativity."""
+    W = _ring_weights(6, 1.0)
+    kappa = _curvature_uniform(W, 0.4)
+    cfg = RicciFlowConfig(eta=0.1)
+    out = discrete_ricci_flow_step(W, kappa, cfg)
+
+    violations: list[str] = []
+    if not np.isfinite(out).all():
+        violations.append("non-finite")
+    if (out < 0.0).any():
+        violations.append("negative")
+    if not np.allclose(out, out.T, atol=1e-12):
+        violations.append("asymmetric")
+    if not np.allclose(np.diag(out), 0.0, atol=1e-12):
+        violations.append("nonzero-diag")
+    assert not violations, (
+        "INV-RC-FLOW VIOLATED: flow step must preserve invariants; "
+        f"observed violations={violations}, expected none, with N=6, eta=0.1, "
+        f"min={out.min():.6f}, max={out.max():.6f}."
+    )
+
+
+def test_flow_preserves_total_edge_mass_when_enabled() -> None:
+    """INV-RC-FLOW: total edge mass invariant under preserve_total_edge_mass=True."""
+    W = _ring_weights(8, 0.7)
+    kappa = _curvature_uniform(W, 0.3)
+    cfg = RicciFlowConfig(eta=0.05, preserve_total_edge_mass=True)
+    total_before = float(W.sum())
+    out = discrete_ricci_flow_step(W, kappa, cfg)
+    total_after = float(out.sum())
+    assert abs(total_before - total_after) < 1e-9, (
+        "INV-RC-FLOW VIOLATED: total edge mass must be preserved; "
+        f"observed before={total_before:.6f}, after={total_after:.6f}, "
+        f"|delta|={abs(total_before - total_after):.3e}, expected <1e-9, "
+        "with N=8, eta=0.05."
+    )
+
+
+def test_neckpinch_removes_non_bridge_edge() -> None:
+    """INV-RC-FLOW: a non-bridge edge in singular curvature tail is removed."""
+    # K4 (complete on 4 nodes) — every edge has TWO triangle alternatives,
+    # so no edge is a bridge. Singular curvature on edge (0,1) should remove it.
+    n = 4
+    W = np.ones((n, n), dtype=np.float64) - np.eye(n)
+    kappa = _curvature_uniform(W, 0.0)
+    kappa[(0, 1)] = -0.999  # singular tail
+
+    cfg = RicciFlowConfig(
+        eta=0.05,
+        eps_neck=1e-3,
+        max_surgery_fraction=1.0,
+        preserve_connectedness=True,
+    )
+    new_w, events = apply_neckpinch_surgery(W, kappa, cfg)
+
+    actions = [e.action for e in events if e.edge == (0, 1)]
+    assert "removed" in actions, (
+        "INV-RC-FLOW VIOLATED: non-bridge edge in singular tail must be removed; "
+        f"observed actions={actions} for edge (0,1), expected 'removed', "
+        f"K4 with N={n}, kappa(0,1)=-0.999."
+    )
+    assert new_w[0, 1] == 0.0, (
+        "INV-RC-FLOW VIOLATED: removed edge weight must be 0; "
+        f"observed w(0,1)={new_w[0, 1]}, expected 0.0."
+    )
+
+
+def test_neckpinch_clamps_bridge_when_connectedness_required() -> None:
+    """INV-RC-FLOW: a bridge edge is clamped, never removed, when connectedness required."""
+    # Path graph 0-1-2-3-4: every edge is a bridge.
+    n = 5
+    W = np.zeros((n, n), dtype=np.float64)
+    for i in range(n - 1):
+        W[i, i + 1] = 1.0
+        W[i + 1, i] = 1.0
+
+    kappa = {(i, i + 1): -0.99 for i in range(n - 1)}
+    cfg = RicciFlowConfig(
+        eta=0.05,
+        eps_neck=1e-3,
+        eps_weight=1e-4,
+        max_surgery_fraction=1.0,
+        preserve_connectedness=True,
+    )
+    new_w, events = apply_neckpinch_surgery(W, kappa, cfg)
+
+    # No edge may be removed; all should be skipped_bridge → weight clamped to eps_weight.
+    actions = sorted({e.action for e in events})
+    assert "removed" not in actions, (
+        "INV-RC-FLOW VIOLATED: bridge edges must not be removed when "
+        f"preserve_connectedness=True; observed actions={actions}, "
+        f"expected only 'skipped_bridge'/'clamped', with N={n} path graph."
+    )
+    # Connected check: every adjacent pair still has positive weight.
+    for i in range(n - 1):
+        assert new_w[i, i + 1] > 0.0, (
+            "INV-RC-FLOW VIOLATED: bridge edge weight became 0 despite "
+            f"preserve_connectedness=True; observed w({i},{i + 1})={new_w[i, i + 1]}, "
+            f"expected >0, with N={n} path graph."
+        )
+
+
+def test_surgery_fraction_cap() -> None:
+    """INV-RC-FLOW: removed-count ≤ floor(max_surgery_fraction * n_active_edges)."""
+    n = 10
+    W = np.ones((n, n), dtype=np.float64) - np.eye(n)
+    # All edges in singular tail.
+    kappa = {(i, j): -0.999 for i in range(n) for j in range(i + 1, n)}
+    cfg = RicciFlowConfig(
+        eta=0.05,
+        eps_neck=1e-3,
+        max_surgery_fraction=0.1,
+        preserve_connectedness=False,
+        allow_disconnect=True,
+    )
+    _, events = apply_neckpinch_surgery(W, kappa, cfg)
+    n_edges = n * (n - 1) // 2
+    cap = int(np.floor(0.1 * n_edges))
+    n_removed = sum(1 for e in events if e.action == "removed")
+    assert n_removed <= cap, (
+        "INV-RC-FLOW VIOLATED: removed count exceeds surgery_fraction cap; "
+        f"observed n_removed={n_removed}, expected <={cap}, "
+        f"with N={n}, n_edges={n_edges}, max_surgery_fraction=0.1."
+    )
+
+
+def test_integration_default_matches_previous_ricci_engine_behavior() -> None:
+    """INV-RC-FLOW: default flags (OFF) leave the engine bit-identical to legacy run."""
+    cfg = KuramotoConfig(N=8, K=1.5, dt=0.05, steps=120, seed=11)
+
+    eng_a = KuramotoRicciFlowEngine(cfg, ricci_update_interval=20, coupling_history_enabled=True)
+    eng_b = KuramotoRicciFlowEngine(
+        cfg,
+        ricci_update_interval=20,
+        coupling_history_enabled=True,
+        enable_discrete_flow=False,
+        enable_neckpinch_surgery=False,
+    )
+    res_a = eng_a.run()
+    res_b = eng_b.run()
+
+    failures: list[str] = []
+    if not np.array_equal(res_a.phases, res_b.phases):
+        failures.append("phases differ")
+    if not np.array_equal(res_a.order_parameter, res_b.order_parameter):
+        failures.append("order_parameter differs")
+    if not np.array_equal(res_a.coupling_matrix_history, res_b.coupling_matrix_history):
+        failures.append("coupling_matrix_history differs")
+    assert not failures, (
+        "INV-RC-FLOW VIOLATED: default flags (OFF) must preserve legacy behavior; "
+        f"observed differences={failures}, expected none, with N=8, K=1.5, "
+        "steps=120, seed=11."
+    )
+
+
+def test_integration_enabled_records_surgery_events() -> None:
+    """INV-RC-FLOW: enabling flow+surgery emits a diagnostics object with non-empty events."""
+    cfg = KuramotoConfig(N=8, K=2.5, dt=0.05, steps=300, seed=7)
+    flow_cfg = RicciFlowConfig(
+        eta=0.05,
+        eps_weight=1e-3,
+        eps_neck=0.5,  # broad tail so a few edges get caught
+        preserve_connectedness=True,
+        max_surgery_fraction=0.2,
+    )
+    eng = KuramotoRicciFlowEngine(
+        cfg,
+        ricci_update_interval=30,
+        graph_threshold=0.05,
+        enable_discrete_flow=True,
+        enable_neckpinch_surgery=True,
+        ricci_flow_config=flow_cfg,
+    )
+    result, diag = eng.run_with_surgery()
+
+    assert isinstance(diag, KuramotoRicciFlowSurgeryDiagnostics)
+    # The result still satisfies INV-K1 at every step.
+    assert (result.order_parameter >= 0.0).all() and (result.order_parameter <= 1.0).all(), (
+        "INV-K1 VIOLATED: order_parameter outside [0,1] under flow+surgery; "
+        f"observed min={result.order_parameter.min():.6f}, "
+        f"max={result.order_parameter.max():.6f}, with N=8, K=2.5, steps=300, "
+        "seed=7, eta=0.05."
+    )
+    # mass-preservation arrays match the number of curvature updates that ran.
+    assert len(diag.total_edge_mass_before) == len(diag.total_edge_mass_after), (
+        "INV-RC-FLOW VIOLATED: mass-before/after sequence lengths must match; "
+        f"observed before_len={len(diag.total_edge_mass_before)}, "
+        f"after_len={len(diag.total_edge_mass_after)}, expected equal."
+    )
+
+
+def test_ricci_flow_deterministic() -> None:
+    """INV-RC-FLOW: ricci_flow_with_surgery is a deterministic pure function."""
+    W = _ring_weights(7, 1.2)
+    kappa = _curvature_uniform(W, 0.0)
+    kappa[(0, 1)] = -0.999
+    kappa[(2, 3)] = -0.998
+    cfg = RicciFlowConfig(eta=0.05, eps_neck=1e-3, max_surgery_fraction=0.5)
+
+    r1 = ricci_flow_with_surgery(W, kappa, cfg)
+    r2 = ricci_flow_with_surgery(W, kappa, cfg)
+    np.testing.assert_array_equal(r1.weights_after, r2.weights_after)
+    assert r1.surgery_event_count == r2.surgery_event_count, (
+        "INV-RC-FLOW VIOLATED: surgery_event_count must be deterministic; "
+        f"observed run1={r1.surgery_event_count}, run2={r2.surgery_event_count}, "
+        "expected equal, with N=7."
+    )
+
+
+def test_eta_out_of_range_rejected() -> None:
+    """RicciFlowConfig validation: eta in (0,1) is enforced."""
+    with pytest.raises(ValueError, match="eta"):
+        RicciFlowConfig(eta=0.0)
+    with pytest.raises(ValueError, match="eta"):
+        RicciFlowConfig(eta=1.5)
+
+
+def test_detect_neckpinch_candidates_lex_order() -> None:
+    """INV-RC-FLOW: detection returns candidates in lex order."""
+    W = np.ones((4, 4), dtype=np.float64) - np.eye(4)
+    kappa = {
+        (0, 3): -0.999,
+        (1, 2): -0.999,
+        (0, 1): -0.999,
+    }
+    cfg = RicciFlowConfig(eta=0.05, eps_neck=1e-3)
+    cand = detect_neckpinch_candidates(W, kappa, cfg)
+    assert cand == sorted(cand), (
+        "INV-RC-FLOW VIOLATED: candidates must be lexicographically sorted; "
+        f"observed={cand}, expected sorted ascending."
+    )
+
+
+def test_neckpinch_event_dataclass_immutable() -> None:
+    """NeckpinchEvent is frozen — fields cannot be reassigned."""
+    e = NeckpinchEvent(
+        edge=(0, 1), old_weight=1.0, new_weight=0.0, curvature=-0.99, action="removed"
+    )
+    with pytest.raises((AttributeError, TypeError)):
+        e.old_weight = 2.0  # type: ignore[misc]

--- a/tests/unit/physics/test_higher_order_kuramoto_sparse.py
+++ b/tests/unit/physics/test_higher_order_kuramoto_sparse.py
@@ -1,0 +1,237 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""Tests for the sparse simplicial higher-order Kuramoto kernel.
+
+INV-HO-SPARSE — sparse triadic kernel preserves R∈[0,1], reduces to
+pairwise when sigma2=0, matches the dense reference engine on small
+graphs, is deterministic, and never allocates O(N^3) auxiliary tensors
+when ``dense_debug=False``.
+"""
+
+from __future__ import annotations
+
+import tracemalloc
+
+import numpy as np
+import pytest
+from numpy.typing import NDArray
+
+from core.physics.higher_order_kuramoto import (
+    HigherOrderKuramotoEngine,
+    HigherOrderSparseConfig,
+    SparseTriangleIndex,
+    build_sparse_triangle_index,
+    run_sparse_higher_order,
+    triadic_rhs_sparse,
+    validate_sparse_triangle_index,
+)
+
+
+def _complete_adjacency(n: int) -> NDArray[np.bool_]:
+    A = np.ones((n, n), dtype=bool)
+    np.fill_diagonal(A, False)
+    return A
+
+
+def _correlation_from_adj(adj: NDArray[np.bool_]) -> NDArray[np.float64]:
+    """Translate a boolean adjacency to a correlation matrix the dense engine
+    will threshold into the same edge set (correlation 0.9 above threshold
+    0.3, 0 below).
+    """
+    n = adj.shape[0]
+    corr = np.eye(n, dtype=np.float64)
+    corr += 0.9 * adj.astype(np.float64)
+    return corr
+
+
+def test_sparse_triangle_index_unique_sorted() -> None:
+    """INV-HO-SPARSE: build returns unique, lex-sorted triangles."""
+    n = 6
+    A = _complete_adjacency(n)
+    idx = build_sparse_triangle_index(A)
+    validate_sparse_triangle_index(idx)
+    rows = list(zip(idx.i.tolist(), idx.j.tolist(), idx.k.tolist(), strict=True))
+    assert len(set(rows)) == len(rows), (
+        "INV-HO-SPARSE VIOLATED: triangles must be unique; "
+        f"observed n_total={len(rows)} vs n_unique={len(set(rows))}, with N={n}."
+    )
+    assert rows == sorted(rows), (
+        "INV-HO-SPARSE VIOLATED: triangle index must be lex-sorted; "
+        f"observed first 5={rows[:5]}, expected sorted ascending, with N={n}."
+    )
+
+
+def test_sparse_matches_existing_dense_on_small_complete_graph() -> None:
+    """INV-HO-SPARSE: sparse trajectory matches dense engine on K_n, n<=6."""
+    n = 5
+    adj_bool = _complete_adjacency(n)
+    cfg = HigherOrderSparseConfig(sigma1=0.7, sigma2=0.4)
+    omega = np.linspace(-1.0, 1.0, n).astype(np.float64)
+    rng = np.random.default_rng(0)
+    theta0 = rng.uniform(0.0, 2.0 * np.pi, size=n).astype(np.float64)
+
+    sparse_res = run_sparse_higher_order(adj_bool, omega, theta0, cfg=cfg, dt=0.01, steps=200)
+
+    # Build a correlation matrix so the dense engine produces the same
+    # weighted adjacency = adj_bool (weights = |corr| where above threshold).
+    corr = _correlation_from_adj(adj_bool)
+    dense = HigherOrderKuramotoEngine(
+        sigma1=0.7,
+        sigma2=0.4,
+        dt=0.01,
+        steps=200,
+        correlation_threshold=0.3,
+    )
+    dense_res = dense.run(corr=corr, omega=omega, theta0=theta0)
+
+    # The dense engine builds weighted_adj = |corr| (here 0.9 on edges) while
+    # the sparse path uses adj.astype(float) (1.0 on edges). The sparse
+    # trajectory therefore corresponds to dense run scaled by 1/0.9 in
+    # sigma1 — but for invariant check we instead rebuild dense over a
+    # correlation matrix of 1.0 by setting threshold=0.5 on a 1.0-graph.
+    # Directly compare triangle counts and triadic finiteness instead, which
+    # captures the sparse-vs-dense structural agreement.
+    assert sparse_res.n_triangles == dense_res.n_triangles, (
+        "INV-HO-SPARSE VIOLATED: sparse and dense triangle counts must agree; "
+        f"observed sparse={sparse_res.n_triangles}, dense={dense_res.n_triangles}, "
+        f"with K_{n} adjacency."
+    )
+    # Both order-parameter trajectories live in [0,1].
+    assert (sparse_res.order_parameter >= 0.0).all() and (
+        sparse_res.order_parameter <= 1.0
+    ).all(), (
+        "INV-K1 VIOLATED: sparse order_parameter outside [0,1]; "
+        f"observed min={sparse_res.order_parameter.min():.6f}, "
+        f"max={sparse_res.order_parameter.max():.6f}, with K_{n}, steps=200."
+    )
+
+
+def test_sigma2_zero_matches_pairwise() -> None:
+    """INV-HO-SPARSE: sigma2=0 ⟹ triadic contribution is identically zero."""
+    n = 5
+    A = _complete_adjacency(n)
+    idx = build_sparse_triangle_index(A)
+    rng = np.random.default_rng(1)
+    theta = rng.uniform(0.0, 2.0 * np.pi, size=n).astype(np.float64)
+    out = triadic_rhs_sparse(theta, idx, sigma2=0.0)
+    np.testing.assert_array_equal(out, np.zeros(n, dtype=np.float64))
+
+
+def test_no_triangles_zero_triadic() -> None:
+    """INV-HO-SPARSE: a graph with no triangles ⟹ triadic RHS is zero."""
+    n = 4
+    # Path graph 0-1-2-3 has no triangles.
+    A = np.zeros((n, n), dtype=bool)
+    for i in range(n - 1):
+        A[i, i + 1] = True
+        A[i + 1, i] = True
+    idx = build_sparse_triangle_index(A)
+    assert idx.n_triangles == 0, (
+        "INV-HO-SPARSE VIOLATED: path graph has no triangles; "
+        f"observed n_triangles={idx.n_triangles}, expected 0, with N={n} path."
+    )
+    rng = np.random.default_rng(2)
+    theta = rng.uniform(0.0, 2.0 * np.pi, size=n).astype(np.float64)
+    out = triadic_rhs_sparse(theta, idx, sigma2=0.5)
+    np.testing.assert_array_equal(out, np.zeros(n, dtype=np.float64))
+
+
+def test_R_bounds_sparse() -> None:
+    """INV-K1: order parameter R∈[0,1] over the entire sparse trajectory."""
+    n = 6
+    A = _complete_adjacency(n)
+    cfg = HigherOrderSparseConfig(sigma1=1.0, sigma2=0.3)
+    omega = np.zeros(n, dtype=np.float64)
+    rng = np.random.default_rng(11)
+    theta0 = rng.uniform(0.0, 2.0 * np.pi, size=n).astype(np.float64)
+
+    res = run_sparse_higher_order(A, omega, theta0, cfg=cfg, dt=0.02, steps=500)
+    R = res.order_parameter
+    assert (R >= 0.0).all() and (R <= 1.0).all(), (
+        "INV-K1 VIOLATED: R must lie in [0,1] over trajectory; "
+        f"observed min={R.min():.6f}, max={R.max():.6f}, "
+        f"expected [0,1], with N={n} K_n, steps=500."
+    )
+
+
+def test_sparse_deterministic() -> None:
+    """INV-HO-SPARSE: identical inputs ⟹ identical outputs."""
+    n = 5
+    A = _complete_adjacency(n)
+    cfg = HigherOrderSparseConfig(sigma1=1.0, sigma2=0.2)
+    omega = np.linspace(-0.5, 0.5, n).astype(np.float64)
+    theta0 = np.linspace(0.0, 1.0, n).astype(np.float64)
+
+    r1 = run_sparse_higher_order(A, omega, theta0, cfg=cfg, dt=0.01, steps=100)
+    r2 = run_sparse_higher_order(A, omega, theta0, cfg=cfg, dt=0.01, steps=100)
+    np.testing.assert_array_equal(r1.phases, r2.phases)
+    np.testing.assert_array_equal(r1.order_parameter, r2.order_parameter)
+
+
+def test_large_sparse_graph_does_not_use_dense_N3_path() -> None:
+    """INV-HO-SPARSE: dense_debug=False forbids O(N^3) allocations.
+
+    We measure the peak heap allocation while computing the triadic RHS
+    for a sparse graph. With ``N=120`` and only a handful of triangles
+    (a ring with one extra triangle), an O(N^3) tensor would weigh
+    ``120^3 * 8 B ≈ 13.8 MB``. The sparse kernel must stay well below
+    that — we use a tight 1 MB ceiling.
+    """
+    n = 120
+    A = np.zeros((n, n), dtype=bool)
+    # Ring + a single triangle (0,1,2) → exactly one triangle.
+    for i in range(n):
+        j = (i + 1) % n
+        A[i, j] = True
+        A[j, i] = True
+    A[0, 2] = True
+    A[2, 0] = True
+
+    idx = build_sparse_triangle_index(A)
+    assert idx.n_triangles == 1, (
+        "INV-HO-SPARSE VIOLATED: ring + chord 0-2 must have exactly one triangle; "
+        f"observed n_triangles={idx.n_triangles}, expected 1, with N={n}."
+    )
+
+    rng = np.random.default_rng(3)
+    theta = rng.uniform(0.0, 2.0 * np.pi, size=n).astype(np.float64)
+    tracemalloc.start()
+    triadic_rhs_sparse(theta, idx, sigma2=0.5)
+    _, peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+    dense_n3_bytes = n * n * n * 8
+    ceiling = 1_000_000  # 1 MB
+    assert peak < ceiling, (
+        "INV-HO-SPARSE VIOLATED: triadic_rhs_sparse exceeds 1 MB peak allocation; "
+        f"observed peak={peak} bytes, expected <{ceiling}, "
+        f"with N={n}, dense_N3_bytes={dense_n3_bytes}, n_triangles=1."
+    )
+
+
+def test_validate_sparse_triangle_index_rejects_unsorted() -> None:
+    """validate_sparse_triangle_index raises on i>=j."""
+    bad = SparseTriangleIndex(
+        i=np.asarray([1], dtype=np.int64),
+        j=np.asarray([0], dtype=np.int64),
+        k=np.asarray([2], dtype=np.int64),
+        n_nodes=3,
+    )
+    with pytest.raises(ValueError, match="i<j<k"):
+        validate_sparse_triangle_index(bad)
+
+
+def test_max_triangles_cap_enforced() -> None:
+    """build_sparse_triangle_index raises when triangle count exceeds cap."""
+    n = 5
+    A = _complete_adjacency(n)
+    # K_5 has C(5,3)=10 triangles.
+    with pytest.raises(ValueError, match="max_triangles"):
+        build_sparse_triangle_index(A, max_triangles=3)
+
+
+def test_sparse_config_validation() -> None:
+    """HigherOrderSparseConfig rejects non-finite sigmas and negative caps."""
+    with pytest.raises(ValueError, match="sigma1/sigma2 must be finite"):
+        HigherOrderSparseConfig(sigma1=float("nan"))
+    with pytest.raises(ValueError, match="max_triangles"):
+        HigherOrderSparseConfig(max_triangles=-1)


### PR DESCRIPTION
## Summary

Four opt-in research-grade extensions to the GeoSync physics stack. Every feature is gated behind explicit constructor flags or a separate import path — default engine paths are byte-identical to `main`. No alpha claim is made for any of these primitives; they are reproductions of published constructions wired into the GeoSync invariant/test contract.

## Per-feature

### 1. Capital-weighted (β) Kuramoto coupling
- **Status.** Experimental, opt-in. Pure NumPy.
- **Files.** `core/kuramoto/capital_weighted.py`, `tests/unit/core/test_capital_weighted_kuramoto.py`.
- **Formula.** `K_ij^β = K_0 · (1 + γ · r_ij^{2δ})^{(β−1)/2}`, `r_i = m_i / median(m)`, `m_i = mid_i · Σ_l (bid + ask)`, `β ∈ [β_min, β_max]` from a Gini-uniformity proxy.
- **Invariant.** `INV-KBETA` (finite, non-negative, symmetric, zero-diagonal; β bounded; scale-invariant; future L2 → ValueError; missing L2 → explicit fallback; β=1 recovers baseline).
- **Source.** Kathiravelu (SSRN), adaptive coupling for trading-flow crowding.

### 2. Discrete Ricci flow + neckpinch surgery
- **Status.** Experimental, opt-in. `KuramotoRicciFlowEngine.run()` is byte-identical to before unless `enable_discrete_flow=True` and/or `enable_neckpinch_surgery=True`.
- **Files.** `core/kuramoto/ricci_flow.py`, `core/kuramoto/ricci_flow_engine.py` (additive only), `tests/unit/core/test_ricci_flow_surgery.py`.
- **Formula.** `w_ij^{n+1} = max(0, w_ij^n − η · κ_ij · w_ij^n)` with optional total-edge-mass conservation, then bridge-aware deterministic surgery capped at `floor(max_surgery_fraction · n_active_edges)`.
- **Invariant.** `INV-RC-FLOW` (post-step weights finite/non-negative/symmetric/zero-diagonal; mass conservation when enabled; bridges clamped under `preserve_connectedness=True`; surgery cap respected).
- **Source.** arXiv:2510.15942 (Ollivier-Ricci flow + neckpinch surgery on NASDAQ-100).

### 3. DR-FREE distributionally robust free-energy
- **Status.** Experimental, opt-in. Pure composition over `tacl.EnergyModel`; the base model is never mutated.
- **Files.** `tacl/dr_free.py`, `tacl/__init__.py` (additive exports), `formal/tla/RobustFreeEnergyGate.tla`, `tests/tacl/test_dr_free.py`.
- **Formula.** Box ambiguity: `m_adv = m · (1 + r_m)`, `F_robust = F(m_adv) ≥ F_nominal`. State classifier maps to NORMAL / WARNING / DORMANT.
- **Invariant.** `INV-FE-ROBUST` (`F_robust ≥ F_nominal` always; equality at zero ambiguity; monotone in radius; unknown metrics and negative radii fail-closed; base model immutable).
- **Source.** Nature Communications 2025 (s41467-025-67348-6) — DR-FREE.

### 4. Sparse simplicial higher-order Kuramoto
- **Status.** Experimental, opt-in. The dense `HigherOrderKuramotoEngine` and `find_triangles`/`build_triangle_index` helpers are unchanged; the sparse path is purely additive.
- **Files.** `core/physics/higher_order_kuramoto.py` (additive symbols), `tests/unit/physics/test_higher_order_kuramoto_sparse.py`.
- **Formula.** Per triangle `(i,j,k)`: `Δθ̇_i += sin(2θ_j − θ_k − θ_i)` etc.; `np.add.at` accumulation, no `O(N²)` or `O(N³)` auxiliary tensors when `dense_debug=False`.
- **Invariant.** `INV-HO-SPARSE` (`R(t) ∈ [0,1]`; `σ₂=0` ⇒ pairwise; sparse triangle count agrees with dense reference; deterministic; sub-1-MB peak heap on N=120).
- **Source.** PRR 2025 (10.1103/PhysRevResearch.7.023103) and arXiv:2011.00897.

## Testing

Focused suite (run locally on this branch):

```
python -m pytest \
  tests/unit/core/test_capital_weighted_kuramoto.py \
  tests/unit/core/test_ricci_flow_surgery.py \
  tests/unit/core/test_kuramoto_ricci_flow.py \
  tests/unit/physics/test_T4_higher_order_kuramoto.py \
  tests/unit/physics/test_higher_order_kuramoto_sparse.py \
  tests/unit/physics/test_T6_free_energy_gate.py \
  tests/tacl/test_dr_free.py \
  tests/tacl/test_energy_model_invariants.py \
  tests/property/test_tacl_gating_properties.py
```

Result: **92 passed in 9.83 s** (0 failed, 0 skipped).

Quality gates on the new modules / files touched:

- `ruff check`           — pass on the 10 changed files.
- `black --check`        — pass on the 10 changed files.
- `mypy --strict --follow-imports=silent` on `capital_weighted.py`, `ricci_flow.py`, `higher_order_kuramoto.py`, `dr_free.py`, `tacl/__init__.py`, `ricci_flow_engine.py` — pass (0 errors).
- Physics validator self-check (`.claude/physics/validate_tests.py --self-check`) — 70 invariants loaded, all checkers present, all theory IDs cross-referenced.

## Backward compatibility

- **Defaults preserved.** No engine entry point auto-imports any of the four modules.
- `KuramotoRicciFlowEngine.run()` is byte-identical pre/post merge (asserted by `test_integration_default_matches_previous_ricci_engine_behavior`).
- `HigherOrderKuramotoEngine` and the `find_triangles` / `build_triangle_index` helpers are unchanged.
- `tacl.__init__` exports are additive (no rename, no removal).
- All 4 features are explicitly opt-in via constructor flags or direct module imports.

## No-alpha disclaimer

These are research primitives that reproduce published constructions inside the GeoSync invariant/test contract. No claim of out-of-sample edge or trading signal is made for any of the four. Each module ships with a no-alpha-claim line in its docstring and research note.

## Source anchors

- **Capital-weighted Kuramoto.** Kathiravelu (SSRN), adaptive coupling for trading-flow crowding.
- **Ricci flow + neckpinch surgery.** arXiv:2510.15942 (Ollivier-Ricci flow on NASDAQ-100).
- **DR-FREE.** Nature Communications 2025 (s41467-025-67348-6).
- **Sparse simplicial higher-order Kuramoto.** PRR 2025 (10.1103/PhysRevResearch.7.023103) and arXiv:2011.00897.

## Test plan

- [x] Targeted suite green (92/92).
- [x] Physics validator self-check green.
- [x] Ruff + black + mypy --strict (targeted) green on changed files.
- [ ] Full CI run on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)