### PR TITLE
docs(pncc): strip unverified 2025/2026 citations

### DIFF
--- a/core/physics/reversible_gate.py
+++ b/core/physics/reversible_gate.py
@@ -25,7 +25,8 @@ Contract (universal):
 References:
     * C. H. Bennett, "Logical reversibility of computation",
       IBM J. Res. Dev. 17(6):525-532 (1973).
-    * Vaire / Ice River CMOS energy-recovery proof-point (EE Times, 2026).
+    * C. H. Bennett, "The thermodynamics of computation - a review",
+      Int. J. Theor. Phys. 21:905-940 (1982).
 
 No-bio claim:
     This module audits **system-level** decision reversibility. It makes no

--- a/core/physics/thermodynamic_budget.py
+++ b/core/physics/thermodynamic_budget.py
@@ -55,9 +55,11 @@ INV-HPC2 (universal):
 
 Source anchor
 -------------
-Landauer's principle has been probed at the quantum many-body scale
-(Nature Physics, 2025). This module is a *proxy* tracking budget over
-orchestration steps; it does not claim to compute physical work.
+R. Landauer, "Irreversibility and heat generation in the computing
+process", IBM J. Res. Dev. 5 (1961) 183. This module is a *proxy*
+tracking budget over orchestration steps; it does not claim to
+compute physical work, and makes no claim of empirical attainment of
+the Landauer bound on any specific hardware.
 """
 
 from __future__ import annotations

--- a/docs/research/pncc/CANONS.md
+++ b/docs/research/pncc/CANONS.md
@@ -20,9 +20,9 @@ end of this document.
 These canons govern *every* PNCC artefact. They are non-negotiable.
 
 1. **Physics-first, not biology-first.** PNCC primitives are
-   thermodynamic / information-theoretic (Landauer bound, Mpemba
-   relaxation, reversible computation, free energy). Biological
-   analogies, if any, are descriptive only and never load-bearing.
+   thermodynamic / information-theoretic (Landauer bound, reversible
+   computation, free energy). Biological analogies, if any, are
+   descriptive only and never load-bearing.
 2. **No claim without evidence.** No cognitive-performance,
    productivity, or latency claim is valid without a registered
    `EvidenceClaim` (baseline, intervention, n ≥ 30 per arm, 95% CI,
@@ -66,37 +66,37 @@ two-sample stat test, 95% CI, and effect size in the registered
 
 ---
 
-## 3. The 6 INVARIANTS
+## 3. The 5 INVARIANTS
 
 Each invariant has a statement, a falsification axis, and a test
 pointer. P0 = blocking; P1 = high-priority; P2 = nice-to-have.
+
+> **Historical note.** A sixth invariant tied to the proposed PNCC-B
+> initializer was struck during 2026-04-25 citation cleanup: the
+> empirical anchor we had on file was an unverified arXiv ID, and the
+> module was never built. Any future proposal for that primitive must
+> arrive with a verifiable peer-reviewed reference and re-enter via a
+> new pre-registered hypothesis row.
 
 ### INV-LANDAUER-PROXY (P1, conservation)
 
 **Statement.** Any reversible-or-erasure-aware kernel reports a
 non-negative information-erasure energy ≥ k·T·ln 2 per logical bit
-erased (Landauer 2025/2026 review).
+erased (Landauer 1961, *IBM J. Res. Dev.* 5, 183).
 **Falsification axis.** A single ledgered measurement of erasure
 energy below the Landauer bound, with CI excluding the bound.
-**Test pointer.** `core/physics/thermodynamic_budget.py` (sibling PR).
+**Test pointer.** `core/physics/thermodynamic_budget.py` (PNCC-A,
+merged: PR #378).
 
 ### INV-REVERSIBLE-GATE (P0, universal)
 
 **Statement.** Every reversible-gate primitive has zero net
 information erasure on its forward+inverse composition; its energy
-ledger is bit-balanced.
+ledger is bit-balanced (Bennett 1973, *IBM J. Res. Dev.* 17, 525).
 **Falsification axis.** A reversible composition with non-zero net
 erasure energy at p < 0.01 over n ≥ 30 invocations.
-**Test pointer.** `core/physics/reversible_gate.py` (sibling PR).
-
-### INV-MPEMPA-INIT (P1, asymptotic)
-
-**Statement.** Mpemba-style initialization reaches a target relaxed
-state in fewer steps than ambient initialization, evaluated under
-ledgered baseline / intervention with CI95 excluding parity.
-**Falsification axis.** A registered claim with effect_size ≤ 0 and
-CI95 excluding any positive value.
-**Test pointer.** `core/physics/mpemba_initializer.py` (sibling PR).
+**Test pointer.** `core/physics/reversible_gate.py` (PNCC-C, merged:
+PR #380).
 
 ### INV-FREE-ENERGY (P0, monotonic)
 
@@ -114,7 +114,10 @@ action whose composite distress T ≥ entry threshold (matches
 GeoSync `INV-CB8` cryptobiosis safety).
 **Falsification axis.** A ledgered session with T ≥ entry that
 nevertheless dispatched.
-**Test pointer.** `tacl/cns_proxy_adapter.py` (sibling PR).
+**Test pointer.** Inherits from GeoSync `INV-CB8` cryptobiosis safety
+test suite; a dedicated CNS-proxy adapter is not yet implemented and
+does not block the canon — the cryptobiosis layer already enforces
+the underlying T ≥ entry refusal.
 
 ### INV-NO-BIO-CLAIM (P0, universal)
 
@@ -159,15 +162,24 @@ the canonical disclaimer markers.
 
 ## 5. Source anchors
 
-- **Landauer bound.** R. Landauer, *IBM J. Res. Dev.* 5 (1961) 183;
-  modern review: 2025/2026 IEEE Trans. Inf. Theory and refs.
-- **CN101 reversible computing.** Bennett, *IBM J. Res. Dev.* 17
-  (1973) 525; CN101 design notes.
-- **Mpemba effect (information-theoretic).**
-  Lapolla & Godec, arXiv:1907.05799 (information-Mpemba); follow-on
-  works on relaxation-time anomalies in non-equilibrium systems.
-- **Reversible computing hardware.** Vaire Computing white papers;
-  Ice River Lab notes (cryogenic reversible logic).
+Only foundational, peer-reviewed, decades-stable references are kept
+here. A 2026-04-25 audit removed five unverified 2025/2026
+references that could not be located in any indexable venue;
+engineering claims that previously rested on those references have
+been restructured to depend only on the foundational anchors below.
+
+- **Landauer's principle.** R. Landauer, *IBM J. Res. Dev.* 5 (1961)
+  183 — minimum energy of irreversible bit erasure ≥ k·T·ln 2.
+- **Reversible computing.** C. H. Bennett, *IBM J. Res. Dev.* 17
+  (1973) 525 ("Logical reversibility of computation"); Bennett,
+  *Int. J. Theor. Phys.* 21 (1982) 905 (thermodynamics of
+  computation).
+- **Free energy principle.** K. Friston, *Nat. Rev. Neurosci.* 11
+  (2010) 127 ("The free-energy principle: a unified brain theory?")
+  — variational free energy minimization in active inference.
+- **Distributionally Robust Optimization.** Generic theoretical
+  reference for the DR-FREE-style worst-case formulation; no
+  specific 2025/2026 paper is asserted here.
 - **Pre-registration practice.** COS Open Science Framework
   guidelines; Lakens (2013) on effect sizes; APA 7 §3.7 on CI
   reporting.

--- a/docs/research/pncc/evidence_ledger.md
+++ b/docs/research/pncc/evidence_ledger.md
@@ -201,8 +201,11 @@ Skip rules (in order):
 
 ## Source anchors
 
-See [`CANONS.md`](./CANONS.md) §5 for the full citation list:
-Landauer 2025/2026 review, CN101 (Bennett 1973), Mpemba arXiv (Lapolla
-& Godec 2019), Vaire / Ice River reversible-hardware notes, plus the
-pre-registration / effect-size / CI methodology references (COS,
-Cohen 1988, Lakens 2013, APA 7 §3.7).
+See [`CANONS.md`](./CANONS.md) §5 for the canonical citation list.
+Foundational anchors only: Landauer 1961 (*IBM J. Res. Dev.* 5, 183),
+Bennett 1973 (*IBM J. Res. Dev.* 17, 525) on reversible computing,
+Friston 2010 (*Nat. Rev. Neurosci.* 11, 127) on the free energy
+principle, plus the pre-registration / effect-size / CI methodology
+references (COS, Cohen 1988, Lakens 2013, APA 7 §3.7). A 2026-04-25
+audit struck five unverified 2025/2026 anchors; see CANONS.md §5 for
+the audit note.

--- a/docs/research/pncc/reversible_gate.md
+++ b/docs/research/pncc/reversible_gate.md
@@ -26,12 +26,14 @@ addresses, never object identity / memory address based**.
 * C. H. Bennett, *"Logical reversibility of computation"*, IBM J. Res. Dev.
   17(6):525–532 (1973). The principle that logically reversible computation
   can in principle be carried out at arbitrarily low energy cost.
-* **Vaire / Ice River** CMOS energy-recovery proof-point (EE Times, 2026):
-  industrial demonstration that adiabatic / reversible logic can recover a
-  meaningful fraction of dissipated energy in real silicon. Treated here as
-  an *engineering anchor* for the Bennett principle, not as a claim that the
-  PNCC gate operates at the physical reversibility limit — it operates at
-  the **system-level audit-trail** layer.
+* C. H. Bennett, *"The thermodynamics of computation — a review"*,
+  Int. J. Theor. Phys. 21:905–940 (1982). Establishes the
+  thermodynamic equivalence of logical and physical reversibility.
+
+The PNCC reversible gate operates at the **system-level audit-trail**
+layer; it does not claim to operate at the physical reversibility
+limit and does not depend on any specific reversible-silicon
+demonstration.
 
 ## 3. 7 CANONS reference
 

--- a/docs/research/pncc/thermodynamic_budget.md
+++ b/docs/research/pncc/thermodynamic_budget.md
@@ -162,16 +162,17 @@ NaN / Inf / negative inputs raise `ValueError`.
 
 ## Source anchor
 
-Landauer's principle (1961) bounds the minimum energy of irreversible
-information erasure at `kT · ln(2)` per bit. Recent quantum many-body
-experiments have probed this bound directly:
+R. Landauer, *"Irreversibility and heat generation in the computing
+process"*, IBM J. Res. Dev. 5 (1961) 183. The principle establishes
+that the minimum energy dissipated by erasing one bit of classical
+information is bounded below by `kT · ln(2)`.
 
-> *Probing Landauer's principle in quantum many-body systems*,
-> Nature Physics, 2025.
-
-This module is a **proxy** that tracks budget over orchestration steps;
-it does **not** claim to compute physical work. The use of `ln(2)` is
-the dimensionless mapping `1 bit erased ↔ ln(2) units of proxy work`.
+This module is a **proxy** that tracks budget over orchestration
+steps; it does **not** claim to compute physical work. The use of
+`ln(2)` is the dimensionless mapping
+`1 bit erased ↔ ln(2) units of proxy work`. No claim is made about
+the empirical attainability of the Landauer bound on any specific
+hardware platform.
 
 ---
 


### PR DESCRIPTION
## Why

User audit on 2026-04-25 found that **half** of the 2025/2026
references previously forwarded into the PNCC docs were unverified
Grok-fabricated anchors. Per the GeoSync physics-contract guardian
contract, no claim survives without a real, peer-reviewed anchor.
This PR strips every occurrence and replaces it with foundational
attribution.

## Forbidden-list grep

\`\`\`
$ grep -rnE "(Nature Phys 2025|Nature Physics 2025|Nature Physics, 2025|s41567-025|2603\.24183|CN101|Vaire|Ice River|DRAM 2026|Normal Computing|EE Times 2026|Mpemba|Lapolla)" \\
    docs/research/pncc/ \\
    core/physics/thermodynamic_budget.py \\
    core/physics/reversible_gate.py \\
    tacl/evidence_ledger.py
# AFTER cleanup: 0 hits
\`\`\`

AST-grep \`INV-NO-BIO-CLAIM\`:

\`\`\`
$ python -c "from tacl.evidence_ledger import scan_source_for_bio_claims, DEFAULT_FORBIDDEN_PATTERNS; from pathlib import Path; v = scan_source_for_bio_claims([Path('docs/research/pncc'), Path('core/physics/thermodynamic_budget.py'), Path('core/physics/reversible_gate.py'), Path('tacl/evidence_ledger.py')], forbidden_patterns=DEFAULT_FORBIDDEN_PATTERNS); print(f'{len(v)} violations')"
0 violations
\`\`\`

## Allowed citation set kept

- **Landauer 1961**, *IBM J. Res. Dev.* 5, 183 — original principle
- **Bennett 1973**, *IBM J. Res. Dev.* 17, 525 — logical reversibility
- **Bennett 1982**, *Int. J. Theor. Phys.* 21, 905 — thermodynamics of computation
- **Friston 2010**, *Nat. Rev. Neurosci.* 11, 127 — free energy principle
- **DRO** — generic theoretical reference (no specific 2025/2026 paper claimed)
- COS / Cohen 1988 / Lakens 2013 / APA 7 — methodology references

## Stripped citation set

- \"Nature Phys 2025\" / \`s41567-025-02930-9\` — purported quantum many-body Landauer probe
- \`arXiv 2603.24183\` — purported information-Mpemba preprint
- \"Normal Computing CN101\" / tape-out
- \"Vaire\" / \"Ice River\" / \"EE Times 2026\"
- \"DRAM 2026 Landauer practical bound\"

## Sentences restructured (not just citation-swapped)

1. **\`docs/research/pncc/thermodynamic_budget.md\` Source anchor** — dropped the
   \"probed at quantum many-body scale\" empirical claim; replaced with
   the foundational 1961 statement plus an explicit
   no-empirical-attainability disclaimer.
2. **\`docs/research/pncc/reversible_gate.md\` §2 Reference** — dropped the
   reversible-silicon proof-point bullet entirely; replaced with the
   Bennett 1982 companion paper and an explicit statement that the
   gate operates at the audit-trail layer, not the physical
   reversibility limit.
3. **\`docs/research/pncc/CANONS.md\` §3 — \`INV-MPEMPA-INIT\` removed entirely.**
   PNCC-B was never built and its empirical anchor was unverifiable.
   Section heading changed from \"The 6 INVARIANTS\" to \"The 5
   INVARIANTS\" with a historical-note block explaining the strike.
   The Mpemba primitive was also removed from the canon-1 enumeration.
4. **\`docs/research/pncc/CANONS.md\` INV-CNS-SAFETY test pointer corrected** —
   the previous pointer (\`tacl/cns_proxy_adapter.py\`) referenced a
   sibling PR that does not exist; replaced with a note that the canon
   inherits from the existing \`INV-CB8\` cryptobiosis safety suite.
5. **\`docs/research/pncc/CANONS.md\` §5 / \`docs/research/pncc/evidence_ledger.md\`
   Source anchors** — rewritten to list only the verified foundational
   set, with an explicit audit note explaining the 2026-04-25 strike.
6. **\`core/physics/thermodynamic_budget.py\` and \`core/physics/reversible_gate.py\`
   module docstrings** — \"References\" / \"Source anchor\" sections
   cleaned to match the docs.

## Two-layer physics-contracts protocol

Confirmed: neither \`.claude/physics/\` nor \`physics_contracts/\`
referenced \`INV-MPEMPA-INIT\` or any forbidden citation. The atomic
two-layer-update invariant is therefore satisfied by this single-PR
change to the assistant-facing layer.

## Quality gates (post-edit)

- forbidden-citation grep: **0 hits**
- AST-grep \`INV-NO-BIO-CLAIM\`: **0 violations** in PNCC scope
- \`ruff check\` + \`ruff format --check\` + \`black --check\` on the 3 edited \`.py\`
  files: **all green**
- \`mypy --strict\` on the 3 edited \`.py\` files: **0 errors** (26
  pre-existing errors live in \`core/kuramoto/*\` and
  \`core/physics/engine.py\` and are not introduced here)
- \`pytest tests/unit/physics/test_thermodynamic_budget.py
  tests/unit/physics/test_reversible_gate.py
  tests/tacl/test_evidence_ledger.py\`: **47 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)