### PR TITLE
fix(spikes): rename efficiency_margin → bekenstein_saturation_ratio + PhysicsViolation injection tests (inference flaws #2 + #3)

### DIFF
--- a/spikes/bekenstein_margin_scan.py
+++ b/spikes/bekenstein_margin_scan.py
@@ -1,14 +1,20 @@
 #!/usr/bin/env python3
 # Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
 # SPDX-License-Identifier: MIT
-"""Bekenstein margin scan: 5 systems, daily-energy-throughput interpretation.
+"""Bekenstein saturation-ratio scan: 5 systems, daily-energy-throughput interpretation.
+
+Per-system saturation ratio = claimed_bits / I_max(R, E). The ratio does NOT
+measure cognitive efficiency — I_max depends only on (R, E) and is identical
+for any object of those dimensions, regardless of whether it computes. The
+ratio measures the fraction of the universal Bekenstein-Hawking ceiling that
+the system's claimed information content occupies.
 
 Fulfils PR #406 promise. Energy convention here is E = P · 86400 s (one
 day of throughput), not E = m·c² (rest energy). Both are valid Bekenstein
 inputs; daily-throughput is the user-specified interpretation for this scan.
 
 Output: markdown table to stdout + JSON to spikes/bekenstein_scan_results.json
-Invariant: every efficiency_margin must be < 1.0. Otherwise PhysicsViolation.
+Invariant: every bekenstein_saturation_ratio must be < 1.0. Otherwise PhysicsViolation.
 """
 
 from __future__ import annotations
@@ -29,7 +35,7 @@ SECONDS_PER_DAY: float = 86_400.0
 
 
 class PhysicsViolation(Exception):
-    """Raised when a row's efficiency_margin >= 1.0 (INV-BEKENSTEIN-COGNITIVE)."""
+    """Raised when a row's bekenstein_saturation_ratio >= 1.0 (INV-BEKENSTEIN-COGNITIVE)."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -47,7 +53,7 @@ class MarginRow:
     energy_J: float
     theoretical_max_bits: float
     estimated_actual_bits: float
-    efficiency_margin: float
+    bekenstein_saturation_ratio: float
     log10_margin: float
 
 
@@ -89,17 +95,17 @@ def compute_row(system: System) -> MarginRow:
     energy_J = system.power_W * SECONDS_PER_DAY
     ceiling = bekenstein_cognitive_ceiling(system.radius_m, energy_J)
     if ceiling <= 0.0:
-        margin = math.inf
+        ratio = math.inf
     else:
-        margin = system.estimated_actual_bits / ceiling
-    log10_margin = math.log10(margin) if margin > 0.0 else float("-inf")
+        ratio = system.estimated_actual_bits / ceiling
+    log10_margin = math.log10(ratio) if ratio > 0.0 else float("-inf")
     return MarginRow(
         name=system.name,
         radius_m=system.radius_m,
         energy_J=energy_J,
         theoretical_max_bits=ceiling,
         estimated_actual_bits=system.estimated_actual_bits,
-        efficiency_margin=margin,
+        bekenstein_saturation_ratio=ratio,
         log10_margin=log10_margin,
     )
 
@@ -109,9 +115,9 @@ def scan(systems: tuple[System, ...] = SYSTEMS) -> tuple[MarginRow, ...]:
 
 
 def assert_no_violation(rows: tuple[MarginRow, ...]) -> None:
-    violations = [r for r in rows if r.efficiency_margin >= 1.0]
+    violations = [r for r in rows if r.bekenstein_saturation_ratio >= 1.0]
     if violations:
-        names = ", ".join(f"{r.name}={r.efficiency_margin:.3e}" for r in violations)
+        names = ", ".join(f"{r.name}={r.bekenstein_saturation_ratio:.3e}" for r in violations)
         raise PhysicsViolation(f"INV-BEKENSTEIN-COGNITIVE violated: {names}")
 
 
@@ -125,14 +131,14 @@ def _fmt(value: float) -> str:
 
 def render_markdown(rows: tuple[MarginRow, ...]) -> str:
     lines = [
-        "| system | R [m] | E [J] | I_max bits | actual bits | margin | log10(margin) |",
+        "| system | R [m] | E [J] | I_max bits | actual bits | saturation ratio | log10(ratio) |",
         "|---|---:|---:|---:|---:|---:|---:|",
     ]
     for r in rows:
         lines.append(
             f"| {r.name} | {_fmt(r.radius_m)} | {_fmt(r.energy_J)} | "
             f"{_fmt(r.theoretical_max_bits)} | {_fmt(r.estimated_actual_bits)} | "
-            f"{_fmt(r.efficiency_margin)} | {r.log10_margin:.2f} |"
+            f"{_fmt(r.bekenstein_saturation_ratio)} | {r.log10_margin:.2f} |"
         )
     return "\n".join(lines)
 
@@ -145,7 +151,7 @@ def rows_to_json(rows: tuple[MarginRow, ...]) -> list[dict[str, object]]:
             "energy_J": r.energy_J,
             "theoretical_max_bits": r.theoretical_max_bits,
             "estimated_actual_bits": r.estimated_actual_bits,
-            "efficiency_margin": r.efficiency_margin,
+            "bekenstein_saturation_ratio": r.bekenstein_saturation_ratio,
             "log10_margin": r.log10_margin,
         }
         for r in rows
@@ -161,7 +167,7 @@ def main() -> None:
         json.dumps(rows_to_json(rows), indent=2, ensure_ascii=False),
         encoding="utf-8",
     )
-    print("\nPASS: 5/5 efficiency_margin < 1.0")
+    print("\nPASS: 5/5 bekenstein_saturation_ratio < 1.0")
     print(f"JSON: {out_path}")
 
 

--- a/spikes/bekenstein_scan_results.json
+++ b/spikes/bekenstein_scan_results.json
@@ -5,7 +5,7 @@
     "energy_J": 1728000.0,
     "theoretical_max_bits": 3.4681615710941886e+31,
     "estimated_actual_bits": 2500000000000000.0,
-    "efficiency_margin": 7.208430024819351e-17,
+    "bekenstein_saturation_ratio": 7.208430024819351e-17,
     "log10_margin": -16.142159313061814
   },
   {
@@ -14,7 +14,7 @@
     "energy_J": 0.8640000000000001,
     "theoretical_max_bits": 1.2386291325336389e+23,
     "estimated_actual_bits": 1000000000.0,
-    "efficiency_margin": 8.073441627797672e-15,
+    "bekenstein_saturation_ratio": 8.073441627797672e-15,
     "log10_margin": -14.092941290391632
   },
   {
@@ -23,7 +23,7 @@
     "energy_J": 0.00864,
     "theoretical_max_bits": 1.2386291325336386e+20,
     "estimated_actual_bits": 10000.0,
-    "efficiency_margin": 8.073441627797674e-17,
+    "bekenstein_saturation_ratio": 8.073441627797674e-17,
     "log10_margin": -16.092941290391632
   },
   {
@@ -32,7 +32,7 @@
     "energy_J": 86400000000.0,
     "theoretical_max_bits": 1.2386291325336387e+37,
     "estimated_actual_bits": 10000000000000.0,
-    "efficiency_margin": 8.073441627797673e-25,
+    "bekenstein_saturation_ratio": 8.073441627797673e-25,
     "log10_margin": -24.092941290391632
   },
   {
@@ -41,7 +41,7 @@
     "energy_J": 4320000.0,
     "theoretical_max_bits": 1.2386291325336388e+32,
     "estimated_actual_bits": 1000000000000.0,
-    "efficiency_margin": 8.073441627797672e-21,
+    "bekenstein_saturation_ratio": 8.073441627797672e-21,
     "log10_margin": -20.092941290391632
   }
 ]

--- a/tests/spikes/test_bekenstein_margin_scan.py
+++ b/tests/spikes/test_bekenstein_margin_scan.py
@@ -1,0 +1,103 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""Determinism + injection tests for spikes/bekenstein_margin_scan.py.
+
+Covers self-audit inference flaws #2 (assert_no_violation never fires) and
+#3 (efficiency_margin misnomer → bekenstein_saturation_ratio).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SPIKES_DIR = _REPO_ROOT / "spikes"
+if str(_SPIKES_DIR) not in sys.path:
+    sys.path.insert(0, str(_SPIKES_DIR))
+
+from bekenstein_margin_scan import (  # noqa: E402
+    MarginRow,
+    PhysicsViolation,
+    assert_no_violation,
+    render_markdown,
+    rows_to_json,
+    scan,
+)
+
+
+def _make_row(ratio: float, name: str = "synthetic") -> MarginRow:
+    return MarginRow(
+        name=name,
+        radius_m=1.0,
+        energy_J=1.0,
+        theoretical_max_bits=1.0,
+        estimated_actual_bits=ratio,
+        bekenstein_saturation_ratio=ratio,
+        log10_margin=0.0,
+    )
+
+
+def test_scan_is_deterministic() -> None:
+    """scan() must return identical tuples across invocations (no RNG, no clock)."""
+    a = scan()
+    b = scan()
+    assert a == b
+
+
+def test_assert_no_violation_passes_for_canonical_systems() -> None:
+    """Real 5-system scan must not raise — all ratios are << 1."""
+    rows = scan()
+    assert_no_violation(rows)
+
+
+def test_assert_no_violation_raises_at_margin_one() -> None:
+    """Boundary case: ratio == 1.0 must trip the guard (>=, not >)."""
+    rows = (_make_row(1.0, name="boundary"),)
+    with pytest.raises(PhysicsViolation, match="INV-BEKENSTEIN-COGNITIVE"):
+        assert_no_violation(rows)
+
+
+def test_assert_no_violation_raises_at_margin_above_one() -> None:
+    """Strict overrun: ratio = 2.5 must raise."""
+    rows = (_make_row(2.5, name="overrun"),)
+    with pytest.raises(PhysicsViolation, match="overrun"):
+        assert_no_violation(rows)
+
+
+def test_assert_no_violation_does_not_raise_at_margin_below_one() -> None:
+    """Just-below boundary: ratio = 0.999 must pass."""
+    rows = (_make_row(0.999, name="subcritical"),)
+    assert_no_violation(rows)
+
+
+def test_render_markdown_uses_renamed_column() -> None:
+    """Markdown header must say 'saturation', not 'efficiency'."""
+    rows = scan()
+    md = render_markdown(rows)
+    header = md.splitlines()[0]
+    assert "saturation" in header.lower()
+    assert "efficiency" not in header.lower()
+
+
+def test_rows_to_json_uses_new_key() -> None:
+    """Serialised dicts must carry bekenstein_saturation_ratio, not efficiency_margin."""
+    rows = scan()
+    payload = rows_to_json(rows)
+    assert payload, "scan returned no rows"
+    for entry in payload:
+        assert "bekenstein_saturation_ratio" in entry
+        assert "efficiency_margin" not in entry
+
+
+def test_persisted_json_uses_new_key() -> None:
+    """The committed bekenstein_scan_results.json must reflect the renamed key."""
+    json_path = _REPO_ROOT / "spikes" / "bekenstein_scan_results.json"
+    data = json.loads(json_path.read_text(encoding="utf-8"))
+    assert isinstance(data, list) and data
+    for entry in data:
+        assert "bekenstein_saturation_ratio" in entry
+        assert "efficiency_margin" not in entry


### PR DESCRIPTION
## Summary

Self-audit fixes #2 + #3 on `spikes/bekenstein_margin_scan.py`, scoped strictly to `spikes/` and `tests/spikes/`. Does NOT touch `core/physics` or `.claude/physics/INVARIANTS.yaml`.

### #2 — `assert_no_violation` had no negative-injection coverage
Same anti-pattern PR #416 caught for `truth_coherence_score`: the guard never fired in canonical runs, so a regression that broke the `>= 1.0` check would have been silent.

Added 4 boundary tests:
- `test_assert_no_violation_passes_for_canonical_systems` — real 5-system scan stays clean.
- `test_assert_no_violation_raises_at_margin_one` — ratio = 1.0 trips guard (`>=`, not `>`).
- `test_assert_no_violation_raises_at_margin_above_one` — ratio = 2.5 raises.
- `test_assert_no_violation_does_not_raise_at_margin_below_one` — ratio = 0.999 passes.

### #3 — `efficiency_margin` is misnamed
`I_max(R, E)` depends only on radius and energy. A rock and a brain at the same `(R, E)` share an identical ceiling regardless of whether they compute. The word "efficiency" implied cognitive efficiency, which the metric does not measure.

- Renamed dataclass field, JSON key, markdown column header, internal refs, and docstring framing to `bekenstein_saturation_ratio`.
- Module docstring now states explicitly: "ratio measures the fraction of the universal Bekenstein-Hawking ceiling that the system's claimed information content occupies… does NOT measure cognitive efficiency".
- Regenerated `spikes/bekenstein_scan_results.json` with the new key.

### Tests added (8 total)
| # | test | covers |
|---|---|---|
| 1 | `test_scan_is_deterministic` | scan() pure (no RNG, no clock) |
| 2 | `test_assert_no_violation_passes_for_canonical_systems` | canonical case |
| 3 | `test_assert_no_violation_raises_at_margin_one` | boundary `>=` |
| 4 | `test_assert_no_violation_raises_at_margin_above_one` | strict overrun |
| 5 | `test_assert_no_violation_does_not_raise_at_margin_below_one` | just-below |
| 6 | `test_render_markdown_uses_renamed_column` | header rename |
| 7 | `test_rows_to_json_uses_new_key` | JSON key rename |
| 8 | `test_persisted_json_uses_new_key` | committed artifact rename |

## Test plan
- [x] `python spikes/bekenstein_margin_scan.py` — exits 0, regenerates JSON
- [x] `python -m pytest tests/spikes/ -v` — 8 passed
- [x] `python -m ruff check` — clean
- [x] `python -m ruff format --check` — clean
- [x] `python -m black --check` — clean
- [x] `python -m mypy --strict` — Success: no issues found in 3 source files
- [x] `python .claude/physics/validate_tests.py --self-check` — PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)