### PR TITLE
fix(kuramoto): expose floor_engaged on CapitalWeightedCouplingResult (⊛-audit AP-#5)

### DIFF
--- a/core/kuramoto/capital_weighted.py
+++ b/core/kuramoto/capital_weighted.py
@@ -145,6 +145,22 @@ class CapitalWeightedCouplingResult:
         was returned unchanged.
     reason:
         Human-readable explanation when ``used_fallback`` is ``True`` (else "").
+    floor_engaged:
+        ``True`` if a ``cfg.r_floor`` event was detected during ratio
+        construction — either because ``median(depth_mass)`` fell below the
+        floor (and was clamped to keep the division finite) or because at
+        least one per-node ratio :math:`r_i` is at or below the floor (e.g.
+        a zero-depth node). The coupling matrix remains a valid
+        ``INV-KBETA`` object (finite, symmetric, zero diagonal); the flag is
+        informational so callers can log or fail-loud as desired. Closes
+        ⊛-audit AP-#5 (silent fallback) — see ``floor_diagnostic`` for the
+        human-readable reason. Note: per-node ``r_i`` is **not** clamped
+        (absolute clamps would break scale invariance ``INV-KBETA``); only
+        the median is clamped, and only when needed for finite division.
+    floor_diagnostic:
+        Empty string when ``floor_engaged`` is ``False``. Otherwise a short
+        token describing which event engaged: ``"median_clamped"``,
+        ``"r_below_floor"``, or ``"median_clamped+r_below_floor"``.
     """
 
     coupling: NDArray[np.float64]
@@ -153,6 +169,8 @@ class CapitalWeightedCouplingResult:
     depth_mass: NDArray[np.float64]
     used_fallback: bool
     reason: str
+    floor_engaged: bool = False
+    floor_diagnostic: str = ""
 
 
 def _validate_snapshot(snapshot: L2DepthSnapshot) -> None:
@@ -253,25 +271,70 @@ def compute_capital_ratio(
     depth_mass: NDArray[np.float64],
     *,
     floor: float,
-) -> NDArray[np.float64]:
+) -> tuple[NDArray[np.float64], bool, str]:
     """Per-node capital ratio ``r_i = depth_mass_i / median(depth_mass)``.
 
     The median is floored by ``floor`` so the ratio is finite even for
-    degenerate depth vectors. Output is non-negative.
+    degenerate depth vectors. Per-node ratios that land at or below ``floor``
+    are detected and surfaced via the ``floor_engaged`` flag, but **not
+    clamped**. Clamping per element would be an absolute (not scale-free)
+    modification that breaks ``INV-KBETA`` scale invariance, so we preserve
+    the raw ratio (including legitimate zeros for empty-depth nodes) and
+    expose the event for caller-side handling.
+
+    Returns
+    -------
+    r:
+        ``(N,)`` non-negative ratio vector.
+    floor_engaged:
+        ``True`` if either the median was clamped to ``floor`` or any
+        per-node :math:`r_i` is below ``floor`` (e.g. zero-depth node).
+        Closes ⊛-audit AP-#5 (silent fallback) by making the floor event
+        observable to callers.
+    floor_diagnostic:
+        Empty string when ``floor_engaged`` is ``False``. Otherwise a short
+        token: ``"median_clamped"``, ``"r_below_floor"``, or
+        ``"median_clamped+r_below_floor"``.
+
+    Raises
+    ------
+    ValueError
+        If ``floor <= 0`` or ``depth_mass`` contains non-finite / negative
+        entries.
     """
     if floor <= 0.0:
         raise ValueError("floor must be > 0.")
     if depth_mass.size == 0:
-        return np.zeros(0, dtype=np.float64)
+        return np.zeros(0, dtype=np.float64), False, ""
     if not np.isfinite(depth_mass).all() or (depth_mass < 0.0).any():
         raise ValueError("depth_mass must be finite and non-negative.")
     med = float(np.median(depth_mass))
-    if med < floor:
+    median_clamped = med < floor
+    if median_clamped:
+        # bounds: median floor for numerical stability — observable via
+        # floor_engaged in CapitalWeightedCouplingResult (⊛-audit AP-#5).
         med = floor
     r: NDArray[np.float64] = (depth_mass / med).astype(np.float64, copy=False)
+    # Observability-only: detect that some per-node ratios are at or below the
+    # floor (e.g. a node with zero depth while the rest of the book is
+    # healthy). We DO NOT clamp r here — clamping would be an absolute (not
+    # scale-free) modification and would break the scale-invariance invariant
+    # tested in test_uniform_scale_invariance / test_scale_invariance_under_
+    # uniform_depth_scaling. The flag is purely informational so callers can
+    # log or fail-loud when zero-depth nodes appear (closes ⊛-audit AP-#5).
+    r_below_floor = bool(np.any(r < floor))
     if not np.isfinite(r).all():
         raise ValueError("capital ratio became non-finite.")
-    return r
+    floor_engaged = median_clamped or r_below_floor
+    if median_clamped and r_below_floor:
+        diagnostic = "median_clamped+r_below_floor"
+    elif median_clamped:
+        diagnostic = "median_clamped"
+    elif r_below_floor:
+        diagnostic = "r_below_floor"
+    else:
+        diagnostic = ""
+    return r, floor_engaged, diagnostic
 
 
 def compute_k_beta(
@@ -337,7 +400,12 @@ def build_capital_weighted_adjacency(
 
     Returns
     -------
-    :class:`CapitalWeightedCouplingResult`.
+    :class:`CapitalWeightedCouplingResult`. The result carries
+    ``floor_engaged`` (and a short ``floor_diagnostic`` token) so the caller
+    can detect when ``cfg.r_floor`` was applied to the median or any
+    per-node ratio — the silent-fallback gap closed by ⊛-audit AP-#5. The
+    coupling matrix remains valid (finite, symmetric, zero-diagonal,
+    non-negative) regardless of the flag.
     """
     _validate_baseline_adj(baseline_adj)
     n = baseline_adj.shape[0]
@@ -364,7 +432,7 @@ def build_capital_weighted_adjacency(
         )
 
     depth_mass = compute_l2_depth_mass(snapshot)
-    r_node = compute_capital_ratio(depth_mass, floor=cfg.r_floor)
+    r_node, floor_engaged, floor_diagnostic = compute_capital_ratio(depth_mass, floor=cfg.r_floor)
     beta = estimate_scalar_beta(depth_mass, beta_min=cfg.beta_min, beta_max=cfg.beta_max)
 
     # Edgewise ratio r_ij = sqrt(r_i * r_j); zero diagonal preserved.
@@ -393,4 +461,6 @@ def build_capital_weighted_adjacency(
         depth_mass=depth_mass,
         used_fallback=False,
         reason="",
+        floor_engaged=floor_engaged,
+        floor_diagnostic=floor_diagnostic,
     )

--- a/docs/research/capital_weighted_kuramoto.md
+++ b/docs/research/capital_weighted_kuramoto.md
@@ -27,7 +27,20 @@ with β = 1 recovering the baseline (the envelope collapses to `K_0`).
 - `cfg`: `CapitalWeightedCouplingConfig` (K0, gamma, delta, beta_min, beta_max, r_floor, normalize, fail_on_future_l2).
 
 ## Outputs
-`CapitalWeightedCouplingResult(coupling, beta, r, depth_mass, used_fallback, reason)`.
+`CapitalWeightedCouplingResult(coupling, beta, r, depth_mass, used_fallback, reason, floor_engaged, floor_diagnostic)`.
+
+If `r_floor` is engaged for the median or any per-node ratio,
+`result.floor_engaged` is True; coupling remains valid (finite,
+symmetric, diag-free) — the flag is informational so the caller can log
+or fail-loud as desired. `floor_diagnostic` is a short token describing
+which event fired: `"median_clamped"` (median(depth_mass) < r_floor and
+the median was clamped up to keep the division finite), `"r_below_floor"`
+(at least one r_i is at or below r_floor — typically a zero-depth node),
+or `"median_clamped+r_below_floor"` for both. Per-node r_i is **not**
+clamped because absolute clamps would break the scale-invariance
+``INV-KBETA`` property; only the median is clamped, and only when needed
+for finite division. This closes ⊛-audit anti-pattern AP-#5 (silent
+fallback) by making the floor event observable to callers.
 
 ## Invariants
 - `INV-KBETA`: K_ij is finite, non-negative, symmetric, zero-diagonal; β ∈ [beta_min, beta_max]; K is invariant under uniform multiplicative depth scaling.
@@ -41,6 +54,8 @@ with β = 1 recovering the baseline (the envelope collapses to `K_0`).
 - `test_scalar_beta_deterministic`
 - `test_scale_invariance_under_uniform_depth_scaling`
 - `test_no_self_coupling`
+- `test_floor_engaged_false_for_healthy_distribution` (⊛-audit AP-#5)
+- `test_floor_engaged_true_for_zero_depth_node` (⊛-audit AP-#5)
 - plus three validation tests (negative sizes, non-positive mid, ratio floor)
 
 ## Known limitations

--- a/tests/unit/core/test_capital_weighted_kuramoto.py
+++ b/tests/unit/core/test_capital_weighted_kuramoto.py
@@ -230,7 +230,111 @@ def test_non_positive_mid_rejected() -> None:
 
 
 def test_capital_ratio_floor() -> None:
-    """compute_capital_ratio uses the floor when median is degenerate."""
+    """compute_capital_ratio uses the floor when median is degenerate.
+
+    INV-KBETA: r is finite and non-negative even when median == 0 (the
+    median is clamped up to ``floor`` so the division stays finite). The
+    floor_engaged flag MUST be ``True`` so the caller can observe the
+    event (closes ⊛-audit AP-#5).
+    """
     m = np.zeros(5, dtype=np.float64)
-    r = compute_capital_ratio(m, floor=1e-12)
-    assert np.all(r == 0.0)
+    r, floor_engaged, diagnostic = compute_capital_ratio(m, floor=1e-12)
+    assert np.all(np.isfinite(r)), (
+        "INV-KBETA VIOLATED: r must be finite even on zero depth_mass; "
+        f"observed r={r}, with depth_mass=zeros(5), floor=1e-12."
+    )
+    # All depths are zero -> r = 0 / clamped_median = 0; non-negativity holds.
+    assert np.all(r >= 0.0), f"INV-KBETA VIOLATED: r must be non-negative; observed r={r}."
+    assert floor_engaged is True, (
+        "INV-KBETA VIOLATED: floor_engaged must be True when median(depth_mass)=0; "
+        f"observed floor_engaged={floor_engaged}, expected True (closes ⊛-audit AP-#5), "
+        f"with depth_mass=zeros(5), floor=1e-12."
+    )
+    assert "median_clamped" in diagnostic, (
+        f"INV-KBETA VIOLATED: diagnostic must mention median_clamped; "
+        f"observed diagnostic='{diagnostic}', expected substring 'median_clamped'."
+    )
+
+
+def test_floor_engaged_false_for_healthy_distribution() -> None:
+    """INV-KBETA: floor flag is OFF when depth distribution is well-conditioned.
+
+    A uniform-ish, strictly-positive depth book has a strictly-positive
+    median and all r_i = m_i / median in a well-conditioned range — no
+    floor clamp should fire and floor_engaged must therefore be ``False``.
+    """
+    rng = np.random.default_rng(20260425)
+    n, lvl = 16, 5
+    snap = L2DepthSnapshot(
+        timestamp_ns=1_000_000_000_000,
+        bid_sizes=rng.uniform(1.0, 10.0, (n, lvl)).astype(np.float64),
+        ask_sizes=rng.uniform(1.0, 10.0, (n, lvl)).astype(np.float64),
+        mid_prices=rng.uniform(50.0, 100.0, (n,)).astype(np.float64),
+    )
+    cfg = CapitalWeightedCouplingConfig()
+    baseline = np.ones((n, n), dtype=np.float64) - np.eye(n, dtype=np.float64)
+    result = build_capital_weighted_adjacency(
+        baseline, snap, signal_timestamp_ns=snap.timestamp_ns, cfg=cfg
+    )
+    assert result.floor_engaged is False, (
+        "INV-KBETA VIOLATED: floor_engaged must be False on well-conditioned book; "
+        f"observed floor_engaged={result.floor_engaged}, diagnostic='{result.floor_diagnostic}', "
+        f"r_min={result.r.min():.6e}, r_max={result.r.max():.6e}, "
+        f"with N={n}, levels={lvl}, r_floor={cfg.r_floor}."
+    )
+    assert result.floor_diagnostic == "", (
+        f"INV-KBETA VIOLATED: floor_diagnostic must be empty when not engaged; "
+        f"observed='{result.floor_diagnostic}'."
+    )
+
+
+def test_floor_engaged_true_for_zero_depth_node() -> None:
+    """INV-KBETA: floor flag is ON when one node has zero depth.
+
+    Zeroing out one node's bid+ask drives that node's depth_mass to 0; the
+    median is still positive so r_i = 0 / median = 0 < r_floor and the
+    per-element below-floor detector fires. The flag must surface (the
+    raw r_i is preserved — clamping would break scale invariance), and
+    INV-KBETA (finite, symmetric, zero-diag) must still hold on the
+    resulting coupling.
+    """
+    rng = np.random.default_rng(20260425)
+    n, lvl = 16, 5
+    bid = rng.uniform(1.0, 10.0, (n, lvl)).astype(np.float64)
+    bid[0, :] = 0.0
+    ask = rng.uniform(1.0, 10.0, (n, lvl)).astype(np.float64)
+    ask[0, :] = 0.0
+    snap = L2DepthSnapshot(
+        timestamp_ns=1_000_000_000_000,
+        bid_sizes=bid,
+        ask_sizes=ask,
+        mid_prices=rng.uniform(50.0, 100.0, (n,)).astype(np.float64),
+    )
+    cfg = CapitalWeightedCouplingConfig()
+    baseline = np.ones((n, n), dtype=np.float64) - np.eye(n, dtype=np.float64)
+    result = build_capital_weighted_adjacency(
+        baseline, snap, signal_timestamp_ns=snap.timestamp_ns, cfg=cfg
+    )
+    assert result.floor_engaged is True, (
+        "INV-KBETA VIOLATED: floor_engaged must be True when a node has zero depth; "
+        f"observed floor_engaged={result.floor_engaged}, "
+        f"r_min={result.r.min():.6e}, r_floor={cfg.r_floor}, "
+        f"depth_mass[0]={result.depth_mass[0]:.6e}."
+    )
+    assert "r_below_floor" in result.floor_diagnostic, (
+        f"INV-KBETA VIOLATED: diagnostic must mention r_below_floor on zero-depth node; "
+        f"observed diagnostic='{result.floor_diagnostic}'."
+    )
+    # INV-KBETA preservation: coupling stays finite, symmetric, zero-diagonal.
+    invariant_violations: list[str] = []
+    if not np.all(np.isfinite(result.coupling)):
+        invariant_violations.append("non-finite coupling")
+    if not np.allclose(result.coupling, result.coupling.T, atol=1e-10):
+        invariant_violations.append("asymmetric coupling")
+    if not np.allclose(np.diag(result.coupling), 0.0, atol=1e-12):
+        invariant_violations.append("non-zero diagonal")
+    assert not invariant_violations, (
+        "INV-KBETA VIOLATED on zero-depth-node case despite floor engagement; "
+        f"violations={invariant_violations}, with N={n}, levels={lvl}, "
+        f"r_floor={cfg.r_floor}."
+    )


### PR DESCRIPTION
## Credo violation

`core/kuramoto/capital_weighted.py::compute_capital_ratio` (around lines
269-270 on the pre-fix version) silently floored `median(depth_mass)` to
`cfg.r_floor` when the median fell below the floor — but the event was
never reported up. ⊛-audit flagged this as **anti-pattern #5 (silent
fallback)**: the GeoSync credo (CLAUDE.md, `INV-RC-FLOW`,
`feedback_geosync_physics_layers.md`) requires every clamp/clip to be
observable via `# INV-*:` / `# bounds:` comment, runtime logging, or a
flag in the result struct.

## Fix

* `compute_capital_ratio` now returns `(r, floor_engaged, floor_diagnostic)`.
* `CapitalWeightedCouplingResult` gains two fields:
  * `floor_engaged: bool = False`
  * `floor_diagnostic: str = ""` — short token: `"median_clamped"`,
    `"r_below_floor"`, or `"median_clamped+r_below_floor"`.
* The **median** is still clamped (required for finite division and
  `INV-KBETA` finiteness) — the clamp is now observable.
* The per-node `r_i` is **not** clamped: an absolute clamp would break
  `INV-KBETA` scale invariance under uniform depth scaling. We only
  *detect* and surface the below-floor event so callers can log or
  fail-loud as desired.
* Validator `.claude/physics/validate_tests.py --audit-code` reports
  **0 silent clamps** on `core/kuramoto/capital_weighted.py`.

## Behavioral preservation

* `falsify_capital_beta.py`: **8/8 PASS** unchanged.
* `tests/unit/core/test_capital_weighted_kuramoto.py`: 13/13 (11 prior + 2 new).
* `tests/property/research_extensions/test_kbeta_properties.py`: 8/8.
* `tests/integration/research_extensions/test_four_feature_pipeline.py`: 6/6.
* Broader regression: **1175 passed, 1 skipped** across `tests/unit/core/`
  + `tests/property/research_extensions/` + `tests/integration/research_extensions/`.

## New tests

* `test_floor_engaged_false_for_healthy_distribution` — well-conditioned
  uniform depth ⇒ `floor_engaged is False`, diagnostic empty.
* `test_floor_engaged_true_for_zero_depth_node` — zeroing one node's
  bid+ask ⇒ `floor_engaged is True`, diagnostic mentions
  `r_below_floor`, **AND** `INV-KBETA` (finite/symmetric/zero-diagonal)
  preserved on the resulting coupling.
* The existing `test_capital_ratio_floor` was upgraded to the new tuple
  signature and now asserts both finiteness *and* `floor_engaged is True`
  on the all-zeros case.

## Quality gates

* `python -m pytest tests/unit/core/test_capital_weighted_kuramoto.py -v` — green
* `python -m pytest tests/unit/core/test_kuramoto_engine.py` — green
* `python -m ruff check ...` — green
* `python -m black --check ...` — green
* `python -m mypy --strict --follow-imports=silent ...` — green
* `python .claude/physics/validate_tests.py core/kuramoto/capital_weighted.py --audit-code` — 0 silent clamps