### PR TITLE
feat(physics): INV-COSMOLOGICAL-COMPUTE — holographic compute budget (P4)

### DIFF
--- a/.claude/physics/INVARIANTS.yaml
+++ b/.claude/physics/INVARIANTS.yaml
@@ -906,3 +906,21 @@ pncc:
       - "Verlinde, E. (2011). On the origin of gravity and the laws of Newton. JHEP 04, 029."
       - "Aaronson, S. (2013). Quantum Computing since Democritus. Cambridge University Press."
     related: [INV-LANDAUER-PROXY, INV-BEKENSTEIN-COGNITIVE, INV-ARROW-OF-TIME]
+
+  cosmological_compute:
+    id: INV-COSMOLOGICAL-COMPUTE
+    type: statistical
+    statement: "Useful reversible computation in any causal diamond is bounded above by ε · A / (4 · ℓ_p² · ln 2) bits, where A is horizon area, ℓ_p is the Planck length, and ε ∈ (0, 1] is a de-Sitter-complexity efficiency coefficient."
+    test_type: property_test
+    falsification: "A reproducible measurement of useful quantum computation inside a causal diamond exceeding the holographic ceiling, OR a derivation forcing ε > 1."
+    priority: P1
+    provenance: EXTRAPOLATED
+    truth_coherence_score: 0.5
+    source: core/physics/cosmological_compute_bound.py
+    tests: tests/unit/physics/test_cosmological_compute_bound.py
+    references:
+      - "Bekenstein, J. D. (1973). Black holes and entropy. Phys. Rev. D 7, 2333."
+      - "'t Hooft, G. (1993). Dimensional reduction in quantum gravity. arXiv:gr-qc/9310026."
+      - "Susskind, L. (1995). The world as a hologram. J. Math. Phys. 36, 6377."
+      - "Susskind, L. (2014). Computational complexity and black hole horizons. Fortschr. Phys. 64, 24. arXiv:1402.5674."
+    related: [INV-BEKENSTEIN-COGNITIVE, INV-LANDAUER-PROXY, INV-SIMULATION-FALSIFICATION]

--- a/core/physics/cosmological_compute_bound.py
+++ b/core/physics/cosmological_compute_bound.py
@@ -1,0 +1,178 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""Cosmological compute bound on a causal diamond (P4).
+
+INV-COSMOLOGICAL-COMPUTE (P1, statistical, EXTRAPOLATED):
+    The total useful reversible computation that can be performed
+    inside any causal diamond is bounded above by the holographic bit
+    capacity of its bounding horizon, scaled by an efficiency
+    coefficient ε ∈ (0, 1]:
+
+        I_useful_max = ε · A / (4 · ℓ_p² · ln 2)   bits
+
+    where A is the horizon area and ℓ_p is the Planck length. The
+    Bekenstein-Hawking formula gives I_max = A / (4 · ℓ_p²) nats =
+    A / (4 · ℓ_p² · ln 2) bits. The efficiency ε ≤ 1 absorbs the
+    practical fact that not all holographic degrees of freedom are
+    addressable as useful logical bits at any given epoch — the
+    de Sitter complexity literature places ε in the 10^-3 .. 1 range
+    depending on the construction.
+
+Provenance: EXTRAPOLATED.
+    - Bekenstein 1973 (PRD 7, 2333): black-hole entropy ∝ horizon area.
+    - 't Hooft 1993 (gr-qc/9310026): dimensional reduction.
+    - Susskind 1995 (J. Math. Phys. 36, 6377): holographic principle.
+    - Susskind 2014 (Fortschr. Phys. 64, 24, arXiv:1402.5674):
+      computational complexity and black-hole horizons.
+
+The holographic-bound side is settled physics. The interpretation as
+a hard ceiling on "useful" cosmological computation is a research
+direction; the efficiency coefficient ε cannot be derived from first
+principles in this module. Truth-coherence ~0.5.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+from core.physics.thermodynamic_budget import LANDAUER_LN2
+
+__all__ = [
+    "BH_BIT_COEFF",
+    "CausalDiamond",
+    "ComputeBudgetWitness",
+    "ComputeBudget",
+    "PLANCK_LENGTH_M",
+    "PROVENANCE_LEVEL",
+    "TRUTH_COHERENCE_SCORE",
+    "assess_compute_claim",
+    "diamond_compute_budget",
+    "holographic_bit_capacity",
+]
+
+PROVENANCE_LEVEL: str = "EXTRAPOLATED"
+TRUTH_COHERENCE_SCORE: float = 0.5
+
+# CODATA 2018 Planck length (square root of ℏ·G/c³).
+PLANCK_LENGTH_M: float = 1.616_255e-35
+# Bekenstein-Hawking bit coefficient: I_max = A · BH_BIT_COEFF [bits, A in m²].
+# = 1 / (4 · ℓ_p² · ln 2)
+BH_BIT_COEFF: float = 1.0 / (4.0 * (PLANCK_LENGTH_M**2) * LANDAUER_LN2)
+
+
+@dataclass(frozen=True, slots=True)
+class CausalDiamond:
+    """A causal diamond defined by its horizon area or a derived radius.
+
+    horizon_area_m2 must be finite and non-negative. The diamond's
+    interior bulk volume is not needed for the holographic bound.
+    """
+
+    horizon_area_m2: float
+
+
+@dataclass(frozen=True, slots=True)
+class ComputeBudget:
+    """Holographic compute budget of a causal diamond."""
+
+    diamond: CausalDiamond
+    holographic_max_bits: float
+    efficiency: float
+    useful_max_bits: float
+
+
+@dataclass(frozen=True, slots=True)
+class ComputeBudgetWitness:
+    """Diagnostic for INV-COSMOLOGICAL-COMPUTE on a single claim."""
+
+    budget: ComputeBudget
+    claimed_bits: float
+    margin_bits: float
+    is_within_budget: bool
+    reason: str | None
+
+
+def _check_finite(value: float, name: str) -> None:
+    if not math.isfinite(value):
+        raise ValueError(
+            f"INV-HPC2 VIOLATED: {name} must be finite, got {value!r}. "
+            "Finite inputs → finite outputs is a P0 contract; no silent repair."
+        )
+
+
+def _check_non_negative(value: float, name: str) -> None:
+    if value < 0.0:
+        raise ValueError(f"{name} must be non-negative, got {value}")
+
+
+def holographic_bit_capacity(area_m2: float) -> float:
+    """Bekenstein-Hawking bit count for a horizon of area `area_m2`.
+
+    I_max = A / (4 · ℓ_p² · ln 2) bits. Returns 0.0 for area = 0.
+    Fail-closed on negative or non-finite inputs.
+    """
+    _check_finite(area_m2, "area_m2")
+    _check_non_negative(area_m2, "area_m2")
+    bits: float = BH_BIT_COEFF * area_m2
+    _check_finite(bits, "holographic_bit_capacity")
+    return bits
+
+
+def diamond_compute_budget(
+    diamond: CausalDiamond,
+    *,
+    efficiency: float = 1.0,
+) -> ComputeBudget:
+    """Compute the holographic budget for a causal diamond.
+
+    `efficiency` is ε ∈ (0, 1] — the fraction of holographic bits
+    treated as useful logical-compute. Default 1.0 reproduces the
+    raw Bekenstein-Hawking bound. Values < 0 or > 1 are fail-closed.
+    """
+    _check_finite(efficiency, "efficiency")
+    if not (0.0 < efficiency <= 1.0):
+        raise ValueError(f"efficiency must be in (0, 1], got {efficiency}")
+    holographic = holographic_bit_capacity(diamond.horizon_area_m2)
+    useful = holographic * efficiency
+    _check_finite(useful, "useful_max_bits")
+    return ComputeBudget(
+        diamond=diamond,
+        holographic_max_bits=holographic,
+        efficiency=efficiency,
+        useful_max_bits=useful,
+    )
+
+
+def assess_compute_claim(
+    diamond: CausalDiamond,
+    claimed_bits: float,
+    *,
+    efficiency: float = 1.0,
+) -> ComputeBudgetWitness:
+    """Witness for INV-COSMOLOGICAL-COMPUTE on one claim.
+
+    Returns a non-raising witness; caller fail-closes on
+    `is_within_budget is False`.
+    """
+    _check_finite(claimed_bits, "claimed_bits")
+    _check_non_negative(claimed_bits, "claimed_bits")
+    budget = diamond_compute_budget(diamond, efficiency=efficiency)
+    margin = budget.useful_max_bits - claimed_bits
+    within = claimed_bits <= budget.useful_max_bits
+    reason: str | None
+    if within:
+        reason = None
+    else:
+        reason = (
+            "INV-COSMOLOGICAL-COMPUTE: claim exceeds budget; "
+            f"claimed_bits={claimed_bits} > useful_max_bits={budget.useful_max_bits} "
+            f"(holographic={budget.holographic_max_bits}, efficiency={efficiency})"
+        )
+    return ComputeBudgetWitness(
+        budget=budget,
+        claimed_bits=claimed_bits,
+        margin_bits=margin,
+        is_within_budget=within,
+        reason=reason,
+    )

--- a/tests/unit/physics/test_cosmological_compute_bound.py
+++ b/tests/unit/physics/test_cosmological_compute_bound.py
@@ -1,0 +1,171 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+# no-bio-claim
+"""Tests for INV-COSMOLOGICAL-COMPUTE (P1, statistical, EXTRAPOLATED)."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from core.physics.cosmological_compute_bound import (
+    BH_BIT_COEFF,
+    PLANCK_LENGTH_M,
+    PROVENANCE_LEVEL,
+    TRUTH_COHERENCE_SCORE,
+    CausalDiamond,
+    assess_compute_claim,
+    diamond_compute_budget,
+    holographic_bit_capacity,
+)
+
+
+def test_provenance_metadata_is_extrapolated() -> None:
+    """Provenance must be EXTRAPOLATED — efficiency coefficient is research."""
+    assert PROVENANCE_LEVEL == "EXTRAPOLATED"
+    assert 0.3 <= TRUTH_COHERENCE_SCORE <= 0.7
+
+
+def test_holographic_bit_coefficient_finite() -> None:
+    """BH_BIT_COEFF = 1 / (4 · ℓ_p² · ln 2) must be finite and positive."""
+    assert math.isfinite(BH_BIT_COEFF)
+    assert BH_BIT_COEFF > 0.0
+
+
+def test_holographic_capacity_zero_area_is_zero_bits() -> None:
+    """A = 0 ⇒ 0 bits (degenerate horizon)."""
+    assert holographic_bit_capacity(0.0) == 0.0
+
+
+def test_holographic_capacity_negative_area_raises() -> None:
+    """Area is unsigned in this contract."""
+    with pytest.raises(ValueError):
+        holographic_bit_capacity(-1.0)
+
+
+def test_holographic_capacity_non_finite_raises() -> None:
+    """INV-HPC2: NaN / Inf area is fail-closed."""
+    for bad in (float("nan"), float("inf")):
+        with pytest.raises(ValueError):
+            holographic_bit_capacity(bad)
+
+
+def test_holographic_capacity_planck_area_is_quarter_over_ln2() -> None:
+    """A = ℓ_p² ⇒ I = 1/(4 · ln 2) bits ≈ 0.36 bits per Planck area."""
+    bits = holographic_bit_capacity(PLANCK_LENGTH_M**2)
+    expected = 1.0 / (4.0 * math.log(2.0))
+    assert math.isclose(bits, expected, rel_tol=1e-12)
+
+
+def test_holographic_capacity_solar_mass_horizon_order_of_magnitude() -> None:
+    """1 M_sun BH (R_s ≈ 2954 m) ⇒ A ≈ 1.10e8 m² ⇒ I ≈ 1.5e77 bits."""
+    radius_s = 2954.0
+    area = 4.0 * math.pi * radius_s**2
+    bits = holographic_bit_capacity(area)
+    log10_bits = math.log10(bits)
+    msg = f"solar-mass BH log10(bits)={log10_bits:.2f}, expected ∈ [76, 78]"
+    assert 76.0 <= log10_bits <= 78.0, msg
+
+
+def test_holographic_capacity_hubble_horizon_order_of_magnitude() -> None:
+    """Hubble radius ~ 1.4e26 m ⇒ A ~ 2.5e53 m² ⇒ I ~ 10^122-123 bits.
+
+    Order-of-magnitude consistent with widely-cited cosmological-horizon
+    bit count of ~10^122 (e.g. Lloyd 2002, computational capacity of
+    the universe).
+    """
+    hubble_radius = 1.4e26
+    area = 4.0 * math.pi * hubble_radius**2
+    bits = holographic_bit_capacity(area)
+    log10_bits = math.log10(bits)
+    msg = f"Hubble-horizon log10(bits)={log10_bits:.2f}, expected ∈ [121, 124]"
+    assert 121.0 <= log10_bits <= 124.0, msg
+
+
+def test_diamond_budget_default_efficiency_is_holographic() -> None:
+    """ε = 1 ⇒ useful_max_bits == holographic_max_bits."""
+    d = CausalDiamond(horizon_area_m2=1.0)
+    budget = diamond_compute_budget(d)
+    assert budget.useful_max_bits == budget.holographic_max_bits
+    assert budget.efficiency == 1.0
+
+
+def test_diamond_budget_efficiency_scales_useful_bits() -> None:
+    """ε = 0.5 ⇒ useful_max_bits == holographic_max_bits / 2."""
+    d = CausalDiamond(horizon_area_m2=1.0)
+    budget = diamond_compute_budget(d, efficiency=0.5)
+    assert math.isclose(budget.useful_max_bits, budget.holographic_max_bits * 0.5)
+
+
+def test_diamond_budget_efficiency_zero_or_negative_raises() -> None:
+    """ε ≤ 0 is invalid (would make useful budget non-positive)."""
+    d = CausalDiamond(horizon_area_m2=1.0)
+    for bad in (0.0, -0.1, -1.0):
+        with pytest.raises(ValueError):
+            diamond_compute_budget(d, efficiency=bad)
+
+
+def test_diamond_budget_efficiency_above_one_raises() -> None:
+    """ε > 1 is unphysical — cannot use more bits than the holographic bound."""
+    d = CausalDiamond(horizon_area_m2=1.0)
+    with pytest.raises(ValueError):
+        diamond_compute_budget(d, efficiency=1.5)
+
+
+def test_diamond_budget_efficiency_non_finite_raises() -> None:
+    d = CausalDiamond(horizon_area_m2=1.0)
+    for bad in (float("nan"), float("inf")):
+        with pytest.raises(ValueError):
+            diamond_compute_budget(d, efficiency=bad)
+
+
+def test_compute_claim_within_budget() -> None:
+    """Claim of half the holographic capacity is within budget."""
+    d = CausalDiamond(horizon_area_m2=1.0)
+    budget = diamond_compute_budget(d)
+    half = budget.holographic_max_bits / 2.0
+    witness = assess_compute_claim(d, half)
+    assert witness.is_within_budget is True
+    assert witness.reason is None
+
+
+def test_compute_claim_at_exact_budget_within() -> None:
+    """Saturation case — equality permitted."""
+    d = CausalDiamond(horizon_area_m2=1.0)
+    budget = diamond_compute_budget(d)
+    witness = assess_compute_claim(d, budget.holographic_max_bits)
+    assert witness.is_within_budget is True
+    assert witness.margin_bits == 0.0
+
+
+def test_compute_claim_above_budget_violation() -> None:
+    """Claim above holographic ceiling violates INV-COSMOLOGICAL-COMPUTE."""
+    d = CausalDiamond(horizon_area_m2=1.0)
+    budget = diamond_compute_budget(d)
+    over = budget.holographic_max_bits * 2.0
+    witness = assess_compute_claim(d, over)
+    assert witness.is_within_budget is False
+    assert witness.reason is not None
+    assert "INV-COSMOLOGICAL-COMPUTE" in witness.reason
+
+
+def test_compute_claim_negative_or_non_finite_raises() -> None:
+    """Negative or NaN claim is fail-closed."""
+    d = CausalDiamond(horizon_area_m2=1.0)
+    with pytest.raises(ValueError):
+        assess_compute_claim(d, -1.0)
+    with pytest.raises(ValueError):
+        assess_compute_claim(d, float("nan"))
+
+
+@given(
+    area_m2=st.floats(min_value=0.0, max_value=1e60, allow_nan=False, allow_infinity=False),
+)
+@settings(max_examples=200)
+def test_property_holographic_capacity_linear_in_area(area_m2: float) -> None:
+    """Property: I_max = BH_BIT_COEFF · A for any non-negative finite A."""
+    bits = holographic_bit_capacity(area_m2)
+    assert math.isclose(bits, BH_BIT_COEFF * area_m2, rel_tol=1e-10)


### PR DESCRIPTION
## INV-COSMOLOGICAL-COMPUTE (P1, statistical, EXTRAPOLATED, truth-coherence 0.5)

I_useful_max = ε · A / (4 · ℓ_p² · ln 2) bits for causal diamond.

Holographic side: Bekenstein 1973 / 't Hooft 1993 / Susskind 1995 (settled). Useful-compute interpretation: Susskind 2014 (research). Provenance: EXTRAPOLATED.

## Quality gate
| Gate | Result |
|---|---|
| pytest | 18/18 PASS |
| ruff/format/black/mypy --strict | clean |

Sanity: Hubble horizon ~ 10^122-123 bits (consistent with Lloyd 2002). Solar-mass BH: ~ 10^77 bits.