### PR TITLE
chore(physics): validator check 8 — related: cross-ref integrity (inference flaw #7)

### DIFF
--- a/.claude/physics/INVARIANTS.yaml
+++ b/.claude/physics/INVARIANTS.yaml
@@ -5,6 +5,33 @@
 # Format: each invariant has type, condition, falsification criteria.
 
 # ═══════════════════════════════════════════════════
+# YAROSLAV'S GRADIENT ONTOLOGY — ROOT AXIOM (Layer 0)
+# ═══════════════════════════════════════════════════
+# CLAUDE.md §0: a system is a sustained potential difference; a static
+# gradient is a capacitor, a living gradient is a process. Intelligence
+# requires the second. Maintenance hierarchy Layers 0–3 = 40 percent;
+# Layer 4 (processing) computes noise if any of 0–3 fails. Registered
+# here so that `related:` cross-references from INV-CRITICALITY and
+# INV-BEKENSTEIN-COGNITIVE resolve under validator check 8.
+
+gradient_ontology:
+  living_gradient:
+    id: INV-YV1
+    type: universal
+    statement: "ΔV > 0 ∧ dΔV/dt ≠ 0 — gradient must be positive AND dynamic. A static gradient is a capacitor; a living gradient is a process. Intelligence requires the second."
+    test_type: property_test
+    falsification: "Any operating window in which ΔV ≤ 0 OR dΔV/dt ≡ 0 over a non-empty interval while the system claims live cognitive computation."
+    priority: P0
+    provenance: ANCHORED
+    source: core/neuro/gradient_vital_signs.py
+    tests: tests/integration/test_neurostack_integration.py
+    references:
+      - "Hodgkin, A. L. & Huxley, A. F. (1952). A quantitative description of membrane current and its application to conduction and excitation in nerve. J. Physiol. 117, 500."
+      - "Schrödinger, E. (1944). What Is Life? — negentropy as the substrate of organized matter."
+      - "Prigogine, I. (1977). Self-Organization in Nonequilibrium Systems. Wiley."
+    related: [INV-CRITICALITY, INV-BEKENSTEIN-COGNITIVE]
+
+# ═══════════════════════════════════════════════════
 # KURAMOTO SYNCHRONIZATION
 # ═══════════════════════════════════════════════════
 

--- a/.claude/physics/validate_tests.py
+++ b/.claude/physics/validate_tests.py
@@ -35,7 +35,7 @@ from typing import Any
 SCRIPT_DIR = Path(__file__).parent
 INVARIANTS_PATH = SCRIPT_DIR / "INVARIANTS.yaml"
 
-INV_PATTERN = re.compile(r"INV-[A-Z0-9]+")
+INV_PATTERN = re.compile(r"INV-[A-Z0-9][A-Z0-9-]*")
 
 PHYSICS_KEYWORDS = {
     "physics",
@@ -78,7 +78,7 @@ def load_invariants() -> dict[str, dict[str, Any]]:
     current_block: dict[str, str] = {}
 
     for line in text.splitlines():
-        id_match = re.match(r"\s+id:\s+(INV-[A-Z0-9]+)", line)
+        id_match = re.match(r"\s+id:\s+(INV-[A-Z0-9][A-Z0-9-]*)", line)
         if id_match:
             if current_id and current_block:
                 registry[current_id] = current_block
@@ -958,7 +958,33 @@ def _self_check() -> None:
     else:
         print("7. Path integrity OK: every invariant's source/tests resolves on disk")
 
-    # 8. Summary
+    # 8. Cross-reference integrity for `related:` lists. Each invariant
+    #    may declare related: [INV-X, INV-Y, ...]. The parser captures
+    #    the value as a single string ("[INV-X, INV-Y]"). Extract the
+    #    INV-IDs and confirm each is present in the registry. Catches
+    #    typos, deletions, and stale cross-references — same class of
+    #    issue check 7 catches for source/tests paths.
+    broken_refs: list[str] = []
+    for inv_id, data in reg.items():
+        related_raw = data.get("related", "")
+        if not related_raw:
+            continue
+        inner = related_raw.strip().lstrip("[").rstrip("]")
+        if not inner:
+            continue
+        referenced_ids = [
+            token.strip() for token in inner.split(",") if token.strip().startswith("INV-")
+        ]
+        for ref in referenced_ids:
+            if ref not in reg:
+                broken_refs.append(f"{inv_id}.related → {ref}")
+    if broken_refs:
+        print(f"8. FAIL: {len(broken_refs)} broken `related:` cross-references: {broken_refs}")
+        errors.append(f"broken_related_refs: {broken_refs}")
+    else:
+        print("8. Cross-ref integrity OK: every `related:` ID resolves to a registered invariant")
+
+    # 9. Summary
     ok = not errors
     print(f"\n{'✅' if ok else '❌'} Self-check {'PASSED' if ok else 'FAILED'}")
     if not ok:


### PR DESCRIPTION
## Summary
- Adds check 8 to `.claude/physics/validate_tests.py::_self_check`: walks every invariant's `related:` list and confirms each `INV-*` ID resolves to a registered entry. Same class of guard as check 7 (source/tests path integrity), but for cross-references.
- Tightens `INV_PATTERN` from `INV-[A-Z0-9]+` to `INV-[A-Z0-9][A-Z0-9-]*` at the two call sites that previously truncated multi-segment IDs at the first `-` (e.g. `INV-LANDAUER-PROXY` → `INV-LANDAUER`). Registry now loads 87 invariants vs 81 under the silent-overwrite artefact; checks 2/3/4/7 also benefit.
- Registers `INV-YV1` (Yaroslav's Gradient Ontology — root axiom of CLAUDE.md §0) which was already declared in CLAUDE.md and referenced by two `related:` lists but missing from the YAML registry. Source `core/neuro/gradient_vital_signs.py`, tests `tests/integration/test_neurostack_integration.py`, P0, ANCHORED.

## Why three changes in one PR
Without (1) the regex fix, the registry held truncated keys and check 8 fired 18 false positives. Without (2) registering `INV-YV1`, check 8 fired 2 true positives that pre-existed on `main`. Each change is a prerequisite for check 8 to operate as specified — they are not independent. All three are physics-contract guardian work.

## Injection test (verifies check 8 fires)
```
cp .claude/physics/INVARIANTS.yaml /tmp/yaml_backup
python -c "from pathlib import Path; p=Path('.claude/physics/INVARIANTS.yaml'); p.write_text(p.read_text().replace('    related: [INV-LANDAUER-PROXY, INV-CRITICALITY, INV-BEKENSTEIN-COGNITIVE]', '    related: [INV-LANDAUER-PROXY, INV-CRITICALITY, INV-BEKENSTEIN-COGNITIVE, INV-DOES-NOT-EXIST]', 1))"
python .claude/physics/validate_tests.py --self-check ; echo $?  # → 1 (broken ref)
cp /tmp/yaml_backup .claude/physics/INVARIANTS.yaml
python .claude/physics/validate_tests.py --self-check ; echo $?  # → 0 (clean)
```
Result: `injected_exit=1`, `clean_exit=0`. Check 8 demonstrably fires on broken refs and is silent on clean state.

## Test plan
- [x] `python .claude/physics/validate_tests.py --self-check` exits 0; check 8 prints `Cross-ref integrity OK: every related: ID resolves to a registered invariant`.
- [x] `python -m ruff check .claude/physics/validate_tests.py`
- [x] `python -m ruff format --check .claude/physics/validate_tests.py`
- [x] `python -m black --check .claude/physics/validate_tests.py`
- [x] `python -m mypy --strict .claude/physics/validate_tests.py`
- [x] Negative injection: clean → exit 0, broken → exit 1
- [x] Rebased on origin/main; conflicts resolved auto by git

🤖 Generated with [Claude Code](https://claude.com/claude-code)