### PR TITLE
feat(physics): simulation_falsification point-eval bridge — SignatureEvaluation (Task 5)

### DIFF
--- a/core/physics/simulation_falsification.py
+++ b/core/physics/simulation_falsification.py
@@ -47,7 +47,9 @@ __all__ = [
     "FalsificationSignature",
     "ObservationStatus",
     "ReasoningTier",
+    "SignatureEvaluation",
     "build_canonical_ladder",
+    "evaluate_signature_observation",
 ]
 
 
@@ -322,3 +324,87 @@ def build_canonical_ladder() -> FalsificationLadder:
     that share the same underlying CANONICAL_SIGNATURES tuple.
     """
     return FalsificationLadder(signatures=CANONICAL_SIGNATURES)
+
+
+@dataclass(frozen=True, slots=True)
+class SignatureEvaluation:
+    """Result of evaluating one signature against one observation.
+
+    The evaluation is a *point* result on a single (signature, observed)
+    pair. It NEVER infers global probability of simulation. It NEVER
+    aggregates across signatures. It NEVER produces a substrate-state
+    verdict.
+
+    Fields preserve the per-signature contract for downstream consumers
+    (loggers, evidence ledgers, audits). The reasoning_tier flows
+    through unchanged from the source signature so a consumer can
+    weight DERIVED vs ANALOGICAL evidence honestly.
+    """
+
+    signature_id: str
+    reasoning_tier: ReasoningTier
+    observation_status: ObservationStatus
+    detectability_threshold: float
+    detectability_units: str
+    observed_value: float
+    hardware_class_ruled_out: bool
+    reason: str | None
+
+
+def evaluate_signature_observation(
+    signature_id: str,
+    observed_value: float,
+    *,
+    ladder: FalsificationLadder | None = None,
+) -> SignatureEvaluation:
+    """Point-evaluate one observation against one named signature.
+
+    Returns a structured SignatureEvaluation carrying the per-signature
+    threshold, the reasoning_tier (DERIVED vs ANALOGICAL), and a
+    boolean for whether the observation rules out the corresponding
+    hardware class. Does NOT infer simulation probability. Does NOT
+    aggregate across signatures.
+
+    Args:
+        signature_id: e.g. "SIM-LATTICE-UHECR". Must exist in the
+            ladder; unknown ids raise KeyError.
+        observed_value: numeric measurement to compare against the
+            signature's detectability_threshold. Must be finite;
+            non-finite values raise ValueError.
+        ladder: optional ladder to evaluate against; defaults to the
+            canonical ladder. The ladder argument exists so future
+            non-canonical ladders can be evaluated through the same
+            point-eval surface without monkey-patching the canonical.
+
+    Raises:
+        KeyError: signature_id not in ladder.
+        ValueError: observed_value is non-finite.
+    """
+    if not _is_finite(observed_value):
+        raise ValueError(
+            f"observed_value must be finite, got {observed_value!r}; "
+            "point-eval refuses to produce a verdict on unphysical input."
+        )
+    target_ladder = ladder if ladder is not None else build_canonical_ladder()
+    signature = target_ladder.signature_by_id(signature_id)
+    ruled_out = observed_value > signature.detectability_threshold
+    if ruled_out:
+        reason: str | None = (
+            f"observation {observed_value} {signature.detectability_units} "
+            f"exceeds detectability threshold "
+            f"{signature.detectability_threshold} {signature.detectability_units} "
+            f"for {signature_id}; the simulation hardware class predicting "
+            "signal below threshold is ruled out by this observation."
+        )
+    else:
+        reason = None
+    return SignatureEvaluation(
+        signature_id=signature.signature_id,
+        reasoning_tier=signature.reasoning_tier,
+        observation_status=signature.current_observation_status,
+        detectability_threshold=signature.detectability_threshold,
+        detectability_units=signature.detectability_units,
+        observed_value=observed_value,
+        hardware_class_ruled_out=ruled_out,
+        reason=reason,
+    )

--- a/tests/unit/physics/test_simulation_falsification.py
+++ b/tests/unit/physics/test_simulation_falsification.py
@@ -23,7 +23,9 @@ from core.physics.simulation_falsification import (
     FalsificationLadder,
     FalsificationSignature,
     ObservationStatus,
+    SignatureEvaluation,
     build_canonical_ladder,
+    evaluate_signature_observation,
 )
 
 # ---------------------------------------------------------------------------
@@ -241,3 +243,137 @@ def test_signatures_by_tier_buckets_correctly() -> None:
     }
     assert union_ids == {s.signature_id for s in CANONICAL_SIGNATURES}
     assert len(union_ids) == len(CANONICAL_SIGNATURES)
+
+
+# ---------------------------------------------------------------------------
+# Point-eval bridge (Task 5) — evaluate_signature_observation
+# ---------------------------------------------------------------------------
+
+
+def test_point_eval_below_threshold_does_not_rule_out() -> None:
+    """observed < threshold ⇒ hardware_class_ruled_out is False; no reason."""
+    sig = next(s for s in CANONICAL_SIGNATURES if s.signature_id == "SIM-HOLOGRAPHIC-SATURATION")
+    eval_result = evaluate_signature_observation(
+        "SIM-HOLOGRAPHIC-SATURATION",
+        sig.detectability_threshold * 0.5,
+    )
+    assert isinstance(eval_result, SignatureEvaluation)
+    assert eval_result.signature_id == "SIM-HOLOGRAPHIC-SATURATION"
+    assert eval_result.hardware_class_ruled_out is False
+    assert eval_result.reason is None
+
+
+def test_point_eval_at_exact_threshold_does_not_rule_out() -> None:
+    """Boundary case: observed == threshold. Per ladder contract
+    (hardware_class_ruled_out uses strict >), equality does NOT rule out."""
+    sig = next(s for s in CANONICAL_SIGNATURES if s.signature_id == "SIM-HOLOGRAPHIC-SATURATION")
+    eval_result = evaluate_signature_observation(
+        "SIM-HOLOGRAPHIC-SATURATION",
+        sig.detectability_threshold,
+    )
+    assert eval_result.hardware_class_ruled_out is False
+    assert eval_result.reason is None
+
+
+def test_point_eval_above_threshold_rules_out_with_reason() -> None:
+    """observed > threshold ⇒ ruled_out True with quantitative reason."""
+    sig = next(s for s in CANONICAL_SIGNATURES if s.signature_id == "SIM-HOLOGRAPHIC-SATURATION")
+    eval_result = evaluate_signature_observation(
+        "SIM-HOLOGRAPHIC-SATURATION",
+        sig.detectability_threshold * 2.0,
+    )
+    assert eval_result.hardware_class_ruled_out is True
+    assert eval_result.reason is not None
+    assert "exceeds detectability threshold" in eval_result.reason
+    assert "SIM-HOLOGRAPHIC-SATURATION" in eval_result.reason
+
+
+def test_point_eval_non_finite_observed_value_raises() -> None:
+    """NaN / ±Inf must be rejected before producing any verdict."""
+    for bad in (float("nan"), float("inf"), -float("inf")):
+        with pytest.raises(ValueError):
+            evaluate_signature_observation("SIM-HOLOGRAPHIC-SATURATION", bad)
+
+
+def test_point_eval_unknown_signature_id_raises() -> None:
+    """KeyError, not silent SignatureEvaluation, on unknown signature."""
+    with pytest.raises(KeyError):
+        evaluate_signature_observation("SIM-DOES-NOT-EXIST", 1.0)
+
+
+def test_point_eval_preserves_derived_reasoning_tier() -> None:
+    """DERIVED signatures evaluate with reasoning_tier='DERIVED' in result."""
+    eval_result = evaluate_signature_observation(
+        "SIM-LATTICE-UHECR",
+        observed_value=1.0,
+    )
+    assert eval_result.reasoning_tier == "DERIVED"
+
+
+def test_point_eval_preserves_analogical_reasoning_tier() -> None:
+    """ANALOGICAL signatures evaluate with reasoning_tier='ANALOGICAL'."""
+    eval_result = evaluate_signature_observation(
+        "SIM-HOLOGRAPHIC-SATURATION",
+        observed_value=0.0,
+    )
+    assert eval_result.reasoning_tier == "ANALOGICAL"
+
+
+def test_point_eval_preserves_observation_status() -> None:
+    """Result carries the registry's current_observation_status verbatim;
+    point evaluation does NOT mutate the ladder."""
+    eval_result = evaluate_signature_observation("SIM-LATTICE-UHECR", 0.0)
+    sig = next(s for s in CANONICAL_SIGNATURES if s.signature_id == "SIM-LATTICE-UHECR")
+    assert eval_result.observation_status == sig.current_observation_status
+
+
+def test_point_eval_does_not_aggregate_across_signatures() -> None:
+    """Sanity: the function returns ONE SignatureEvaluation, never a
+    composite. There is no API path that turns multiple point evals
+    into a global simulation verdict."""
+    # Type assertion + pinning the return shape.
+    eval_result = evaluate_signature_observation("SIM-LATTICE-UHECR", 0.0)
+    assert isinstance(eval_result, SignatureEvaluation)
+    fields = {f.name for f in SignatureEvaluation.__dataclass_fields__.values()}
+    assert fields == {
+        "signature_id",
+        "reasoning_tier",
+        "observation_status",
+        "detectability_threshold",
+        "detectability_units",
+        "observed_value",
+        "hardware_class_ruled_out",
+        "reason",
+    }
+
+
+def test_point_eval_registry_order_unchanged_after_evaluation() -> None:
+    """Registry order is invariant; point evaluation is read-only."""
+    before = tuple(s.signature_id for s in CANONICAL_SIGNATURES)
+    _ = evaluate_signature_observation("SIM-LATTICE-UHECR", 0.0)
+    _ = evaluate_signature_observation("SIM-HOLOGRAPHIC-SATURATION", 0.0)
+    after = tuple(s.signature_id for s in CANONICAL_SIGNATURES)
+    assert before == after
+
+
+def test_point_eval_signature_evaluation_is_frozen() -> None:
+    """SignatureEvaluation is immutable post-construction."""
+    eval_result = evaluate_signature_observation("SIM-LATTICE-UHECR", 0.0)
+    with pytest.raises(AttributeError):
+        eval_result.hardware_class_ruled_out = True  # type: ignore[misc]
+
+
+def test_point_eval_accepts_custom_ladder() -> None:
+    """Optional `ladder` argument allows evaluating against a non-canonical
+    ladder without monkey-patching CANONICAL_SIGNATURES."""
+    custom = FalsificationLadder(
+        signatures=(CANONICAL_SIGNATURES[0],),  # subset
+    )
+    sig = CANONICAL_SIGNATURES[0]
+    eval_result = evaluate_signature_observation(
+        sig.signature_id,
+        observed_value=sig.detectability_threshold + 0.1,
+        ladder=custom,
+    )
+    assert eval_result.signature_id == sig.signature_id
+    assert eval_result.hardware_class_ruled_out is True


### PR DESCRIPTION
Task 5 of 7. Controlled runtime point-evaluation for simulation signatures. Never aggregates, never infers global simulation verdict.

Public API:
- `SignatureEvaluation` (frozen): signature_id, reasoning_tier, observation_status, threshold, observed_value, hardware_class_ruled_out, reason
- `evaluate_signature_observation(signature_id, observed_value, *, ladder=None)` → SignatureEvaluation
- Optional `ladder` argument supports non-canonical ladders without monkey-patching

Threshold comparison uses strict > (consistent with existing `hardware_class_ruled_out` method). Non-finite → ValueError. Unknown signature_id → KeyError. Tier (DERIVED/ANALOGICAL) preserved.

| Gate | Result |
|---|---|
| pytest | 32/32 PASS (12 new + 20 existing) |
| ruff/format/black/mypy --strict | clean |