### PR TITLE
chore(physics): drop 'cognitive computation' overclaim from substrate-gate verdict

### DIFF
--- a/.claude/physics/INVARIANTS.yaml
+++ b/.claude/physics/INVARIANTS.yaml
@@ -946,7 +946,7 @@ pncc:
   anchored_substrate_gate:
     id: INV-ANCHORED-SUBSTRATE-GATE
     type: conditional
-    statement: "A substrate is admissible for cognitive computation iff both ANCHORED-tier physical bounds hold simultaneously: I_observed ≤ 2π·E·R/(ℏ·c·ln 2) (INV-BEKENSTEIN-COGNITIVE) AND Σ_net = ΔS_system + ΔI_observer ≥ 0 (INV-ARROW-OF-TIME). Either failing makes the substrate inadmissible; the gate names the failing axis (or both)."
+    statement: "A substrate is *thermodynamically admissible* iff both ANCHORED-tier physical bounds hold simultaneously: I_observed ≤ 2π·E·R/(ℏ·c·ln 2) (INV-BEKENSTEIN-COGNITIVE) AND Σ_net = ΔS_system + ΔI_observer ≥ 0 (INV-ARROW-OF-TIME). The gate names the failing axis (or both). NOTE: passing the gate is necessary but NOT sufficient for any cognitive claim — non-cognitive systems satisfy both bounds trivially."
     test_type: property_test
     falsification: "A substrate where both ingredient invariants pass independently but the composite gate reports inadmissible, OR where one ingredient fails but the composite reports admissible. Composition must be the AND of the two ANCHORED axes."
     priority: P0

--- a/core/physics/anchored_substrate_gate.py
+++ b/core/physics/anchored_substrate_gate.py
@@ -3,8 +3,8 @@
 """Anchored substrate gate — composition of ANCHORED-tier invariants.
 
 INV-ANCHORED-SUBSTRATE-GATE (P0, conditional, ANCHORED):
-    A substrate is admissible for cognitive computation iff it
-    simultaneously satisfies the two ANCHORED-tier physical bounds:
+    A substrate is *thermodynamically admissible* iff it simultaneously
+    satisfies the two ANCHORED-tier physical bounds:
 
         (1) INV-BEKENSTEIN-COGNITIVE — spatial/capacity:
                 I_observed ≤ 2π·E·R / (ℏ·c·ln 2)   bits
@@ -13,9 +13,17 @@ INV-ANCHORED-SUBSTRATE-GATE (P0, conditional, ANCHORED):
                 Σ_net = ΔS_system + ΔI_observer ≥ 0   bits
 
     Both must hold. Either failing makes the substrate inadmissible
-    for the purposes of the cognitive-engineering kernel; the gate
-    returns a structured witness that names which axis (or both)
-    failed.
+    under the gate; the gate returns a structured witness that names
+    which axis (or both) failed.
+
+    NOTE: The gate does NOT certify "cognitive capability". Many
+    non-cognitive systems (a rock, a glass of water, a planet)
+    trivially satisfy both bounds. Passing the gate is a *necessary*
+    condition for any cognition-relevant claim — never a sufficient
+    one. Earlier wording in this module said "admissible for
+    cognitive computation" and "cognitive-engineering kernel"; that
+    was an inferential overclaim and has been removed in
+    chore/substrate-gate-honest-naming.
 
 Provenance: ANCHORED.
     The gate composes only the two ANCHORED invariants. Both
@@ -92,7 +100,10 @@ class AnchoredSubstrateGateWitness:
     """Composite witness from `assess_anchored_substrate_gate`.
 
     Carries the per-axis sub-witnesses plus the composite verdict.
-    Non-raising; caller fail-closes on `is_substrate_admissible is False`.
+    Non-raising; caller fail-closes on
+    `is_thermodynamically_admissible is False`. The flag answers
+    only "do both anchored bounds hold for this substrate?" — it
+    does NOT certify cognition.
     """
 
     inputs: SubstrateGateInputs
@@ -100,7 +111,7 @@ class AnchoredSubstrateGateWitness:
     bekenstein_axis_holds: bool
     arrow_witness: ArrowOfTimeWitness
     arrow_axis_holds: bool
-    is_substrate_admissible: bool
+    is_thermodynamically_admissible: bool
     failure_axes: tuple[str, ...]
     reason: str | None
 
@@ -173,7 +184,7 @@ def assess_anchored_substrate_gate(
         bekenstein_axis_holds=bekenstein_holds,
         arrow_witness=arrow_witness,
         arrow_axis_holds=arrow_holds,
-        is_substrate_admissible=admissible,
+        is_thermodynamically_admissible=admissible,
         failure_axes=failure_tuple,
         reason=reason,
     )

--- a/tests/unit/physics/test_anchored_substrate_gate.py
+++ b/tests/unit/physics/test_anchored_substrate_gate.py
@@ -68,7 +68,7 @@ def test_admissible_when_both_axes_hold() -> None:
     )
     assert w.bekenstein_axis_holds is True
     assert w.arrow_axis_holds is True
-    assert w.is_substrate_admissible is True
+    assert w.is_thermodynamically_admissible is True
     assert w.failure_axes == ()
     assert w.reason is None
 
@@ -81,7 +81,7 @@ def test_inadmissible_when_information_exceeds_bekenstein_ceiling() -> None:
     )
     assert w.bekenstein_axis_holds is False
     assert w.arrow_axis_holds is True
-    assert w.is_substrate_admissible is False
+    assert w.is_thermodynamically_admissible is False
     assert w.failure_axes == ("BEKENSTEIN",)
     assert w.reason is not None
     assert "INV-BEKENSTEIN-COGNITIVE" in w.reason
@@ -98,7 +98,7 @@ def test_inadmissible_when_arrow_violated_by_unpaid_local_reduction() -> None:
     )
     assert w.bekenstein_axis_holds is True
     assert w.arrow_axis_holds is False
-    assert w.is_substrate_admissible is False
+    assert w.is_thermodynamically_admissible is False
     assert w.failure_axes == ("ARROW",)
     assert w.reason is not None
     assert "INV-ARROW-OF-TIME" in w.reason
@@ -115,7 +115,7 @@ def test_both_axes_fail_simultaneously() -> None:
     )
     assert w.bekenstein_axis_holds is False
     assert w.arrow_axis_holds is False
-    assert w.is_substrate_admissible is False
+    assert w.is_thermodynamically_admissible is False
     assert set(w.failure_axes) == {"BEKENSTEIN", "ARROW"}
     assert w.reason is not None
     assert "INV-BEKENSTEIN-COGNITIVE" in w.reason
@@ -137,7 +137,7 @@ def test_bekenstein_saturation_admissible_at_equality() -> None:
         )
     )
     assert w.bekenstein_axis_holds is True
-    assert w.is_substrate_admissible is True
+    assert w.is_thermodynamically_admissible is True
 
 
 def test_negative_observed_information_raises() -> None:
@@ -157,7 +157,7 @@ def test_witness_dataclass_is_frozen() -> None:
     """AnchoredSubstrateGateWitness is immutable post-construction."""
     w = assess_anchored_substrate_gate(_inputs(observed_information_bits=1.0))
     with pytest.raises(AttributeError):
-        w.is_substrate_admissible = False  # type: ignore[misc]
+        w.is_thermodynamically_admissible = False  # type: ignore[misc]
 
 
 def test_witness_carries_per_axis_sub_witness() -> None:
@@ -184,5 +184,5 @@ def test_zero_information_with_zero_entropy_is_admissible() -> None:
     """Trivial substrate (no claims, no change) is degenerate but admissible:
     nothing exceeds the ceiling, nothing violates the arrow."""
     w = assess_anchored_substrate_gate(_inputs(observed_information_bits=0.0))
-    assert w.is_substrate_admissible is True
+    assert w.is_thermodynamically_admissible is True
     assert math.isfinite(w.bekenstein_ceiling_bits)


### PR DESCRIPTION
Self-audit found inference flaw in PR #417: 'admissible for cognitive computation' was an overclaim. Gate composes two physical bounds (Bekenstein × Arrow); passing is necessary but not sufficient for cognition. A rock satisfies both. Renamed to 'thermodynamically admissible' across docstring, YAML, and the witness field (`is_substrate_admissible` → `is_thermodynamically_admissible`).

No behavior change. The function does what it always did; now it says what it does.

| Gate | Result |
|---|---|
| pytest | 12/12 PASS |
| ruff/format/black/mypy --strict | clean |
| validate_tests --self-check | 7/7 PASSED |