### PR TITLE
chore(physics): downgrade INV-OBSERVER-BANDWIDTH EXTRAPOLATED→SPECULATIVE, P1→P2 (inference flaw #4)

### DIFF
--- a/.claude/physics/INVARIANTS.yaml
+++ b/.claude/physics/INVARIANTS.yaml
@@ -892,11 +892,11 @@ pncc:
   observer_bandwidth:
     id: INV-OBSERVER-BANDWIDTH
     type: conditional
-    statement: "For any observer-system pair under decoherence coupling, the system's effective decoherence rate Γ (Hz) is bounded above by the observer's information-acquisition rate Σ̇ (bit/s, treated 1:1 with Hz of resolvable events): Γ ≤ Σ̇."
+    statement: "For any observer-system pair under decoherence coupling, the system's effective decoherence rate Γ (Hz) is bounded above by the observer's information-acquisition rate Σ̇ (bit/s, treated 1:1 with Hz of resolvable events): Γ ≤ Σ̇. Schema-only: the unit equivalence 1 bit/s ↔ 1 Hz of resolvable events is an ansatz, and the cited references (Zurek 2003, Lieb-Robinson 1972) provide adjacent context rather than direct derivation."
     test_type: property_test
     falsification: "A measured observer-system pair where Γ > Σ̇ in well-isolated conditions, with the observer's bandwidth independently characterized."
-    priority: P1
-    provenance: EXTRAPOLATED
+    priority: P2
+    provenance: SPECULATIVE
     source: core/physics/observer_bandwidth.py
     tests: tests/unit/physics/test_observer_bandwidth.py
     references:

--- a/core/physics/observer_bandwidth.py
+++ b/core/physics/observer_bandwidth.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 """Observer bandwidth bound on decoherence rate (P2).
 
-INV-OBSERVER-BANDWIDTH (P1, conditional, EXTRAPOLATED):
+INV-OBSERVER-BANDWIDTH (P2, conditional, SPECULATIVE):
     For any observer-system pair under a Zurek-style decoherence
     coupling, the effective decoherence rate Γ of the system from the
     observer's perspective is upper-bounded by the observer's
@@ -14,24 +14,25 @@ INV-OBSERVER-BANDWIDTH (P1, conditional, EXTRAPOLATED):
     decohere from its own perspective, faster than its finite
     bit-acquisition rate allows.
 
-Provenance: EXTRAPOLATED.
+Provenance: SPECULATIVE.
     - Zurek (2003): Decoherence, einselection, and the quantum origins
       of the classical. Rev. Mod. Phys. 75, 715.
-      (anchors the decoherence framework that the bandwidth bound
-      extends.)
+      (adjacent context: anchors the decoherence framework, but does
+      not derive an observer-bandwidth ceiling on Γ.)
     - Lieb-Robinson (1972): The finite group velocity of quantum spin
       systems. Comm. Math. Phys. 28, 251.
-      (anchors the principle that information cannot propagate faster
-      than a finite speed in quantum lattice systems — the closest
-      direct precedent for an observer-side rate bound on decoherence.)
+      (adjacent context: bounds info-propagation speed in lattice
+      systems, not the bandwidth-observer-decoherence claim.)
 
-Decoherence is established physics (Zurek); finite information-
-propagation speed is established physics (Lieb-Robinson). The specific
-claim Γ ≤ Σ̇ — that an observer's bit-acquisition rate bounds the
-decoherence rate it can resolve — combines these but is not derived
-from them. EXTRAPOLATED. The unit equivalence "1 bit/s ↔ 1 Hz of
-resolvable events" is an ansatz: it makes the inequality dimensionally
-admissible by convention, not by physical first principles.
+Schema-only honesty: the unit equivalence "1 bit/s ↔ 1 Hz of
+resolvable events" is an ansatz that makes the inequality
+dimensionally admissible by convention, not by physical first
+principles. Lieb-Robinson 1972 bounds info-propagation in lattice
+systems — adjacent context, not direct derivation of the
+bandwidth-observer-decoherence claim. The two cited references jointly
+provide adjacent support; they do not derive Γ ≤ Σ̇. Tier therefore
+honestly downgraded EXTRAPOLATED → SPECULATIVE; per validator
+check 5, SPECULATIVE caps priority at P2.
 """
 
 from __future__ import annotations
@@ -51,7 +52,7 @@ __all__ = [
 ]
 
 # Discrete provenance tier; see arrow_of_time.py for definition.
-PROVENANCE_TIER: Literal["ANCHORED", "EXTRAPOLATED", "SPECULATIVE"] = "EXTRAPOLATED"
+PROVENANCE_TIER: Literal["ANCHORED", "EXTRAPOLATED", "SPECULATIVE"] = "SPECULATIVE"
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/unit/physics/test_observer_bandwidth.py
+++ b/tests/unit/physics/test_observer_bandwidth.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
 # SPDX-License-Identifier: MIT
 # no-bio-claim
-"""Tests for INV-OBSERVER-BANDWIDTH (P1, conditional, EXTRAPOLATED)."""
+"""Tests for INV-OBSERVER-BANDWIDTH (P2, conditional, SPECULATIVE)."""
 
 from __future__ import annotations
 
@@ -17,12 +17,12 @@ from core.physics.observer_bandwidth import (
 )
 
 
-def test_provenance_tier_is_extrapolated() -> None:
-    """Provenance tier must be EXTRAPOLATED — not a settled theorem.
+def test_provenance_tier_is_speculative() -> None:
+    """Provenance tier must be SPECULATIVE — refs Zurek/Lieb-Robinson are adjacent, not derivative.
 
-    Discrete tier; no float score.
+    Discrete tier; no float score. SPECULATIVE → P2 cap (validator check 5).
     """
-    assert PROVENANCE_TIER == "EXTRAPOLATED"
+    assert PROVENANCE_TIER == "SPECULATIVE"
 
 
 def test_decoherence_rate_zero_is_isolated_system() -> None:


### PR DESCRIPTION
## Summary
Honest tier downgrade for **INV-OBSERVER-BANDWIDTH** (PR #410, refs tightened in #415).

Self-audit: the inequality `Γ ≤ Σ̇` rests entirely on the ansatz `1 bit/s ↔ 1 Hz of resolvable events`. Cited references provide *adjacent* context, not direct derivation:

- **Zurek 2003** anchors the decoherence framework but does not derive an observer-bandwidth ceiling on Γ.
- **Lieb-Robinson 1972** bounds info-propagation speed in lattice systems but does not derive the bandwidth-observer-decoherence claim.

Honest tier therefore = **SPECULATIVE**. Per validator check 5, `SPECULATIVE → max P2`. Both tier *and* priority change.

## Changes (atomic across both physics-contract layers)
- `core/physics/observer_bandwidth.py`
  - `PROVENANCE_TIER: "EXTRAPOLATED" → "SPECULATIVE"`
  - Module docstring header `(P1, conditional, EXTRAPOLATED) → (P2, conditional, SPECULATIVE)`
  - Explicit schema-only honesty note added (ansatz + adjacent-context call-out)
- `tests/unit/physics/test_observer_bandwidth.py`
  - `test_provenance_tier_is_extrapolated → test_provenance_tier_is_speculative` (asserts `"SPECULATIVE"`)
  - Module docstring updated to `(P2, conditional, SPECULATIVE)`
- `.claude/physics/INVARIANTS.yaml` `observer_bandwidth:` block
  - `priority: P1 → P2`
  - `provenance: EXTRAPOLATED → SPECULATIVE`
  - `statement:` appended with schema-only ansatz + adjacent-references disclaimer

## Test plan
- [x] `pytest tests/unit/physics/test_observer_bandwidth.py -v` — 13/13 pass
- [x] `ruff check` clean on both files
- [x] `ruff format --check` clean
- [x] `black --check` clean
- [x] `mypy --strict` clean
- [x] `.claude/physics/validate_tests.py --self-check` PASSED (check 5 still admits SPECULATIVE@P2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)