### PR TITLE
feat(physics+tacl): INV-CRITICALITY root invariant + evidence_ledger criticality fields

### DIFF
--- a/.claude/physics/INVARIANTS.yaml
+++ b/.claude/physics/INVARIANTS.yaml
@@ -825,3 +825,19 @@ pncc:
     priority: P0
     source: tacl/evidence_ledger.py
     tests: tests/tacl/test_evidence_ledger.py
+
+  criticality:
+    id: INV-CRITICALITY
+    type: universal
+    statement: "Substrate is intelligence-capable iff γ ∈ [1−ε, 1+ε] where γ = 2·H + 1 (DFA-1 Hurst). Outside the metastable window, decisions must fail-closed to DORMANT. ε = cfg.criticality_epsilon."
+    test_type: property_test
+    falsification: "Any non-DORMANT decision registered with substrate_criticality_at_decision outside [1−ε, 1+ε] AND criticality_window_confirmed=False"
+    priority: P0
+    source: tacl/evidence_ledger.py
+    tests: tests/tacl/test_evidence_ledger.py
+    references:
+      - "Bak, P. (1996). How Nature Works: The Science of Self-Organized Criticality."
+      - "Langton, C. G. (1990). Computation at the edge of chaos. Physica D 42, 12."
+      - "Mora, T. & Bialek, W. (2011). Are biological systems poised at criticality? J. Stat. Phys. 144, 268."
+      - "Beggs, J. M. & Plenz, D. (2003). Neuronal avalanches in neocortical circuits. J. Neurosci. 23, 11167."
+    related: [INV-DRO1, INV-DRO2, INV-DRO4, INV-YV1]

--- a/tacl/evidence_ledger.py
+++ b/tacl/evidence_ledger.py
@@ -58,10 +58,18 @@ from collections.abc import Iterable
 from dataclasses import asdict, dataclass
 from enum import Enum
 from pathlib import Path
-from typing import Final
+from typing import Final, Literal
+
+# INV-CRITICALITY: substrate decision signals tracked alongside evidence.
+# Mirrors tacl/dr_free.robust_energy_state and tacl/physics_native_kernel
+# KernelDecision.state. Kept as Literal (not Enum) for cross-module type
+# unification.
+DecisionSignalKind = Literal["NORMAL", "WARNING", "DORMANT"]
+_VALID_SIGNAL_VALUES: Final[frozenset[str]] = frozenset({"NORMAL", "WARNING", "DORMANT"})
 
 __all__ = [
     "BioClaimViolation",
+    "DecisionSignalKind",
     "EvidenceClaim",
     "EvidenceLedger",
     "EvidenceRegistry",
@@ -130,6 +138,13 @@ class EvidenceClaim:
     registered_at_ns: int
     pre_registered: bool
     notes: str | None = None
+    # INV-CRITICALITY (Bak 1996; Langton 1990; Mora-Bialek 2011; Beggs-Plenz 2003).
+    # γ = 2·H + 1 (DFA-1 Hurst). Substrate is intelligence-capable iff
+    # γ ∈ [1−ε, 1+ε]. Outside the metastable window any non-DORMANT signal
+    # is rejected (fail-closed). None ⇒ legacy claim, criticality bypassed.
+    substrate_criticality_at_decision: float | None = None
+    criticality_window_confirmed: bool = False
+    signal: DecisionSignalKind = "NORMAL"
 
 
 @dataclass(frozen=True, slots=True)
@@ -255,6 +270,25 @@ def validate_claim(
 
     if claim.baseline_n < 1 or claim.intervention_n < 1:
         return False, "n < 1 not permitted"
+
+    # INV-CRITICALITY: when γ is recorded, it must be a finite positive
+    # number, and a non-confirmed window forces the claim's signal to
+    # DORMANT (fail-closed). γ is None ⇒ legacy claim, no check.
+    gamma = claim.substrate_criticality_at_decision
+    if gamma is not None:
+        if not math.isfinite(gamma):
+            return False, f"non-finite substrate_criticality_at_decision: {gamma!r}"
+        if gamma <= 0.0:
+            return False, f"substrate_criticality_at_decision must be > 0 (γ > 0), got {gamma}"
+        if claim.signal not in _VALID_SIGNAL_VALUES:
+            return False, f"signal={claim.signal!r} not in {sorted(_VALID_SIGNAL_VALUES)}"
+        if not claim.criticality_window_confirmed and claim.signal != "DORMANT":
+            return (
+                False,
+                "INV-CRITICALITY: criticality_window_confirmed=False with "
+                f"signal={claim.signal!r}; non-DORMANT signals require an "
+                "explicitly confirmed criticality window",
+            )
 
     return True, None
 
@@ -520,6 +554,19 @@ def _claim_from_dict(raw: dict[str, object]) -> EvidenceClaim:
     notes_raw = raw.get("notes")
     if notes_raw is not None and not isinstance(notes_raw, str):
         raise ValueError("notes must be str or null")
+    # INV-CRITICALITY backward-compat: legacy JSON without these fields
+    # deserializes with default sentinels; γ=None ⇒ legacy claim.
+    sub_crit = _optional_float(raw, "substrate_criticality_at_decision")
+    crit_confirmed_raw = raw.get("criticality_window_confirmed", False)
+    if not isinstance(crit_confirmed_raw, bool):
+        raise ValueError(
+            f"criticality_window_confirmed must be bool, got {type(crit_confirmed_raw).__name__}"
+        )
+    signal_raw = raw.get("signal", "NORMAL")
+    if not isinstance(signal_raw, str) or signal_raw not in _VALID_SIGNAL_VALUES:
+        raise ValueError(
+            f"signal must be one of {sorted(_VALID_SIGNAL_VALUES)}, got {signal_raw!r}"
+        )
     return EvidenceClaim(
         hypothesis=hypothesis,
         baseline_mean=_require_float(raw, "baseline_mean"),
@@ -535,6 +582,9 @@ def _claim_from_dict(raw: dict[str, object]) -> EvidenceClaim:
         registered_at_ns=_require_int(raw, "registered_at_ns"),
         pre_registered=_require_bool(raw, "pre_registered"),
         notes=notes_raw,
+        substrate_criticality_at_decision=sub_crit,
+        criticality_window_confirmed=crit_confirmed_raw,
+        signal=signal_raw,  # type: ignore[arg-type]
     )
 
 

--- a/tests/tacl/test_evidence_ledger.py
+++ b/tests/tacl/test_evidence_ledger.py
@@ -23,11 +23,14 @@ from pathlib import Path
 from typing import Final
 
 import pytest
+from hypothesis import given
+from hypothesis import strategies as st
 
 from tacl.evidence_ledger import (
     DEFAULT_DISCLAIMER_PHRASES,
     DEFAULT_FORBIDDEN_PATTERNS,
     BioClaimViolation,
+    DecisionSignalKind,
     EvidenceClaim,
     EvidenceRegistry,
     HypothesisId,
@@ -65,6 +68,9 @@ def _claim(
     registered_at_ns: int = _FIXED_TS,
     pre_registered: bool = True,
     notes: str | None = None,
+    substrate_criticality_at_decision: float | None = None,
+    criticality_window_confirmed: bool = False,
+    signal: DecisionSignalKind = "NORMAL",
 ) -> EvidenceClaim:
     return EvidenceClaim(
         hypothesis=hypothesis,
@@ -81,6 +87,9 @@ def _claim(
         registered_at_ns=registered_at_ns,
         pre_registered=pre_registered,
         notes=notes,
+        substrate_criticality_at_decision=substrate_criticality_at_decision,
+        criticality_window_confirmed=criticality_window_confirmed,
+        signal=signal,
     )
 
 
@@ -454,3 +463,152 @@ def test_self_scan_evidence_ledger_module_clean() -> None:
         "INV-NO-BIO-CLAIM VIOLATED in evidence_ledger.py: "
         f"{len(violations)} naked claims: {violations}"
     )
+
+
+# ---------------------------------------------------------------------------
+# INV-CRITICALITY (P0, universal)
+# γ = 2H+1 (DFA-1). Substrate intelligence-capable iff γ ∈ [1−ε, 1+ε].
+# Outside the metastable window any non-DORMANT signal is rejected.
+# Refs: Bak 1996; Langton 1990; Mora-Bialek 2011; Beggs-Plenz 2003.
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_claim_without_criticality_field_validates() -> None:
+    """Legacy: γ=None ⇒ INV-CRITICALITY bypassed; pre-existing claims still valid."""
+    claim = _claim()
+    ok, reason = validate_claim(claim)
+    assert ok is True, reason
+    assert claim.substrate_criticality_at_decision is None
+    assert claim.criticality_window_confirmed is False
+    assert claim.signal == "NORMAL"
+
+
+def test_criticality_confirmed_with_normal_signal_valid() -> None:
+    """γ in window AND confirmed=True ⇒ NORMAL signal is admissible."""
+    claim = _claim(
+        substrate_criticality_at_decision=1.0,
+        criticality_window_confirmed=True,
+        signal="NORMAL",
+    )
+    ok, reason = validate_claim(claim)
+    assert ok is True, reason
+
+
+def test_criticality_not_confirmed_dormant_signal_valid() -> None:
+    """Outside-window claim is admissible iff signal=DORMANT (fail-closed exit)."""
+    claim = _claim(
+        substrate_criticality_at_decision=1.7,
+        criticality_window_confirmed=False,
+        signal="DORMANT",
+    )
+    ok, reason = validate_claim(claim)
+    assert ok is True, reason
+
+
+def test_criticality_not_confirmed_non_dormant_signal_rejected() -> None:
+    """INV-CRITICALITY VIOLATED: confirmed=False with NORMAL signal ⇒ rejected."""
+    claim = _claim(
+        substrate_criticality_at_decision=1.7,
+        criticality_window_confirmed=False,
+        signal="NORMAL",
+    )
+    ok, reason = validate_claim(claim)
+    assert ok is False
+    assert reason is not None and "INV-CRITICALITY" in reason
+
+
+def test_criticality_warning_signal_also_rejected_when_unconfirmed() -> None:
+    """Only DORMANT is admissible when window is unconfirmed; WARNING is not."""
+    claim = _claim(
+        substrate_criticality_at_decision=1.7,
+        criticality_window_confirmed=False,
+        signal="WARNING",
+    )
+    ok, reason = validate_claim(claim)
+    assert ok is False
+    assert reason is not None and "INV-CRITICALITY" in reason
+
+
+def test_criticality_nan_or_non_positive_rejected() -> None:
+    """γ must be finite and strictly positive (γ = 2H+1 with H >= 0)."""
+    for bad in (float("nan"), float("inf"), -1.0, 0.0):
+        claim = _claim(
+            substrate_criticality_at_decision=bad,
+            criticality_window_confirmed=True,
+            signal="NORMAL",
+        )
+        ok, reason = validate_claim(claim)
+        assert ok is False, f"γ={bad!r} should have been rejected"
+        assert reason is not None
+
+
+@given(
+    gamma=st.floats(
+        min_value=0.01,
+        max_value=10.0,
+        allow_nan=False,
+        allow_infinity=False,
+    ),
+    confirmed=st.booleans(),
+    signal=st.sampled_from(("NORMAL", "WARNING", "DORMANT")),
+)
+def test_inv_criticality_property_random(
+    gamma: float, confirmed: bool, signal: DecisionSignalKind
+) -> None:
+    """Property: validate accepts iff (confirmed) OR (signal == DORMANT)."""
+    claim = _claim(
+        substrate_criticality_at_decision=gamma,
+        criticality_window_confirmed=confirmed,
+        signal=signal,
+    )
+    ok, _reason = validate_claim(claim)
+    expected = confirmed or signal == "DORMANT"
+    assert ok is expected, (
+        f"INV-CRITICALITY mismatch at γ={gamma}, confirmed={confirmed}, "
+        f"signal={signal!r}: validate={ok}, expected={expected}"
+    )
+
+
+def test_serialization_round_trip_preserves_criticality_fields() -> None:
+    """Round-trip via to_json/from_json preserves all three INV-CRITICALITY fields."""
+    reg = EvidenceRegistry()
+    reg.register(
+        _claim(
+            substrate_criticality_at_decision=1.0,
+            criticality_window_confirmed=True,
+            signal="NORMAL",
+        )
+    )
+    payload = reg.to_json()
+    reg2 = EvidenceRegistry.from_json(payload)
+    [entry] = list(reg2.query(HypothesisId.HYP_1_DECISION_LATENCY))
+    assert entry.claim.substrate_criticality_at_decision == 1.0
+    assert entry.claim.criticality_window_confirmed is True
+    assert entry.claim.signal == "NORMAL"
+
+
+def test_in_memory_claim_omitting_criticality_fields_uses_defaults() -> None:
+    """100% backward compat: constructing EvidenceClaim without the new fields
+    yields defaults (γ=None, confirmed=False, signal=NORMAL); hash and
+    validation work unchanged from the legacy schema's behaviour."""
+    legacy_shape = EvidenceClaim(
+        hypothesis=HypothesisId.HYP_1_DECISION_LATENCY,
+        baseline_mean=100.0,
+        baseline_std=12.0,
+        baseline_n=32,
+        intervention_mean=92.0,
+        intervention_std=11.0,
+        intervention_n=33,
+        effect_size=-0.7,
+        ci_95_low=-1.1,
+        ci_95_high=-0.3,
+        stat_test=_stat_test(),
+        registered_at_ns=_FIXED_TS,
+        pre_registered=True,
+    )
+    assert legacy_shape.substrate_criticality_at_decision is None
+    assert legacy_shape.criticality_window_confirmed is False
+    assert legacy_shape.signal == "NORMAL"
+    ok, reason = validate_claim(legacy_shape)
+    assert ok is True, reason
+    assert isinstance(claim_hash(legacy_shape), str)


### PR DESCRIPTION
## Two sequential tasks per spec

### TASK 1 — `.claude/physics/INVARIANTS.yaml`
- INV-CRITICALITY (P0, universal) added under `pncc:` section
- γ = 2·H + 1 (DFA-1 Hurst); substrate intelligence-capable iff γ ∈ [1−ε, 1+ε]
- Outside metastable window → fail-closed to DORMANT
- references: Bak 1996, Langton 1990, Mora-Bialek 2011, Beggs-Plenz 2003
- related: INV-DRO1, INV-DRO2, INV-DRO4, INV-YV1

### TASK 2 — `tacl/evidence_ledger.py`
- `DecisionSignalKind = Literal["NORMAL", "WARNING", "DORMANT"]` (mirrors `physics_native_kernel.KernelDecision.state`)
- `EvidenceClaim` gains 3 fields with defaults (100% backward compat):
  - `substrate_criticality_at_decision: float | None = None` (None = legacy)
  - `criticality_window_confirmed: bool = False`
  - `signal: DecisionSignalKind = "NORMAL"`
- `validate_claim`: when γ is recorded, must be finite & > 0; when `criticality_window_confirmed=False` the only admissible signal is `DORMANT`. Legacy claims (γ=None) bypass.
- `_claim_from_dict` deserializes new fields with defaults.

## Quality gate (pass/fail counts only)

| Gate | Result |
|---|---|
| pytest tests/tacl/test_evidence_ledger.py | **29/29 PASS** |
| pytest tests/tacl/ + thermodynamic_budget + reversible_gate | **118/118 PASS** (no regressions) |
| ruff check | clean |
| ruff format --check | clean |
| black --check | clean |
| mypy --strict | clean |

## Tests added (≥6 required)
8 functions:
1. `test_legacy_claim_without_criticality_field_validates`
2. `test_criticality_confirmed_with_normal_signal_valid`
3. `test_criticality_not_confirmed_dormant_signal_valid`
4. `test_criticality_not_confirmed_non_dormant_signal_rejected`
5. `test_criticality_warning_signal_also_rejected_when_unconfirmed`
6. `test_criticality_nan_or_non_positive_rejected`
7. `test_inv_criticality_property_random` (Hypothesis sweep)
8. `test_serialization_round_trip_preserves_criticality_fields`
9. `test_in_memory_claim_omitting_criticality_fields_uses_defaults`