### PR TITLE
feat(physics): INV-OBSERVER-CPT — observer-induced effective asymmetry, schema-only (P5)

### DIFF
--- a/.claude/physics/INVARIANTS.yaml
+++ b/.claude/physics/INVARIANTS.yaml
@@ -924,3 +924,19 @@ pncc:
       - "Susskind, L. (1995). The world as a hologram. J. Math. Phys. 36, 6377."
       - "Susskind, L. (2014). Computational complexity and black hole horizons. Fortschr. Phys. 64, 24. arXiv:1402.5674."
     related: [INV-BEKENSTEIN-COGNITIVE, INV-LANDAUER-PROXY, INV-SIMULATION-FALSIFICATION]
+
+  observer_cpt:
+    id: INV-OBSERVER-CPT
+    type: qualitative
+    statement: "For a CPT-symmetric Lagrangian coupled to an observer with decoherence kernel K, the observed asymmetry η = (n_m - n_m̄)/(n_m + n_m̄) is zero iff K(matter) = K(antimatter). Any η ≠ 0 requires a kernel-level asymmetry; the Lagrangian itself remains CPT-symmetric."
+    test_type: property_test
+    falsification: "An observed η ≠ 0 in a system where the decoherence kernel is independently measured to be CPT-symmetric, OR an η = 0 in a system with a measured asymmetric kernel."
+    priority: P2
+    provenance: SPECULATIVE
+    truth_coherence_score: 0.3
+    source: core/physics/observer_cpt_asymmetry.py
+    tests: tests/unit/physics/test_observer_cpt_asymmetry.py
+    references:
+      - "Sakharov, A. D. (1967). Violation of CP invariance, C asymmetry, and baryon asymmetry of the universe. JETP Lett. 5, 24."
+      - "Particle Data Group (2024). Review of Particle Physics. Prog. Theor. Exp. Phys. 2024, 083C01 (η = (n_b - n_b̄)/n_γ ≈ 6×10⁻¹⁰)."
+    related: [INV-OBSERVER-BANDWIDTH, INV-ARROW-OF-TIME]

--- a/core/physics/observer_cpt_asymmetry.py
+++ b/core/physics/observer_cpt_asymmetry.py
@@ -1,0 +1,189 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""Observer-induced effective asymmetry in CPT-symmetric dynamics (P5).
+
+INV-OBSERVER-CPT (P2, qualitative, SPECULATIVE):
+    For a CPT-symmetric Lagrangian coupled to an observer with an
+    asymmetric decoherence kernel K, the observed matter / antimatter
+    counts integrated over a window are equal iff K is CPT-symmetric:
+
+        η_observed = (N_matter - N_antimatter) / (N_matter + N_antimatter)
+        η_observed = 0   iff   K(matter) = K(antimatter)
+
+    Equivalently: any observed baryon-asymmetry-like signal η ≠ 0 in a
+    Lagrangian-CPT-symmetric universe REQUIRES an observer with
+    K(matter) ≠ K(antimatter). This module does NOT derive that such
+    a kernel exists in our universe; it operationalizes the contract
+    so that any future model proposing one must declare a concrete
+    asymmetric K and pass falsification.
+
+Provenance: SPECULATIVE.
+    Sakharov 1967 (JETP Lett. 5, 24) lists three conditions for
+    baryogenesis in standard Big Bang cosmology: (i) baryon-number
+    violation, (ii) C and CP violation, (iii) departure from thermal
+    equilibrium. The observer-asymmetry route is an alternative
+    framing that requires the observer's coupling to break a discrete
+    symmetry without modifying the Lagrangian. No specific peer-
+    reviewed model of such a kernel for our universe is cited here;
+    this module is schema only. Truth-coherence ~0.3.
+
+The intended use of this module is to keep proposals of "the universe
+is CPT-symmetric and our observed baryon asymmetry comes from
+observer-side decoherence" honest: any such proposal must supply a
+concrete kernel K(matter) and K(antimatter) satisfying the contract
+and produce a measurable η consistent with cosmological observation
+(η_observed ≈ 6 × 10^-10 from BBN / CMB).
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+__all__ = [
+    "DecoherenceKernel",
+    "ObservedAsymmetry",
+    "ObserverCPTWitness",
+    "PROVENANCE_LEVEL",
+    "TRUTH_COHERENCE_SCORE",
+    "asymmetry_from_kernel",
+    "assess_observer_cpt",
+]
+
+PROVENANCE_LEVEL: str = "SPECULATIVE"
+TRUTH_COHERENCE_SCORE: float = 0.3
+
+# Observed baryon asymmetry parameter η = (n_b - n_b̄) / n_γ from BBN/CMB.
+# Order ~6e-10 (Planck Collaboration 2018; PDG 2024 review).
+OBSERVED_BARYON_ASYMMETRY: float = 6.0e-10
+
+
+@dataclass(frozen=True, slots=True)
+class DecoherenceKernel:
+    """An asymmetric decoherence kernel applied by an observer.
+
+    Both rates are in Hz (1/s). A CPT-symmetric kernel has equal rates;
+    observer-induced asymmetry exists when the rates differ.
+    """
+
+    matter_rate_hz: float
+    antimatter_rate_hz: float
+
+
+@dataclass(frozen=True, slots=True)
+class ObservedAsymmetry:
+    """Cumulative matter / antimatter counts integrated over a window."""
+
+    n_matter: float
+    n_antimatter: float
+
+
+@dataclass(frozen=True, slots=True)
+class ObserverCPTWitness:
+    """Diagnostic for INV-OBSERVER-CPT.
+
+    Fields:
+    - kernel: the asymmetric or symmetric decoherence kernel
+    - asymmetry: derived (n_m - n_m̄) / (n_m + n_m̄)
+    - is_kernel_cpt_symmetric: K(matter) == K(antimatter) within tolerance
+    - is_asymmetry_zero: η == 0 within tolerance
+    - is_contract_consistent:
+        (kernel symmetric AND η == 0) OR (kernel asymmetric AND η != 0)
+    """
+
+    kernel: DecoherenceKernel
+    asymmetry: float
+    is_kernel_cpt_symmetric: bool
+    is_asymmetry_zero: bool
+    is_contract_consistent: bool
+    reason: str | None
+
+
+def _check_finite(value: float, name: str) -> None:
+    if not math.isfinite(value):
+        raise ValueError(
+            f"INV-HPC2 VIOLATED: {name} must be finite, got {value!r}. "
+            "Finite inputs → finite outputs is a P0 contract; no silent repair."
+        )
+
+
+def _check_non_negative(value: float, name: str) -> None:
+    if value < 0.0:
+        raise ValueError(f"{name} must be non-negative, got {value}")
+
+
+def asymmetry_from_kernel(
+    kernel: DecoherenceKernel,
+    *,
+    population_per_rate: float = 1.0,
+) -> float:
+    """Derive η = (n_m - n_m̄) / (n_m + n_m̄) from kernel rates.
+
+    Convention: the cumulative counts after a unit window are
+    proportional to the kernel rates. `population_per_rate` is a
+    multiplicative scale that cancels in the ratio; included only
+    for unit-handling clarity at higher-level callers.
+
+    Returns 0.0 when both rates are exactly zero (no observation —
+    no asymmetry to report).
+    """
+    _check_finite(kernel.matter_rate_hz, "kernel.matter_rate_hz")
+    _check_finite(kernel.antimatter_rate_hz, "kernel.antimatter_rate_hz")
+    _check_non_negative(kernel.matter_rate_hz, "kernel.matter_rate_hz")
+    _check_non_negative(kernel.antimatter_rate_hz, "kernel.antimatter_rate_hz")
+    _check_finite(population_per_rate, "population_per_rate")
+    if population_per_rate <= 0.0:
+        raise ValueError(f"population_per_rate must be > 0, got {population_per_rate}")
+    n_matter = kernel.matter_rate_hz * population_per_rate
+    n_antimatter = kernel.antimatter_rate_hz * population_per_rate
+    total = n_matter + n_antimatter
+    if total == 0.0:
+        return 0.0
+    return (n_matter - n_antimatter) / total
+
+
+def assess_observer_cpt(
+    kernel: DecoherenceKernel,
+    *,
+    population_per_rate: float = 1.0,
+    kernel_symmetry_tol: float = 1e-12,
+    asymmetry_tol: float = 1e-12,
+) -> ObserverCPTWitness:
+    """Witness for INV-OBSERVER-CPT on one kernel.
+
+    Reports both the kernel symmetry status and the resulting
+    observed-asymmetry status, and confirms they agree:
+
+        kernel CPT-symmetric  iff  η == 0
+
+    The witness is non-raising; caller fail-closes on
+    `is_contract_consistent is False`.
+    """
+    _check_finite(kernel_symmetry_tol, "kernel_symmetry_tol")
+    _check_finite(asymmetry_tol, "asymmetry_tol")
+    if kernel_symmetry_tol < 0.0 or asymmetry_tol < 0.0:
+        raise ValueError("tolerances must be non-negative")
+    eta = asymmetry_from_kernel(kernel, population_per_rate=population_per_rate)
+    delta_kernel = abs(kernel.matter_rate_hz - kernel.antimatter_rate_hz)
+    is_symmetric = delta_kernel <= kernel_symmetry_tol
+    is_zero = abs(eta) <= asymmetry_tol
+    consistent = is_symmetric == is_zero
+    reason: str | None
+    if consistent:
+        reason = None
+    else:
+        reason = (
+            "INV-OBSERVER-CPT: kernel-symmetry / observed-asymmetry mismatch — "
+            f"|ΔK|={delta_kernel} (tol {kernel_symmetry_tol}), "
+            f"|η|={abs(eta)} (tol {asymmetry_tol}); "
+            "a CPT-symmetric kernel must produce η=0, and any η≠0 must "
+            "carry an asymmetric kernel."
+        )
+    return ObserverCPTWitness(
+        kernel=kernel,
+        asymmetry=eta,
+        is_kernel_cpt_symmetric=is_symmetric,
+        is_asymmetry_zero=is_zero,
+        is_contract_consistent=consistent,
+        reason=reason,
+    )

--- a/tests/unit/physics/test_observer_cpt_asymmetry.py
+++ b/tests/unit/physics/test_observer_cpt_asymmetry.py
@@ -1,0 +1,140 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+# no-bio-claim
+"""Tests for INV-OBSERVER-CPT (P2, qualitative, SPECULATIVE).
+
+This module is schema-only. It enforces the contract that any proposal
+of "observer-induced effective baryon asymmetry in a CPT-symmetric
+universe" must declare a concrete asymmetric decoherence kernel.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+from core.physics.observer_cpt_asymmetry import (
+    OBSERVED_BARYON_ASYMMETRY,
+    PROVENANCE_LEVEL,
+    TRUTH_COHERENCE_SCORE,
+    DecoherenceKernel,
+    assess_observer_cpt,
+    asymmetry_from_kernel,
+)
+
+
+def test_provenance_metadata_is_speculative() -> None:
+    """Provenance must mark this as SPECULATIVE — no specific kernel cited."""
+    assert PROVENANCE_LEVEL == "SPECULATIVE"
+    assert 0.1 <= TRUTH_COHERENCE_SCORE <= 0.45
+
+
+def test_observed_baryon_asymmetry_constant_is_finite_and_small() -> None:
+    """Sanity: η_observed ~ 6e-10 from BBN/CMB."""
+    assert math.isfinite(OBSERVED_BARYON_ASYMMETRY)
+    assert 1e-11 < OBSERVED_BARYON_ASYMMETRY < 1e-8
+
+
+def test_symmetric_kernel_yields_zero_asymmetry() -> None:
+    """K(matter) == K(antimatter) ⇒ η = 0."""
+    k = DecoherenceKernel(matter_rate_hz=1.0, antimatter_rate_hz=1.0)
+    assert asymmetry_from_kernel(k) == 0.0
+
+
+def test_asymmetric_kernel_yields_non_zero_asymmetry() -> None:
+    """K(matter) > K(antimatter) ⇒ η > 0."""
+    k = DecoherenceKernel(matter_rate_hz=1.5, antimatter_rate_hz=0.5)
+    eta = asymmetry_from_kernel(k)
+    assert eta == 0.5
+    assert eta > 0.0
+
+
+def test_zero_zero_kernel_yields_zero_asymmetry() -> None:
+    """No observation at all ⇒ no asymmetry to report (degenerate case)."""
+    k = DecoherenceKernel(matter_rate_hz=0.0, antimatter_rate_hz=0.0)
+    assert asymmetry_from_kernel(k) == 0.0
+
+
+def test_negative_rate_raises() -> None:
+    """Negative rate is unphysical — fail-closed."""
+    with pytest.raises(ValueError):
+        asymmetry_from_kernel(DecoherenceKernel(matter_rate_hz=-1.0, antimatter_rate_hz=1.0))
+
+
+def test_non_finite_rate_raises() -> None:
+    """INV-HPC2: NaN / Inf rates are fail-closed."""
+    for bad in (float("nan"), float("inf")):
+        with pytest.raises(ValueError):
+            asymmetry_from_kernel(DecoherenceKernel(matter_rate_hz=bad, antimatter_rate_hz=1.0))
+
+
+def test_population_per_rate_non_positive_raises() -> None:
+    """The scale factor must be strictly positive — zero or negative is fail-closed."""
+    k = DecoherenceKernel(matter_rate_hz=1.0, antimatter_rate_hz=1.0)
+    with pytest.raises(ValueError):
+        asymmetry_from_kernel(k, population_per_rate=0.0)
+    with pytest.raises(ValueError):
+        asymmetry_from_kernel(k, population_per_rate=-1.0)
+
+
+def test_witness_symmetric_kernel_is_consistent() -> None:
+    """Symmetric kernel ⇒ η=0 ⇒ contract consistent."""
+    k = DecoherenceKernel(matter_rate_hz=1.0, antimatter_rate_hz=1.0)
+    w = assess_observer_cpt(k)
+    assert w.is_kernel_cpt_symmetric is True
+    assert w.is_asymmetry_zero is True
+    assert w.is_contract_consistent is True
+    assert w.reason is None
+
+
+def test_witness_asymmetric_kernel_is_consistent() -> None:
+    """Asymmetric kernel ⇒ η≠0 ⇒ contract consistent."""
+    k = DecoherenceKernel(matter_rate_hz=2.0, antimatter_rate_hz=1.0)
+    w = assess_observer_cpt(k)
+    assert w.is_kernel_cpt_symmetric is False
+    assert w.is_asymmetry_zero is False
+    assert w.is_contract_consistent is True
+
+
+def test_witness_dataclass_is_frozen() -> None:
+    """ObserverCPTWitness is immutable post-construction."""
+    k = DecoherenceKernel(matter_rate_hz=1.0, antimatter_rate_hz=1.0)
+    w = assess_observer_cpt(k)
+    with pytest.raises(AttributeError):
+        w.is_contract_consistent = False  # type: ignore[misc]
+
+
+def test_assess_negative_tolerance_raises() -> None:
+    """Tolerances must be non-negative."""
+    k = DecoherenceKernel(matter_rate_hz=1.0, antimatter_rate_hz=1.0)
+    with pytest.raises(ValueError):
+        assess_observer_cpt(k, kernel_symmetry_tol=-1.0)
+    with pytest.raises(ValueError):
+        assess_observer_cpt(k, asymmetry_tol=-1.0)
+
+
+@given(
+    matter=st.floats(min_value=0.0, max_value=1e9, allow_nan=False, allow_infinity=False),
+    antimatter=st.floats(min_value=0.0, max_value=1e9, allow_nan=False, allow_infinity=False),
+)
+def test_property_eta_in_unit_interval(matter: float, antimatter: float) -> None:
+    """Property: η = (a-b)/(a+b) ∈ [-1, 1] for any non-negative finite a, b."""
+    k = DecoherenceKernel(matter_rate_hz=matter, antimatter_rate_hz=antimatter)
+    eta = asymmetry_from_kernel(k)
+    assert -1.0 <= eta <= 1.0
+
+
+@given(
+    matter=st.floats(min_value=0.0, max_value=1e6, allow_nan=False, allow_infinity=False),
+    antimatter=st.floats(min_value=0.0, max_value=1e6, allow_nan=False, allow_infinity=False),
+)
+def test_property_witness_consistency_iff_kernel_eta_match(
+    matter: float, antimatter: float
+) -> None:
+    """Property: contract consistent iff (kernel symmetric ↔ η ≈ 0)."""
+    k = DecoherenceKernel(matter_rate_hz=matter, antimatter_rate_hz=antimatter)
+    w = assess_observer_cpt(k)
+    assert w.is_contract_consistent is (w.is_kernel_cpt_symmetric is w.is_asymmetry_zero)


### PR DESCRIPTION
## INV-OBSERVER-CPT (P2, qualitative, SPECULATIVE, truth-coherence 0.3)

η_observed = 0 iff K(matter) = K(antimatter). Any η ≠ 0 in a Lagrangian-CPT-symmetric universe requires kernel-level asymmetry.

**Schema only.** Module does NOT derive that such a kernel exists. Enforces the contract that any future model proposing observer-induced baryon asymmetry must declare a concrete asymmetric K and pass falsification.

Provenance: SPECULATIVE. No specific peer-reviewed kernel for our universe is cited. Sakharov 1967 + PDG 2024 are anchors for the observed η ≈ 6×10⁻¹⁰.

## Quality gate
| Gate | Result |
|---|---|
| pytest | 14/14 PASS |
| ruff/format/black/mypy --strict | clean |