### PR TITLE
feat(physics): reasoning_tier per FalsificationSignature — DERIVED vs ANALOGICAL (inference flaw #6)

### DIFF
--- a/.claude/physics/INVARIANTS.yaml
+++ b/.claude/physics/INVARIANTS.yaml
@@ -860,7 +860,7 @@ pncc:
   simulation_falsification:
     id: INV-SIMULATION-FALSIFICATION
     type: statistical
-    statement: "The simulation hypothesis is operationalized as an enumerable registry of physical signatures, each with a published prediction, an explicit detectability threshold, and a current observation status (NOT_OBSERVED / OPEN / RULED_OUT). Probability is not a field; only status against observation."
+    statement: "The simulation hypothesis is operationalized as an enumerable registry of physical signatures, each with a published prediction, an explicit detectability threshold, and a current observation status (NOT_OBSERVED / OPEN / RULED_OUT). Probability is not a field; only status against observation. Each signature carries a reasoning_tier (DERIVED or ANALOGICAL) reflecting whether the link from observable to simulation-hypothesis is published derivation (Beane/Davoudi/Savage 2014, 't Hooft 1993, Susskind 1995) or interpretive analogy. Currently: 4 DERIVED, 2 ANALOGICAL."
     test_type: property_test
     falsification: "Any positive detection at or above a registered signature's threshold without independent corroboration is rejected; a productive ladder must have at least one entry with a published null bound (NOT_OBSERVED) within current instrument reach."
     priority: P1

--- a/core/physics/simulation_falsification.py
+++ b/core/physics/simulation_falsification.py
@@ -39,15 +39,40 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import Final
+from typing import Final, Literal
 
 __all__ = [
     "CANONICAL_SIGNATURES",
     "FalsificationLadder",
     "FalsificationSignature",
     "ObservationStatus",
+    "ReasoningTier",
     "build_canonical_ladder",
 ]
+
+
+ReasoningTier = Literal["DERIVED", "ANALOGICAL"]
+"""Strength of the link between an observable and the simulation hypothesis.
+
+DERIVED:
+    The signature's prediction follows from a specific peer-reviewed
+    derivation that explicitly treats the universe-as-simulation
+    framing (e.g. Beane/Davoudi/Savage 2014 for cubic-lattice imprints
+    on cosmic rays and on photon dispersion; 't Hooft 1993 / Susskind
+    1995 for holography → Planck-scale resolution).
+
+ANALOGICAL:
+    The signature is plausibly *interpretable* as a simulation
+    fingerprint, but no published paper derives the threshold from a
+    concrete substrate model. The link is by analogy and the entry
+    exists to keep the ladder honest about which signatures are
+    genuinely derived versus interpretive.
+
+This field exists to surface, at the contract layer, the asymmetric
+evidential weight of canonical signatures — a uniform contract weight
+across all six entries would silently inflate ANALOGICAL signatures to
+the same status as DERIVED ones.
+"""
 
 
 class ObservationStatus(str, Enum):
@@ -88,6 +113,7 @@ class FalsificationSignature:
     current_observation_status: ObservationStatus
     current_observation_value: float | None
     reference: str
+    reasoning_tier: ReasoningTier
 
 
 @dataclass(frozen=True, slots=True)
@@ -120,6 +146,26 @@ class FalsificationLadder:
             if sig.signature_id == signature_id:
                 return sig
         raise KeyError(f"unknown signature_id: {signature_id!r}")
+
+    def signatures_by_tier(self) -> dict[str, tuple[FalsificationSignature, ...]]:
+        """Bucket the ladder by `reasoning_tier`.
+
+        Returns a dict with exactly two keys, "DERIVED" and "ANALOGICAL",
+        each mapped to the tuple of signatures carrying that tier
+        (preserving registry order). Both keys are always present even
+        if a bucket is empty, so callers can iterate without KeyError.
+        """
+        derived: list[FalsificationSignature] = []
+        analogical: list[FalsificationSignature] = []
+        for sig in self.signatures:
+            if sig.reasoning_tier == "DERIVED":
+                derived.append(sig)
+            else:
+                analogical.append(sig)
+        return {
+            "DERIVED": tuple(derived),
+            "ANALOGICAL": tuple(analogical),
+        }
 
     def hardware_class_ruled_out(self, signature_id: str, observed_value: float) -> bool:
         """Return True iff `observed_value` exceeds the threshold of the
@@ -176,6 +222,7 @@ CANONICAL_SIGNATURES: Final[tuple[FalsificationSignature, ...]] = (
             "'t Hooft 1993 (gr-qc/9310026); "
             "Susskind 1995 (J. Math. Phys. 36, 6377)."
         ),
+        reasoning_tier="ANALOGICAL",
     ),
     FalsificationSignature(
         signature_id="SIM-LATTICE-UHECR",
@@ -195,6 +242,7 @@ CANONICAL_SIGNATURES: Final[tuple[FalsificationSignature, ...]] = (
             "Constraints on the universe as a numerical simulation. "
             "Eur. Phys. J. A 50, 148. arXiv:1210.1847."
         ),
+        reasoning_tier="DERIVED",
     ),
     FalsificationSignature(
         signature_id="SIM-PLANCK-DISCRETIZATION",
@@ -211,6 +259,7 @@ CANONICAL_SIGNATURES: Final[tuple[FalsificationSignature, ...]] = (
         current_observation_status=ObservationStatus.OPEN,
         current_observation_value=None,
         reference=("'t Hooft 1993 (gr-qc/9310026); Susskind 1995 (J. Math. Phys. 36, 6377)."),
+        reasoning_tier="DERIVED",
     ),
     FalsificationSignature(
         signature_id="SIM-LATTICE-DISPERSION",
@@ -226,6 +275,7 @@ CANONICAL_SIGNATURES: Final[tuple[FalsificationSignature, ...]] = (
         current_observation_status=ObservationStatus.NOT_OBSERVED,
         current_observation_value=None,
         reference=("Beane, Davoudi, Savage (2014), §IV. Eur. Phys. J. A 50, 148."),
+        reasoning_tier="DERIVED",
     ),
     FalsificationSignature(
         signature_id="SIM-COMPUTE-COMPLEXITY-WALL",
@@ -244,6 +294,7 @@ CANONICAL_SIGNATURES: Final[tuple[FalsificationSignature, ...]] = (
             "Bekenstein-bound holography ('t Hooft 1993; Susskind 1995) "
             "applied to quantum-information capacity."
         ),
+        reasoning_tier="ANALOGICAL",
     ),
     FalsificationSignature(
         signature_id="SIM-CMB-MULTIPOLE-CUTOFF",
@@ -259,6 +310,7 @@ CANONICAL_SIGNATURES: Final[tuple[FalsificationSignature, ...]] = (
         current_observation_status=ObservationStatus.NOT_OBSERVED,
         current_observation_value=None,
         reference=("Beane, Davoudi, Savage (2014); context for cosmological observables."),
+        reasoning_tier="DERIVED",
     ),
 )
 

--- a/tests/unit/physics/test_simulation_falsification.py
+++ b/tests/unit/physics/test_simulation_falsification.py
@@ -91,6 +91,7 @@ def test_status_summary_returns_zero_for_unused_buckets() -> None:
                 current_observation_status=ObservationStatus.NOT_OBSERVED,
                 current_observation_value=None,
                 reference="ref",
+                reasoning_tier="DERIVED",
             ),
         )
     )
@@ -193,3 +194,50 @@ def test_property_rule_out_iff_strictly_above_threshold(observed: float) -> None
     expected = observed > sig.detectability_threshold
     actual = ladder.hardware_class_ruled_out("SIM-HOLOGRAPHIC-SATURATION", observed)
     assert actual is expected
+
+
+# ---------------------------------------------------------------------------
+# reasoning_tier (inference flaw #6 — DERIVED vs ANALOGICAL gap)
+# ---------------------------------------------------------------------------
+
+
+_VALID_TIERS: frozenset[str] = frozenset({"DERIVED", "ANALOGICAL"})
+
+
+def test_each_canonical_signature_has_valid_reasoning_tier() -> None:
+    """Every canonical signature must carry a valid reasoning_tier label."""
+    for sig in CANONICAL_SIGNATURES:
+        msg = f"{sig.signature_id} has invalid reasoning_tier {sig.reasoning_tier!r}"
+        assert sig.reasoning_tier in _VALID_TIERS, msg
+
+
+def test_canonical_distribution_is_4_derived_2_analogical() -> None:
+    """Pre-registered tier distribution: 4 DERIVED + 2 ANALOGICAL.
+
+    Changing this count is a contract change and must be accompanied by a
+    documented justification in INVARIANTS.yaml under
+    `simulation_falsification.statement`.
+    """
+    derived = [s for s in CANONICAL_SIGNATURES if s.reasoning_tier == "DERIVED"]
+    analogical = [s for s in CANONICAL_SIGNATURES if s.reasoning_tier == "ANALOGICAL"]
+    assert len(derived) == 4, [s.signature_id for s in derived]
+    assert len(analogical) == 2, [s.signature_id for s in analogical]
+    assert {s.signature_id for s in analogical} == {
+        "SIM-HOLOGRAPHIC-SATURATION",
+        "SIM-COMPUTE-COMPLEXITY-WALL",
+    }
+
+
+def test_signatures_by_tier_buckets_correctly() -> None:
+    """signatures_by_tier exposes both buckets with correct counts and content."""
+    ladder = build_canonical_ladder()
+    buckets = ladder.signatures_by_tier()
+    assert set(buckets.keys()) == _VALID_TIERS
+    assert len(buckets["DERIVED"]) == 4
+    assert len(buckets["ANALOGICAL"]) == 2
+    # Round-trip: every signature appears in exactly one bucket.
+    union_ids = {s.signature_id for s in buckets["DERIVED"]} | {
+        s.signature_id for s in buckets["ANALOGICAL"]
+    }
+    assert union_ids == {s.signature_id for s in CANONICAL_SIGNATURES}
+    assert len(union_ids) == len(CANONICAL_SIGNATURES)


### PR DESCRIPTION
## Inference flaw #6 — DERIVED vs ANALOGICAL gap

### Problem
PR #407 shipped six canonical simulation-hypothesis signatures with uniform contract weight. Self-audit surfaced an asymmetry: some signatures derive from a concrete peer-reviewed lattice / holography argument; others are interpretive analogies. Treating them as equally weighted silently inflates ANALOGICAL signatures to the same evidential status as DERIVED ones.

### Fix
Add a `reasoning_tier: Literal["DERIVED", "ANALOGICAL"]` field to `FalsificationSignature` and tag every canonical entry.

| Signature | Tier | Justification |
|---|---|---|
| SIM-LATTICE-UHECR | DERIVED | Beane/Davoudi/Savage 2014 §III |
| SIM-LATTICE-DISPERSION | DERIVED | Beane 2014 §IV |
| SIM-CMB-MULTIPOLE-CUTOFF | DERIVED | Beane 2014 cosmological observable |
| SIM-PLANCK-DISCRETIZATION | DERIVED | 't Hooft 1993 / Susskind 1995 holography |
| SIM-HOLOGRAPHIC-SATURATION | ANALOGICAL | BH saturation → "substrate resolution" is interpretation, not derivation |
| SIM-COMPUTE-COMPLEXITY-WALL | ANALOGICAL | extrapolation; no hardware-class derivation |

Distribution: **4 DERIVED + 2 ANALOGICAL**.

### Surface
- `ReasoningTier = Literal["DERIVED", "ANALOGICAL"]` exported in `__all__`.
- `FalsificationLadder.signatures_by_tier() -> dict[str, tuple[FalsificationSignature, ...]]` returns 2 buckets preserving registry order.

### Both physics layers updated atomically
- `core/physics/simulation_falsification.py` — runtime contract.
- `.claude/physics/INVARIANTS.yaml` — assistant-facing spec; `simulation_falsification.statement` extended with the reasoning_tier clause and the 4-2 distribution.

### Tests
- `test_each_canonical_signature_has_valid_reasoning_tier` — tier ∈ {DERIVED, ANALOGICAL}.
- `test_canonical_distribution_is_4_derived_2_analogical` — exact counts + identifies the two ANALOGICAL entries.
- `test_signatures_by_tier_buckets_correctly` — both keys present, counts match, round-trip equals registry.

20/20 unit tests pass (was 17, +3).

### Quality gates (local)
- pytest 20/20 passed
- ruff check + ruff format --check
- black --check
- mypy --strict (2 files clean)
- `.claude/physics/validate_tests.py --self-check` PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)