### PR TITLE
docs(pncc): fix CANONS §3 INV-LANDAUER-PROXY metadata drift (P1→P0)

### DIFF
--- a/docs/research/pncc/CANONS.md
+++ b/docs/research/pncc/CANONS.md
@@ -78,15 +78,21 @@ pointer. P0 = blocking; P1 = high-priority; P2 = nice-to-have.
 > arrive with a verifiable peer-reviewed reference and re-enter via a
 > new pre-registered hypothesis row.
 
-### INV-LANDAUER-PROXY (P1, conservation)
+### INV-LANDAUER-PROXY (P0, universal)
 
-**Statement.** Any reversible-or-erasure-aware kernel reports a
-non-negative information-erasure energy ≥ k·T·ln 2 per logical bit
-erased (Landauer 1961, *IBM J. Res. Dev.* 5, 183).
-**Falsification axis.** A single ledgered measurement of erasure
-energy below the Landauer bound, with CI excluding the bound.
-**Test pointer.** `core/physics/thermodynamic_budget.py` (PNCC-A,
-merged: PR #378).
+**Statement.** For any pair of actions with identical
+(token, latency, entropy) components, the irreversible-action proxy
+cost dominates the reversible-alternative cost: C_irr ≥ C_rev,
+with strict > whenever irreversibility_score > 0
+(Landauer 1961, *IBM J. Res. Dev.* 5, 183).
+**Falsification axis.** Any (irrev, rev) pair with identical
+(token, latency, entropy) components where C_irr < C_rev.
+**Test pointer.** `tests/unit/physics/test_thermodynamic_budget.py`
+(11 functions, 1000-pair sweep).
+**Source.** `core/physics/thermodynamic_budget.py` (PNCC-A, merged: PR #378).
+**Registry.** `.claude/physics/INVARIANTS.yaml::pncc.landauer_proxy`,
+`physics_contracts/catalog.yaml::pncc.landauer_proxy_dominance`
+(Wave 1.5, PR #383).
 
 ### INV-REVERSIBLE-GATE (P0, universal)
 


### PR DESCRIPTION
## Summary

Wave 1.5 coordination PR (#383) surfaced a metadata drift: `docs/research/pncc/CANONS.md` §3 still labeled **INV-LANDAUER-PROXY as P1/conservation**, while the landed contract in both physics-contracts layers is **P0/universal**:

- `.claude/physics/INVARIANTS.yaml::pncc.landauer_proxy` — type: universal, priority: P0
- `physics_contracts/catalog.yaml::pncc.landauer_proxy_dominance` — registered Wave 1.5
- Test suite (`tests/unit/physics/test_thermodynamic_budget.py`) exercises a 1000-pair universal sweep, not a conservation-law check

## What changed

- §3 header: `INV-LANDAUER-PROXY (P1, conservation)` → `INV-LANDAUER-PROXY (P0, universal)`
- Statement tightened to match the executable contract: proxy-cost domination (`C_irr ≥ C_rev`, strict `>` when score > 0), not an absolute energy bound
- Added registry pointers so the canonical doc stays in sync with INVARIANTS.yaml and physics_contracts/catalog.yaml

## Test plan
- [x] Self-grep: no other P1/conservation labels remain on INV-LANDAUER-PROXY
- [x] Cross-reference: INVARIANTS.yaml + catalog.yaml both list P0 universal
- [x] Test pointer matches actual test file