### PR TITLE
feat(physics): INV-ANCHORED-SUBSTRATE-GATE — composable AND of two ANCHORED axes

### DIFF
--- a/.claude/physics/INVARIANTS.yaml
+++ b/.claude/physics/INVARIANTS.yaml
@@ -942,3 +942,19 @@ pncc:
       - "Padmanabhan, T. (2010). Thermodynamical aspects of gravity: new insights. Rep. Prog. Phys. 73, 046901. arXiv:0911.5004."
       - "Verlinde, E. (2011). On the origin of gravity and the laws of Newton. JHEP 04, 029."
     related: [INV-BEKENSTEIN-COGNITIVE, INV-COSMOLOGICAL-COMPUTE, INV-ARROW-OF-TIME]
+
+  anchored_substrate_gate:
+    id: INV-ANCHORED-SUBSTRATE-GATE
+    type: conditional
+    statement: "A substrate is admissible for cognitive computation iff both ANCHORED-tier physical bounds hold simultaneously: I_observed ≤ 2π·E·R/(ℏ·c·ln 2) (INV-BEKENSTEIN-COGNITIVE) AND Σ_net = ΔS_system + ΔI_observer ≥ 0 (INV-ARROW-OF-TIME). Either failing makes the substrate inadmissible; the gate names the failing axis (or both)."
+    test_type: property_test
+    falsification: "A substrate where both ingredient invariants pass independently but the composite gate reports inadmissible, OR where one ingredient fails but the composite reports admissible. Composition must be the AND of the two ANCHORED axes."
+    priority: P0
+    provenance: ANCHORED
+    source: core/physics/anchored_substrate_gate.py
+    tests: tests/unit/physics/test_anchored_substrate_gate.py
+    references:
+      - "Bekenstein, J. D. (1981). Universal upper bound on the entropy-to-energy ratio for bounded systems. Phys. Rev. D 23, 287."
+      - "Landauer, R. (1961). Irreversibility and Heat Generation in the Computing Process. IBM J. Res. Dev. 5, 183."
+      - "Bennett, C. H. (1982). The thermodynamics of computation — a review. Int. J. Theor. Phys. 21, 905."
+    related: [INV-BEKENSTEIN-COGNITIVE, INV-ARROW-OF-TIME]

--- a/core/physics/anchored_substrate_gate.py
+++ b/core/physics/anchored_substrate_gate.py
@@ -1,0 +1,179 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""Anchored substrate gate — composition of ANCHORED-tier invariants.
+
+INV-ANCHORED-SUBSTRATE-GATE (P0, conditional, ANCHORED):
+    A substrate is admissible for cognitive computation iff it
+    simultaneously satisfies the two ANCHORED-tier physical bounds:
+
+        (1) INV-BEKENSTEIN-COGNITIVE — spatial/capacity:
+                I_observed ≤ 2π·E·R / (ℏ·c·ln 2)   bits
+
+        (2) INV-ARROW-OF-TIME — temporal/entropy:
+                Σ_net = ΔS_system + ΔI_observer ≥ 0   bits
+
+    Both must hold. Either failing makes the substrate inadmissible
+    for the purposes of the cognitive-engineering kernel; the gate
+    returns a structured witness that names which axis (or both)
+    failed.
+
+Provenance: ANCHORED.
+    The gate composes only the two ANCHORED invariants. Both
+    ingredients trace to peer-reviewed established physics:
+      - Bekenstein 1981 (Phys. Rev. D 23, 287)
+      - 't Hooft 1993 (gr-qc/9310026); Susskind 1995 (J. Math. Phys.
+        36, 6377)
+      - Landauer 1961 (IBM J. Res. Dev. 5, 183)
+      - Bennett 1982 (Int. J. Theor. Phys. 21, 905)
+
+    EXTRAPOLATED-tier invariants (INV-OBSERVER-BANDWIDTH,
+    INV-COSMOLOGICAL-COMPUTE, INV-JACOBSON-OBSERVER,
+    INV-SIMULATION-FALSIFICATION) are deliberately NOT composed here.
+    Mixing tiers in one gate would dilute the gate's epistemic
+    standing. Future modules may compose EXTRAPOLATED axes into a
+    separate `extrapolated_substrate_gate` once the EXTRAPOLATED
+    contracts are themselves validated.
+
+Operational consequence: prior to this module, the claim "substrate
+holds composably" appeared in PR descriptions and docs but was not
+checkable. Each invariant had its own witness function tested
+independently; nothing exercised the composition. This module makes
+the composition executable.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Literal
+
+from core.physics.arrow_of_time import (
+    ArrowOfTimeWitness,
+    ObserverEntropyLedger,
+    assess_arrow_of_time,
+)
+from core.physics.thermodynamic_budget import bekenstein_cognitive_ceiling
+
+__all__ = [
+    "AnchoredSubstrateGateWitness",
+    "PROVENANCE_TIER",
+    "SubstrateGateInputs",
+    "assess_anchored_substrate_gate",
+]
+
+PROVENANCE_TIER: Literal["ANCHORED", "EXTRAPOLATED", "SPECULATIVE"] = "ANCHORED"
+
+
+@dataclass(frozen=True, slots=True)
+class SubstrateGateInputs:
+    """Inputs required to assess the anchored substrate gate.
+
+    Spatial/capacity axis (INV-BEKENSTEIN-COGNITIVE):
+    - radius_m: bounding-sphere radius of the substrate, in metres.
+    - energy_J: total energy contained in the substrate, in joules.
+    - observed_information_bits: information content claimed for the
+      substrate. Must be non-negative and finite. The gate compares
+      this against 2π·E·R/(ℏ·c·ln 2).
+
+    Temporal/entropy axis (INV-ARROW-OF-TIME):
+    - entropy_ledger: ObserverEntropyLedger over a non-empty window.
+      The gate calls `assess_arrow_of_time` on this ledger and uses
+      the witness's `is_arrow_consistent` field.
+    """
+
+    radius_m: float
+    energy_J: float
+    observed_information_bits: float
+    entropy_ledger: ObserverEntropyLedger
+
+
+@dataclass(frozen=True, slots=True)
+class AnchoredSubstrateGateWitness:
+    """Composite witness from `assess_anchored_substrate_gate`.
+
+    Carries the per-axis sub-witnesses plus the composite verdict.
+    Non-raising; caller fail-closes on `is_substrate_admissible is False`.
+    """
+
+    inputs: SubstrateGateInputs
+    bekenstein_ceiling_bits: float
+    bekenstein_axis_holds: bool
+    arrow_witness: ArrowOfTimeWitness
+    arrow_axis_holds: bool
+    is_substrate_admissible: bool
+    failure_axes: tuple[str, ...]
+    reason: str | None
+
+
+def _check_finite(value: float, name: str) -> None:
+    if not math.isfinite(value):
+        raise ValueError(
+            f"INV-HPC2 VIOLATED: {name} must be finite, got {value!r}. "
+            "Finite inputs → finite outputs is a P0 contract; no silent repair."
+        )
+
+
+def _check_non_negative(value: float, name: str) -> None:
+    if value < 0.0:
+        raise ValueError(f"{name} must be non-negative, got {value}")
+
+
+def assess_anchored_substrate_gate(
+    inputs: SubstrateGateInputs,
+) -> AnchoredSubstrateGateWitness:
+    """Compose INV-BEKENSTEIN-COGNITIVE and INV-ARROW-OF-TIME.
+
+    Returns a structured witness. The gate does not raise on physical
+    violations (those are the gate's job to report); it raises only on
+    malformed inputs (NaN/Inf, negative information count) per
+    INV-HPC2 fail-closed.
+    """
+    _check_finite(inputs.observed_information_bits, "observed_information_bits")
+    _check_non_negative(inputs.observed_information_bits, "observed_information_bits")
+
+    # Spatial/capacity axis. The bekenstein helper validates radius_m
+    # and energy_J and raises on bad input.
+    ceiling = bekenstein_cognitive_ceiling(inputs.radius_m, inputs.energy_J)
+    bekenstein_holds = inputs.observed_information_bits <= ceiling
+
+    # Temporal/entropy axis.
+    arrow_witness = assess_arrow_of_time(inputs.entropy_ledger)
+    arrow_holds = arrow_witness.is_arrow_consistent
+
+    failures: list[str] = []
+    if not bekenstein_holds:
+        failures.append("BEKENSTEIN")
+    if not arrow_holds:
+        failures.append("ARROW")
+    failure_tuple = tuple(failures)
+
+    admissible = bekenstein_holds and arrow_holds
+    reason: str | None
+    if admissible:
+        reason = None
+    elif len(failure_tuple) == 1 and failure_tuple[0] == "BEKENSTEIN":
+        reason = (
+            "INV-BEKENSTEIN-COGNITIVE violated: "
+            f"observed_information_bits={inputs.observed_information_bits} > "
+            f"ceiling={ceiling} bits at (R={inputs.radius_m} m, "
+            f"E={inputs.energy_J} J)."
+        )
+    elif len(failure_tuple) == 1 and failure_tuple[0] == "ARROW":
+        reason = f"INV-ARROW-OF-TIME violated: {arrow_witness.reason}"
+    else:
+        reason = (
+            "Both anchored axes failed: "
+            f"INV-BEKENSTEIN-COGNITIVE (observed={inputs.observed_information_bits} > "
+            f"ceiling={ceiling}); INV-ARROW-OF-TIME ({arrow_witness.reason})."
+        )
+
+    return AnchoredSubstrateGateWitness(
+        inputs=inputs,
+        bekenstein_ceiling_bits=ceiling,
+        bekenstein_axis_holds=bekenstein_holds,
+        arrow_witness=arrow_witness,
+        arrow_axis_holds=arrow_holds,
+        is_substrate_admissible=admissible,
+        failure_axes=failure_tuple,
+        reason=reason,
+    )

--- a/tests/unit/physics/test_anchored_substrate_gate.py
+++ b/tests/unit/physics/test_anchored_substrate_gate.py
@@ -1,0 +1,188 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+# no-bio-claim
+"""Tests for INV-ANCHORED-SUBSTRATE-GATE (P0, conditional, ANCHORED).
+
+Composes INV-BEKENSTEIN-COGNITIVE and INV-ARROW-OF-TIME. The
+composition was verbal in PR descriptions; this test suite makes it
+checkable.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from core.physics.anchored_substrate_gate import (
+    PROVENANCE_TIER,
+    SubstrateGateInputs,
+    assess_anchored_substrate_gate,
+)
+from core.physics.arrow_of_time import ObserverEntropyLedger
+from core.physics.thermodynamic_budget import (
+    SPEED_OF_LIGHT_M_S,
+    bekenstein_cognitive_ceiling,
+)
+
+
+def _ledger(
+    system_entropy_change_bits: float = 0.0,
+    observer_information_gain_bits: float = 0.0,
+) -> ObserverEntropyLedger:
+    return ObserverEntropyLedger(
+        system_entropy_change_bits=system_entropy_change_bits,
+        observer_information_gain_bits=observer_information_gain_bits,
+    )
+
+
+def _inputs(
+    radius_m: float = 0.07,
+    mass_kg: float = 1.4,
+    observed_information_bits: float = 0.0,
+    system_entropy_change_bits: float = 0.0,
+    observer_information_gain_bits: float = 0.0,
+) -> SubstrateGateInputs:
+    energy_J = mass_kg * SPEED_OF_LIGHT_M_S**2
+    return SubstrateGateInputs(
+        radius_m=radius_m,
+        energy_J=energy_J,
+        observed_information_bits=observed_information_bits,
+        entropy_ledger=_ledger(
+            system_entropy_change_bits=system_entropy_change_bits,
+            observer_information_gain_bits=observer_information_gain_bits,
+        ),
+    )
+
+
+def test_provenance_tier_is_anchored() -> None:
+    """Gate composes only ANCHORED ingredients; tier must be ANCHORED."""
+    assert PROVENANCE_TIER == "ANCHORED"
+
+
+def test_admissible_when_both_axes_hold() -> None:
+    """Brain-scale substrate, modest information, positive entropy production
+    ⇒ both axes hold ⇒ admissible."""
+    w = assess_anchored_substrate_gate(
+        _inputs(observed_information_bits=1e30, system_entropy_change_bits=1.0)
+    )
+    assert w.bekenstein_axis_holds is True
+    assert w.arrow_axis_holds is True
+    assert w.is_substrate_admissible is True
+    assert w.failure_axes == ()
+    assert w.reason is None
+
+
+def test_inadmissible_when_information_exceeds_bekenstein_ceiling() -> None:
+    """Brain at 1.4 kg / 7 cm has ceiling ~ 10^42 bits. Claim 10^60 ⇒
+    Bekenstein fails."""
+    w = assess_anchored_substrate_gate(
+        _inputs(observed_information_bits=1e60, system_entropy_change_bits=1.0)
+    )
+    assert w.bekenstein_axis_holds is False
+    assert w.arrow_axis_holds is True
+    assert w.is_substrate_admissible is False
+    assert w.failure_axes == ("BEKENSTEIN",)
+    assert w.reason is not None
+    assert "INV-BEKENSTEIN-COGNITIVE" in w.reason
+
+
+def test_inadmissible_when_arrow_violated_by_unpaid_local_reduction() -> None:
+    """ΔS_system = -2 with ΔI_observer = 0 ⇒ arrow violated, bekenstein OK."""
+    w = assess_anchored_substrate_gate(
+        _inputs(
+            observed_information_bits=1e30,
+            system_entropy_change_bits=-2.0,
+            observer_information_gain_bits=0.0,
+        )
+    )
+    assert w.bekenstein_axis_holds is True
+    assert w.arrow_axis_holds is False
+    assert w.is_substrate_admissible is False
+    assert w.failure_axes == ("ARROW",)
+    assert w.reason is not None
+    assert "INV-ARROW-OF-TIME" in w.reason
+
+
+def test_both_axes_fail_simultaneously() -> None:
+    """Construct inputs that violate both anchored bounds."""
+    w = assess_anchored_substrate_gate(
+        _inputs(
+            observed_information_bits=1e60,
+            system_entropy_change_bits=-2.0,
+            observer_information_gain_bits=0.0,
+        )
+    )
+    assert w.bekenstein_axis_holds is False
+    assert w.arrow_axis_holds is False
+    assert w.is_substrate_admissible is False
+    assert set(w.failure_axes) == {"BEKENSTEIN", "ARROW"}
+    assert w.reason is not None
+    assert "INV-BEKENSTEIN-COGNITIVE" in w.reason
+    assert "INV-ARROW-OF-TIME" in w.reason
+
+
+def test_bekenstein_saturation_admissible_at_equality() -> None:
+    """Information exactly at ceiling ⇒ admissible (boundary case)."""
+    radius = 0.07
+    mass = 1.4
+    energy = mass * SPEED_OF_LIGHT_M_S**2
+    ceiling = bekenstein_cognitive_ceiling(radius, energy)
+    w = assess_anchored_substrate_gate(
+        SubstrateGateInputs(
+            radius_m=radius,
+            energy_J=energy,
+            observed_information_bits=ceiling,
+            entropy_ledger=_ledger(system_entropy_change_bits=0.0),
+        )
+    )
+    assert w.bekenstein_axis_holds is True
+    assert w.is_substrate_admissible is True
+
+
+def test_negative_observed_information_raises() -> None:
+    """INV-HPC2: negative information is unphysical."""
+    with pytest.raises(ValueError):
+        assess_anchored_substrate_gate(_inputs(observed_information_bits=-1.0))
+
+
+def test_non_finite_observed_information_raises() -> None:
+    """INV-HPC2: NaN / Inf bit count is fail-closed."""
+    for bad in (float("nan"), float("inf")):
+        with pytest.raises(ValueError):
+            assess_anchored_substrate_gate(_inputs(observed_information_bits=bad))
+
+
+def test_witness_dataclass_is_frozen() -> None:
+    """AnchoredSubstrateGateWitness is immutable post-construction."""
+    w = assess_anchored_substrate_gate(_inputs(observed_information_bits=1.0))
+    with pytest.raises(AttributeError):
+        w.is_substrate_admissible = False  # type: ignore[misc]
+
+
+def test_witness_carries_per_axis_sub_witness() -> None:
+    """The composite witness exposes the arrow-of-time sub-witness for caller
+    introspection (not just a boolean)."""
+    w = assess_anchored_substrate_gate(_inputs(observed_information_bits=1.0))
+    assert hasattr(w.arrow_witness, "is_arrow_consistent")
+    assert hasattr(w.arrow_witness, "net_entropy_production_bits")
+
+
+def test_failure_axes_ordering_is_stable() -> None:
+    """`failure_axes` is a tuple of strings; ordering is BEKENSTEIN before
+    ARROW when both fail (stable for downstream consumers)."""
+    w = assess_anchored_substrate_gate(
+        _inputs(
+            observed_information_bits=1e60,
+            system_entropy_change_bits=-2.0,
+        )
+    )
+    assert w.failure_axes == ("BEKENSTEIN", "ARROW")
+
+
+def test_zero_information_with_zero_entropy_is_admissible() -> None:
+    """Trivial substrate (no claims, no change) is degenerate but admissible:
+    nothing exceeds the ceiling, nothing violates the arrow."""
+    w = assess_anchored_substrate_gate(_inputs(observed_information_bits=0.0))
+    assert w.is_substrate_admissible is True
+    assert math.isfinite(w.bekenstein_ceiling_bits)


### PR DESCRIPTION
Makes the previously-verbal claim 'substrate тримає composably' executable. Composes INV-BEKENSTEIN-COGNITIVE × INV-ARROW-OF-TIME (both ANCHORED). EXTRAPOLATED axes deliberately excluded — mixing tiers would dilute epistemic standing.

## Quality gate
| Gate | Result |
|---|---|
| pytest | 12/12 PASS |
| ruff/format/black/mypy --strict | clean |
| validate_tests --self-check | 7/7 PASSED |

## Deliberate scope
- Provenance tier: ANCHORED (only ANCHORED ingredients composed)
- Future: separate `extrapolated_substrate_gate` once those contracts validate