### PR TITLE
docs+feat(kuramoto): iterated Ricci flow semantics + IteratedRicciFlow wrapper

### DIFF
--- a/core/kuramoto/ricci_flow.py
+++ b/core/kuramoto/ricci_flow.py
@@ -45,6 +45,7 @@ edge or out-of-sample performance is made.
 
 from __future__ import annotations
 
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
 from typing import Final, Literal
 
@@ -56,10 +57,12 @@ __all__ = [
     "RicciFlowConfig",
     "NeckpinchEvent",
     "RicciFlowStepResult",
+    "IteratedRicciFlowResult",
     "discrete_ricci_flow_step",
     "detect_neckpinch_candidates",
     "apply_neckpinch_surgery",
     "ricci_flow_with_surgery",
+    "iterated_ricci_flow_with_surgery",
 ]
 
 
@@ -413,4 +416,190 @@ def ricci_flow_with_surgery(
         surgery_events=events,
         total_edge_mass_before=float(weights_before.sum()),
         total_edge_mass_after=float(after.sum()),
+    )
+
+
+# ── Iterated wrapper (closes API gap surfaced by falsification battery) ────
+
+
+@dataclass(frozen=True, slots=True)
+class IteratedRicciFlowResult:
+    """Outcome of an iterated Ricci-flow + surgery loop with explicit monitoring.
+
+    Attributes
+    ----------
+    final_weights:
+        ``(N, N)`` weight matrix after the last successfully executed step
+        (or the initial state if ``n_steps_executed == 0``).
+    n_steps_executed:
+        Number of steps actually executed before completion or abort.
+    n_steps_requested:
+        ``n_steps`` originally requested by the caller.
+    mass_drift_per_step:
+        Length ``n_steps_executed`` array; entry ``t`` holds
+        ``|mass_t - mass_0| / mass_0`` (or 0 when ``mass_0 == 0``).
+    connectedness_per_step:
+        Length ``n_steps_executed`` boolean array; entry ``t`` is ``True``
+        iff the active subgraph after step ``t`` is connected over the
+        nodes that started with at least one positive incident weight.
+    aborted_reason:
+        ``None`` if all ``n_steps_requested`` steps completed within
+        contract; otherwise one of:
+        ``"mass_drift_exceeded"``, ``"disconnected"``, ``"step_failed"``.
+    """
+
+    final_weights: NDArray[np.float64]
+    n_steps_executed: int
+    n_steps_requested: int
+    mass_drift_per_step: NDArray[np.float64]
+    connectedness_per_step: NDArray[np.bool_]
+    aborted_reason: str | None
+
+
+def _initial_active_nodes(weights: NDArray[np.float64]) -> set[int]:
+    """Nodes that have at least one strictly-positive incident weight."""
+    n = weights.shape[0]
+    iu, ju = np.triu_indices(n, k=1)
+    nodes: set[int] = set()
+    for i, j, w in zip(iu.tolist(), ju.tolist(), weights[iu, ju].tolist(), strict=True):
+        if w > 0.0:
+            nodes.add(int(i))
+            nodes.add(int(j))
+    return nodes
+
+
+def _is_active_subgraph_connected(weights: NDArray[np.float64], reference_nodes: set[int]) -> bool:
+    """Connectedness of the ``w > 0`` subgraph restricted to ``reference_nodes``.
+
+    Mirrors the connectedness check in :func:`apply_neckpinch_surgery` so the
+    iterated wrapper reports the same notion of connectedness as the
+    single-step contract.
+    """
+    if not reference_nodes:
+        return True
+    n = weights.shape[0]
+    graph = nx.Graph()
+    graph.add_nodes_from(range(n))
+    iu, ju = np.triu_indices(n, k=1)
+    for i, j, w in zip(iu.tolist(), ju.tolist(), weights[iu, ju].tolist(), strict=True):
+        if w > 0.0:
+            graph.add_edge(int(i), int(j))
+    sub = graph.subgraph(reference_nodes)
+    if sub.number_of_nodes() == 0:
+        return True
+    return bool(nx.is_connected(sub))
+
+
+def iterated_ricci_flow_with_surgery(
+    weights: NDArray[np.float64],
+    curvature_fn: Callable[[NDArray[np.float64]], Mapping[tuple[int, int], float]],
+    n_steps: int,
+    cfg: RicciFlowConfig,
+    *,
+    max_mass_drift: float = 0.10,
+    abort_on_disconnect: bool = True,
+) -> IteratedRicciFlowResult:
+    """Iterate :func:`ricci_flow_with_surgery` with explicit invariant monitoring.
+
+    Closes the iterated-step API gap documented in
+    ``docs/research/ricci_flow_surgery.md`` ("Iterated-Step Semantics").
+    Single-step ``ricci_flow_with_surgery`` preserves mass and connectedness
+    when configured, but those guarantees DO NOT compose across iterations
+    under the default ``eps_weight=1e-8`` clamp policy. This wrapper records
+    drift per step and aborts early when the contract would be broken.
+
+    Parameters
+    ----------
+    weights:
+        Initial ``(N, N)`` symmetric, non-negative, zero-diagonal weight
+        matrix.
+    curvature_fn:
+        Callable invoked once per step with the current weights; must
+        return a curvature dict over active edges. Recomputed every step
+        (no caching is assumed).
+    n_steps:
+        Number of flow + surgery steps to attempt (``n_steps >= 0``).
+    cfg:
+        Single-step configuration. Forwarded to each
+        :func:`ricci_flow_with_surgery` call unchanged.
+    max_mass_drift:
+        Abort if relative drift ``|mass_t - mass_0| / mass_0`` strictly
+        exceeds this threshold. Must be in ``[0, +inf)``. Default 0.10.
+    abort_on_disconnect:
+        When True (default) and ``cfg.preserve_connectedness=True``, abort
+        the iteration as soon as the active subgraph becomes disconnected.
+
+    Returns
+    -------
+    IteratedRicciFlowResult
+        Final weights, executed step count, per-step drift / connectedness,
+        and an optional ``aborted_reason``.
+
+    Raises
+    ------
+    ValueError
+        On invalid ``n_steps`` or ``max_mass_drift`` argument.
+
+    Notes
+    -----
+    See ``docs/research/ricci_flow_surgery.md`` for the iterated-step gap
+    that motivated this wrapper. The wrapper is descriptive — it does not
+    redefine the single-step contract or alter ``cfg``. INV-RC-FLOW
+    (single-step) remains the source of truth for one call.
+    """
+    if n_steps < 0:
+        raise ValueError("n_steps must be >= 0.")
+    if not np.isfinite(max_mass_drift) or max_mass_drift < 0.0:
+        raise ValueError("max_mass_drift must be a finite non-negative float.")
+
+    _validate_weights(weights)
+    current = weights.astype(np.float64, copy=True)
+    initial_mass = float(current.sum())
+    reference_nodes = _initial_active_nodes(current)
+
+    drift_history: list[float] = []
+    connected_history: list[bool] = []
+    aborted_reason: str | None = None
+
+    for _ in range(n_steps):
+        curvature = dict(curvature_fn(current))
+        try:
+            step_result = ricci_flow_with_surgery(current, curvature, cfg)
+        except (RuntimeError, ValueError):
+            # Single-step physics check failed — record nothing for this
+            # step, abort with a structured reason. Caller can inspect
+            # n_steps_executed to see where things broke.
+            aborted_reason = "step_failed"
+            break
+
+        next_weights = step_result.weights_after
+        # Drift relative to t=0; 0/0 case → 0.0 by convention. INV-RC-FLOW
+        # mass-preservation is single-step; this records the iterated drift.
+        if initial_mass > _FLOAT_TOL:
+            drift = abs(float(next_weights.sum()) - initial_mass) / initial_mass
+        else:
+            drift = 0.0
+        connected = _is_active_subgraph_connected(next_weights, reference_nodes)
+
+        drift_history.append(drift)
+        connected_history.append(connected)
+        current = next_weights
+
+        if drift > max_mass_drift:
+            aborted_reason = "mass_drift_exceeded"
+            break
+        if abort_on_disconnect and cfg.preserve_connectedness and not connected:
+            aborted_reason = "disconnected"
+            break
+
+    drift_arr = np.asarray(drift_history, dtype=np.float64)
+    connected_arr = np.asarray(connected_history, dtype=np.bool_)
+
+    return IteratedRicciFlowResult(
+        final_weights=current,
+        n_steps_executed=len(drift_history),
+        n_steps_requested=n_steps,
+        mass_drift_per_step=drift_arr,
+        connectedness_per_step=connected_arr,
+        aborted_reason=aborted_reason,
     )

--- a/docs/research/ricci_flow_surgery.md
+++ b/docs/research/ricci_flow_surgery.md
@@ -62,3 +62,45 @@ This is a geometric primitive. No claim of trading edge or out-of-sample perform
 
 ## Source anchor
 arXiv:2510.15942 — Ollivier-Ricci flow with neckpinch surgery on NASDAQ-100.
+
+## Iterated-Step Semantics (Known API Gap)
+
+**Single-step contract (INV-RC-FLOW):** `ricci_flow_with_surgery` preserves finite/symmetric/non-negative
+weights, mass (when enabled), and connectedness (when enabled). This contract was empirically
+verified by the falsification battery (`falsify_ricci_surgery.py`): 6/7 PASS, single-step axes all
+machine-precision.
+
+**Iterated-step gap (NOT covered by INV-RC-FLOW):** repeated application of `ricci_flow_with_surgery`
+on the same graph state with `preserve_total_edge_mass=True` and `preserve_connectedness=True`
+DOES NOT preserve total edge mass or connectedness across iterations.
+
+Empirical evidence (100 sequential steps, 20 ER graphs, N=10, eps_weight=1e-8):
+- 8 / 20 final graphs disconnected (40%)
+- max mass drift: ~100% (full mass leakage in worst case)
+- median final edge count: 3
+
+**Mechanism:** surgery clamps bridge candidates to `eps_weight` rather than removing them.
+On the next iteration these clamped edges are re-flagged by `detect_neckpinch_candidates` (which
+admits `0 < w ≤ eps_weight`). Once all incident edges of a node become clamped, the active-subgraph
+definition shifts between `w > 0` (admits) and `w > eps_weight` (rejects), and `preserve_total_edge_mass`
+re-normalizes mass away from these stub edges.
+
+### Recommended Practice
+
+- For **single-step research use**: the function works as documented. Use freely.
+- For **multi-step iteration**: do NOT loop `ricci_flow_with_surgery` directly with default config.
+  Use one of:
+  1. Set `eps_weight=0.0` to make `detect_neckpinch_candidates` non-degenerate across iterations
+     (at cost of: bridge candidates being fully removed instead of clamped, which can disconnect
+     graphs faster — different trade-off, not better).
+  2. Use the explicit `iterated_ricci_flow_with_surgery(weights, n_steps, cfg)` wrapper (added in
+     this PR) which records mass-drift and connectedness state per step and aborts if invariants
+     would be broken.
+  3. Implement your own outer loop that re-asserts mass/connectedness manually between steps.
+
+### Status
+
+- 2026-04-25 — gap surfaced by falsification battery
+- 2026-04-25 — documented as INV-RC-FLOW-ITER (P1, statistical) for future enforcement
+- Open question: should this be promoted to a P0 universal invariant once the wrapper is in place?
+

--- a/tests/unit/core/test_ricci_flow_iterated.py
+++ b/tests/unit/core/test_ricci_flow_iterated.py
@@ -1,0 +1,216 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""Tests for the iterated Ricci-flow + surgery wrapper.
+
+These tests guard the iterated-step API gap surfaced by the falsification
+battery (`falsify_ricci_surgery.py`). Single-step INV-RC-FLOW remains the
+contract owner; this file documents and pins the iterated-loop semantics
+(``IteratedRicciFlowResult.aborted_reason``, drift / connectedness arrays).
+
+Reference: ``docs/research/ricci_flow_surgery.md`` — "Iterated-Step Semantics".
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+import numpy as np
+import pytest
+from numpy.typing import NDArray
+
+from core.kuramoto.ricci_flow import (
+    IteratedRicciFlowResult,
+    RicciFlowConfig,
+    iterated_ricci_flow_with_surgery,
+    ricci_flow_with_surgery,
+)
+
+
+def _er_weights(n: int, p: float, seed: int) -> NDArray[np.float64]:
+    """Reproducible Erdős–Rényi weight matrix used by the falsification battery."""
+    rng = np.random.default_rng(seed)
+    adj = rng.random((n, n)) < p
+    adj |= adj.T
+    np.fill_diagonal(adj, False)
+    weights = rng.random((n, n)) * adj.astype(np.float64)
+    weights = 0.5 * (weights + weights.T)
+    np.fill_diagonal(weights, 0.0)
+    return weights.astype(np.float64, copy=False)
+
+
+def _constant_negative_curvature_fn(
+    kappa: float = -0.5,
+) -> object:
+    """Return a curvature_fn that emits κ on every active upper-triangular edge."""
+
+    def fn(W: NDArray[np.float64]) -> Mapping[tuple[int, int], float]:
+        out: dict[tuple[int, int], float] = {}
+        n = W.shape[0]
+        iu, ju = np.triu_indices(n, k=1)
+        for i, j, w in zip(iu.tolist(), ju.tolist(), W[iu, ju].tolist(), strict=True):
+            if w > 0.0:
+                out[(int(i), int(j))] = float(kappa)
+        return out
+
+    return fn
+
+
+def test_iterated_wrapper_aborts_on_mass_drift_or_disconnect() -> None:
+    """Reproduce the falsification-battery setup: 100-step ER loop on default cfg.
+
+    The wrapper must EITHER abort with a structured reason before the contract
+    breaks OR record a trajectory that stayed within bounds. Either branch is
+    acceptable; silent breakage is not.
+    """
+    weights = _er_weights(n=10, p=0.4, seed=20260425)
+    curvature_fn = _constant_negative_curvature_fn(kappa=-0.5)
+
+    cfg = RicciFlowConfig(
+        preserve_total_edge_mass=True,
+        preserve_connectedness=True,
+    )
+    result = iterated_ricci_flow_with_surgery(
+        weights,
+        curvature_fn,  # type: ignore[arg-type]
+        n_steps=100,
+        cfg=cfg,
+        max_mass_drift=0.10,
+        abort_on_disconnect=True,
+    )
+
+    assert isinstance(result, IteratedRicciFlowResult)
+    assert result.n_steps_requested == 100
+    assert result.mass_drift_per_step.shape == (result.n_steps_executed,)
+    assert result.connectedness_per_step.shape == (result.n_steps_executed,)
+    assert np.all(result.mass_drift_per_step >= 0.0)
+
+    if result.aborted_reason is not None:
+        assert result.aborted_reason in {
+            "mass_drift_exceeded",
+            "disconnected",
+            "step_failed",
+        }
+        assert result.n_steps_executed < 100
+    else:
+        assert result.n_steps_executed == 100
+        assert bool(np.all(result.mass_drift_per_step <= 0.10)), (
+            "INV-RC-FLOW-ITER VIOLATED: drift exceeded threshold without abort; "
+            f"observed max_drift={float(result.mass_drift_per_step.max()):.6e}, "
+            f"expected <= 0.10, with N=10, n_steps=100, seed=20260425."
+        )
+        assert bool(np.all(result.connectedness_per_step)), (
+            "INV-RC-FLOW-ITER VIOLATED: graph disconnected without abort; "
+            f"observed connected={result.connectedness_per_step.tolist()}, "
+            "expected all True, with preserve_connectedness=True."
+        )
+
+
+def test_iterated_wrapper_zero_steps_returns_initial() -> None:
+    """``n_steps=0`` is a no-op: returns the initial weights unchanged with empty trajectories."""
+    weights = _er_weights(n=8, p=0.5, seed=1)
+    curvature_fn = _constant_negative_curvature_fn(kappa=-0.5)
+    cfg = RicciFlowConfig()
+
+    result = iterated_ricci_flow_with_surgery(
+        weights,
+        curvature_fn,  # type: ignore[arg-type]
+        n_steps=0,
+        cfg=cfg,
+    )
+
+    assert result.n_steps_executed == 0
+    assert result.n_steps_requested == 0
+    assert result.aborted_reason is None
+    assert result.mass_drift_per_step.shape == (0,)
+    assert result.connectedness_per_step.shape == (0,)
+    np.testing.assert_array_equal(result.final_weights, weights)
+    # Zero-step path must NOT alias the caller's array (defensive copy).
+    assert result.final_weights is not weights
+
+
+def test_iterated_wrapper_records_one_step_correctly() -> None:
+    """``n_steps=1`` matches a direct ``ricci_flow_with_surgery`` call bit-identically."""
+    weights = _er_weights(n=6, p=0.6, seed=42)
+    curvature_fn = _constant_negative_curvature_fn(kappa=-0.3)
+    cfg = RicciFlowConfig(eta=0.05, preserve_connectedness=True)
+
+    direct = ricci_flow_with_surgery(weights, dict(curvature_fn(weights)), cfg)  # type: ignore[operator]
+    iterated = iterated_ricci_flow_with_surgery(
+        weights,
+        curvature_fn,  # type: ignore[arg-type]
+        n_steps=1,
+        cfg=cfg,
+    )
+
+    np.testing.assert_array_equal(iterated.final_weights, direct.weights_after)
+    assert iterated.n_steps_executed == 1
+    assert iterated.n_steps_requested == 1
+    assert iterated.aborted_reason is None
+    assert iterated.mass_drift_per_step.shape == (1,)
+    assert iterated.connectedness_per_step.shape == (1,)
+
+
+def test_iterated_wrapper_deterministic() -> None:
+    """Fixed seed → bit-identical drift trajectory across two runs."""
+    weights = _er_weights(n=10, p=0.4, seed=20260425)
+    curvature_fn = _constant_negative_curvature_fn(kappa=-0.5)
+    cfg = RicciFlowConfig(
+        preserve_total_edge_mass=True,
+        preserve_connectedness=True,
+    )
+
+    r1 = iterated_ricci_flow_with_surgery(
+        weights,
+        curvature_fn,  # type: ignore[arg-type]
+        n_steps=20,
+        cfg=cfg,
+        max_mass_drift=0.50,  # loose bound so we get a long trajectory
+    )
+    r2 = iterated_ricci_flow_with_surgery(
+        weights,
+        curvature_fn,  # type: ignore[arg-type]
+        n_steps=20,
+        cfg=cfg,
+        max_mass_drift=0.50,
+    )
+
+    assert r1.n_steps_executed == r2.n_steps_executed
+    assert r1.aborted_reason == r2.aborted_reason
+    np.testing.assert_array_equal(r1.mass_drift_per_step, r2.mass_drift_per_step)
+    np.testing.assert_array_equal(r1.connectedness_per_step, r2.connectedness_per_step)
+    np.testing.assert_array_equal(r1.final_weights, r2.final_weights)
+
+
+def test_iterated_wrapper_negative_n_steps_rejected() -> None:
+    """Negative ``n_steps`` is rejected fail-closed."""
+    weights = _er_weights(n=4, p=0.5, seed=0)
+    curvature_fn = _constant_negative_curvature_fn()
+    with pytest.raises(ValueError, match="n_steps"):
+        iterated_ricci_flow_with_surgery(
+            weights,
+            curvature_fn,  # type: ignore[arg-type]
+            n_steps=-1,
+            cfg=RicciFlowConfig(),
+        )
+
+
+def test_iterated_wrapper_invalid_drift_threshold_rejected() -> None:
+    """Non-finite or negative ``max_mass_drift`` is rejected fail-closed."""
+    weights = _er_weights(n=4, p=0.5, seed=0)
+    curvature_fn = _constant_negative_curvature_fn()
+    with pytest.raises(ValueError, match="max_mass_drift"):
+        iterated_ricci_flow_with_surgery(
+            weights,
+            curvature_fn,  # type: ignore[arg-type]
+            n_steps=1,
+            cfg=RicciFlowConfig(),
+            max_mass_drift=-0.1,
+        )
+    with pytest.raises(ValueError, match="max_mass_drift"):
+        iterated_ricci_flow_with_surgery(
+            weights,
+            curvature_fn,  # type: ignore[arg-type]
+            n_steps=1,
+            cfg=RicciFlowConfig(),
+            max_mass_drift=float("inf"),
+        )


### PR DESCRIPTION
## Summary

Closes the iterated-step API gap surfaced by the falsification battery
(`~/spikes/four_extensions_falsification/falsify_ricci_surgery.py`).

- **Finding.** 100 sequential `ricci_flow_with_surgery` calls on 20 random ER
  graphs (N=10), default `RicciFlowConfig(preserve_total_edge_mass=True,
  preserve_connectedness=True)`: 8/20 final graphs disconnected, max mass drift
  ~100%, median final edge count 3. Single-step INV-RC-FLOW still holds;
  iterated semantics were silent.
- **Mechanism.** Surgery clamps bridge candidates to `eps_weight=1e-8`. On the
  next iteration `detect_neckpinch_candidates` re-flags those clamped edges
  (`0 < w ≤ eps_weight`); active-subgraph definition shifts between `w > 0`
  (admits) and `w > eps_weight` (rejects); `preserve_total_edge_mass` then
  re-normalises mass away from the stub edges.
- **Resolution.** Document the gap as INV-RC-FLOW-ITER (P1, statistical) and
  ship a thin `iterated_ricci_flow_with_surgery` wrapper that monitors mass
  drift + connectedness per step and aborts fail-closed on threshold breach
  (`mass_drift_exceeded` / `disconnected` / `step_failed`).

## Changes

- `docs/research/ricci_flow_surgery.md` — new "Iterated-Step Semantics (Known
  API Gap)" section: evidence, mechanism, recommended practice, status.
- `core/kuramoto/ricci_flow.py` — `IteratedRicciFlowResult` dataclass +
  `iterated_ricci_flow_with_surgery()` wrapper; single-step API unchanged.
- `tests/unit/core/test_ricci_flow_iterated.py` — 6 new tests:
  battery-reproduction loop, `n_steps=0` no-op, `n_steps=1` parity with direct
  call, deterministic replay, fail-closed input validation.

## Coordination note

Concurrent branch `fix/ricci-flow-bridge-cache` is fixing the O(E²) bridge
cache inside `apply_neckpinch_surgery`/`_is_bridge`. This PR did **not** touch
those internals — only the new top-level wrapper + dataclass were added,
explicitly to avoid conflicts.

## Test plan

- [x] `ruff check` + `ruff format --check` + `black --check`: clean on both
      files.
- [x] `mypy --strict core/kuramoto/ricci_flow.py`: 0 errors in this file
      (pre-existing errors in unrelated modules are out of scope).
- [x] `pytest tests/unit/core/test_ricci_flow_surgery.py
      tests/unit/core/test_ricci_flow_iterated.py -v`: 17/17 passed.
- [x] Falsification battery single-step axes: 6/7 PASS unchanged
      (`ricci_surgery_verdict.json`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)