### PR TITLE
feat(physics): INV-JACOBSON-OBSERVER — Clausius + observer-coherence (P6)

### DIFF
--- a/.claude/physics/INVARIANTS.yaml
+++ b/.claude/physics/INVARIANTS.yaml
@@ -940,3 +940,20 @@ pncc:
       - "Sakharov, A. D. (1967). Violation of CP invariance, C asymmetry, and baryon asymmetry of the universe. JETP Lett. 5, 24."
       - "Particle Data Group (2024). Review of Particle Physics. Prog. Theor. Exp. Phys. 2024, 083C01 (η = (n_b - n_b̄)/n_γ ≈ 6×10⁻¹⁰)."
     related: [INV-OBSERVER-BANDWIDTH, INV-ARROW-OF-TIME]
+
+  jacobson_observer:
+    id: INV-JACOBSON-OBSERVER
+    type: conditional
+    statement: "Jacobson 1995 derived Einstein equations from local Clausius δQ = T·dS on causal horizons. An observer-coherence correction c, residual = δQ − T·dS − c, must satisfy: (i) c → 0 in the decoupled limit (pure Jacobson recovery), (ii) any non-zero c at observable scale is a falsifiable extension of GR."
+    test_type: property_test
+    falsification: "A measured local context where δQ = T·dS holds (Einstein gravity confirmed) but the proposed c is non-zero above tolerance, OR δQ ≠ T·dS at a scale where Einstein gravity is independently confirmed."
+    priority: P1
+    provenance: EXTRAPOLATED
+    truth_coherence_score: 0.55
+    source: core/physics/jacobson_observer_coherence.py
+    tests: tests/unit/physics/test_jacobson_observer_coherence.py
+    references:
+      - "Jacobson, T. (1995). Thermodynamics of spacetime: the Einstein equation of state. Phys. Rev. Lett. 75, 1260. arXiv:gr-qc/9504004."
+      - "Padmanabhan, T. (2010). Thermodynamical aspects of gravity: new insights. Rep. Prog. Phys. 73, 046901. arXiv:0911.5004."
+      - "Verlinde, E. (2011). On the origin of gravity and the laws of Newton. JHEP 04, 029."
+    related: [INV-BEKENSTEIN-COGNITIVE, INV-COSMOLOGICAL-COMPUTE, INV-ARROW-OF-TIME]

--- a/core/physics/jacobson_observer_coherence.py
+++ b/core/physics/jacobson_observer_coherence.py
@@ -1,0 +1,159 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""Jacobson + observer-coherence Clausius witness (P6).
+
+INV-JACOBSON-OBSERVER (P1, conditional, EXTRAPOLATED):
+    Jacobson 1995 derived the Einstein field equations from the local
+    Clausius relation δQ = T·dS imposed on causal Rindler horizons of
+    every uniformly accelerated observer. Equivalently, Einstein
+    gravity is the equation of state of spacetime thermodynamics.
+
+    This module operationalizes the contract that any observer-coherence
+    correction `c` to the Clausius bookkeeping must satisfy:
+
+        residual = δQ - T·dS - c
+
+    Standard Jacobson recovery: residual ≈ 0 iff c → 0 in the
+    decoupled limit (the observer does not shape the local horizon).
+    Any non-zero c at observable scale is a falsifiable extension —
+    not a redefinition of GR.
+
+Provenance: EXTRAPOLATED.
+    - Jacobson, T. (1995). Thermodynamics of spacetime: the Einstein
+      equation of state. Phys. Rev. Lett. 75, 1260. arXiv:gr-qc/9504004.
+    - Verlinde, E. (2011). On the origin of gravity and the laws of
+      Newton. JHEP 04, 029.
+    - Padmanabhan, T. (2010). Thermodynamical aspects of gravity:
+      new insights. Rep. Prog. Phys. 73, 046901. arXiv:0911.5004.
+
+Jacobson 1995 is settled physics. The observer-coherence correction is
+a research direction; this module operationalizes the contract structure
+without claiming a particular form of `c`. Truth-coherence ~0.55.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+__all__ = [
+    "ClausiusContext",
+    "JacobsonObserverWitness",
+    "PROVENANCE_LEVEL",
+    "TRUTH_COHERENCE_SCORE",
+    "assess_jacobson_observer",
+    "clausius_residual",
+]
+
+PROVENANCE_LEVEL: str = "EXTRAPOLATED"
+TRUTH_COHERENCE_SCORE: float = 0.55
+
+
+@dataclass(frozen=True, slots=True)
+class ClausiusContext:
+    """A local Clausius accounting context on a causal horizon patch.
+
+    All quantities are in SI:
+    - heat_flow_J: δQ flowing across the patch (positive = inflow).
+    - unruh_temperature_K: T as seen by the local accelerated observer.
+    - entropy_change_J_per_K: dS of the horizon (k_B · ΔA / 4·ℓ_p² in
+      natural units; here we accept it as input so the module remains
+      a witness, not a derivation engine).
+    - observer_coherence_correction_J: `c` — the proposed extension.
+      Defaults to 0 (pure Jacobson). Caller supplies any non-zero
+      value and must publish a justification.
+    """
+
+    heat_flow_J: float
+    unruh_temperature_K: float
+    entropy_change_J_per_K: float
+    observer_coherence_correction_J: float = 0.0
+
+
+@dataclass(frozen=True, slots=True)
+class JacobsonObserverWitness:
+    """Diagnostic for INV-JACOBSON-OBSERVER on a single context."""
+
+    context: ClausiusContext
+    pure_jacobson_residual_J: float
+    observer_extended_residual_J: float
+    is_pure_jacobson_consistent: bool
+    is_extended_consistent: bool
+    reason: str | None
+
+
+def _check_finite(value: float, name: str) -> None:
+    if not math.isfinite(value):
+        raise ValueError(
+            f"INV-HPC2 VIOLATED: {name} must be finite, got {value!r}. "
+            "Finite inputs → finite outputs is a P0 contract; no silent repair."
+        )
+
+
+def clausius_residual(context: ClausiusContext) -> float:
+    """Compute the extended Clausius residual: δQ - T·dS - c.
+
+    For the pure Jacobson 1995 derivation, c = 0 and the residual must
+    vanish on a thermal horizon. With observer-coherence c ≠ 0, the
+    residual becomes a witness of the extension's compatibility with
+    Einstein gravity at observable scale.
+    """
+    _check_finite(context.heat_flow_J, "heat_flow_J")
+    _check_finite(context.unruh_temperature_K, "unruh_temperature_K")
+    _check_finite(context.entropy_change_J_per_K, "entropy_change_J_per_K")
+    _check_finite(
+        context.observer_coherence_correction_J,
+        "observer_coherence_correction_J",
+    )
+    if context.unruh_temperature_K < 0.0:
+        raise ValueError(f"unruh_temperature_K must be >= 0, got {context.unruh_temperature_K}")
+    pure = context.heat_flow_J - context.unruh_temperature_K * context.entropy_change_J_per_K
+    return pure - context.observer_coherence_correction_J
+
+
+def assess_jacobson_observer(
+    context: ClausiusContext,
+    *,
+    tolerance_J: float = 1e-30,
+) -> JacobsonObserverWitness:
+    """Witness for INV-JACOBSON-OBSERVER on one Clausius context.
+
+    Reports both the pure-Jacobson residual (c-free) and the extended
+    residual (c included). Either residual within `tolerance_J` is
+    consistent with the corresponding contract. Tolerance defaults to
+    1e-30 J — well below any laboratory-accessible heat flow but
+    above float64 noise.
+    """
+    _check_finite(tolerance_J, "tolerance_J")
+    if tolerance_J < 0.0:
+        raise ValueError(f"tolerance_J must be non-negative, got {tolerance_J}")
+    pure = context.heat_flow_J - context.unruh_temperature_K * context.entropy_change_J_per_K
+    extended = pure - context.observer_coherence_correction_J
+    pure_consistent = abs(pure) <= tolerance_J
+    extended_consistent = abs(extended) <= tolerance_J
+    reason: str | None
+    if pure_consistent and extended_consistent:
+        reason = None
+    elif pure_consistent and not extended_consistent:
+        reason = (
+            "INV-JACOBSON-OBSERVER: pure Clausius δQ = T·dS holds, but the "
+            f"observer-coherence correction c={context.observer_coherence_correction_J} J "
+            f"introduces a residual {extended} J above tolerance {tolerance_J} J — "
+            "the extension does not vanish in the decoupled limit and is "
+            "inconsistent with Einstein gravity at observable scale."
+        )
+    else:
+        reason = (
+            "INV-JACOBSON-OBSERVER: pure Clausius residual is non-zero "
+            f"(pure_residual={pure} J above tolerance {tolerance_J} J); "
+            "the input context does not represent a thermal Rindler horizon "
+            "to within the supplied tolerance."
+        )
+    return JacobsonObserverWitness(
+        context=context,
+        pure_jacobson_residual_J=pure,
+        observer_extended_residual_J=extended,
+        is_pure_jacobson_consistent=pure_consistent,
+        is_extended_consistent=extended_consistent,
+        reason=reason,
+    )

--- a/tests/unit/physics/test_jacobson_observer_coherence.py
+++ b/tests/unit/physics/test_jacobson_observer_coherence.py
@@ -1,0 +1,184 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+# no-bio-claim
+"""Tests for INV-JACOBSON-OBSERVER (P1, conditional, EXTRAPOLATED)."""
+
+from __future__ import annotations
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+from core.physics.jacobson_observer_coherence import (
+    PROVENANCE_LEVEL,
+    TRUTH_COHERENCE_SCORE,
+    ClausiusContext,
+    assess_jacobson_observer,
+    clausius_residual,
+)
+
+
+def test_provenance_metadata_is_extrapolated() -> None:
+    """Provenance must mark this as EXTRAPOLATED — Jacobson 1995 settled,
+    observer-coherence extension is research direction."""
+    assert PROVENANCE_LEVEL == "EXTRAPOLATED"
+    assert 0.4 <= TRUTH_COHERENCE_SCORE <= 0.7
+
+
+def test_pure_jacobson_satisfied_when_dQ_equals_T_dS() -> None:
+    """Pure Jacobson recovery: δQ = T·dS, c = 0 ⇒ residual = 0."""
+    ctx = ClausiusContext(
+        heat_flow_J=10.0,
+        unruh_temperature_K=2.0,
+        entropy_change_J_per_K=5.0,
+    )
+    assert clausius_residual(ctx) == 0.0
+
+
+def test_pure_jacobson_violated_when_dQ_neq_T_dS() -> None:
+    """δQ ≠ T·dS, c = 0 ⇒ non-zero residual indicates non-thermal horizon."""
+    ctx = ClausiusContext(
+        heat_flow_J=10.0,
+        unruh_temperature_K=2.0,
+        entropy_change_J_per_K=4.0,  # T·dS = 8, residual = 2
+    )
+    assert clausius_residual(ctx) == 2.0
+
+
+def test_extended_residual_includes_observer_correction() -> None:
+    """residual = δQ - T·dS - c."""
+    ctx = ClausiusContext(
+        heat_flow_J=10.0,
+        unruh_temperature_K=2.0,
+        entropy_change_J_per_K=5.0,
+        observer_coherence_correction_J=3.0,
+    )
+    assert clausius_residual(ctx) == -3.0
+
+
+def test_witness_pure_jacobson_consistent_when_residual_below_tol() -> None:
+    """Default tol 1e-30 J: small residuals at machine precision are OK."""
+    ctx = ClausiusContext(
+        heat_flow_J=10.0,
+        unruh_temperature_K=2.0,
+        entropy_change_J_per_K=5.0,
+    )
+    w = assess_jacobson_observer(ctx)
+    assert w.is_pure_jacobson_consistent is True
+    assert w.is_extended_consistent is True
+    assert w.reason is None
+
+
+def test_witness_extended_inconsistent_when_correction_breaks_balance() -> None:
+    """Pure Jacobson holds but c introduces a non-zero residual ⇒
+    extended inconsistent; reason explains."""
+    ctx = ClausiusContext(
+        heat_flow_J=10.0,
+        unruh_temperature_K=2.0,
+        entropy_change_J_per_K=5.0,
+        observer_coherence_correction_J=1.0,
+    )
+    w = assess_jacobson_observer(ctx)
+    assert w.is_pure_jacobson_consistent is True
+    assert w.is_extended_consistent is False
+    assert w.reason is not None
+    assert "INV-JACOBSON-OBSERVER" in w.reason
+
+
+def test_witness_pure_inconsistent_when_input_is_not_thermal_horizon() -> None:
+    """Input where δQ ≠ T·dS (and c=0) ⇒ pure-Jacobson inconsistent."""
+    ctx = ClausiusContext(
+        heat_flow_J=10.0,
+        unruh_temperature_K=2.0,
+        entropy_change_J_per_K=4.0,
+    )
+    w = assess_jacobson_observer(ctx)
+    assert w.is_pure_jacobson_consistent is False
+    assert w.is_extended_consistent is False
+    assert w.reason is not None
+
+
+def test_decoupled_limit_recovers_jacobson() -> None:
+    """As c → 0, extended residual → pure residual (no observer effect)."""
+    base_ctx = ClausiusContext(
+        heat_flow_J=10.0,
+        unruh_temperature_K=2.0,
+        entropy_change_J_per_K=5.0,
+    )
+    base_residual = clausius_residual(base_ctx)
+    for tiny_c in (1e-40, 1e-50, 0.0):
+        ctx = ClausiusContext(
+            heat_flow_J=10.0,
+            unruh_temperature_K=2.0,
+            entropy_change_J_per_K=5.0,
+            observer_coherence_correction_J=tiny_c,
+        )
+        # As c shrinks, residual approaches pure residual.
+        assert abs(clausius_residual(ctx) - base_residual) <= max(tiny_c, 1e-40)
+
+
+def test_negative_unruh_temperature_raises() -> None:
+    """T < 0 is unphysical for a thermal horizon — fail-closed."""
+    with pytest.raises(ValueError):
+        clausius_residual(
+            ClausiusContext(
+                heat_flow_J=10.0,
+                unruh_temperature_K=-1.0,
+                entropy_change_J_per_K=5.0,
+            )
+        )
+
+
+def test_non_finite_inputs_raise() -> None:
+    """INV-HPC2: NaN / Inf in any field is fail-closed."""
+    for bad in (float("nan"), float("inf")):
+        with pytest.raises(ValueError):
+            clausius_residual(
+                ClausiusContext(
+                    heat_flow_J=bad,
+                    unruh_temperature_K=2.0,
+                    entropy_change_J_per_K=5.0,
+                )
+            )
+
+
+def test_witness_dataclass_is_frozen() -> None:
+    """JacobsonObserverWitness is immutable post-construction."""
+    ctx = ClausiusContext(
+        heat_flow_J=0.0,
+        unruh_temperature_K=0.0,
+        entropy_change_J_per_K=0.0,
+    )
+    w = assess_jacobson_observer(ctx)
+    with pytest.raises(AttributeError):
+        w.is_pure_jacobson_consistent = False  # type: ignore[misc]
+
+
+def test_negative_tolerance_raises() -> None:
+    ctx = ClausiusContext(
+        heat_flow_J=0.0,
+        unruh_temperature_K=0.0,
+        entropy_change_J_per_K=0.0,
+    )
+    with pytest.raises(ValueError):
+        assess_jacobson_observer(ctx, tolerance_J=-1.0)
+
+
+@given(
+    dQ=st.floats(min_value=-1e6, max_value=1e6, allow_nan=False, allow_infinity=False),
+    T=st.floats(min_value=0.0, max_value=1e6, allow_nan=False, allow_infinity=False),
+    dS=st.floats(min_value=-1e6, max_value=1e6, allow_nan=False, allow_infinity=False),
+    c=st.floats(min_value=-1e6, max_value=1e6, allow_nan=False, allow_infinity=False),
+)
+def test_property_residual_equals_dQ_minus_T_dS_minus_c(
+    dQ: float, T: float, dS: float, c: float
+) -> None:
+    """Property: clausius_residual = δQ - T·dS - c for any finite inputs."""
+    ctx = ClausiusContext(
+        heat_flow_J=dQ,
+        unruh_temperature_K=T,
+        entropy_change_J_per_K=dS,
+        observer_coherence_correction_J=c,
+    )
+    expected = dQ - T * dS - c
+    assert clausius_residual(ctx) == pytest.approx(expected, rel=1e-10, abs=1e-10)


### PR DESCRIPTION
## INV-JACOBSON-OBSERVER (P1, conditional, EXTRAPOLATED, truth-coherence 0.55)

residual = δQ - T·dS - c on local Rindler horizons. Pure Jacobson 1995 recovered when c → 0.

Provenance: EXTRAPOLATED. Jacobson 1995 settled; observer-coherence extension is research direction.

## Quality gate
| Gate | Result |
|---|---|
| pytest | 13/13 PASS |
| ruff/format/black/mypy --strict | clean |

References: Jacobson 1995, Padmanabhan 2010, Verlinde 2011. No 2025/2026 unverified citations.