### PR TITLE
feat(physics): INV-ARROW-OF-TIME — observer-coupled 2nd law (P1)

### DIFF
--- a/.claude/physics/INVARIANTS.yaml
+++ b/.claude/physics/INVARIANTS.yaml
@@ -872,3 +872,20 @@ pncc:
       - "Susskind, L. (1995). The world as a hologram. J. Math. Phys. 36, 6377."
       - "Beane, S. R., Davoudi, Z., Savage, M. J. (2014). Constraints on the universe as a numerical simulation. Eur. Phys. J. A 50, 148. arXiv:1210.1847."
     related: [INV-BEKENSTEIN-COGNITIVE, INV-CRITICALITY, INV-LANDAUER-PROXY]
+
+  arrow_of_time:
+    id: INV-ARROW-OF-TIME
+    type: monotonic
+    statement: "For any observer-coupled closed system, cumulative net entropy production over any non-empty window is non-negative: Σ_net = ΔS_system + ΔI_observer (bit-space proxy) ≥ 0. Apparent local reductions of S_system must be paid for by observer information cost (Maxwell-demon resolution)."
+    test_type: property_test
+    falsification: "Any observed sequence of (ΔS_system, ΔI_observer) with ΔS_system + ΔI_observer < 0 in any contiguous window."
+    priority: P0
+    provenance: ANCHORED
+    truth_coherence_score: 0.9
+    source: core/physics/arrow_of_time.py
+    tests: tests/unit/physics/test_arrow_of_time.py
+    references:
+      - "Landauer, R. (1961). Irreversibility and Heat Generation in the Computing Process. IBM J. Res. Dev. 5, 183."
+      - "Bennett, C. H. (1982). The thermodynamics of computation — a review. Int. J. Theor. Phys. 21, 905."
+      - "Penrose, R. (1989). The Emperor's New Mind. Oxford University Press (cosmological-vs-thermodynamic arrow context)."
+    related: [INV-LANDAUER-PROXY, INV-CRITICALITY, INV-BEKENSTEIN-COGNITIVE]

--- a/core/physics/arrow_of_time.py
+++ b/core/physics/arrow_of_time.py
@@ -1,0 +1,170 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""Arrow of time in the presence of an internal observer (P1).
+
+INV-ARROW-OF-TIME (P0, monotonic):
+    For any observer-coupled closed system, the cumulative net entropy
+    production over any non-empty contiguous time window is non-negative,
+    where net entropy production = system entropy change + the Landauer
+    floor cost of any information the observer has acquired:
+
+        Σ_net = ΔS_system + (ΔI_observer · ln 2)   nats
+
+    Equivalently in bits:
+
+        Σ_net_bits = ΔS_system_bits + ΔI_observer_bits
+
+    Σ_net >= 0 over any window. Local violations (e.g. Maxwell-demon
+    style apparent reductions of S_system) must be paid for by the
+    observer's information gain.
+
+Provenance: ANCHORED.
+    - Landauer 1961 (Phys. Rev. D-style minimum entropy cost of bit erasure)
+    - Bennett 1982 (resolution of Maxwell demon paradox via the
+      thermodynamic cost of information storage / erasure)
+    - Penrose 1989 (cosmological-vs-thermodynamic arrow distinction
+      contextualizing the observer-internal arrow)
+
+This module operationalizes the well-established second law as it
+applies to internal-observer ledgers. It is not a derivation of the
+arrow of time from first principles; it is a witness that any
+proposed reduction of system entropy must be matched by observer
+information cost.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+__all__ = [
+    "ArrowOfTimeWitness",
+    "ObserverEntropyLedger",
+    "PROVENANCE_LEVEL",
+    "TRUTH_COHERENCE_SCORE",
+    "assess_arrow_of_time",
+    "cumulative_arrow_of_time",
+    "landauer_floor_cost_bits",
+    "net_entropy_production_bits",
+]
+
+# Provenance metadata. ANCHORED = derivable from peer-reviewed established
+# physics; EXTRAPOLATED = research direction with one anchor; SPECULATIVE =
+# schema only, requires further empirical anchor before treating as fact.
+PROVENANCE_LEVEL: str = "ANCHORED"
+TRUTH_COHERENCE_SCORE: float = 0.9
+
+
+@dataclass(frozen=True, slots=True)
+class ObserverEntropyLedger:
+    """One bookkeeping entry for an observer-coupled closed window.
+
+    Both fields are in bits. system_entropy_change_bits may be negative
+    (apparent local entropy reduction). observer_information_gain_bits
+    must be non-negative (information cannot be unlearned without
+    additional cost, which would form a separate ledger entry).
+    """
+
+    system_entropy_change_bits: float
+    observer_information_gain_bits: float
+
+
+@dataclass(frozen=True, slots=True)
+class ArrowOfTimeWitness:
+    """Diagnostic record from `assess_arrow_of_time`.
+
+    Carries the input ledger plus the derived Landauer floor cost,
+    the net entropy production, and a boolean witness of consistency
+    with INV-ARROW-OF-TIME. The witness does not raise; callers
+    decide whether to fail-closed on a False result.
+    """
+
+    ledger: ObserverEntropyLedger
+    landauer_floor_cost_bits: float
+    net_entropy_production_bits: float
+    is_arrow_consistent: bool
+    reason: str | None
+
+
+def _check_finite(value: float, name: str) -> None:
+    if not math.isfinite(value):
+        raise ValueError(
+            f"INV-HPC2 VIOLATED: {name} must be finite, got {value!r}. "
+            "Finite inputs → finite outputs is a P0 contract; no silent repair."
+        )
+
+
+def landauer_floor_cost_bits(information_gain_bits: float) -> float:
+    """Landauer floor cost in bits for storing or erasing the given gain.
+
+    The floor cost in bits is numerically equal to the information gain
+    in bits — multiplying by ln 2 lifts to nats, by k_B·T·ln 2 lifts to
+    joules. Here we stay in bit-space, which is the proxy currency of
+    the rest of GeoSync's thermodynamic_budget module.
+
+    Negative information gain is a contract violation: information
+    cannot be "ungained" within a single ledger entry. Such cases must
+    be modeled as a separate erasure ledger.
+    """
+    _check_finite(information_gain_bits, "information_gain_bits")
+    if information_gain_bits < 0.0:
+        raise ValueError(
+            "information_gain_bits must be non-negative; observer "
+            "information loss must be modeled as a separate erasure "
+            f"ledger entry, got {information_gain_bits}"
+        )
+    return information_gain_bits
+
+
+def net_entropy_production_bits(ledger: ObserverEntropyLedger) -> float:
+    """Σ_net (bits) = ΔS_system + Landauer floor cost of ΔI_observer."""
+    _check_finite(ledger.system_entropy_change_bits, "system_entropy_change_bits")
+    floor = landauer_floor_cost_bits(ledger.observer_information_gain_bits)
+    net = ledger.system_entropy_change_bits + floor
+    _check_finite(net, "net_entropy_production_bits")
+    return net
+
+
+def assess_arrow_of_time(ledger: ObserverEntropyLedger) -> ArrowOfTimeWitness:
+    """Return a witness for INV-ARROW-OF-TIME on a single ledger entry.
+
+    Consistent iff Σ_net >= 0. Non-raising; caller can fail-closed
+    on `is_arrow_consistent is False`.
+    """
+    floor = landauer_floor_cost_bits(ledger.observer_information_gain_bits)
+    net = net_entropy_production_bits(ledger)
+    consistent = net >= 0.0
+    reason: str | None
+    if consistent:
+        reason = None
+    else:
+        reason = (
+            "INV-ARROW-OF-TIME: Σ_net < 0; observer information gain "
+            f"({ledger.observer_information_gain_bits} bits) is insufficient to "
+            f"offset system entropy decrease ({ledger.system_entropy_change_bits} bits)"
+        )
+    return ArrowOfTimeWitness(
+        ledger=ledger,
+        landauer_floor_cost_bits=floor,
+        net_entropy_production_bits=net,
+        is_arrow_consistent=consistent,
+        reason=reason,
+    )
+
+
+def cumulative_arrow_of_time(ledgers: Iterable[ObserverEntropyLedger]) -> float:
+    """Sum of net entropy production over a sequence of ledger entries.
+
+    Must be >= 0 over any non-empty contiguous window per INV-ARROW-OF-TIME.
+    Iterates the input once; suitable for streaming ledgers.
+    """
+    total = 0.0
+    seen = False
+    for entry in ledgers:
+        seen = True
+        total += net_entropy_production_bits(entry)
+    if not seen:
+        raise ValueError("cumulative_arrow_of_time requires a non-empty ledger window")
+    _check_finite(total, "cumulative_arrow_of_time")
+    return total

--- a/tests/unit/physics/test_arrow_of_time.py
+++ b/tests/unit/physics/test_arrow_of_time.py
@@ -1,0 +1,172 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+# no-bio-claim
+"""Tests for INV-ARROW-OF-TIME (P0, monotonic).
+
+Anchor: Landauer 1961 + Bennett 1982 (Maxwell demon resolution).
+Provenance level: ANCHORED.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+from core.physics.arrow_of_time import (
+    PROVENANCE_LEVEL,
+    TRUTH_COHERENCE_SCORE,
+    ObserverEntropyLedger,
+    assess_arrow_of_time,
+    cumulative_arrow_of_time,
+    landauer_floor_cost_bits,
+    net_entropy_production_bits,
+)
+
+
+def _ledger(
+    system_entropy_change_bits: float = 0.0,
+    observer_information_gain_bits: float = 0.0,
+) -> ObserverEntropyLedger:
+    return ObserverEntropyLedger(
+        system_entropy_change_bits=system_entropy_change_bits,
+        observer_information_gain_bits=observer_information_gain_bits,
+    )
+
+
+def test_provenance_metadata_is_anchored() -> None:
+    """Provenance must be the strongest tier — Landauer + Bennett are peer-reviewed."""
+    assert PROVENANCE_LEVEL == "ANCHORED"
+    assert 0.85 <= TRUTH_COHERENCE_SCORE <= 1.0
+
+
+def test_landauer_floor_zero_information_gain_is_zero() -> None:
+    """No information gained ⇒ no floor cost (degenerate case)."""
+    assert landauer_floor_cost_bits(0.0) == 0.0
+
+
+def test_landauer_floor_positive_information_gain_is_proportional() -> None:
+    """Floor is bit-for-bit the information gain in bit-space proxy."""
+    for bits in (0.5, 1.0, 7.0, 1e6):
+        assert landauer_floor_cost_bits(bits) == bits
+
+
+def test_landauer_floor_negative_information_gain_raises() -> None:
+    """Negative gain is fail-closed — model erasure as a separate entry."""
+    with pytest.raises(ValueError):
+        landauer_floor_cost_bits(-1.0)
+
+
+def test_landauer_floor_non_finite_raises() -> None:
+    """INV-HPC2: NaN / Inf are fail-closed."""
+    for bad in (float("nan"), float("inf")):
+        with pytest.raises(ValueError):
+            landauer_floor_cost_bits(bad)
+
+
+def test_net_entropy_zero_zero_is_zero() -> None:
+    """No system change, no observation ⇒ zero net production."""
+    ledger = _ledger()
+    assert net_entropy_production_bits(ledger) == 0.0
+
+
+def test_net_entropy_pure_system_increase_is_consistent() -> None:
+    """Standard 2nd law: positive ΔS_system, no observer ⇒ Σ_net >= 0."""
+    ledger = _ledger(system_entropy_change_bits=2.5)
+    witness = assess_arrow_of_time(ledger)
+    assert witness.is_arrow_consistent is True
+    assert witness.net_entropy_production_bits == 2.5
+    assert witness.reason is None
+
+
+def test_maxwell_demon_balanced_is_consistent() -> None:
+    """Apparent local reduction ΔS = -1 bit paid for by observer +1 bit info gain.
+
+    Bennett 1982: Maxwell demon does not violate 2nd law because the
+    information stored about the gas molecule's velocity costs at
+    least k_B T ln 2 to erase (or hold). Σ_net == 0 here is the
+    boundary case; equality permitted.
+    """
+    ledger = _ledger(system_entropy_change_bits=-1.0, observer_information_gain_bits=1.0)
+    witness = assess_arrow_of_time(ledger)
+    assert witness.is_arrow_consistent is True
+    assert witness.net_entropy_production_bits == 0.0
+
+
+def test_maxwell_demon_underpaid_is_inconsistent() -> None:
+    """Apparent reduction ΔS = -2 bits not fully paid by 1 bit info gain ⇒ violation."""
+    ledger = _ledger(system_entropy_change_bits=-2.0, observer_information_gain_bits=1.0)
+    witness = assess_arrow_of_time(ledger)
+    assert witness.is_arrow_consistent is False
+    assert witness.net_entropy_production_bits == -1.0
+    assert witness.reason is not None
+    assert "INV-ARROW-OF-TIME" in witness.reason
+
+
+def test_witness_is_frozen_dataclass() -> None:
+    """ArrowOfTimeWitness is immutable post-construction."""
+    witness = assess_arrow_of_time(_ledger())
+    with pytest.raises(AttributeError):
+        witness.is_arrow_consistent = False  # type: ignore[misc]
+
+
+def test_cumulative_empty_window_raises() -> None:
+    """No entries ⇒ no claim about the arrow; fail-closed not silent zero."""
+    with pytest.raises(ValueError):
+        cumulative_arrow_of_time([])
+
+
+def test_cumulative_single_consistent_entry() -> None:
+    """Single positive-Σ entry ⇒ cumulative equals that entry."""
+    total = cumulative_arrow_of_time([_ledger(system_entropy_change_bits=3.0)])
+    assert total == 3.0
+
+
+def test_cumulative_local_violation_balanced_by_global_excess() -> None:
+    """Window of three: -2, 0.5+1, +5 ⇒ each individually may violate, sum is still
+    the relevant bookkeeping for the contiguous window. Cumulative >= 0 here."""
+    entries = [
+        _ledger(system_entropy_change_bits=-2.0, observer_information_gain_bits=1.5),
+        _ledger(system_entropy_change_bits=5.0, observer_information_gain_bits=0.0),
+    ]
+    total = cumulative_arrow_of_time(entries)
+    assert math.isclose(total, 4.5, rel_tol=1e-12)
+    assert total >= 0.0
+
+
+def test_cumulative_unpaid_window_is_negative_signal() -> None:
+    """If the entire window has more local reductions than observer payments,
+    cumulative_arrow_of_time returns a negative number — the caller is then
+    obligated to fail-closed on this invariant."""
+    entries = [
+        _ledger(system_entropy_change_bits=-3.0, observer_information_gain_bits=1.0),
+        _ledger(system_entropy_change_bits=-1.0, observer_information_gain_bits=0.5),
+    ]
+    total = cumulative_arrow_of_time(entries)
+    assert total < 0.0
+
+
+@given(
+    delta_S=st.floats(
+        min_value=-1e6,
+        max_value=1e6,
+        allow_nan=False,
+        allow_infinity=False,
+    ),
+    delta_I=st.floats(
+        min_value=0.0,
+        max_value=1e6,
+        allow_nan=False,
+        allow_infinity=False,
+    ),
+)
+def test_property_arrow_consistent_iff_landauer_pays_for_local_reduction(
+    delta_S: float, delta_I: float
+) -> None:
+    """Property: witness reports consistent iff ΔS + ΔI >= 0 (in bits)."""
+    ledger = _ledger(system_entropy_change_bits=delta_S, observer_information_gain_bits=delta_I)
+    witness = assess_arrow_of_time(ledger)
+    expected_consistent = (delta_S + delta_I) >= 0.0
+    assert witness.is_arrow_consistent is expected_consistent


### PR DESCRIPTION
## INV-ARROW-OF-TIME (P0, monotonic, ANCHORED, truth-coherence 0.9)

Σ_net = ΔS_system + ΔI_observer (bit-space proxy) ≥ 0 over any non-empty contiguous window.

Anchors: Landauer 1961, Bennett 1982 (Maxwell demon resolution), Penrose 1989.

## Quality gate
| Gate | Result |
|---|---|
| pytest | 15/15 PASS |
| ruff check / format | clean |
| black --check | clean |
| mypy --strict | clean |

Provenance: ANCHORED. No 2025/2026 unverified citations.