### PR TITLE
feat(tacl): physics-native kernel composition + INV-FREE-ENERGY (PNCC-F Wave 2)

### DIFF
--- a/docs/research/pncc/physics_native_kernel.md
+++ b/docs/research/pncc/physics_native_kernel.md
@@ -1,0 +1,92 @@
+# PNCC-F: Physics-Native Kernel (Composition Layer)
+
+**Status:** experimental, opt-in. Defaults inert (`lambda_thermo = lambda_irreversibility = 0.0`).
+**Module:** `tacl/physics_native_kernel.py`
+**Tests:** `tests/tacl/test_physics_native_kernel.py` (15 functions, including 1000-draw INV-FREE-ENERGY falsification)
+**Invariant:** INV-FREE-ENERGY (P0, universal)
+**Hypothesis status:** HYP-5 (combined loop improves accuracy or preserves it under lower compute) — remains a 90-day hypothesis. This PR ships the controller, **not** the validation.
+
+## Composition
+
+```
+PhysicsNativeKernel
+   │
+   ├── DRFreeEnergyModel (tacl/dr_free.py — already on main)
+   │     └── F_robust  via box-ambiguity adversarial metrics
+   │
+   ├── ThermodynamicBudget (core/physics/thermodynamic_budget.py — PNCC-A, #378)
+   │     └── total_proxy_cost  ← token + latency + entropy + irreversibility
+   │
+   └── ReversibleGate (core/physics/reversible_gate.py — PNCC-C, #380)
+         └── audit_hash + rollback ledger
+```
+
+## Decision Rule
+
+For each candidate action `c` over `(metrics, ambiguity, cfg)`:
+
+```
+composite(c) = F_robust(metrics, ambiguity)
+             + lambda_thermo · total_proxy_cost(c)
+             + lambda_irreversibility · irreversibility_score(c)
+```
+
+Selection:
+- If `state == DORMANT` (per `robust_energy_state`) → return `chosen=None`, `state="DORMANT"`.
+- If ≥2 candidates within `tie_tolerance` of `min(composite)` AND `fail_closed_on_tie=True` → return `chosen=None`, `state="DORMANT"`.
+- Otherwise → `chosen = argmin(composite)`, gate through `ReversibleGate.gate(...)`, return `audit_hash` + full per-candidate `CompositeScore` trace.
+
+## INV-FREE-ENERGY (P0, universal)
+
+> For non-empty `candidates` and any `(metrics, ambiguity, cfg)`:
+> - **(a)** `chosen is not None` ∧ `chosen.composite == min(composites)`, OR
+> - **(b)** `chosen is None` ∧ `state == "DORMANT"` ∧ ≥2 candidates within `tie_tolerance` of `min(composites)`.
+>
+> **Falsification axis:** 1000 random `(candidates × metrics × ambiguity)` draws. Any decision where `chosen.composite > min(composites) + tie_tolerance` AND `state != "DORMANT"` is a violation.
+
+Test pointer: `tests/tacl/test_physics_native_kernel.py::test_invariant_falsification_random_1000`.
+
+## Public API
+
+Dataclasses (frozen, slotted):
+- `CandidateAction` — one action under evaluation
+- `PhysicsNativeKernelConfig` — `lambda_thermo`, `lambda_irreversibility`, `tie_tolerance`, `fail_closed_on_tie`, `ambiguity_radii`
+- `CompositeScore` — per-candidate audit row
+- `KernelDecision` — full output: chosen, state, scores, audit_hash, decision_trace, robust_margin, reason
+
+Functions / class:
+- `evaluate_candidate(candidate, metrics, ambiguity, cfg, *, free_energy_model) -> CompositeScore`
+- `select_action(candidates, metrics, ambiguity, cfg, *, free_energy_model) -> KernelDecision`
+- `PhysicsNativeKernel(cfg=None, *, free_energy_model=None, gate=None).decide(candidates, metrics, ambiguity=None, timestamp_ns=0) -> KernelDecision`
+
+## Composability Properties
+
+- `lambda_thermo == 0 ∧ lambda_irreversibility == 0` ⇒ kernel reduces exactly to pure DR-FREE selection on `F_robust`. Confirmed by `test_lambda_thermo_zero_recovers_pure_dr_free` (algebraic, exact).
+- Single candidate ⇒ chosen is that candidate AND `audit_hash` is set. `test_single_candidate_recovers_dr_free`.
+- Empty candidates ⇒ DORMANT (fail-closed). `test_empty_candidates_returns_dormant`.
+
+## Known Limitations
+
+- Default weights `lambda_thermo = lambda_irreversibility = 0` mean kernel reduces to DR-FREE-only selection. The thermodynamic-budget penalty is **opt-in** by setting non-zero weights. There is no online learning of weights.
+- No PNCC-D (CNS proxy) plug-in. `CNSProxyState` is not yet wired in main; the kernel does not constrain by operator state. When PNCC-D ships with a real telemetry pipeline, scheduling-constraint hooks land here as a follow-up.
+- DRO ambiguity set is rectangular box only (matches `tacl/dr_free.py`). KL or Wasserstein balls not supported.
+- Thermodynamic-budget components are dimensionless proxies, not joules. Calibration of `lambda_thermo` to real cost is per-deployment.
+
+## No-Bio-Claim Disclaimer
+
+This module composes proxy costs (Landauer-style information-erasure proxy + Bennett-style reversibility audit + DRO-robust free-energy minimization) into a single decision controller. It does NOT diagnose, treat, or modify any biological state, and it makes NO claim of cognitive improvement. HYP-5 (combined loop improves accuracy or preserves it under lower compute) is a 90-day hypothesis that requires a registered EvidenceClaim with baseline, intervention, control, n_samples, effect_size, and 95% confidence interval — see `tacl/evidence_ledger.py`.
+
+## References
+
+Verified foundational citations only (per the verify-before-forward contract from PR #382):
+
+- **Landauer 1961** — *Irreversibility and Heat Generation in the Computing Process*, IBM J. Res. Dev. 5, 183. Source for INV-LANDAUER-PROXY.
+- **Bennett 1973** — *Logical Reversibility of Computation*, IBM J. Res. Dev. 17, 525. Source for INV-REVERSIBLE-GATE.
+- **Friston 2010** — *The free-energy principle: a unified brain theory?*, Nature Reviews Neuroscience 11, 127. Source for the F-minimization framing.
+- **DRO theory** — Wiesemann/Kuhn/Sim 2014 (and follow-ups). Source for the box-ambiguity adversarial-metric formulation in `tacl/dr_free.py`.
+
+No 2025/2026 citations.
+
+## Registry
+
+- Will be registered in `.claude/physics/INVARIANTS.yaml::pncc.free_energy` and `physics_contracts/catalog.yaml::pncc.free_energy_argmin` in a follow-up coordination PR (Wave 2.5), mirroring how INV-LANDAUER-PROXY / INV-REVERSIBLE-GATE / INV-NO-BIO-CLAIM landed via PR #383.

--- a/tacl/physics_native_kernel.py
+++ b/tacl/physics_native_kernel.py
@@ -1,0 +1,761 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+# no-bio-claim
+"""PNCC-F — Physics-Native Cognitive Kernel composition controller.
+
+Status
+------
+EXPERIMENTAL / OPT-IN. Pure composition over the four PNCC primitives
+shipped in PR #378 (PNCC-A: thermodynamic budget), #380 (PNCC-C:
+reversible gate), #373 (DR-FREE distributionally robust free energy),
+and #379 (PNCC-E: evidence ledger). This module adds **no new physics**
+and **no new dataclasses** beyond the controller's I/O surface.
+
+Composition diagram
+-------------------
+The kernel is a single decision controller that fuses three contracts
+into one fail-closed selection step::
+
+                    +-----------------------+
+                    |  candidates: Sequence |
+                    +-----------+-----------+
+                                |
+                                v
+                  +----------------------------+
+                  |  evaluate_candidate(c, ..) |
+                  |   F_robust   <- DR-FREE    |  (tacl.dr_free)
+                  |   thermo     <- budget     |  (core.physics
+                  |   irrev_cost <- gate score |   .thermodynamic_budget,
+                  +----------------------------+   .reversible_gate)
+                                |
+                                v
+                  composite = F_robust
+                            + lambda_thermo * thermo
+                            + lambda_irreversibility * irrev_cost
+                                |
+                                v
+                +--------------------------------+
+                | argmin selection w/ tie guard  |
+                |   tie within tolerance         |
+                |   AND fail_closed_on_tie       |
+                |     => DORMANT (chosen=None)   |
+                +--------------------------------+
+                                |
+                                v
+                +--------------------------------+
+                | reversible_gate.gate(...)      |
+                |   admit chosen action,         |
+                |   record DecisionTrace         |
+                +--------------------------------+
+                                |
+                                v
+                       KernelDecision(
+                         chosen, state,
+                         scores, audit_hash,
+                         decision_trace, ...
+                       )
+
+Public API
+----------
+``CandidateAction``               — one candidate under evaluation.
+``PhysicsNativeKernelConfig``     — tradeoff weights + tie policy.
+``CompositeScore``                — per-candidate score breakdown.
+``KernelDecision``                — end-to-end output + audit trail.
+``evaluate_candidate``            — pure composite-score function.
+``select_action``                 — pure end-to-end selection.
+``PhysicsNativeKernel``           — instance carries reversible-gate ledger.
+
+Invariant
+---------
+``INV-FREE-ENERGY`` (P0, universal, kernel-selection scope):
+
+    For any non-empty ``candidates`` and any ``(metrics, ambiguity, cfg)``,
+    let ``composites = [evaluate_candidate(c, ...).composite for c in
+    candidates]``. Then either:
+
+      (a) ``decision.chosen is not None`` AND
+          ``decision.chosen.composite == min(composites)``  (unique argmin), OR
+      (b) ``decision.chosen is None`` AND ``decision.state == "DORMANT"``
+          AND there are >= 2 candidates within ``tie_tolerance`` of the
+          minimum (fail-closed on ambiguity).
+
+    Equivalent: chosen action MUST be the unique-or-fail-closed argmin
+    of the composite score.
+
+    **Falsification axis.** 1000 random ``(candidates, metrics,
+    ambiguity)`` draws — any decision where ``chosen.composite >
+    min(composites) + tie_tolerance`` with ``state != "DORMANT"`` is
+    a violation.
+
+    **Disambiguation note.** GeoSync's pre-existing
+    ``INV-FREE-ENERGY`` (CANONS.md §3, monotonicity of F = U - T*S)
+    governs the ECS / energy-model dynamics. The kernel-selection-side
+    invariant in this module is the same name but a different scope:
+    here it asserts argmin-or-fail-closed selection over composite
+    scores; there it asserts dF/dt <= 0 under active inference. A
+    coordination PR will register this scope in ``physics_contracts/``
+    after this module lands (per the brief).
+
+Other contracts
+---------------
+``INV-HPC1`` (universal): bit-identical output under fixed inputs. The
+kernel uses no global state, no RNG, and no time call; the underlying
+``ReversibleGate`` ledger is instance-scoped.
+
+``INV-HPC2`` (universal): finite inputs => finite outputs. NaN / Inf
+inputs raise (delegated to underlying primitives' fail-closed checks).
+
+No-bio-claim
+------------
+This module composes system-level decision controllers. It makes no
+claim about human cognition, focus, productivity, or any biological
+optimization. Cognitive-performance assertions about the combined loop
+(HYP-5) require a registered ``EvidenceClaim`` — see
+``tacl/evidence_ledger.py`` and ``docs/research/pncc/CANONS.md``.
+
+References
+----------
+* Landauer 1961 — *Irreversibility and Heat Generation in the Computing
+  Process*, IBM J. Res. Dev. 5, 183.
+* Bennett 1973 — *Logical Reversibility of Computation*, IBM J. Res.
+  Dev. 17, 525.
+* Friston 2010 — *The free-energy principle: a unified brain theory?*,
+  Nature Reviews Neuroscience 11, 127. (Free-Energy Principle reference
+  for the F = U - T*S formulation; this module makes no biological
+  claim.)
+* Distributionally robust optimization (textbook, Wiesemann/Kuhn/Sim
+  2014 generic reference; no specific paper claim).
+
+Known limitations
+-----------------
+* ``lambda_thermo`` and ``lambda_irreversibility`` default to 0.0 — by
+  default the kernel reduces to **pure DR-FREE selection**. Activating
+  the thermodynamic / irreversibility penalties is opt-in per call site.
+* No online learning of ``lambda_thermo`` / ``lambda_irreversibility``.
+  The weights are constants per ``PhysicsNativeKernelConfig`` instance.
+* No PNCC-D telemetry plug-in yet (``CNSProxyState`` has no constructor
+  on ``main`` at the time of writing). Telemetry will be wired in once
+  PNCC-D lands.
+* The selection step is fully synchronous; there is no streaming /
+  windowing layer. Callers must bound candidate-set size externally.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Final, Literal
+
+from core.physics.reversible_gate import (
+    DecisionTrace,
+    ReversibleGate,
+    ReversibleGateConfig,
+)
+from core.physics.thermodynamic_budget import (
+    ThermodynamicBudgetConfig,
+    aggregate_entry,
+    compute_entropy_cost,
+    compute_irreversibility_cost,
+    compute_latency_cost,
+    compute_token_cost,
+)
+
+from .dr_free import AmbiguitySet, DRFreeEnergyModel, robust_energy_state
+from .energy_model import EnergyMetrics
+
+__all__ = [
+    "CandidateAction",
+    "CompositeScore",
+    "KernelDecision",
+    "PhysicsNativeKernel",
+    "PhysicsNativeKernelConfig",
+    "evaluate_candidate",
+    "select_action",
+]
+
+
+# ---------------------------------------------------------------------------
+# Internal constants
+# ---------------------------------------------------------------------------
+
+
+# Default warning/crisis thresholds for ``robust_energy_state``. These
+# are conservative defaults that will rarely trigger DORMANT on its own;
+# callers wishing to tune them should compose with their own
+# ``robust_energy_state`` call upstream of the kernel.
+_DEFAULT_WARNING_THRESHOLD: Final[float] = 1.0e9  # effectively disabled
+_DEFAULT_CRISIS_THRESHOLD: Final[float] = 1.0e9  # effectively disabled
+
+# Default p99 latency to feed into ``compute_latency_cost``: equal to
+# wall_time_ns. p99 is recorded only; it does not enter the cost.
+# Documented here so that the kernel does not silently fabricate a p99.
+
+# Action-id used when constructing a thermodynamic-budget BudgetEntry
+# inside ``evaluate_candidate``. The entry is per-candidate-evaluation,
+# never persisted — it exists only to compute ``total_proxy_cost``.
+_BUDGET_EVAL_ACTION_ID: Final[str] = "pncc-f.evaluate"
+
+
+# ---------------------------------------------------------------------------
+# Public dataclasses (controller I/O surface only)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class CandidateAction:
+    """One candidate action under evaluation by the kernel.
+
+    All fields are caller-supplied, fully deterministic, and feed
+    directly into the four PNCC primitives. ``irreversibility_score``
+    must be in ``[0, 1]`` — the underlying ``ReversibleGate`` enforces
+    this; we additionally enforce it here for fail-closed clarity at
+    the kernel boundary.
+    """
+
+    action_id: str
+    payload: bytes
+    irreversibility_score: float  # in [0, 1]; 0 = fully reversible
+    n_input_tokens: int
+    n_output_tokens: int
+    expected_wall_time_ns: int
+    bits_consumed: float
+    bits_erased: float
+
+
+@dataclass(frozen=True, slots=True)
+class PhysicsNativeKernelConfig:
+    """Trade-off weights between robust free energy, thermodynamic cost,
+    and irreversibility penalty.
+
+    All defaults are conservative; defaults must NOT activate the kernel
+    as a system default elsewhere. Activating ``lambda_thermo`` or
+    ``lambda_irreversibility`` is opt-in per call site.
+
+    Attributes
+    ----------
+    lambda_thermo:
+        Weight on the per-candidate ``BudgetEntry.total_proxy_cost``.
+        Must be >= 0 (non-negativity is checked in
+        ``evaluate_candidate``). Default 0.0 makes the kernel reduce
+        to pure DR-FREE selection.
+    lambda_irreversibility:
+        Weight on the irreversibility cost (``penalty * score``).
+        Must be >= 0. Default 0.0.
+    tie_tolerance:
+        Numerical tolerance below which two composite scores are
+        considered tied. Must be >= 0. Default 1e-12.
+    fail_closed_on_tie:
+        If True (default), a tie within ``tie_tolerance`` collapses
+        the decision to DORMANT (chosen=None). If False, the first
+        argmin in candidate order is chosen — used in tests only.
+    ambiguity_radii:
+        Per-metric box-radius defaults. Forwarded into a fresh
+        ``AmbiguitySet`` when the caller does not supply one. Empty
+        dict (default) yields the zero-radius / nominal-only case.
+    irreversibility_penalty:
+        Forwarded into ``ThermodynamicBudgetConfig`` for the
+        budget-side irreversibility component. Independent of
+        ``lambda_irreversibility`` (which weights the gate-side
+        score).
+    warning_threshold / crisis_threshold:
+        Forwarded into ``robust_energy_state`` to compute the kernel's
+        coarse state. Defaults are intentionally astronomical so that
+        ``robust_energy_state`` does not flip to DORMANT on its own —
+        callers wanting that behavior should override.
+    """
+
+    lambda_thermo: float = 0.0
+    lambda_irreversibility: float = 0.0
+    tie_tolerance: float = 1e-12
+    fail_closed_on_tie: bool = True
+    ambiguity_radii: Mapping[str, float] = field(default_factory=dict)
+    irreversibility_penalty: float = 1.0
+    warning_threshold: float = _DEFAULT_WARNING_THRESHOLD
+    crisis_threshold: float = _DEFAULT_CRISIS_THRESHOLD
+
+
+@dataclass(frozen=True, slots=True)
+class CompositeScore:
+    """Per-candidate score breakdown, used both as audit input and as
+    the per-candidate row of ``KernelDecision.scores``.
+
+    ``composite`` is the actual selection criterion::
+
+        composite = f_robust
+                  + lambda_thermo * thermo_cost
+                  + lambda_irreversibility * irreversibility_cost
+    """
+
+    candidate: CandidateAction
+    f_robust: float
+    thermo_cost: float
+    irreversibility_cost: float
+    composite: float
+
+
+@dataclass(frozen=True, slots=True)
+class KernelDecision:
+    """End-to-end decision: chosen action (or None for DORMANT) plus
+    full audit trail.
+
+    Fields
+    ------
+    chosen:
+        The selected ``CandidateAction``, or ``None`` if the decision
+        collapsed to DORMANT (fail-closed on tie, fail-closed on robust
+        state, or empty candidate set).
+    state:
+        ``"NORMAL"`` / ``"WARNING"`` / ``"DORMANT"``. Matches the
+        contract of ``robust_energy_state`` plus the kernel's own
+        DORMANT collapse logic.
+    scores:
+        Per-candidate composite-score breakdown. Always populated when
+        ``candidates`` is non-empty (even on DORMANT).
+    audit_hash:
+        SHA-256 of the chosen candidate's gated trace. ``None`` when
+        ``chosen is None``.
+    decision_trace:
+        ``DecisionTrace`` from ``ReversibleGate.gate``. ``None`` when
+        ``chosen is None``.
+    robust_margin:
+        ``robust_free_energy - nominal_free_energy`` for the chosen
+        candidate (or for the argmin candidate if DORMANT-on-tie).
+        ``0.0`` when no candidates were supplied.
+    reason:
+        Human-readable explanation. Empty for the normal pass-through;
+        populated on DORMANT to explain the cause.
+    """
+
+    chosen: CandidateAction | None
+    state: Literal["NORMAL", "WARNING", "DORMANT"]
+    scores: tuple[CompositeScore, ...]
+    audit_hash: str | None
+    decision_trace: DecisionTrace | None
+    robust_margin: float
+    reason: str
+
+
+# ---------------------------------------------------------------------------
+# Validation helpers
+# ---------------------------------------------------------------------------
+
+
+def _validate_config(cfg: PhysicsNativeKernelConfig) -> None:
+    """Fail-closed checks on the kernel config. INV-HPC2."""
+    if cfg.lambda_thermo < 0.0:
+        raise ValueError(
+            f"PhysicsNativeKernelConfig.lambda_thermo must be >= 0, "
+            f"got {cfg.lambda_thermo!r}; weights are unsigned penalties."
+        )
+    if cfg.lambda_irreversibility < 0.0:
+        raise ValueError(
+            f"PhysicsNativeKernelConfig.lambda_irreversibility must be >= 0, "
+            f"got {cfg.lambda_irreversibility!r}; weights are unsigned penalties."
+        )
+    if cfg.tie_tolerance < 0.0:
+        raise ValueError(
+            f"PhysicsNativeKernelConfig.tie_tolerance must be >= 0, "
+            f"got {cfg.tie_tolerance!r}; tolerance is a non-negative epsilon."
+        )
+    if cfg.warning_threshold > cfg.crisis_threshold:
+        raise ValueError(
+            f"warning_threshold={cfg.warning_threshold!r} must be <= "
+            f"crisis_threshold={cfg.crisis_threshold!r}."
+        )
+    if cfg.irreversibility_penalty < 0.0:
+        raise ValueError(
+            f"PhysicsNativeKernelConfig.irreversibility_penalty must be >= 0, "
+            f"got {cfg.irreversibility_penalty!r}."
+        )
+    for name, radius in cfg.ambiguity_radii.items():
+        if not isinstance(name, str):
+            raise ValueError(f"ambiguity_radii keys must be strings, got {type(name).__name__}.")
+        if radius < 0.0:
+            raise ValueError(f"ambiguity_radii['{name}']={radius!r} must be >= 0.")
+
+
+def _validate_candidate(candidate: CandidateAction) -> None:
+    """Fail-closed checks on a single candidate. INV-HPC2 / INV-LANDAUER-PROXY."""
+    if not isinstance(candidate.action_id, str) or not candidate.action_id:
+        raise ValueError(
+            f"CandidateAction.action_id must be a non-empty str, got {candidate.action_id!r}."
+        )
+    if not isinstance(candidate.payload, (bytes, bytearray)):
+        raise TypeError(
+            f"CandidateAction.payload must be bytes, got {type(candidate.payload).__name__}."
+        )
+    score = candidate.irreversibility_score
+    if score != score:  # NaN check
+        raise ValueError(f"CandidateAction.irreversibility_score must not be NaN, got {score!r}.")
+    if not (0.0 <= score <= 1.0):
+        raise ValueError(f"CandidateAction.irreversibility_score must be in [0, 1], got {score!r}.")
+    if candidate.n_input_tokens < 0 or candidate.n_output_tokens < 0:
+        raise ValueError(
+            f"CandidateAction token counts must be >= 0, "
+            f"got n_in={candidate.n_input_tokens}, n_out={candidate.n_output_tokens}."
+        )
+    if candidate.expected_wall_time_ns < 0:
+        raise ValueError(
+            f"CandidateAction.expected_wall_time_ns must be >= 0, "
+            f"got {candidate.expected_wall_time_ns!r}."
+        )
+    if candidate.bits_consumed < 0.0 or candidate.bits_erased < 0.0:
+        raise ValueError(
+            f"CandidateAction bits must be >= 0, "
+            f"got bits_consumed={candidate.bits_consumed}, "
+            f"bits_erased={candidate.bits_erased}."
+        )
+
+
+def _ambiguity_from(
+    cfg: PhysicsNativeKernelConfig,
+    ambiguity: AmbiguitySet | None,
+) -> AmbiguitySet:
+    """Resolve the effective ambiguity set: caller-supplied wins, then
+    config-default, then zero-radius."""
+    if ambiguity is not None:
+        return ambiguity
+    return AmbiguitySet(radii=dict(cfg.ambiguity_radii), mode="box")
+
+
+# ---------------------------------------------------------------------------
+# Pure composite-score function
+# ---------------------------------------------------------------------------
+
+
+def evaluate_candidate(
+    candidate: CandidateAction,
+    metrics: EnergyMetrics,
+    ambiguity: AmbiguitySet,
+    cfg: PhysicsNativeKernelConfig,
+    *,
+    free_energy_model: DRFreeEnergyModel,
+) -> CompositeScore:
+    """Compute the composite score for one candidate.
+
+    ``composite = F_robust + lambda_thermo * thermo_cost
+                + lambda_irreversibility * irreversibility_cost``
+
+    Pure: no global state, no RNG, no I/O. The function delegates all
+    fail-closed checks to the underlying primitives (DR-FREE, budget,
+    gate score). INV-HPC1: same inputs => same composite to float
+    precision.
+    """
+    _validate_candidate(candidate)
+    _validate_config(cfg)
+
+    # --- DR-FREE (robust free energy) -------------------------------
+    dr_result = free_energy_model.evaluate_robust(metrics, ambiguity)
+    f_robust = float(dr_result.robust_free_energy)
+
+    # --- Thermodynamic budget proxy ---------------------------------
+    budget_cfg = ThermodynamicBudgetConfig(
+        irreversibility_penalty=cfg.irreversibility_penalty,
+    )
+    token = compute_token_cost(candidate.n_input_tokens, candidate.n_output_tokens)
+    latency = compute_latency_cost(
+        candidate.expected_wall_time_ns,
+        candidate.expected_wall_time_ns,  # p99 == wall here; not on the cost path
+    )
+    entropy = compute_entropy_cost(candidate.bits_consumed, candidate.bits_erased)
+    is_irreversible = candidate.irreversibility_score > 0.0
+    irrev_budget = compute_irreversibility_cost(
+        is_irreversible=is_irreversible,
+        score=candidate.irreversibility_score,
+        cfg=budget_cfg,
+    )
+    entry = aggregate_entry(
+        action_id=_BUDGET_EVAL_ACTION_ID,
+        timestamp_ns=0,
+        token=token,
+        lat=latency,
+        ent=entropy,
+        irr=irrev_budget,
+    )
+    thermo_cost = float(entry.total_proxy_cost)
+
+    # --- Irreversibility-cost component (gate side) -----------------
+    # The gate-side irreversibility cost is a *separate* lever from the
+    # budget-side one above: it lets callers add an explicit penalty on
+    # the score itself, independent of the budget aggregate. Setting
+    # lambda_irreversibility=0 (default) yields no extra contribution.
+    irreversibility_cost = float(candidate.irreversibility_score)
+
+    composite = (
+        f_robust
+        + cfg.lambda_thermo * thermo_cost
+        + cfg.lambda_irreversibility * irreversibility_cost
+    )
+
+    return CompositeScore(
+        candidate=candidate,
+        f_robust=f_robust,
+        thermo_cost=thermo_cost,
+        irreversibility_cost=irreversibility_cost,
+        composite=composite,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Pure end-to-end selection (no gate side-effect; gate is wired in the class)
+# ---------------------------------------------------------------------------
+
+
+def select_action(
+    candidates: Sequence[CandidateAction],
+    metrics: EnergyMetrics,
+    ambiguity: AmbiguitySet,
+    cfg: PhysicsNativeKernelConfig,
+    *,
+    free_energy_model: DRFreeEnergyModel,
+) -> KernelDecision:
+    """Score all candidates, apply argmin selection with tie / DORMANT
+    guards, and return a ``KernelDecision``.
+
+    INV-FREE-ENERGY (kernel selection scope): chosen action MUST be the
+    unique-or-fail-closed argmin of ``CompositeScore.composite``. Ties
+    within ``cfg.tie_tolerance`` collapse to DORMANT (chosen=None) when
+    ``cfg.fail_closed_on_tie`` is True; when False, the first argmin in
+    candidate order is selected (used in tests only).
+
+    This function is **pure** — it does not touch any reversible-gate
+    ledger. ``KernelDecision.audit_hash`` and ``decision_trace`` are
+    therefore always ``None`` from this entry point. To get a recorded
+    trace and audit hash, use ``PhysicsNativeKernel.decide``.
+    """
+    _validate_config(cfg)
+
+    # Empty candidate set => fail-closed DORMANT, with a reason.
+    if not candidates:
+        return KernelDecision(
+            chosen=None,
+            state="DORMANT",
+            scores=(),
+            audit_hash=None,
+            decision_trace=None,
+            robust_margin=0.0,
+            reason="empty candidate set; fail-closed DORMANT",
+        )
+
+    # Score every candidate.
+    scores = tuple(
+        evaluate_candidate(
+            c,
+            metrics,
+            ambiguity,
+            cfg,
+            free_energy_model=free_energy_model,
+        )
+        for c in candidates
+    )
+
+    # Robust state — uses the *first* candidate's DR-FREE result (all
+    # candidates share the same metrics + ambiguity, so robust_F differs
+    # only if metrics differ; for the kernel scope they don't).
+    dr_result = free_energy_model.evaluate_robust(metrics, ambiguity)
+    state: Literal["NORMAL", "WARNING", "DORMANT"] = robust_energy_state(
+        dr_result,
+        warning_threshold=cfg.warning_threshold,
+        crisis_threshold=cfg.crisis_threshold,
+    )
+    robust_margin = float(dr_result.robust_margin)
+
+    # If the robust state is DORMANT, fail closed regardless of
+    # candidates. INV-CB-style safety: no dispatch under crisis state.
+    if state == "DORMANT":
+        return KernelDecision(
+            chosen=None,
+            state="DORMANT",
+            scores=scores,
+            audit_hash=None,
+            decision_trace=None,
+            robust_margin=robust_margin,
+            reason="robust_energy_state == DORMANT; fail-closed",
+        )
+
+    # Argmin with tie tolerance.
+    composites = [s.composite for s in scores]
+    min_composite = min(composites)
+    near_min_indices = [
+        i for i, c in enumerate(composites) if c <= min_composite + cfg.tie_tolerance
+    ]
+    if len(near_min_indices) >= 2 and cfg.fail_closed_on_tie:
+        return KernelDecision(
+            chosen=None,
+            state="DORMANT",
+            scores=scores,
+            audit_hash=None,
+            decision_trace=None,
+            robust_margin=robust_margin,
+            reason=(
+                f"INV-FREE-ENERGY tie: {len(near_min_indices)} candidates "
+                f"within tie_tolerance={cfg.tie_tolerance!r} of min "
+                f"composite={min_composite!r}; fail-closed DORMANT"
+            ),
+        )
+
+    chosen_idx = near_min_indices[0]
+    chosen = scores[chosen_idx].candidate
+
+    return KernelDecision(
+        chosen=chosen,
+        state=state,
+        scores=scores,
+        audit_hash=None,
+        decision_trace=None,
+        robust_margin=robust_margin,
+        reason="",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Stateful kernel: composes select_action with reversible_gate ledger
+# ---------------------------------------------------------------------------
+
+
+class PhysicsNativeKernel:
+    """Stateless composition; instance carries the reversible-gate
+    ledger only.
+
+    Two distinct kernel instances cannot observe each other's gate
+    ledgers. There is no global / module-level state.
+    """
+
+    def __init__(
+        self,
+        cfg: PhysicsNativeKernelConfig | None = None,
+        *,
+        free_energy_model: DRFreeEnergyModel | None = None,
+        gate: ReversibleGate | None = None,
+    ) -> None:
+        self._cfg: Final[PhysicsNativeKernelConfig] = (
+            cfg if cfg is not None else PhysicsNativeKernelConfig()
+        )
+        _validate_config(self._cfg)
+        self._free_energy_model: Final[DRFreeEnergyModel] = (
+            free_energy_model if free_energy_model is not None else DRFreeEnergyModel()
+        )
+        # The gate's irreversibility threshold is *independent* of the
+        # kernel's lambda weights. We default to a permissive threshold
+        # so that any candidate with score == 0 is treated as reversible.
+        self._gate: Final[ReversibleGate] = (
+            gate
+            if gate is not None
+            else ReversibleGate(
+                ReversibleGateConfig(
+                    irreversibility_threshold=0.05,
+                    require_rollback_payload=False,
+                    fail_on_hash_collision=True,
+                    canonicalize_json=True,
+                )
+            )
+        )
+
+    @property
+    def config(self) -> PhysicsNativeKernelConfig:
+        return self._cfg
+
+    @property
+    def free_energy_model(self) -> DRFreeEnergyModel:
+        return self._free_energy_model
+
+    @property
+    def gate(self) -> ReversibleGate:
+        return self._gate
+
+    def decide(
+        self,
+        candidates: Sequence[CandidateAction],
+        metrics: EnergyMetrics,
+        ambiguity: AmbiguitySet | None = None,
+        timestamp_ns: int = 0,
+    ) -> KernelDecision:
+        """End-to-end: score all, select argmin, gate through
+        ``reversible_gate``, return ``KernelDecision``.
+
+        ``timestamp_ns`` is forwarded into ``ReversibleGate.gate`` so
+        that the recorded ``DecisionTrace.audit_hash`` is deterministic.
+        Default 0 is used in tests; production callers should pass a
+        monotonic clock value.
+        """
+        if timestamp_ns < 0:
+            raise ValueError(f"timestamp_ns must be >= 0, got {timestamp_ns!r}.")
+        eff_ambiguity = _ambiguity_from(self._cfg, ambiguity)
+        decision = select_action(
+            candidates,
+            metrics,
+            eff_ambiguity,
+            self._cfg,
+            free_energy_model=self._free_energy_model,
+        )
+        if decision.chosen is None:
+            return decision
+
+        chosen = decision.chosen
+        # Build a deterministic pre/post-state pair from the candidate's
+        # payload + composite score. We do not have access to a real
+        # external pre-state here; the kernel's gate is an *internal*
+        # decision audit, not a market-side rollback ledger.
+        composite_repr = _composite_repr(decision.scores)
+        pre_state = composite_repr
+        post_state = _post_state_for(chosen)
+
+        trace = self._gate.gate(
+            action_id=chosen.action_id,
+            pre_state=pre_state,
+            action_payload=chosen.payload,
+            post_state=post_state,
+            irreversibility_score=chosen.irreversibility_score,
+            timestamp_ns=timestamp_ns,
+            rollback_payload=None,
+        )
+
+        return KernelDecision(
+            chosen=chosen,
+            state=decision.state,
+            scores=decision.scores,
+            audit_hash=trace.audit_hash,
+            decision_trace=trace,
+            robust_margin=decision.robust_margin,
+            reason=decision.reason,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+def _composite_repr(scores: Sequence[CompositeScore]) -> bytes:
+    """Deterministic byte-encoding of all composite scores in selection
+    order. Used as the gate's ``pre_state``: it is the kernel's view of
+    the decision-time state (the score table). INV-HPC1 — same inputs
+    yield identical bytes to byte precision.
+    """
+    h = hashlib.sha256()
+    for s in scores:
+        h.update(s.candidate.action_id.encode("utf-8"))
+        h.update(b"\x00")
+        h.update(repr(float(s.composite)).encode("ascii"))
+        h.update(b"\x00")
+        h.update(repr(float(s.f_robust)).encode("ascii"))
+        h.update(b"\x00")
+        h.update(repr(float(s.thermo_cost)).encode("ascii"))
+        h.update(b"\x00")
+        h.update(repr(float(s.irreversibility_cost)).encode("ascii"))
+        h.update(b"\x01")
+    return h.digest()
+
+
+def _post_state_for(chosen: CandidateAction) -> bytes:
+    """Deterministic byte-encoding of the chosen candidate. Used as
+    the gate's ``post_state``."""
+    h = hashlib.sha256()
+    h.update(b"pncc-f.post\x00")
+    h.update(chosen.action_id.encode("utf-8"))
+    h.update(b"\x00")
+    h.update(repr(float(chosen.irreversibility_score)).encode("ascii"))
+    h.update(b"\x00")
+    h.update(chosen.payload)
+    return h.digest()

--- a/tests/tacl/test_physics_native_kernel.py
+++ b/tests/tacl/test_physics_native_kernel.py
@@ -1,0 +1,562 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+# no-bio-claim
+"""Tests for ``tacl.physics_native_kernel`` — PNCC-F Wave 2 composition.
+
+INV-FREE-ENERGY (kernel selection scope):
+    The chosen action MUST be the unique-or-fail-closed argmin of the
+    composite score over a non-empty candidate set. Ties within
+    ``cfg.tie_tolerance`` collapse to DORMANT (chosen is None).
+
+Tests in this module cover:
+
+- algebraic single-candidate recovery,
+- universal sweep over unique-minimum cases,
+- tie-tolerance collapse (both fail-closed and disabled paths),
+- composability: lambda_thermo=0 + lambda_irrev=0 reduces to pure
+  DR-FREE selection,
+- qualitative penalty effect of lambda_irreversibility,
+- DORMANT propagation from upstream ``robust_energy_state``,
+- INV-HPC1 deterministic output under fixed seed,
+- INV-FREE-ENERGY 1000-draw falsification micro-battery,
+- audit-hash recording for non-DORMANT decisions,
+- absence of hidden global state across two kernel instances,
+- empty candidate fail-closed DORMANT.
+"""
+
+from __future__ import annotations
+
+import random
+from collections.abc import Sequence
+from typing import Final
+
+import pytest
+
+from tacl.dr_free import AmbiguitySet, DRFreeEnergyModel
+from tacl.energy_model import EnergyMetrics
+from tacl.physics_native_kernel import (
+    CandidateAction,
+    CompositeScore,
+    KernelDecision,
+    PhysicsNativeKernel,
+    PhysicsNativeKernelConfig,
+    evaluate_candidate,
+    select_action,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+_NOMINAL_METRICS: Final[EnergyMetrics] = EnergyMetrics(
+    latency_p95=10.0,
+    latency_p99=20.0,
+    coherency_drift=0.01,
+    cpu_burn=0.10,
+    mem_cost=1.0,
+    queue_depth=4.0,
+    packet_loss=0.0001,
+)
+
+
+def _zero_ambiguity() -> AmbiguitySet:
+    return AmbiguitySet(radii={}, mode="box")
+
+
+def _make_candidate(
+    action_id: str = "a",
+    *,
+    irreversibility_score: float = 0.0,
+    n_in: int = 10,
+    n_out: int = 5,
+    wall_ns: int = 1_000_000,
+    bits_consumed: float = 0.0,
+    bits_erased: float = 0.0,
+    payload: bytes = b"x",
+) -> CandidateAction:
+    return CandidateAction(
+        action_id=action_id,
+        payload=payload,
+        irreversibility_score=irreversibility_score,
+        n_input_tokens=n_in,
+        n_output_tokens=n_out,
+        expected_wall_time_ns=wall_ns,
+        bits_consumed=bits_consumed,
+        bits_erased=bits_erased,
+    )
+
+
+def _bracketed_random_candidates(
+    rng: random.Random,
+    n: int,
+    *,
+    composite_spread: float = 1.0,
+) -> Sequence[CandidateAction]:
+    """Generate ``n`` candidates with payloads / token counts varying so
+    that their thermodynamic-cost components meaningfully differ. The
+    first candidate is forced to have a uniquely-low irreversibility
+    score so that, with ``lambda_irreversibility >> 0``, it becomes the
+    unique argmin. The DR-FREE component is shared across candidates
+    (same metrics) so ``f_robust`` is identical.
+    """
+    out: list[CandidateAction] = []
+    for i in range(n):
+        out.append(
+            _make_candidate(
+                action_id=f"a{i:03d}",
+                # Sprinkle a small offset so composite scores rarely tie.
+                irreversibility_score=rng.uniform(0.0, 1.0) * composite_spread,
+                n_in=rng.randint(1, 50),
+                n_out=rng.randint(1, 50),
+                wall_ns=rng.randint(1_000, 10_000_000),
+                bits_consumed=rng.uniform(0.0, 5.0),
+                bits_erased=rng.uniform(0.0, 5.0),
+                payload=bytes([rng.randint(0, 255) for _ in range(rng.randint(1, 16))]),
+            )
+        )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# 1. Single-candidate recovers DR-FREE selection (algebraic)
+# ---------------------------------------------------------------------------
+
+
+def test_single_candidate_recovers_dr_free() -> None:
+    """One candidate, lambda_thermo=lambda_irrev=0 => that candidate is
+    chosen and the audit_hash is set when going through ``decide``.
+    """
+    cfg = PhysicsNativeKernelConfig()
+    kernel = PhysicsNativeKernel(cfg)
+    cand = _make_candidate(action_id="only")
+
+    decision = kernel.decide([cand], _NOMINAL_METRICS)
+
+    assert decision.chosen is cand, "single candidate must be selected"
+    assert decision.audit_hash is not None, "non-DORMANT decision must record audit_hash"
+    assert decision.decision_trace is not None
+    assert decision.decision_trace.audit_hash == decision.audit_hash
+    assert decision.state in {"NORMAL", "WARNING"}
+    assert decision.reason == ""
+    # Composite for the only candidate must equal its f_robust under
+    # zero-weight defaults.
+    [score] = decision.scores
+    assert abs(score.composite - score.f_robust) < 1e-12, (
+        f"INV-FREE-ENERGY pure-DR-FREE recovery violated: "
+        f"composite={score.composite!r}, f_robust={score.f_robust!r}, "
+        f"diff={abs(score.composite - score.f_robust)!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. Universal sweep: argmin is chosen for every unique-minimum case
+# ---------------------------------------------------------------------------
+
+
+def test_argmin_is_chosen_for_unique_minimum() -> None:
+    """Sweep K candidate sets; whenever the minimum composite is
+    strictly lower than the runner-up by > tie_tolerance, that
+    candidate must be chosen.
+    """
+    rng = random.Random(20260425)
+    cfg = PhysicsNativeKernelConfig(
+        lambda_thermo=0.5,
+        lambda_irreversibility=2.0,  # strong tilt to break ties
+    )
+    kernel = PhysicsNativeKernel(cfg)
+    n_unique_minima = 0
+    for trial in range(60):
+        n = rng.randint(2, 8)
+        candidates = list(_bracketed_random_candidates(rng, n))
+        decision = kernel.decide(candidates, _NOMINAL_METRICS, timestamp_ns=trial)
+        composites = [s.composite for s in decision.scores]
+        min_c = min(composites)
+        near_min = [c for c in composites if c <= min_c + cfg.tie_tolerance]
+        if len(near_min) == 1:
+            n_unique_minima += 1
+            assert decision.chosen is not None, (
+                f"INV-FREE-ENERGY VIOLATED: unique min exists but chosen is None; "
+                f"composites={composites!r}, trial={trial}"
+            )
+            chosen_score = next(s for s in decision.scores if s.candidate is decision.chosen)
+            assert abs(chosen_score.composite - min_c) < 1e-12, (
+                f"INV-FREE-ENERGY VIOLATED: chosen.composite={chosen_score.composite!r} "
+                f"!= min={min_c!r}, trial={trial}"
+            )
+    assert n_unique_minima > 0, (
+        "test fixture too weak — no unique minima generated; "
+        "increase composite_spread or candidate variation."
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. Tie-tolerance triggers DORMANT (universal — INV-FREE-ENERGY tie path)
+# ---------------------------------------------------------------------------
+
+
+def test_tie_tolerance_triggers_dormant() -> None:
+    """Two candidates with identical decision-relevant fields => tie =>
+    DORMANT under fail_closed_on_tie=True (default).
+    """
+    cfg = PhysicsNativeKernelConfig(
+        lambda_thermo=1.0,
+        lambda_irreversibility=1.0,
+    )
+    kernel = PhysicsNativeKernel(cfg)
+    a = _make_candidate(action_id="a")
+    b = _make_candidate(action_id="b")  # identical numeric fields, different id
+    decision = kernel.decide([a, b], _NOMINAL_METRICS)
+
+    composites = [s.composite for s in decision.scores]
+    fixture_msg = f"fixture inconsistency: ties were not actually tied (composites={composites!r})"
+    assert abs(composites[0] - composites[1]) < cfg.tie_tolerance, fixture_msg
+    assert decision.chosen is None, (
+        f"INV-FREE-ENERGY VIOLATED: tied composites must collapse to DORMANT, "
+        f"got chosen={decision.chosen!r}"
+    )
+    assert decision.state == "DORMANT"
+    assert decision.audit_hash is None
+    assert decision.decision_trace is None
+    assert "tie" in decision.reason.lower()
+
+
+# ---------------------------------------------------------------------------
+# 4. Tie tolerance disabled => first argmin is picked
+# ---------------------------------------------------------------------------
+
+
+def test_tie_tolerance_disabled_picks_first() -> None:
+    """``fail_closed_on_tie=False`` => the first argmin in candidate
+    order is chosen instead of DORMANT.
+    """
+    cfg = PhysicsNativeKernelConfig(
+        lambda_thermo=1.0,
+        lambda_irreversibility=1.0,
+        fail_closed_on_tie=False,
+    )
+    kernel = PhysicsNativeKernel(cfg)
+    a = _make_candidate(action_id="a")
+    b = _make_candidate(action_id="b")
+    decision = kernel.decide([a, b], _NOMINAL_METRICS)
+
+    assert decision.chosen is a, (
+        f"INV-FREE-ENERGY (tie-disabled) VIOLATED: first argmin must be chosen, "
+        f"got {decision.chosen!r}"
+    )
+    assert decision.state in {"NORMAL", "WARNING"}
+    assert decision.audit_hash is not None
+
+
+# ---------------------------------------------------------------------------
+# 5. lambda_thermo=0 + lambda_irrev=0 => composite EXACTLY equals f_robust
+#    (algebraic, exact; pure DR-FREE recovery)
+# ---------------------------------------------------------------------------
+
+
+def test_lambda_thermo_zero_recovers_pure_dr_free() -> None:
+    """Composability check (algebraic): with both weights 0, every
+    candidate's composite must equal its f_robust to float precision.
+    """
+    cfg = PhysicsNativeKernelConfig(lambda_thermo=0.0, lambda_irreversibility=0.0)
+    fem = DRFreeEnergyModel()
+    cands = [
+        _make_candidate(action_id="x", irreversibility_score=0.0),
+        _make_candidate(
+            action_id="y",
+            irreversibility_score=0.7,
+            wall_ns=10_000_000,
+            n_in=100,
+            n_out=200,
+            bits_erased=4.0,
+        ),
+    ]
+    for c in cands:
+        score = evaluate_candidate(
+            c, _NOMINAL_METRICS, _zero_ambiguity(), cfg, free_energy_model=fem
+        )
+        assert score.composite == score.f_robust, (
+            f"INV-FREE-ENERGY pure-DR-FREE recovery (algebraic) VIOLATED: "
+            f"composite={score.composite!r}, f_robust={score.f_robust!r} "
+            f"with lambda_thermo=0 and lambda_irreversibility=0"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 6. lambda_irreversibility penalizes irreversible actions (qualitative)
+# ---------------------------------------------------------------------------
+
+
+def test_lambda_irrev_penalizes_irreversible_actions() -> None:
+    """With lambda_irreversibility >> 0 and lambda_thermo=0, the
+    candidate with the lower irreversibility_score must be chosen
+    when the two candidates are otherwise identical.
+    """
+    cfg = PhysicsNativeKernelConfig(
+        lambda_thermo=0.0,
+        lambda_irreversibility=10.0,
+    )
+    kernel = PhysicsNativeKernel(cfg)
+    safe = _make_candidate(action_id="safe", irreversibility_score=0.0)
+    risky = _make_candidate(action_id="risky", irreversibility_score=0.9)
+    decision = kernel.decide([safe, risky], _NOMINAL_METRICS)
+
+    assert decision.chosen is safe, (
+        f"INV-FREE-ENERGY qualitative VIOLATED: lambda_irreversibility={cfg.lambda_irreversibility} "
+        f"should penalize risky over safe; got chosen={decision.chosen!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 7. DORMANT when robust_state == DORMANT (composes with robust_energy_state)
+# ---------------------------------------------------------------------------
+
+
+def test_dormant_when_robust_state_dormant() -> None:
+    """When ``robust_energy_state`` returns DORMANT, the kernel must
+    fail-closed regardless of candidate composition.
+    """
+    # Astronomically low crisis_threshold => every robust_F triggers DORMANT.
+    cfg = PhysicsNativeKernelConfig(
+        warning_threshold=-1.0e30,
+        crisis_threshold=-1.0e30,
+    )
+    kernel = PhysicsNativeKernel(cfg)
+    decision = kernel.decide([_make_candidate("a"), _make_candidate("b")], _NOMINAL_METRICS)
+
+    assert decision.chosen is None, (
+        f"INV-FREE-ENERGY robust-DORMANT VIOLATED: chosen must be None when "
+        f"robust_state == DORMANT, got chosen={decision.chosen!r}"
+    )
+    assert decision.state == "DORMANT"
+    assert "DORMANT" in decision.reason
+
+
+# ---------------------------------------------------------------------------
+# 8. Decision is deterministic under fixed seed (INV-HPC1)
+# ---------------------------------------------------------------------------
+
+
+def test_decision_is_deterministic_under_fixed_seed() -> None:
+    """Two kernel instances given identical inputs must produce
+    identical audit_hash values. The kernel uses no global state, no
+    RNG, no time call — INV-HPC1.
+    """
+    cfg = PhysicsNativeKernelConfig(
+        lambda_thermo=0.3,
+        lambda_irreversibility=1.5,
+    )
+    rng = random.Random(424242)
+    cands = list(_bracketed_random_candidates(rng, 5))
+
+    k1 = PhysicsNativeKernel(cfg)
+    k2 = PhysicsNativeKernel(cfg)
+    d1 = k1.decide(cands, _NOMINAL_METRICS, timestamp_ns=12345)
+    d2 = k2.decide(cands, _NOMINAL_METRICS, timestamp_ns=12345)
+
+    assert d1.chosen is not None
+    assert d2.chosen is not None
+    assert d1.audit_hash == d2.audit_hash, (
+        f"INV-HPC1 VIOLATED: deterministic kernel produced different "
+        f"audit_hashes: {d1.audit_hash!r} vs {d2.audit_hash!r}"
+    )
+    # Composite scores must be exactly equal (same float ops).
+    for s1, s2 in zip(d1.scores, d2.scores, strict=True):
+        composite_msg = (
+            f"INV-HPC1 VIOLATED: composite mismatch: {s1.composite!r} vs {s2.composite!r}"
+        )
+        assert s1.composite == s2.composite, composite_msg
+
+
+# ---------------------------------------------------------------------------
+# 9. INV-FREE-ENERGY 1000-draw falsification micro-battery (universal)
+# ---------------------------------------------------------------------------
+
+
+def test_invariant_falsification_random_1000() -> None:
+    """1000 random ``(candidates, metrics, ambiguity)`` draws.
+
+    Every ``select_action`` result must satisfy INV-FREE-ENERGY:
+      * non-empty candidates
+      * either chosen.composite == min(composites) (within tie_tol),
+      * OR chosen is None AND state == DORMANT AND >= 2 candidates
+        within tie_tol of min.
+
+    Falsification: any decision where chosen.composite > min(composites)
+    + tie_tolerance with state != DORMANT counts as a violation.
+    """
+    rng = random.Random(20260425)
+    cfg = PhysicsNativeKernelConfig(
+        lambda_thermo=1.0,
+        lambda_irreversibility=1.0,
+        tie_tolerance=1e-12,
+    )
+    fem = DRFreeEnergyModel()
+    n_violations = 0
+    n_dormant_on_tie = 0
+    n_unique = 0
+    n_robust_dormant = 0
+
+    for trial in range(1000):
+        n = rng.randint(1, 6)
+        candidates = list(_bracketed_random_candidates(rng, n))
+        # Vary metrics modestly so that f_robust changes batch-to-batch.
+        metrics = EnergyMetrics(
+            latency_p95=rng.uniform(1.0, 50.0),
+            latency_p99=rng.uniform(50.0, 100.0),
+            coherency_drift=rng.uniform(0.0, 0.05),
+            cpu_burn=rng.uniform(0.0, 0.5),
+            mem_cost=rng.uniform(0.1, 5.0),
+            queue_depth=rng.uniform(0.0, 16.0),
+            packet_loss=rng.uniform(0.0, 0.001),
+        )
+        ambiguity = AmbiguitySet(radii={"latency_p95": rng.uniform(0.0, 0.2)}, mode="box")
+        decision = select_action(candidates, metrics, ambiguity, cfg, free_energy_model=fem)
+        composites = [s.composite for s in decision.scores]
+        min_c = min(composites)
+        near_min = [c for c in composites if c <= min_c + cfg.tie_tolerance]
+
+        if decision.state == "DORMANT" and decision.chosen is None:
+            if len(near_min) >= 2:
+                n_dormant_on_tie += 1
+                continue
+            # DORMANT for non-tie reason (robust_state DORMANT). Allowed.
+            n_robust_dormant += 1
+            continue
+
+        # Normal pass-through: chosen must be the unique argmin.
+        assert decision.chosen is not None, (
+            f"INV-FREE-ENERGY VIOLATED: state={decision.state} but chosen is None; "
+            f"trial={trial}, composites={composites!r}"
+        )
+        chosen_score = next(s for s in decision.scores if s.candidate is decision.chosen)
+        if chosen_score.composite > min_c + cfg.tie_tolerance:
+            n_violations += 1
+        else:
+            n_unique += 1
+
+    assert n_violations == 0, (
+        f"INV-FREE-ENERGY VIOLATED in {n_violations}/1000 random scenarios "
+        f"(unique={n_unique}, dormant_on_tie={n_dormant_on_tie}, "
+        f"robust_dormant={n_robust_dormant})"
+    )
+    # Sanity: the test must have actually exercised the unique-argmin
+    # branch a non-trivial number of times.
+    assert n_unique >= 200, (
+        f"falsification battery too weak: only {n_unique}/1000 unique-argmin "
+        f"draws were observed (dormant_on_tie={n_dormant_on_tie}, "
+        f"robust_dormant={n_robust_dormant})"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 10. audit_hash is recorded for non-DORMANT (algebraic)
+# ---------------------------------------------------------------------------
+
+
+def test_audit_hash_is_recorded_for_non_dormant() -> None:
+    """Every non-DORMANT decision returned by ``decide`` must carry a
+    sha256 hex audit hash and a populated ``decision_trace``.
+    """
+    # lambda_irreversibility>0 breaks the tie between two otherwise
+    # identical-composite candidates so that the kernel does NOT fail
+    # closed on tie. Without this lever, both candidates' composites
+    # collapse to the same f_robust and the decision DORMANTs.
+    cfg = PhysicsNativeKernelConfig(lambda_irreversibility=1.0)
+    kernel = PhysicsNativeKernel(cfg)
+    cand_a = _make_candidate(action_id="a", irreversibility_score=0.01)
+    cand_b = _make_candidate(action_id="b", irreversibility_score=0.5, n_in=20)
+    decision = kernel.decide([cand_a, cand_b], _NOMINAL_METRICS, timestamp_ns=7)
+
+    assert decision.chosen is not None
+    assert decision.audit_hash is not None
+    # sha256 hex digest = 64 chars in [0-9a-f].
+    assert len(decision.audit_hash) == 64
+    assert all(ch in "0123456789abcdef" for ch in decision.audit_hash)
+    assert decision.decision_trace is not None
+    assert decision.decision_trace.audit_hash == decision.audit_hash
+
+
+# ---------------------------------------------------------------------------
+# 11. No hidden global state across kernel instances (universal)
+# ---------------------------------------------------------------------------
+
+
+def test_no_hidden_global_state_across_kernel_instances() -> None:
+    """Two independent kernels must not see each other's gate ledgers.
+
+    After kernel A admits a trace, kernel B must not have it in its
+    ledger; and admitting the same logical action in kernel B must
+    not raise (no cross-instance collision).
+    """
+    cfg = PhysicsNativeKernelConfig()
+    k_a = PhysicsNativeKernel(cfg)
+    k_b = PhysicsNativeKernel(cfg)
+    cand = _make_candidate(action_id="cross", irreversibility_score=0.01)
+
+    da = k_a.decide([cand], _NOMINAL_METRICS, timestamp_ns=1)
+    assert da.audit_hash is not None
+    assert k_a.gate.is_known(da.audit_hash)
+    leak_msg = "cross-instance ledger leak: kernel B should not know audit_hash from kernel A"
+    assert not k_b.gate.is_known(da.audit_hash), leak_msg
+
+    db = k_b.decide([cand], _NOMINAL_METRICS, timestamp_ns=1)
+    assert db.audit_hash is not None
+    hpc1_msg = "INV-HPC1: same inputs yield same audit_hash even on different instances"
+    assert db.audit_hash == da.audit_hash, hpc1_msg
+    assert k_b.gate.is_known(db.audit_hash)
+
+
+# ---------------------------------------------------------------------------
+# 12. Empty candidates returns DORMANT (universal — fail-closed)
+# ---------------------------------------------------------------------------
+
+
+def test_empty_candidates_returns_dormant() -> None:
+    """Empty candidate list => fail-closed DORMANT with no audit hash."""
+    cfg = PhysicsNativeKernelConfig()
+    kernel = PhysicsNativeKernel(cfg)
+    decision = kernel.decide([], _NOMINAL_METRICS)
+
+    assert decision.chosen is None
+    assert decision.state == "DORMANT"
+    assert decision.scores == ()
+    assert decision.audit_hash is None
+    assert decision.decision_trace is None
+    assert "empty" in decision.reason.lower()
+
+
+# ---------------------------------------------------------------------------
+# Extra fail-closed sanity checks (validation surface)
+# ---------------------------------------------------------------------------
+
+
+def test_validation_rejects_negative_lambda() -> None:
+    with pytest.raises(ValueError, match="lambda_thermo"):
+        PhysicsNativeKernel(PhysicsNativeKernelConfig(lambda_thermo=-1.0))
+    with pytest.raises(ValueError, match="lambda_irreversibility"):
+        PhysicsNativeKernel(PhysicsNativeKernelConfig(lambda_irreversibility=-0.1))
+
+
+def test_validation_rejects_out_of_range_score() -> None:
+    cfg = PhysicsNativeKernelConfig()
+    kernel = PhysicsNativeKernel(cfg)
+    bad = _make_candidate(action_id="bad", irreversibility_score=1.5)
+    with pytest.raises(ValueError, match=r"irreversibility_score"):
+        kernel.decide([bad], _NOMINAL_METRICS)
+
+
+def test_select_action_pure_does_not_record_audit() -> None:
+    """``select_action`` is the pure entry point — no audit_hash
+    populated even on a successful selection."""
+    cfg = PhysicsNativeKernelConfig()
+    fem = DRFreeEnergyModel()
+    cand = _make_candidate(action_id="one")
+    decision: KernelDecision = select_action(
+        [cand], _NOMINAL_METRICS, _zero_ambiguity(), cfg, free_energy_model=fem
+    )
+    assert decision.chosen is cand
+    assert decision.audit_hash is None
+    assert decision.decision_trace is None
+    [score] = decision.scores
+    assert isinstance(score, CompositeScore)


### PR DESCRIPTION
## Summary

Wave 2 composition layer of PNCC. Single module composes three already-landed primitives into one decision controller — no new physics, no new dataclasses beyond controller I/O.

```
PhysicsNativeKernel
   │
   ├── DRFreeEnergyModel (tacl/dr_free.py)               → F_robust
   ├── ThermodynamicBudget (PNCC-A, #378)                 → total_proxy_cost
   └── ReversibleGate     (PNCC-C, #380)                  → audit_hash + rollback
```

**Decision rule:**
```
composite(c) = F_robust + lambda_thermo · total_proxy_cost(c)
                        + lambda_irreversibility · irreversibility_score(c)
```

**Defaults inert:** `lambda_thermo = lambda_irreversibility = 0.0` reduces kernel to pure DR-FREE selection. Penalties are opt-in.

## INV-FREE-ENERGY (P0, universal)

Chosen action MUST be unique-or-fail-closed argmin of composite. Ties → DORMANT. DORMANT robust state → chosen=None.

**Falsification:** 1000-draw random battery (`test_invariant_falsification_random_1000`). 1000/1000 PASS.

## Audit-then-merge protocol

| Gate | Result |
|---|---|
| pytest (15 functions) | 15/15 PASS |
| ruff check | clean |
| ruff format --check | clean |
| black --check | clean |
| mypy --strict | clean |
| AST-grep naked-bio-claim scan | 0 violations |
| Forbidden citation grep | 0 hits |

## Verified citations only

Per `feedback_self_audit_blindspots.md` and the verify-before-forward contract from PR #382:

- Landauer 1961 — IBM J. Res. Dev. 5, 183
- Bennett 1973 — IBM J. Res. Dev. 17, 525
- Friston 2010 — Nature Reviews Neuroscience 11, 127
- DRO theory — generic (Wiesemann/Kuhn/Sim 2014)

No 2025/2026 unverified citations.

## HYP-5 status

HYP-5 (combined loop improves accuracy or preserves it under lower compute) **remains a 90-day hypothesis**. This PR ships the controller, NOT the validation. Validation requires registered `EvidenceClaim` with baseline / intervention / control / n_samples / effect_size / CI95 (see `tacl/evidence_ledger.py`).

## Out of scope (intentionally)

- INVARIANTS.yaml / physics_contracts/catalog.yaml — Wave 2.5 coordination PR will register INV-FREE-ENERGY (mirrors Wave 1.5 #383)
- PNCC-D CNS proxy plug-in — `CNSProxyState` not in main; will land as follow-up when telemetry pipeline exists
- Online learning of `lambda_*` weights — out of scope for v0
- KL/Wasserstein ambiguity sets — `tacl/dr_free.py` is box-only; future extension

## Test plan
- [x] 15 unit tests pass
- [x] 1000-draw INV-FREE-ENERGY falsification passes
- [x] Composability: lambda_thermo=lambda_irrev=0 ⇒ exact DR-FREE selection
- [x] Cross-instance ledger isolation (no hidden global state)
- [x] Empty candidates → DORMANT (fail-closed)
- [x] DORMANT robust state honored