### PR TITLE
feat(physics): explicit gate policy versioning — ANCHORED_ONLY (Task 3)

### DIFF
--- a/core/physics/anchored_substrate_gate.py
+++ b/core/physics/anchored_substrate_gate.py
@@ -63,13 +63,26 @@ from core.physics.arrow_of_time import (
 from core.physics.thermodynamic_budget import bekenstein_cognitive_ceiling
 
 __all__ = [
+    "DEFAULT_GATE_POLICY",
     "AnchoredSubstrateGateWitness",
+    "GatePolicy",
     "PROVENANCE_TIER",
     "SubstrateGateInputs",
     "assess_anchored_substrate_gate",
 ]
 
 PROVENANCE_TIER: Literal["ANCHORED", "EXTRAPOLATED", "SPECULATIVE"] = "ANCHORED"
+
+# Gate composition policy. ANCHORED_ONLY is the only currently-implemented
+# policy: the composite verdict considers ANCHORED-tier axes (Bekenstein
+# + Arrow) only. EXTRAPOLATED and SPECULATIVE axes (observer-bandwidth,
+# cosmological-compute, jacobson) may produce concerns independently but
+# DO NOT silently veto the composite under this policy. Future policies
+# (e.g. ALL_TIERS, ANCHORED_PLUS_EXTRAPOLATED) require an explicit API
+# extension — adding a new Literal value AND updating consumers — never
+# a silent behavior change.
+GatePolicy = Literal["ANCHORED_ONLY"]
+DEFAULT_GATE_POLICY: GatePolicy = "ANCHORED_ONLY"
 
 
 @dataclass(frozen=True, slots=True)
@@ -114,6 +127,7 @@ class AnchoredSubstrateGateWitness:
     is_thermodynamically_admissible: bool
     failure_axes: tuple[str, ...]
     reason: str | None
+    policy_used: GatePolicy = "ANCHORED_ONLY"
 
 
 def _check_finite(value: float, name: str) -> None:
@@ -131,6 +145,8 @@ def _check_non_negative(value: float, name: str) -> None:
 
 def assess_anchored_substrate_gate(
     inputs: SubstrateGateInputs,
+    *,
+    policy: GatePolicy = DEFAULT_GATE_POLICY,
 ) -> AnchoredSubstrateGateWitness:
     """Compose INV-BEKENSTEIN-COGNITIVE and INV-ARROW-OF-TIME.
 
@@ -138,7 +154,21 @@ def assess_anchored_substrate_gate(
     violations (those are the gate's job to report); it raises only on
     malformed inputs (NaN/Inf, negative information count) per
     INV-HPC2 fail-closed.
+
+    `policy` controls which tier set the composite verdict consumes.
+    Currently only "ANCHORED_ONLY" is implemented — the verdict
+    considers Bekenstein + Arrow only. EXTRAPOLATED / SPECULATIVE
+    axes are NOT silently consulted under this policy. Future policy
+    values require an explicit Literal extension; passing an unknown
+    string fails fast (Literal-typed argument rejected by static
+    type checkers AND runtime via the equality check below).
     """
+    if policy != "ANCHORED_ONLY":
+        raise ValueError(
+            f"Unsupported gate policy {policy!r}; only 'ANCHORED_ONLY' is "
+            "implemented. Adding a new policy requires extending GatePolicy "
+            "Literal AND updating consumers — never a silent behavior change."
+        )
     _check_finite(inputs.observed_information_bits, "observed_information_bits")
     _check_non_negative(inputs.observed_information_bits, "observed_information_bits")
 
@@ -187,4 +217,5 @@ def assess_anchored_substrate_gate(
         is_thermodynamically_admissible=admissible,
         failure_axes=failure_tuple,
         reason=reason,
+        policy_used=policy,
     )

--- a/tests/unit/physics/test_anchored_substrate_gate.py
+++ b/tests/unit/physics/test_anchored_substrate_gate.py
@@ -186,3 +186,70 @@ def test_zero_information_with_zero_entropy_is_admissible() -> None:
     w = assess_anchored_substrate_gate(_inputs(observed_information_bits=0.0))
     assert w.is_thermodynamically_admissible is True
     assert math.isfinite(w.bekenstein_ceiling_bits)
+
+
+# ---------------------------------------------------------------------------
+# Gate policy versioning (Task 3)
+# ---------------------------------------------------------------------------
+
+
+def test_default_policy_is_anchored_only() -> None:
+    """Default policy is ANCHORED_ONLY — verdict considers Bekenstein +
+    Arrow only, never EXTRAPOLATED/SPECULATIVE axes silently."""
+    from core.physics.anchored_substrate_gate import DEFAULT_GATE_POLICY
+
+    assert DEFAULT_GATE_POLICY == "ANCHORED_ONLY"
+
+
+def test_witness_exposes_policy_used_field() -> None:
+    """Composite witness must carry the policy under which it was
+    computed, so downstream consumers can audit the verdict's tier
+    contract without inferring it."""
+    w = assess_anchored_substrate_gate(_inputs(observed_information_bits=0.0))
+    assert w.policy_used == "ANCHORED_ONLY"
+
+
+def test_explicit_anchored_only_matches_default() -> None:
+    """Passing policy='ANCHORED_ONLY' explicitly produces an identical
+    verdict to relying on the default."""
+    inputs = _inputs(observed_information_bits=2.5e15, system_entropy_change_bits=1.0)
+    default = assess_anchored_substrate_gate(inputs)
+    explicit = assess_anchored_substrate_gate(inputs, policy="ANCHORED_ONLY")
+    assert default.is_thermodynamically_admissible == explicit.is_thermodynamically_admissible
+    assert default.failure_axes == explicit.failure_axes
+    assert default.policy_used == explicit.policy_used == "ANCHORED_ONLY"
+
+
+def test_unknown_policy_raises() -> None:
+    """Unsupported policy values fail fast — no silent fall-through to
+    default. Static type-checker will reject Literal-mismatched strings;
+    runtime raises ValueError as a defense-in-depth guard."""
+    inputs = _inputs(observed_information_bits=0.0)
+    with pytest.raises(ValueError):
+        assess_anchored_substrate_gate(inputs, policy="ALL_TIERS")  # type: ignore[arg-type]
+    with pytest.raises(ValueError):
+        assess_anchored_substrate_gate(inputs, policy="EXTRAPOLATED_PLUS")  # type: ignore[arg-type]
+
+
+def test_policy_used_serializes_as_string_in_dataclass_repr() -> None:
+    """The policy_used field is a plain string Literal value — appears in
+    repr, can be persisted/serialized without custom encoding."""
+    w = assess_anchored_substrate_gate(_inputs(observed_information_bits=0.0))
+    assert "policy_used='ANCHORED_ONLY'" in repr(w)
+
+
+def test_anchored_only_policy_does_not_consult_extrapolated_axes() -> None:
+    """Under ANCHORED_ONLY the gate's verdict depends ONLY on Bekenstein +
+    Arrow inputs. Inputs construct does not even REFERENCE bandwidth /
+    cosmological / Jacobson fields — the gate cannot consume them by
+    construction. This test pins the contract: SubstrateGateInputs
+    fields are the sum total of what the gate sees."""
+    inputs = _inputs(observed_information_bits=0.0)
+    fields = {f.name for f in inputs.__dataclass_fields__.values()}
+    # Only ANCHORED-axis inputs are accepted.
+    assert fields == {
+        "radius_m",
+        "energy_J",
+        "observed_information_bits",
+        "entropy_ledger",
+    }


### PR DESCRIPTION
Task 3 of 7-task protocol. Makes the substrate-gate composition policy explicit and machine-testable. No behavior change.

Public API additions:
- `GatePolicy = Literal["ANCHORED_ONLY"]`
- `DEFAULT_GATE_POLICY: GatePolicy = "ANCHORED_ONLY"`
- `AnchoredSubstrateGateWitness.policy_used: GatePolicy`
- `assess_anchored_substrate_gate(inputs, *, policy=DEFAULT_GATE_POLICY)`

Future policies require Literal extension + consumer update — no silent fall-through. Unknown policy rejected by static type-checker AND runtime ValueError (defense-in-depth).

| Gate | Result |
|---|---|
| pytest gate + chain + boundary | 35/35 PASS |
| ruff/format/black/mypy --strict | clean |
| validate_tests --self-check | 8/8 PASS |