### PR TITLE
chore(physics): drop ε fudge factor from INV-COSMOLOGICAL-COMPUTE (inflaw #5)

### DIFF
--- a/.claude/physics/INVARIANTS.yaml
+++ b/.claude/physics/INVARIANTS.yaml
@@ -907,9 +907,9 @@ pncc:
   cosmological_compute:
     id: INV-COSMOLOGICAL-COMPUTE
     type: statistical
-    statement: "Useful reversible computation in any causal diamond is bounded above by ε · A / (4 · ℓ_p² · ln 2) bits, where A is horizon area, ℓ_p is the Planck length, and ε ∈ (0, 1] is a de-Sitter-complexity efficiency coefficient."
+    statement: "Useful reversible computation in any causal diamond is bounded above by A / (4 · ℓ_p² · ln 2) bits per Bekenstein-Hawking, where A is horizon area and ℓ_p is the Planck length. Caller-side discounting (de Sitter complexity efficiency) is the caller's responsibility, not part of this contract."
     test_type: property_test
-    falsification: "A reproducible measurement of useful quantum computation inside a causal diamond exceeding the holographic ceiling, OR a derivation forcing ε > 1."
+    falsification: "A reproducible measurement of useful quantum computation inside a causal diamond exceeding the holographic ceiling A / (4 · ℓ_p² · ln 2)."
     priority: P1
     provenance: EXTRAPOLATED
     source: core/physics/cosmological_compute_bound.py

--- a/core/physics/cosmological_compute_bound.py
+++ b/core/physics/cosmological_compute_bound.py
@@ -3,20 +3,18 @@
 """Cosmological compute bound on a causal diamond (P4).
 
 INV-COSMOLOGICAL-COMPUTE (P1, statistical, EXTRAPOLATED):
-    The total useful reversible computation that can be performed
-    inside any causal diamond is bounded above by the holographic bit
-    capacity of its bounding horizon, scaled by an efficiency
-    coefficient ε ∈ (0, 1]:
-
-        I_useful_max = ε · A / (4 · ℓ_p² · ln 2)   bits
+    I ≤ A / (4 · ℓ_p² · ln 2) bits per Bekenstein-Hawking 1973.
+    Caller-side discounting is the caller's responsibility; this
+    module ships only the holographic ceiling. The previous
+    `efficiency` parameter was dropped in chore/inflaw-5 because
+    for ε ≤ 1 the inequality reduced to a tautology (any number of
+    useful bits ≤ holographic ceiling is trivially satisfied by the
+    Bekenstein-Hawking bound itself, and ε had no operational
+    definition or first-principles derivation in this module).
 
     where A is the horizon area and ℓ_p is the Planck length. The
     Bekenstein-Hawking formula gives I_max = A / (4 · ℓ_p²) nats =
-    A / (4 · ℓ_p² · ln 2) bits. The efficiency ε ≤ 1 absorbs the
-    practical fact that not all holographic degrees of freedom are
-    addressable as useful logical bits at any given epoch — the
-    de Sitter complexity literature places ε in the 10^-3 .. 1 range
-    depending on the construction.
+    A / (4 · ℓ_p² · ln 2) bits.
 
 Provenance: EXTRAPOLATED.
     - Bekenstein 1973 (PRD 7, 2333): black-hole entropy ∝ horizon area.
@@ -26,9 +24,8 @@ Provenance: EXTRAPOLATED.
       computational complexity and black-hole horizons.
 
 The holographic-bound side is settled physics. The interpretation as
-a hard ceiling on "useful" cosmological computation is a research
-direction; the efficiency coefficient ε cannot be derived from first
-principles in this module. Truth-coherence ~0.5.
+a hard ceiling on cosmological computation is a research direction;
+truth-coherence ~0.5.
 """
 
 from __future__ import annotations
@@ -74,12 +71,15 @@ class CausalDiamond:
 
 @dataclass(frozen=True, slots=True)
 class ComputeBudget:
-    """Holographic compute budget of a causal diamond."""
+    """Holographic compute budget of a causal diamond.
+
+    `holographic_max_bits` is the Bekenstein-Hawking ceiling for the
+    diamond's horizon area. No `efficiency`/`useful_max_bits` split is
+    exposed — caller-side discounting belongs in the caller.
+    """
 
     diamond: CausalDiamond
     holographic_max_bits: float
-    efficiency: float
-    useful_max_bits: float
 
 
 @dataclass(frozen=True, slots=True)
@@ -119,36 +119,24 @@ def holographic_bit_capacity(area_m2: float) -> float:
     return bits
 
 
-def diamond_compute_budget(
-    diamond: CausalDiamond,
-    *,
-    efficiency: float = 1.0,
-) -> ComputeBudget:
+def diamond_compute_budget(diamond: CausalDiamond) -> ComputeBudget:
     """Compute the holographic budget for a causal diamond.
 
-    `efficiency` is ε ∈ (0, 1] — the fraction of holographic bits
-    treated as useful logical-compute. Default 1.0 reproduces the
-    raw Bekenstein-Hawking bound. Values < 0 or > 1 are fail-closed.
+    Returns the Bekenstein-Hawking ceiling A / (4 · ℓ_p² · ln 2) for
+    the diamond's horizon area. Caller-side discounting (de Sitter
+    complexity efficiency) is intentionally not exposed here — see
+    module docstring.
     """
-    _check_finite(efficiency, "efficiency")
-    if not (0.0 < efficiency <= 1.0):
-        raise ValueError(f"efficiency must be in (0, 1], got {efficiency}")
     holographic = holographic_bit_capacity(diamond.horizon_area_m2)
-    useful = holographic * efficiency
-    _check_finite(useful, "useful_max_bits")
     return ComputeBudget(
         diamond=diamond,
         holographic_max_bits=holographic,
-        efficiency=efficiency,
-        useful_max_bits=useful,
     )
 
 
 def assess_compute_claim(
     diamond: CausalDiamond,
     claimed_bits: float,
-    *,
-    efficiency: float = 1.0,
 ) -> ComputeBudgetWitness:
     """Witness for INV-COSMOLOGICAL-COMPUTE on one claim.
 
@@ -157,17 +145,17 @@ def assess_compute_claim(
     """
     _check_finite(claimed_bits, "claimed_bits")
     _check_non_negative(claimed_bits, "claimed_bits")
-    budget = diamond_compute_budget(diamond, efficiency=efficiency)
-    margin = budget.useful_max_bits - claimed_bits
-    within = claimed_bits <= budget.useful_max_bits
+    budget = diamond_compute_budget(diamond)
+    margin = budget.holographic_max_bits - claimed_bits
+    within = claimed_bits <= budget.holographic_max_bits
     reason: str | None
     if within:
         reason = None
     else:
         reason = (
             "INV-COSMOLOGICAL-COMPUTE: claim exceeds budget; "
-            f"claimed_bits={claimed_bits} > useful_max_bits={budget.useful_max_bits} "
-            f"(holographic={budget.holographic_max_bits}, efficiency={efficiency})"
+            f"claimed_bits={claimed_bits} > "
+            f"holographic_max_bits={budget.holographic_max_bits}"
         )
     return ComputeBudgetWitness(
         budget=budget,

--- a/tests/unit/physics/test_cosmological_compute_bound.py
+++ b/tests/unit/physics/test_cosmological_compute_bound.py
@@ -23,7 +23,7 @@ from core.physics.cosmological_compute_bound import (
 
 
 def test_provenance_tier_is_extrapolated() -> None:
-    """Provenance tier must be EXTRAPOLATED — efficiency ε is research, not derivation."""
+    """Provenance tier must be EXTRAPOLATED — useful-compute mapping is research."""
     assert PROVENANCE_TIER == "EXTRAPOLATED"
 
 
@@ -83,41 +83,11 @@ def test_holographic_capacity_hubble_horizon_order_of_magnitude() -> None:
     assert 121.0 <= log10_bits <= 124.0, msg
 
 
-def test_diamond_budget_default_efficiency_is_holographic() -> None:
-    """ε = 1 ⇒ useful_max_bits == holographic_max_bits."""
+def test_diamond_budget_returns_holographic_ceiling() -> None:
+    """diamond_compute_budget reports the Bekenstein-Hawking ceiling."""
     d = CausalDiamond(horizon_area_m2=1.0)
     budget = diamond_compute_budget(d)
-    assert budget.useful_max_bits == budget.holographic_max_bits
-    assert budget.efficiency == 1.0
-
-
-def test_diamond_budget_efficiency_scales_useful_bits() -> None:
-    """ε = 0.5 ⇒ useful_max_bits == holographic_max_bits / 2."""
-    d = CausalDiamond(horizon_area_m2=1.0)
-    budget = diamond_compute_budget(d, efficiency=0.5)
-    assert math.isclose(budget.useful_max_bits, budget.holographic_max_bits * 0.5)
-
-
-def test_diamond_budget_efficiency_zero_or_negative_raises() -> None:
-    """ε ≤ 0 is invalid (would make useful budget non-positive)."""
-    d = CausalDiamond(horizon_area_m2=1.0)
-    for bad in (0.0, -0.1, -1.0):
-        with pytest.raises(ValueError):
-            diamond_compute_budget(d, efficiency=bad)
-
-
-def test_diamond_budget_efficiency_above_one_raises() -> None:
-    """ε > 1 is unphysical — cannot use more bits than the holographic bound."""
-    d = CausalDiamond(horizon_area_m2=1.0)
-    with pytest.raises(ValueError):
-        diamond_compute_budget(d, efficiency=1.5)
-
-
-def test_diamond_budget_efficiency_non_finite_raises() -> None:
-    d = CausalDiamond(horizon_area_m2=1.0)
-    for bad in (float("nan"), float("inf")):
-        with pytest.raises(ValueError):
-            diamond_compute_budget(d, efficiency=bad)
+    assert math.isclose(budget.holographic_max_bits, BH_BIT_COEFF * 1.0, rel_tol=1e-12)
 
 
 def test_compute_claim_within_budget() -> None:


### PR DESCRIPTION
## Summary

Inference flaw #5 — drop ε fudge factor from INV-COSMOLOGICAL-COMPUTE.

`diamond_compute_budget` / `assess_compute_claim` carried an `efficiency: float = 1.0` parameter with `I_useful ≤ ε · A/(4·ℓ_p²·ln 2)`. For ε ≤ 1 this reduces to a tautology under Bekenstein-Hawking. ε had no operational definition or first-principles derivation in this module. Empty as invariant; dropped.

## Changes (atomic across both physics-contract layers)

- `core/physics/cosmological_compute_bound.py`
  - Removed `efficiency` parameter from `diamond_compute_budget()` and `assess_compute_claim()`.
  - Consolidated `ComputeBudget` to a single `holographic_max_bits` field (dropped `efficiency` and `useful_max_bits`).
  - Module docstring rewritten — ships only the holographic ceiling; caller-side discounting is the caller's responsibility.
  - Verified no downstream importers used `efficiency` / `useful_max_bits` outside the test file.
- `tests/unit/physics/test_cosmological_compute_bound.py`
  - Removed 4 efficiency-scaffolding tests (zero/negative, above-one, non-finite, scales-useful-bits).
  - Renamed `test_diamond_budget_default_efficiency_is_holographic` → `test_diamond_budget_returns_holographic_ceiling`.
  - Preserved: closed-form coefficient, area=0 → 0 bits, negative/non-finite raise, Planck-area sanity, solar-mass BH OOM, Hubble-horizon OOM, claim within/at/above budget, Hypothesis property sweep.
- `.claude/physics/INVARIANTS.yaml` `cosmological_compute:`
  - `statement:` — dropped ε; restated as caller-side-discounting note.
  - `falsification:` — dropped "OR a derivation forcing ε > 1" clause.

## Test plan

- [x] `pytest tests/unit/physics/test_cosmological_compute_bound.py` — 14 passed
- [x] `ruff check` — pass
- [x] `ruff format --check` — pass
- [x] `black --check` — pass
- [x] `mypy --strict` — pass
- [x] `.claude/physics/validate_tests.py --self-check` — PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)