### PR TITLE
feat(physics): register PNCC invariants in both contract layers (Wave 1.5)

### DIFF
--- a/.claude/physics/INVARIANTS.yaml
+++ b/.claude/physics/INVARIANTS.yaml
@@ -778,3 +778,50 @@ higher_order_kuramoto:
     test_type: property_test
     falsification: "R outside [0,1]; sigma2=0 produces nonzero triadic RHS; sparse triangle count differs from dense; identical inputs produce different outputs; peak heap exceeds the c·n_triangles ceiling for sparse graphs"
     priority: P0
+
+
+# ═══════════════════════════════════════════════════
+# PNCC — PHYSICS-NATIVE COGNITIVE KERNEL (Wave 1)
+# ═══════════════════════════════════════════════════
+# Experimental / opt-in. Physics-first, not biology-first.
+# Canonical reference: docs/research/pncc/CANONS.md (7 CANONS, 5 pre-registered
+# hypotheses, 6 invariants). Two-layer protocol per CANONS §7: this file is the
+# assistant-facing layer; physics_contracts/catalog.yaml is the runtime layer.
+# Both updated atomically in this commit.
+#
+# Wave 1 landed: PNCC-A (#378), PNCC-E (#379), PNCC-C (#380).
+#   Three invariants registered here.
+# Wave 1 dropped: PNCC-B (Mpemba) — INV-MPEMBA-INIT not registered.
+# Wave 1 halted: PNCC-D (CNS proxy) — INV-CNS-SAFETY not registered, awaits real telemetry.
+# Wave 2 deferred: PNCC-F (free energy) — INV-FREE-ENERGY shadow-tracked by INV-FE1/FE2.
+
+pncc:
+  landauer_proxy:
+    id: INV-LANDAUER-PROXY
+    type: universal
+    statement: "Irreversible action proxy cost dominates reversible-alternative cost: C_irr >= C_rev with strict > whenever irreversibility_score > 0"
+    test_type: property_test
+    falsification: "Any pair of irreversible/reversible actions with identical (token, latency, entropy) where C_irr < C_rev"
+    priority: P0
+    source: core/physics/thermodynamic_budget.py
+    tests: tests/unit/physics/test_thermodynamic_budget.py
+
+  reversible_gate:
+    id: INV-REVERSIBLE-GATE
+    type: universal
+    statement: "Reversible-tagged action implies byte-exact pre-state recovery via rollback(audit_hash)"
+    test_type: property_test
+    falsification: "1000 random reversible actions where rollback(trace.audit_hash).state_bytes != pre_state"
+    priority: P0
+    source: core/physics/reversible_gate.py
+    tests: tests/unit/physics/test_reversible_gate.py
+
+  no_bio_claim:
+    id: INV-NO-BIO-CLAIM
+    type: universal
+    statement: "Cognitive-performance language must be paired with a registered EvidenceClaim or an explicit disclaimer phrase"
+    test_type: property_test
+    falsification: "AST-grep over core/, tacl/, runtime/, geosync/ returns >=1 naked violation in non-test source"
+    priority: P0
+    source: tacl/evidence_ledger.py
+    tests: tests/tacl/test_evidence_ledger.py

--- a/physics_contracts/catalog.yaml
+++ b/physics_contracts/catalog.yaml
@@ -342,3 +342,47 @@ laws:
     validity: "all inputs to geosync_observe"
     source: "core/dro_ara/engine.py::_validate"
     severity: block
+
+  # ───────────────────── PNCC (Physics-Native Cognitive Kernel) ─────────────────────
+  # Wave 1 landed invariants. Two-layer protocol per
+  # docs/research/pncc/CANONS.md §7. Mirror entries live in
+  # .claude/physics/INVARIANTS.yaml under the `pncc:` section.
+
+  - id: pncc.landauer_proxy_dominance
+    module: pncc
+    statement: "Irreversible action proxy cost dominates the reversible-alternative cost; strictly so when irreversibility_score > 0 (INV-LANDAUER-PROXY)."
+    formula: "C_irr ≥ C_rev,  with C_irr > C_rev iff irreversibility_score > 0"
+    variables:
+      C_irr: "aggregate proxy cost of an irreversible action (token + latency + entropy + irreversibility penalty)"
+      C_rev: "aggregate proxy cost of a reversible alternative with identical token/latency/entropy components"
+      irreversibility_score: "scalar in [0, 1] returned by classify_irreversibility"
+    tolerance: "strict — any reversible/irreversible pair with identical (token, latency, entropy) and irreversibility_score > 0 must satisfy C_irr > C_rev exactly; equality only when irreversibility_score == 0"
+    validity: "pure functional path: aggregate_entry → total_cost → reversible_alternative_cost; no global state, no RNG, no time call"
+    source: "Landauer 1961; core/physics/thermodynamic_budget.py; tests/unit/physics/test_thermodynamic_budget.py"
+    severity: warn
+
+  - id: pncc.reversible_gate_byte_exact
+    module: pncc
+    statement: "A reversible-tagged action's rollback recovers the byte-exact pre-state (INV-REVERSIBLE-GATE)."
+    formula: "irreversibility_score(action) ≤ cfg.irreversibility_threshold  ⇒  gate.rollback(trace.audit_hash).state_bytes == pre_state"
+    variables:
+      pre_state: "snapshot bytes captured before action dispatch"
+      audit_hash: "deterministic SHA-256 over canonical-JSON of (action, pre_state, post_state, score)"
+      cfg.irreversibility_threshold: "configured cutoff separating reversible from irreversible actions"
+    tolerance: "strict bit-equality of pre_state and rollback output across 1000 random reversible actions"
+    validity: "rollback called with the trace.audit_hash issued by the same gate instance; action classified reversible"
+    source: "Bennett 1973; core/physics/reversible_gate.py; tests/unit/physics/test_reversible_gate.py"
+    severity: warn
+
+  - id: pncc.no_bio_claim
+    module: tacl
+    statement: "Cognitive-performance language in non-test source must be paired with a registered EvidenceClaim or an allowed disclaimer phrase (INV-NO-BIO-CLAIM)."
+    formula: "for every match m of DEFAULT_FORBIDDEN_PATTERNS in non-test source: ∃ EvidenceClaim_registered(m) ∨ ∃ phrase ∈ allowed_disclaimer_phrases within scope(m)"
+    variables:
+      DEFAULT_FORBIDDEN_PATTERNS: "regex tuple in tacl.evidence_ledger guarding cognitive/medical claims"
+      allowed_disclaimer_phrases: "tuple including 'make no claim', 'is not a', 'no causal', 'correlation-only', 'no-bio-claim', 'does NOT', 'no medical'"
+      EvidenceClaim_registered: "claim recorded via EvidenceRegistry.register with content-addressable hash"
+    tolerance: "strict — zero naked violations across core/, tacl/, runtime/, geosync/ in non-test source"
+    validity: "AST-grep + runtime guard via tacl.evidence_ledger.scan_source_for_bio_claims; test files (tests/**) and explicit disclaimer paragraphs are excluded by construction"
+    source: "GeoSync PNCC CANONS §INV-NO-BIO-CLAIM; tacl/evidence_ledger.py; tests/tacl/test_evidence_ledger.py"
+    severity: warn


### PR DESCRIPTION
## Summary

Wave 1.5 coordination PR: register the three landed PNCC invariants
in **both** physics-contract layers atomically, per
`docs/research/pncc/CANONS.md §7` and `feedback_geosync_physics_layers.md`.

- `.claude/physics/INVARIANTS.yaml` — new `pncc:` section (3 entries).
- `physics_contracts/catalog.yaml` — new `pncc.*` law entries (3 entries).

## Invariants registered

All three are **P0 / universal**, mirroring the docstrings of the
landed implementations.

| ID | Wave / PR | Source | Test backing |
|---|---|---|---|
| `INV-LANDAUER-PROXY`  | PNCC-A #378 | `core/physics/thermodynamic_budget.py` | `tests/unit/physics/test_thermodynamic_budget.py` |
| `INV-REVERSIBLE-GATE` | PNCC-C #380 | `core/physics/reversible_gate.py`      | `tests/unit/physics/test_reversible_gate.py` |
| `INV-NO-BIO-CLAIM`    | PNCC-E #379 | `tacl/evidence_ledger.py`              | `tests/tacl/test_evidence_ledger.py` |

### Statements

- **INV-LANDAUER-PROXY**: irreversible action proxy cost dominates the
  reversible-alternative cost — `C_irr ≥ C_rev`, strict `>` when
  `irreversibility_score > 0`.
- **INV-REVERSIBLE-GATE**: a reversible-tagged action implies byte-exact
  pre-state recovery via `rollback(audit_hash)`.
- **INV-NO-BIO-CLAIM**: cognitive-performance language in non-test source
  must be paired with a registered `EvidenceClaim` or an explicit
  disclaimer phrase. Falsification axis: AST-grep + runtime guard via
  `tacl.evidence_ledger.scan_source_for_bio_claims`.

## Wave-1 status (registered ↔ not registered)

- **Wave 1 landed** (registered here):
  - PNCC-A → `INV-LANDAUER-PROXY`
  - PNCC-C → `INV-REVERSIBLE-GATE`
  - PNCC-E → `INV-NO-BIO-CLAIM`
- **Wave 1 dropped**: PNCC-B (Mpemba) — `INV-MPEMBA-INIT` NOT registered.
- **Wave 1 halted**: PNCC-D (CNS proxy) — `INV-CNS-SAFETY` NOT registered
  (awaits real telemetry).
- **Wave 2 deferred**: PNCC-F (free energy) — `INV-FREE-ENERGY` shadow-
  tracked by existing `INV-FE1` / `INV-FE2`.

## Formal-spec note

PNCC-A / PNCC-C / PNCC-E shipped **without** TLA+ specs. The
`formal_spec:` field is intentionally **absent** for all three — no
fabricated paths.

## Two-layer compliance

`feedback_geosync_physics_layers.md` mandates both layers stay in sync.
This PR updates both atomically in a single commit:

- `.claude/physics/INVARIANTS.yaml`  → `+47 / -0`
- `physics_contracts/catalog.yaml`   → `+44 / -0`

## Validation gates run

- `python .claude/physics/validate_tests.py --self-check` → **PASS**
  (loads 73 invariants, every type has an L3 checker, theory↔YAML
  cross-ref OK).
- `python -c "from physics_contracts import load_catalog; load_catalog()"`
  → **34 laws**, three new `pncc.*` entries with full strict-schema
  fields (`id, module, statement, formula, variables, tolerance,
  validity, source, severity`).
- `ruff check .claude/physics/ physics_contracts/` → **clean**.
- `validate_tests.py` on the three PNCC test files → **L2 = 0**
  (invariant IDs resolve in YAML).
- Strict-list physics tests (`test_T8/T9/T11`) → still **0 issues**.

## Test plan

- [ ] CI `physics-kernel-gate` self-check passes (validates registry
      structural consistency).
- [ ] CI `python-quality` (black + ruff) passes — text-only YAML/markdown
      diff, no python touched.
- [ ] CI `tests` job remains green — the existing PNCC test suites
      (`test_thermodynamic_budget.py`, `test_reversible_gate.py`,
      `test_evidence_ledger.py`) continue to pass; their referenced
      `INV-*` IDs now resolve in `INVARIANTS.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)