### PR TITLE
ci(dependabot): hold eslint on 9.x until plugin ecosystem ships 10-compat

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -69,6 +69,12 @@ updates:
       - javascript
       - frontend
     open-pull-requests-limit: 10
+    ignore:
+      # eslint 10.x breaks transitive eslint-plugin-react@7.37.x bundled by
+      # eslint-config-next (Linter#getFilename removal). Hold on 9.x until the
+      # plugin ecosystem catches up, then drop this ignore.
+      - dependency-name: "eslint"
+        update-types: ["version-update:semver-major"]
     groups:
       # Development tools
       frontend-dev-tools:
@@ -94,6 +100,11 @@ updates:
       - javascript
       - ui
     open-pull-requests-limit: 10
+    ignore:
+      # See /apps/web rationale — eslint 10.x is incompatible with bundled
+      # eslint-plugin-react until upstream releases a compat version.
+      - dependency-name: "eslint"
+        update-types: ["version-update:semver-major"]
     groups:
       # Development tools
       ui-dev-tools:


### PR DESCRIPTION
## Summary
- eslint 10.x removes `Linter#getFilename`, which `eslint-plugin-react@7.37.x` (bundled transitively by `eslint-config-next`) still uses
- PR #390 hit this as a hard `frontend-gate` failure (`TypeError: Error while loading rule 'react/display-name': contextOrFilename.getFilename is not a function`)
- Adds `ignore` rule for eslint major bumps in `/apps/web` and `/ui/dashboard` so dependabot keeps us on 9.x; remove the rule once `eslint-plugin-react` ships a 10-compat release
- After merge, dependabot will recreate the frontend-dev-tools group PR without the eslint major (prettier/typescript/eslint-config-next bumps remain)

## Why not just merge #390?
Merging #390 would land a broken lint pipeline on `main` — zero tech debt contract is non-negotiable.

## Test plan
- [x] `git diff` only touches `.github/dependabot.yml` (11 insertions, 0 deletions)
- [x] No production code or contracts impacted
- [ ] CI green on this PR (no functional changes; only dependabot config)
- [ ] After merge: dependabot opens replacement frontend-dev-tools PR without eslint major