### PR TITLE
feat(physics): INV-OBSERVER-BANDWIDTH — observer info-rate bound on decoherence (P2)

### DIFF
--- a/.claude/physics/INVARIANTS.yaml
+++ b/.claude/physics/INVARIANTS.yaml
@@ -889,3 +889,20 @@ pncc:
       - "Bennett, C. H. (1982). The thermodynamics of computation — a review. Int. J. Theor. Phys. 21, 905."
       - "Penrose, R. (1989). The Emperor's New Mind. Oxford University Press (cosmological-vs-thermodynamic arrow context)."
     related: [INV-LANDAUER-PROXY, INV-CRITICALITY, INV-BEKENSTEIN-COGNITIVE]
+
+  observer_bandwidth:
+    id: INV-OBSERVER-BANDWIDTH
+    type: conditional
+    statement: "For any observer-system pair under decoherence coupling, the system's effective decoherence rate Γ (Hz) is bounded above by the observer's information-acquisition rate Σ̇ (bit/s, treated 1:1 with Hz of resolvable events): Γ ≤ Σ̇."
+    test_type: property_test
+    falsification: "A measured observer-system pair where Γ > Σ̇ in well-isolated conditions, with the observer's bandwidth independently characterized."
+    priority: P1
+    provenance: EXTRAPOLATED
+    truth_coherence_score: 0.6
+    source: core/physics/observer_bandwidth.py
+    tests: tests/unit/physics/test_observer_bandwidth.py
+    references:
+      - "Zurek, W. H. (2003). Decoherence, einselection, and the quantum origins of the classical. Rev. Mod. Phys. 75, 715."
+      - "Verlinde, E. (2011). On the origin of gravity and the laws of Newton. JHEP 04, 029."
+      - "Aaronson, S. (2013). Quantum Computing since Democritus. Cambridge University Press."
+    related: [INV-LANDAUER-PROXY, INV-BEKENSTEIN-COGNITIVE, INV-ARROW-OF-TIME]

--- a/core/physics/observer_bandwidth.py
+++ b/core/physics/observer_bandwidth.py
@@ -1,0 +1,149 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""Observer bandwidth bound on decoherence rate (P2).
+
+INV-OBSERVER-BANDWIDTH (P1, conditional, EXTRAPOLATED):
+    For any observer-system pair under a Zurek-style decoherence
+    coupling, the effective decoherence rate Γ of the system from the
+    observer's perspective is upper-bounded by the observer's
+    information-acquisition rate (bandwidth) Σ̇_observer:
+
+        Γ ≤ Σ̇_observer
+
+    Equivalently: an observer cannot resolve, and therefore cannot
+    decohere from its own perspective, faster than its finite
+    bit-acquisition rate allows.
+
+Provenance: EXTRAPOLATED.
+    - Zurek (2003): Decoherence, einselection, and the quantum origins
+      of the classical. Rev. Mod. Phys. 75, 715.
+    - Verlinde (2011): On the origin of gravity and the laws of
+      Newton. JHEP 04, 029. (entropic-information framing)
+    - Aaronson (2013): Quantum Computing since Democritus, Cambridge
+      University Press. (computational-bandwidth context)
+
+Decoherence is established physics; the bandwidth-bound on the
+observer's perspective is a research direction, not a settled theorem.
+This module operationalizes the contract — comparing Γ to Σ̇ — without
+claiming the inequality is universally derived. Truth-coherence ~0.6.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+__all__ = [
+    "BandwidthWitness",
+    "ObserverBandwidth",
+    "PROVENANCE_LEVEL",
+    "SystemDecoherence",
+    "TRUTH_COHERENCE_SCORE",
+    "assess_bandwidth_bound",
+    "decoherence_rate_hz",
+    "observer_bandwidth_hz",
+]
+
+PROVENANCE_LEVEL: str = "EXTRAPOLATED"
+TRUTH_COHERENCE_SCORE: float = 0.6
+
+
+@dataclass(frozen=True, slots=True)
+class SystemDecoherence:
+    """Effective decoherence rate of a system under an observer coupling.
+
+    rate_hz: Γ in Hz (1/s). Must be finite and non-negative; Γ = 0 means
+    the system is not decohering (perfect isolation).
+    """
+
+    rate_hz: float
+
+
+@dataclass(frozen=True, slots=True)
+class ObserverBandwidth:
+    """Information-acquisition rate of an observer.
+
+    bits_per_second: Σ̇ in bit/s. Must be finite and non-negative.
+    A purely passive observer (Σ̇ = 0) cannot decohere any system.
+    """
+
+    bits_per_second: float
+
+
+@dataclass(frozen=True, slots=True)
+class BandwidthWitness:
+    """Diagnostic for INV-OBSERVER-BANDWIDTH.
+
+    Carries the inputs, the boundary slack (Σ̇ - Γ), the
+    bound-consistency boolean, and a reason on violation.
+    """
+
+    decoherence: SystemDecoherence
+    bandwidth: ObserverBandwidth
+    slack_hz: float
+    is_bound_consistent: bool
+    reason: str | None
+
+
+def _check_finite(value: float, name: str) -> None:
+    if not math.isfinite(value):
+        raise ValueError(
+            f"INV-HPC2 VIOLATED: {name} must be finite, got {value!r}. "
+            "Finite inputs → finite outputs is a P0 contract; no silent repair."
+        )
+
+
+def _check_non_negative(value: float, name: str) -> None:
+    if value < 0.0:
+        raise ValueError(
+            f"{name} must be non-negative for a bandwidth/decoherence rate, got {value}"
+        )
+
+
+def decoherence_rate_hz(rate_hz: float) -> SystemDecoherence:
+    """Construct a validated SystemDecoherence from a Hz scalar."""
+    _check_finite(rate_hz, "decoherence_rate_hz")
+    _check_non_negative(rate_hz, "decoherence_rate_hz")
+    return SystemDecoherence(rate_hz=rate_hz)
+
+
+def observer_bandwidth_hz(bits_per_second: float) -> ObserverBandwidth:
+    """Construct a validated ObserverBandwidth from a bit/s scalar."""
+    _check_finite(bits_per_second, "observer_bandwidth_bits_per_second")
+    _check_non_negative(bits_per_second, "observer_bandwidth_bits_per_second")
+    return ObserverBandwidth(bits_per_second=bits_per_second)
+
+
+def assess_bandwidth_bound(
+    decoherence: SystemDecoherence,
+    bandwidth: ObserverBandwidth,
+) -> BandwidthWitness:
+    """Return a witness for INV-OBSERVER-BANDWIDTH on one observer-system pair.
+
+    Treats 1 bit/s of observer bandwidth as 1 Hz of resolvable
+    decoherence-event rate (information-rate equivalence). A coupling
+    where Γ > Σ̇ violates the bound: the observer cannot resolve more
+    decoherence events per second than its bit-acquisition rate.
+
+    Non-raising; caller fail-closes on `is_bound_consistent is False`.
+    """
+    bound_hz = bandwidth.bits_per_second  # 1 bit/s = 1 Hz of resolvable events
+    slack = bound_hz - decoherence.rate_hz
+    consistent = slack >= 0.0
+    reason: str | None
+    if consistent:
+        reason = None
+    else:
+        reason = (
+            "INV-OBSERVER-BANDWIDTH: Γ > Σ̇; system decoherence rate "
+            f"({decoherence.rate_hz} Hz) exceeds observer bandwidth "
+            f"({bandwidth.bits_per_second} bit/s); the observer cannot "
+            "resolve faster than it acquires bits."
+        )
+    return BandwidthWitness(
+        decoherence=decoherence,
+        bandwidth=bandwidth,
+        slack_hz=slack,
+        is_bound_consistent=consistent,
+        reason=reason,
+    )

--- a/tests/unit/physics/test_observer_bandwidth.py
+++ b/tests/unit/physics/test_observer_bandwidth.py
@@ -1,0 +1,110 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+# no-bio-claim
+"""Tests for INV-OBSERVER-BANDWIDTH (P1, conditional, EXTRAPOLATED)."""
+
+from __future__ import annotations
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+from core.physics.observer_bandwidth import (
+    PROVENANCE_LEVEL,
+    TRUTH_COHERENCE_SCORE,
+    assess_bandwidth_bound,
+    decoherence_rate_hz,
+    observer_bandwidth_hz,
+)
+
+
+def test_provenance_metadata_is_extrapolated() -> None:
+    """Provenance must mark this as EXTRAPOLATED — not a settled theorem."""
+    assert PROVENANCE_LEVEL == "EXTRAPOLATED"
+    assert 0.4 <= TRUTH_COHERENCE_SCORE <= 0.75
+
+
+def test_decoherence_rate_zero_is_isolated_system() -> None:
+    """Γ = 0 means perfect isolation — accepted, no exception."""
+    d = decoherence_rate_hz(0.0)
+    assert d.rate_hz == 0.0
+
+
+def test_observer_bandwidth_zero_is_passive_observer() -> None:
+    """Σ̇ = 0 means the observer acquires no bits — accepted."""
+    b = observer_bandwidth_hz(0.0)
+    assert b.bits_per_second == 0.0
+
+
+def test_decoherence_rate_negative_raises() -> None:
+    """Negative rate is unphysical — fail-closed."""
+    with pytest.raises(ValueError):
+        decoherence_rate_hz(-1.0)
+
+
+def test_observer_bandwidth_negative_raises() -> None:
+    """Negative bandwidth is unphysical — fail-closed."""
+    with pytest.raises(ValueError):
+        observer_bandwidth_hz(-1.0)
+
+
+def test_decoherence_rate_non_finite_raises() -> None:
+    """INV-HPC2: NaN / Inf rate is fail-closed."""
+    for bad in (float("nan"), float("inf")):
+        with pytest.raises(ValueError):
+            decoherence_rate_hz(bad)
+
+
+def test_observer_bandwidth_non_finite_raises() -> None:
+    """INV-HPC2: NaN / Inf bandwidth is fail-closed."""
+    for bad in (float("nan"), float("inf")):
+        with pytest.raises(ValueError):
+            observer_bandwidth_hz(bad)
+
+
+def test_bound_consistent_when_gamma_below_bandwidth() -> None:
+    """Γ = 1 Hz, Σ̇ = 10 bit/s ⇒ slack = 9 Hz, consistent."""
+    witness = assess_bandwidth_bound(decoherence_rate_hz(1.0), observer_bandwidth_hz(10.0))
+    assert witness.is_bound_consistent is True
+    assert witness.slack_hz == 9.0
+    assert witness.reason is None
+
+
+def test_bound_at_equality_is_consistent() -> None:
+    """Γ = Σ̇ is the saturation case — boundary admissible."""
+    witness = assess_bandwidth_bound(decoherence_rate_hz(5.0), observer_bandwidth_hz(5.0))
+    assert witness.is_bound_consistent is True
+    assert witness.slack_hz == 0.0
+
+
+def test_bound_violated_when_gamma_above_bandwidth() -> None:
+    """Γ = 10 Hz, Σ̇ = 1 bit/s ⇒ negative slack, INV violated."""
+    witness = assess_bandwidth_bound(decoherence_rate_hz(10.0), observer_bandwidth_hz(1.0))
+    assert witness.is_bound_consistent is False
+    assert witness.slack_hz == -9.0
+    assert witness.reason is not None
+    assert "INV-OBSERVER-BANDWIDTH" in witness.reason
+
+
+def test_passive_observer_blocks_any_positive_decoherence() -> None:
+    """Σ̇ = 0 ⇒ any Γ > 0 is a violation (consistent with definition)."""
+    witness = assess_bandwidth_bound(decoherence_rate_hz(1e-9), observer_bandwidth_hz(0.0))
+    assert witness.is_bound_consistent is False
+
+
+def test_witness_dataclass_is_frozen() -> None:
+    """BandwidthWitness is immutable post-construction."""
+    witness = assess_bandwidth_bound(decoherence_rate_hz(0.0), observer_bandwidth_hz(0.0))
+    with pytest.raises(AttributeError):
+        witness.is_bound_consistent = False  # type: ignore[misc]
+
+
+@given(
+    gamma=st.floats(min_value=0.0, max_value=1e12, allow_nan=False, allow_infinity=False),
+    sigma=st.floats(min_value=0.0, max_value=1e12, allow_nan=False, allow_infinity=False),
+)
+def test_property_consistent_iff_gamma_le_sigma(gamma: float, sigma: float) -> None:
+    """Property: bound is consistent iff Γ ≤ Σ̇."""
+    witness = assess_bandwidth_bound(decoherence_rate_hz(gamma), observer_bandwidth_hz(sigma))
+    expected = gamma <= sigma
+    assert witness.is_bound_consistent is expected


### PR DESCRIPTION
## INV-OBSERVER-BANDWIDTH (P1, conditional, EXTRAPOLATED, truth-coherence 0.6)

Γ ≤ Σ̇ — system decoherence rate bounded above by observer information-acquisition rate.

Provenance: EXTRAPOLATED. Zurek decoherence is settled; the bandwidth bound on observer perspective is research direction.

## Quality gate
| Gate | Result |
|---|---|
| pytest | 13/13 PASS |
| ruff/format/black/mypy --strict | clean |

References: Zurek 2003, Verlinde 2011, Aaronson 2013. No 2025/2026 unverified citations.