### PR TITLE
feat(research): physics-2026 evidence rail (PR-1, validators only)

### DIFF
--- a/.claude/research/PHYSICS_2026_TRANSLATION.yaml
+++ b/.claude/research/PHYSICS_2026_TRANSLATION.yaml
@@ -1,0 +1,346 @@
+# GeoSync Physics-2026 Translation Matrix
+#
+# This file maps each Physics-2026 source pattern to a GeoSync engineering
+# analog. It is NOT a metaphor table. Every entry is gated by:
+#
+#   - explicit source_ids (must reference docs/research/physics_2026/source_pack.yaml)
+#   - claim_tier:  FACT / ENGINEERING_ANALOG / HYPOTHESIS / REJECTED
+#   - measurable_inputs that the runtime can actually produce
+#   - output_witness with a status / reason / evidence shape
+#   - null_model that establishes a baseline behaviour
+#   - falsifier — the concrete observation that would unmake the claim
+#   - deterministic_tests required at module-implementation time
+#   - mutation_candidate — the line / function the mutation harness would patch
+#
+# implementation_status separates intent from delivery:
+#   PROPOSED      — pattern accepted; module not yet implemented (PR-1 ships
+#                   only the rail; module PRs come later).
+#   IMPLEMENTED   — module shipped; tests pass; entry has a claim ledger row.
+#   REJECTED      — pattern fails one of the gating conditions; rejection_reason
+#                   must be set; the entry is kept as a negative reference.
+#
+# Source-pattern boundaries:
+#
+#   Each pattern targets ONE methodological move (catalog, structured-absence
+#   inference, dynamic-null modelling, global-witness, motional/trajectory
+#   correlation, composite-binding). Patterns do NOT compound. If a runtime
+#   need spans two patterns, it gets two ledger entries and two modules.
+#
+# Forbidden in any pattern body:
+#
+#   "physical equivalence", "quantum market", "universal", "predicts returns"
+#
+# Validator: tools/research/validate_physics_2026_translation.py
+# Tests:     tests/research/test_validate_physics_2026_translation.py
+
+schema_version: 1
+
+patterns:
+
+  # =========================================================================
+  - pattern_id: P1_POPULATION_EVENT_CATALOG
+    source_ids: [S1_GWTC4]
+    source_fact_summary: |
+      GWTC-4 adds 128 compact-binary candidates from O4a; events require
+      p_astro >= 0.5 and survive validation. Catalogue admission is gated
+      by provenance, not by post-hoc curation.
+    methodological_pattern: |
+      Population-scale event catalogue with explicit admission criteria
+      and provenance fields per event.
+    geosync_operational_analog: |
+      Market regimes are tracked as a catalogue of events, each carrying
+      provenance, parameters, evidence tier, and an admission verdict.
+    proposed_module: geosync_hpc/regimes/population_event_catalog.py
+    claim_tier: ENGINEERING_ANALOG
+    implementation_status: PROPOSED
+    measurable_inputs:
+      - timestamp
+      - asset_universe
+      - regime_label
+      - event_features
+      - evidence_tier
+      - source_window
+    output_witness:
+      - event_id
+      - accepted
+      - reason
+      - falsifier_status
+    null_model: |
+      A duplicated event, a missing provenance field, an invalid
+      timestamp, or an unsupported evidence tier MUST cause the
+      catalogue to reject admission.
+    falsifier: |
+      Admission accepts an event whose provenance/timestamp/evidence
+      tier fails the documented admission rule.
+    deterministic_tests:
+      - duplicate event_id is rejected with a stable reason
+      - missing provenance field is rejected
+      - invalid timestamp (non-monotonic, NaN, or wrong type) is rejected
+      - unsupported evidence_tier is rejected
+      - valid event is accepted with falsifier_status = OK
+    property_tests_optional:
+      - "admit(catalog, e)  ⇒  catalog admits no duplicate of e"
+    mutation_candidate: |
+      Negate the duplicate-rejection branch in the admission function.
+      The duplicate-rejection deterministic test must fail.
+    ledger_entry_required: true
+
+  # =========================================================================
+  - pattern_id: P2_STRUCTURED_ABSENCE_INFERENCE
+    source_ids: [S2_PAIR_INSTABILITY_GAP]
+    source_fact_summary: |
+      Pair-instability gap appears in m2 secondary masses with a 90%
+      credible lower edge at 44 -4/+5 solar masses. The claim is gated
+      by a coverage / selection model that distinguishes "absence"
+      from "absent because we cannot see it".
+    methodological_pattern: |
+      An absent observation is not the same as a true absence. Coverage
+      and selection-bias must be modelled before "the data show no X"
+      can support any inference.
+    geosync_operational_analog: |
+      A region of state space with no observed events is classified as
+      TRUE_ABSENCE only when coverage is sufficient and selection bias
+      is documented; otherwise the witness must return SELECTION_BIAS
+      or INSUFFICIENT_COVERAGE or UNKNOWN.
+    proposed_module: geosync_hpc/regimes/structured_absence.py
+    claim_tier: ENGINEERING_ANALOG
+    implementation_status: PROPOSED
+    measurable_inputs:
+      - observed_state_space
+      - candidate_empty_region
+      - coverage_mask
+      - selection_bias_flags
+      - sample_count
+    output_witness:
+      - status
+      - reason
+      - coverage_summary
+      - selection_bias_summary
+    null_model: |
+      With perfect uniform coverage and no selection bias flags, the
+      witness MAY return TRUE_ABSENCE for a candidate empty region with
+      zero observed events. With anything less, the default witness is
+      not TRUE_ABSENCE.
+    falsifier: |
+      The witness returns TRUE_ABSENCE while coverage is below threshold
+      OR while any selection_bias_flag is set, OR sample_count is below
+      the minimum.
+    deterministic_tests:
+      - sufficient coverage + zero observed + no bias => TRUE_ABSENCE
+      - low coverage + zero observed                  => INSUFFICIENT_COVERAGE
+      - any bias flag set                             => SELECTION_BIAS
+      - sample_count below minimum                    => UNKNOWN
+      - mismatched coverage_mask shape is rejected
+    property_tests_optional:
+      - "coverage(x) < threshold ⇒ status ≠ TRUE_ABSENCE  for any x"
+    mutation_candidate: |
+      Drop the coverage threshold check in the classifier. The
+      "low coverage + zero observed" deterministic test must fail.
+    ledger_entry_required: true
+
+  # =========================================================================
+  - pattern_id: P3_DYNAMIC_NULL_MODEL
+    source_ids: [S3_DESI_2026]
+    source_fact_summary: |
+      DESI's milestone surfaces tension in expansion-history baselines:
+      the null itself drifts under bounded rules and is not a static
+      reference. The drift bounds are part of the model, not implicit.
+    methodological_pattern: |
+      The null baseline against which signals are scored may itself
+      drift. The drift is bounded; an excursion outside the bound is
+      a model failure, not a signal.
+    geosync_operational_analog: |
+      A dynamic-null model maintains a baseline series with explicit
+      drift bounds. A signal is anomalous only when it exceeds both
+      the dynamic null and the drift bound; if the null itself blows
+      its bound, the witness must fail closed (UNKNOWN), not silently
+      accept the comparison.
+    proposed_module: geosync_hpc/nulls/dynamic_null_model.py
+    claim_tier: ENGINEERING_ANALOG
+    implementation_status: PROPOSED
+    measurable_inputs:
+      - time_index
+      - baseline_series
+      - drift_bound
+      - observed_signal
+    output_witness:
+      - null_value
+      - drift_used
+      - within_bound
+      - anomaly_status
+    null_model: |
+      A static-baseline reference produces the same anomaly classification
+      as the dynamic baseline when the actual drift is zero. The dynamic
+      model must reduce to the static one in the no-drift limit.
+    falsifier: |
+      Drift exceeds drift_bound, but the witness returns
+      anomaly_status != UNKNOWN. OR: the dynamic null produces a
+      different verdict from the static null at zero observed drift.
+    deterministic_tests:
+      - drift = 0       ⇒ same verdict as static null
+      - drift < bound   ⇒ within_bound = True
+      - drift > bound   ⇒ within_bound = False AND anomaly_status = UNKNOWN
+      - signal exceeds dynamic null AND within bound ⇒ anomaly_status = ANOMALY
+      - signal within dynamic null                   ⇒ anomaly_status = NORMAL
+    property_tests_optional:
+      - "for any drift > drift_bound: anomaly_status == UNKNOWN"
+    mutation_candidate: |
+      Invert the within_bound check so drifts above the bound silently
+      pass. The "drift > bound" deterministic test must fail.
+    ledger_entry_required: true
+
+  # =========================================================================
+  - pattern_id: P4_GLOBAL_PARITY_WITNESS
+    source_ids: [S4_KITAEV_PARITY_READOUT]
+    source_fact_summary: |
+      In a Kitaev-chain readout, local charge sensing cannot distinguish
+      the two parity states; only a global capacitance witness does. The
+      property is invisible to local probes by construction.
+    methodological_pattern: |
+      Some properties of a system can be true / false only at the global
+      level; local checks pass while the global state is inconsistent.
+      The witness must aggregate global surfaces, not just local ones.
+    geosync_operational_analog: |
+      A repository's claim ledger, dependency truth, invariant coverage,
+      and CI status are the global surfaces. Each may be locally GREEN
+      while the composition is RED. The global parity witness aggregates
+      them and refuses to declare global consistency unless every
+      required global surface agrees.
+    proposed_module: geosync_hpc/coherence/global_parity_witness.py
+    claim_tier: ENGINEERING_ANALOG
+    implementation_status: PROPOSED
+    measurable_inputs:
+      - local_witnesses
+      - claim_ledger_status
+      - dependency_truth_status
+      - invariant_coverage_status
+      - ci_gate_status
+    output_witness:
+      - globally_consistent
+      - failed_surfaces
+      - nonlocal_conflict_reason
+    null_model: |
+      With all global surfaces GREEN, the witness reports
+      globally_consistent = True. With any required surface != GREEN,
+      it reports globally_consistent = False with the exact failed
+      surface(s) listed; "local pass ⇒ global pass" is FALSE.
+    falsifier: |
+      Some required global surface reports != GREEN, but the witness
+      reports globally_consistent = True; OR the witness aggregates
+      only local checks and silently ignores a global surface.
+    deterministic_tests:
+      - all surfaces GREEN  ⇒ globally_consistent = True, failed = []
+      - one surface RED     ⇒ globally_consistent = False, failed includes that name
+      - one surface UNKNOWN ⇒ globally_consistent = False, failed includes that name
+      - missing required surface ⇒ rejected with structured error
+      - locally-passing inputs do not flip the global verdict
+    property_tests_optional:
+      - "for any required-surface s != GREEN: globally_consistent == False"
+    mutation_candidate: |
+      Replace the AND-aggregation across global surfaces with OR. The
+      "one surface RED" deterministic test must fail.
+    ledger_entry_required: true
+
+  # =========================================================================
+  - pattern_id: P5_MOTIONAL_CORRELATION_WITNESS
+    source_ids: [S5_HELIUM_MOTIONAL_BELL]
+    source_fact_summary: |
+      The helium-motional Bell experiment demonstrates that correlations
+      can live in trajectory / velocity / acceleration variables, not
+      only in static joint distributions. Trajectory shuffling breaks
+      the correlation; static correlations are insensitive to ordering.
+    methodological_pattern: |
+      A correlation across motional / trajectory variables is distinct
+      from a static correlation. A test that survives shuffling the
+      time axis is not a dynamic-relation test.
+    geosync_operational_analog: |
+      Pair-wise correlations across return-velocity, volatility-
+      acceleration, curvature-flow, and liquidity-displacement should
+      be tested separately from static correlations. The witness reports
+      whether the relation is dynamic by comparing against shuffled
+      trajectory nulls.
+    proposed_module: geosync_hpc/dynamics/motional_correlation_witness.py
+    claim_tier: ENGINEERING_ANALOG
+    implementation_status: PROPOSED
+    measurable_inputs:
+      - return_velocity
+      - volatility_acceleration
+      - curvature_flow
+      - liquidity_displacement
+      - time_index
+    output_witness:
+      - dynamic_relation_detected
+      - static_correlation
+      - trajectory_relation
+      - null_comparison
+    null_model: |
+      A shuffled-trajectory null preserves the static joint
+      distribution but destroys time-ordering. A relation that scores
+      identically under the shuffled null is NOT a dynamic relation.
+    falsifier: |
+      Shuffled-trajectory null produces an indistinguishable score,
+      but the witness reports dynamic_relation_detected = True.
+    deterministic_tests:
+      - identical series ⇒ static_correlation = 1.0, trajectory_relation high
+      - independent noise series ⇒ both correlations near zero
+      - shuffled trajectory preserves score ⇒ dynamic_relation_detected = False
+      - constructed dynamic-only series ⇒ dynamic_relation_detected = True
+      - mismatched series lengths are rejected
+      - non-finite inputs are rejected
+    property_tests_optional:
+      - "for any (x, y) where x and y are independent shuffles: dynamic_relation_detected == False"
+    mutation_candidate: |
+      Drop the shuffled-null comparison so static correlations are
+      reported as dynamic. The "shuffled trajectory" deterministic
+      test must fail.
+    ledger_entry_required: true
+
+  # =========================================================================
+  - pattern_id: P6_COMPOSITE_BINDING_STRUCTURE
+    source_ids: [S6_LHCB_DOUBLY_CHARMED_BARYON]
+    source_fact_summary: |
+      The doubly-charmed baryon is held together by binding distinct
+      from transient correlations; binding survives small perturbations
+      that would dissolve a coincidence.
+    methodological_pattern: |
+      A composite is bound, not merely correlated, when the relation
+      survives perturbation across a persistence window. Transient
+      correlations dissolve under small perturbations; bindings do not.
+    geosync_operational_analog: |
+      An asset cluster is "bound" only when the in-cluster correlation
+      survives perturbation across a documented persistence window.
+      Otherwise it is reported as TRANSIENT_CORRELATION, not as a
+      cluster.
+    proposed_module: geosync_hpc/coherence/composite_binding_structure.py
+    claim_tier: ENGINEERING_ANALOG
+    implementation_status: PROPOSED
+    measurable_inputs:
+      - asset_cluster
+      - correlation_matrix
+      - persistence_window
+      - perturbation_response
+    output_witness:
+      - binding_status
+      - transient_correlation
+      - persistent_binding
+      - reason
+    null_model: |
+      Under random perturbation drawn from a documented null distribution,
+      a transient correlation should dissolve in expectation; a binding
+      should survive. The witness compares against this null.
+    falsifier: |
+      The cluster's relation dissolves under the documented perturbation,
+      but the witness reports binding_status = PERSISTENT_BINDING.
+    deterministic_tests:
+      - persistent correlation across window ⇒ binding_status = PERSISTENT_BINDING
+      - transient correlation that dissolves ⇒ binding_status = TRANSIENT_CORRELATION
+      - empty cluster is rejected
+      - mismatched correlation_matrix shape is rejected
+      - persistence_window <= 0 is rejected
+    property_tests_optional:
+      - "for any perturbation that breaks the relation: binding_status != PERSISTENT_BINDING"
+    mutation_candidate: |
+      Drop the perturbation_response check, so transient correlations
+      are reported as bindings. The "transient correlation that
+      dissolves" deterministic test must fail.
+    ledger_entry_required: true

--- a/docs/research/physics_2026/source_pack.yaml
+++ b/docs/research/physics_2026/source_pack.yaml
@@ -1,0 +1,117 @@
+# GeoSync Physics-2026 Source Pack
+#
+# This file is the EVIDENCE RAIL for the physics-2026 integration. Every
+# entry below is a primary-source publication with three explicit
+# components:
+#
+#   verified_fact       — a claim that is directly supported by the source
+#                         text and that we are willing to defend in a PR.
+#                         If the source is later retracted or amended, the
+#                         entry must be retired here.
+#
+#   allowed_translation — the abstract methodological pattern the source
+#                         demonstrates. ENGINEERING_ANALOG translations
+#                         are derived from this; physical equivalence is
+#                         NEVER claimed.
+#
+#   forbidden_overclaim — exact phrasings that this entry MUST NOT be
+#                         used to justify. The phrasings are also enforced
+#                         by tools/research/validate_physics_2026_sources.py.
+#
+# Adding a source:
+#
+#   1. Cite a primary peer-reviewed or institutional URL.
+#   2. State at least one verified_fact, one allowed_translation, and one
+#      forbidden_overclaim.
+#   3. Run python tools/research/validate_physics_2026_sources.py and
+#      ensure it exits 0.
+#
+# Removing a source:
+#
+#   Mark `retired: true` rather than deleting. Retired sources are kept
+#   for audit trail; the validator skips translation references to
+#   retired sources.
+#
+# This file is read by:
+#   tools/research/validate_physics_2026_sources.py
+#   tools/research/validate_physics_2026_translation.py
+#   tests/research/test_validate_physics_2026_sources.py
+#   tests/research/test_validate_physics_2026_translation.py
+
+schema_version: 1
+
+sources:
+
+  - source_id: S1_GWTC4
+    title: "GWTC-4.0: Updating the Gravitational-Wave Transient Catalog"
+    url: https://dcc.ligo.org/LIGO-P2400386-v11/public
+    verified_fact:
+      - "Adds 128 compact binary coalescence candidates from O4a and the preceding engineering run."
+      - "Candidates require p_astro >= 0.5 and are not vetoed during event validation."
+    allowed_translation:
+      - "Population-scale event catalog under provenance and selection rules."
+    forbidden_overclaim:
+      - "Do not claim market events are gravitational waves."
+      - "Do not claim cataloging implies prediction."
+
+  - source_id: S2_PAIR_INSTABILITY_GAP
+    title: "Evidence of the pair-instability gap from black-hole masses"
+    url: https://www.nature.com/articles/s41586-026-10359-0
+    verified_fact:
+      - "Reports evidence for a pair-instability mass gap in GWTC-4."
+      - "Lower boundary is 44 -4/+5 solar masses at 90 percent credibility."
+      - "The gap is observed in secondary masses m2, not simply in all primary masses."
+    allowed_translation:
+      - "Structured-absence inference under coverage and selection constraints."
+    forbidden_overclaim:
+      - "Do not treat missing market observations as true absence without a coverage model."
+      - "Do not call absence a fact without selection-bias classification."
+
+  - source_id: S3_DESI_2026
+    title: "DESI reaches mapping milestone"
+    url: https://www.desi.lbl.gov/2026/04/15/desi-reaches-mapping-milestone-surpassing-expectations/
+    verified_fact:
+      - "DESI mapped more than 47 million galaxies and quasars and 20 million stars."
+      - "The survey raises questions about dark energy and cosmic expansion history."
+    allowed_translation:
+      - "Dynamic baseline / evolving null model under bounded drift."
+    forbidden_overclaim:
+      - "Do not claim DESI proves market baselines evolve."
+      - "Do not use a dynamic null to erase anomalies."
+
+  - source_id: S4_KITAEV_PARITY_READOUT
+    title: "Single-shot parity readout of a minimal Kitaev chain"
+    url: https://www.nature.com/articles/s41586-025-09927-7
+    verified_fact:
+      - "Parity can be read via quantum capacitance."
+      - "Local charge sensing does not distinguish the two parity states."
+      - "Parity lifetimes exceed one millisecond."
+    allowed_translation:
+      - "Global witness can detect a system state that is invisible to local probes."
+    forbidden_overclaim:
+      - "Do not call repository consistency a quantum parity state."
+      - "Do not collapse the global witness into a fake numeric health score."
+
+  - source_id: S5_HELIUM_MOTIONAL_BELL
+    title: "Bell correlations in momentum-entangled massive helium atoms"
+    url: https://www.nature.com/articles/s41467-026-69070-3
+    verified_fact:
+      - "Reports Bell correlations in motional states of momentum-entangled ultracold helium atoms."
+    allowed_translation:
+      - "Trajectory and motional correlation witness, distinct from static joint-distribution correlation."
+    forbidden_overclaim:
+      - "Do not claim market nonlocality."
+      - "Do not use the word quantum in runtime module names."
+
+  - source_id: S6_LHCB_DOUBLY_CHARMED_BARYON
+    title: "LHCb Collaboration discovers new proton-like particle"
+    url: https://home.cern/news/news/physics/lhcb-collaboration-discovers-new-proton-particle
+    verified_fact:
+      - "The new particle contains two charm quarks and one down quark."
+      - "It is approximately four times heavier than a proton."
+      - "It informs how the strong force binds composite particles."
+    allowed_translation:
+      - "Composite-binding structure for asset clusters, distinct from transient correlation."
+    forbidden_overclaim:
+      - "Do not map quarks to assets."
+      - "Do not treat correlation as binding."

--- a/docs/research/physics_2026/source_validation.md
+++ b/docs/research/physics_2026/source_validation.md
@@ -1,0 +1,128 @@
+# Physics-2026 source-validation protocol
+
+Source-of-truth: [`source_pack.yaml`](source_pack.yaml)
+Validator: [`tools/research/validate_physics_2026_sources.py`](../../../tools/research/validate_physics_2026_sources.py)
+Tests: [`tests/research/test_validate_physics_2026_sources.py`](../../../tests/research/test_validate_physics_2026_sources.py)
+
+## Why this exists
+
+The Physics-2026 integration is gated by an **evidence rail**, not by
+metaphor. Before any GeoSync runtime module borrows a methodological
+pattern from a 2026 physics result, the pattern's source must be
+recorded here with three explicit components:
+
+- **`verified_fact`** — what the source text actually establishes
+- **`allowed_translation`** — the methodological pattern that may be
+  re-used in engineering
+- **`forbidden_overclaim`** — the exact phrasings that this entry must
+  NOT be used to support
+
+The validator enforces those components mechanically. A new source
+cannot enter the rail without all three.
+
+## Six initial sources
+
+| ID | Title | Provenance |
+|---|---|---|
+| `S1_GWTC4` | GWTC-4.0: Updating the Gravitational-Wave Transient Catalog | LIGO Scientific Collaboration / Virgo / KAGRA |
+| `S2_PAIR_INSTABILITY_GAP` | Evidence of the pair-instability gap from black-hole masses | Nature, 2026 |
+| `S3_DESI_2026` | DESI reaches mapping milestone | DESI / LBNL |
+| `S4_KITAEV_PARITY_READOUT` | Single-shot parity readout of a minimal Kitaev chain | Nature, 2025 |
+| `S5_HELIUM_MOTIONAL_BELL` | Bell correlations in momentum-entangled massive helium atoms | Nature Communications, 2026 |
+| `S6_LHCB_DOUBLY_CHARMED_BARYON` | LHCb Collaboration discovers new proton-like particle | CERN / LHCb |
+
+Each entry's `verified_fact` lists are derived directly from the cited
+source. They are NOT paraphrases of secondary commentary.
+
+## Validation contracts (six)
+
+The validator refuses any source pack that violates any of:
+
+1. **Schema parse**: file must parse as YAML and declare `schema_version: 1`.
+2. **Required keys per source**: `source_id`, `title`, `url`,
+   `verified_fact`, `allowed_translation`, `forbidden_overclaim`.
+3. **Non-empty evidence lists**: each of the three evidence lists
+   (`verified_fact`, `allowed_translation`, `forbidden_overclaim`)
+   must contain at least one entry.
+4. **No forbidden phrasings** in `title` / `verified_fact` /
+   `allowed_translation`. The five forbidden phrasings are:
+   ```
+   "proves market"
+   "quantum market"
+   "predicts returns"
+   "universal law"
+   "physical equivalence"
+   ```
+   These are NOT scanned inside `forbidden_overclaim` — that field
+   exists precisely to forbid them by quoting them.
+5. **Stable, unique `source_id`**: matches `S<digits>_<UPPER_TOKEN>`.
+   Duplicates are rejected.
+6. **Deterministic JSON output** to
+   `/tmp/geosync_physics2026_source_validation.json`. Same inputs →
+   byte-identical bytes, sorted keys, sorted source_ids.
+
+## Running
+
+```bash
+# Validate the shipping source pack:
+python tools/research/validate_physics_2026_sources.py
+
+# Custom paths:
+python tools/research/validate_physics_2026_sources.py \
+    --pack docs/research/physics_2026/source_pack.yaml \
+    --output /tmp/geosync_physics2026_source_validation.json
+
+# Tests for the validator:
+python -m pytest tests/research/test_validate_physics_2026_sources.py -q
+```
+
+Exit code is `0` on a clean pack, non-zero on any violation. The JSON
+report is written even on failure so CI can persist evidence.
+
+## Adding a source
+
+1. Cite a primary peer-reviewed or institutional URL.
+2. State at least one `verified_fact`, one `allowed_translation`, and
+   one `forbidden_overclaim`. Phrase verified facts conservatively;
+   prefer source quotation over paraphrase.
+3. Run `python tools/research/validate_physics_2026_sources.py`.
+4. The new source becomes referenceable in the translation matrix
+   (`.claude/research/PHYSICS_2026_TRANSLATION.yaml`).
+
+## Retiring a source
+
+Add `retired: true` to the source entry rather than deleting it. The
+validator currently treats retired sources identically to active ones,
+but downstream tools (translation validator, future ledger entries)
+may distinguish them. Removing a source breaks the audit trail and is
+not allowed.
+
+## What the rail explicitly does NOT do
+
+- It does NOT vet the physics. The validator only checks that the
+  declarations exist and do not overclaim. The PHYSICS is upstream and
+  is the responsibility of the cited source's authors and reviewers.
+- It does NOT score sources. The rail is ordinal: a source is either
+  in or out. Within the rail, all sources have the same epistemic
+  weight by default; per-pattern weight comes from the translation
+  matrix.
+- It does NOT translate sources into runtime modules. That is the
+  translation matrix's job. Sources record *what is true upstream*;
+  translations record *what we propose to engineer downstream*.
+- It does NOT permit verbal correspondence (e.g. "asset cluster" =
+  "doubly-charmed baryon"). Translation is methodological pattern
+  re-use, not entity mapping. The forbidden-overclaim entries enforce
+  this at the per-source level.
+
+## Origin
+
+The 2026-04-26 audit established that GeoSync's strongest historical
+failure mode was **claim inflation through metaphor** — borrowing a
+physics word to describe an engineering behaviour without paying the
+falsifier and the test. The Physics-2026 integration explicitly refuses
+that path: every translation is gated by a verified source, and every
+runtime module that follows will be gated by the translation matrix.
+
+This is the discipline-import side of the work. The companion document
+[`translation_matrix.md`](translation_matrix.md) covers the
+analog-export side.

--- a/docs/research/physics_2026/translation_matrix.md
+++ b/docs/research/physics_2026/translation_matrix.md
@@ -1,0 +1,189 @@
+# Physics-2026 translation matrix
+
+Source-of-truth: [`PHYSICS_2026_TRANSLATION.yaml`](../../../.claude/research/PHYSICS_2026_TRANSLATION.yaml)
+Validator: [`tools/research/validate_physics_2026_translation.py`](../../../tools/research/validate_physics_2026_translation.py)
+Tests: [`tests/research/test_validate_physics_2026_translation.py`](../../../tests/research/test_validate_physics_2026_translation.py)
+
+Companion: [`source_validation.md`](source_validation.md)
+
+## Why this exists
+
+The translation matrix is the **methodological pattern → engineering
+analog** mapping. It is NOT a metaphor table. Every entry is gated by
+mechanical contracts that the validator enforces.
+
+Each pattern names:
+
+- the source(s) it borrows from
+- the abstract methodological move it imports
+- the GeoSync operational analog that re-uses that move
+- a `proposed_module` path
+- a `claim_tier` (FACT / ENGINEERING_ANALOG / HYPOTHESIS / REJECTED)
+- an `implementation_status` (PROPOSED / IMPLEMENTED / REJECTED)
+- the `measurable_inputs` runtime can produce
+- the `output_witness` shape
+- a `null_model` baseline behaviour
+- a `falsifier` — the concrete observation that would unmake the claim
+- the `deterministic_tests` required at module-implementation time
+- a `mutation_candidate` — what the mutation harness would patch
+
+## Six initial patterns (PR-1)
+
+| Pattern | Sources | Tier | Status |
+|---|---|---|---|
+| `P1_POPULATION_EVENT_CATALOG` | S1 (GWTC-4) | ENGINEERING_ANALOG | PROPOSED |
+| `P2_STRUCTURED_ABSENCE_INFERENCE` | S2 (pair-instability gap) | ENGINEERING_ANALOG | PROPOSED |
+| `P3_DYNAMIC_NULL_MODEL` | S3 (DESI 2026) | ENGINEERING_ANALOG | PROPOSED |
+| `P4_GLOBAL_PARITY_WITNESS` | S4 (Kitaev parity readout) | ENGINEERING_ANALOG | PROPOSED |
+| `P5_MOTIONAL_CORRELATION_WITNESS` | S5 (helium motional Bell) | ENGINEERING_ANALOG | PROPOSED |
+| `P6_COMPOSITE_BINDING_STRUCTURE` | S6 (doubly-charmed baryon) | ENGINEERING_ANALOG | PROPOSED |
+
+All six are at `claim_tier: ENGINEERING_ANALOG` and
+`implementation_status: PROPOSED`. PR-1 ships only the rail; the runtime
+modules are deferred to PRs 2–7 (one module per PR).
+
+## Validation contracts
+
+The validator refuses any translation matrix that violates any of:
+
+1. **Schema parse**: file must parse as YAML and declare `schema_version: 1`.
+
+2. **Required keys per pattern**: `pattern_id`, `source_ids`,
+   `source_fact_summary`, `methodological_pattern`,
+   `geosync_operational_analog`, `proposed_module`, `claim_tier`,
+   `implementation_status`, `measurable_inputs`, `output_witness`,
+   `null_model`, `falsifier`, `deterministic_tests`,
+   `mutation_candidate`, `ledger_entry_required`.
+
+3. **Source references resolve**: every `source_ids` entry must exist
+   in `docs/research/physics_2026/source_pack.yaml`.
+
+4. **Non-REJECTED patterns must carry evidence**: at least one
+   `measurable_input`, one `output_witness`, a non-empty `null_model`,
+   a non-empty `falsifier`, and at least one `deterministic_test`.
+
+5. **ENGINEERING_ANALOG bodies refuse forbidden phrasings**:
+   ```
+   "physical equivalence"
+   "quantum market"
+   "universal"
+   "predicts returns"
+   ```
+   The scan covers `geosync_operational_analog`,
+   `methodological_pattern`, `null_model`, `falsifier`. It deliberately
+   does NOT cover `source_fact_summary` — that field may quote source
+   phrasings (e.g. a paper title with the word "universal").
+
+6. **HYPOTHESIS cannot be marked FACT** (cross-check via legacy fields).
+
+7. **REJECTED patterns must include `rejection_reason`**.
+
+8. **`proposed_module` paths are unique** across all patterns.
+
+9. **`claim_tier` ∈ {FACT, ENGINEERING_ANALOG, HYPOTHESIS, REJECTED}**.
+
+10. **`implementation_status` ∈ {PROPOSED, IMPLEMENTED, REJECTED}**.
+
+## Tier semantics
+
+| Tier | Means | Allowed status |
+|---|---|---|
+| `FACT` | The pattern is a verified physical fact about GeoSync's runtime. Reserved for entries with mutation-killed tests + integration evidence. | IMPLEMENTED only |
+| `ENGINEERING_ANALOG` | We borrow the discipline of the source pattern. Engineering claim, not physical. The default tier for everything in PR-1. | PROPOSED / IMPLEMENTED |
+| `HYPOTHESIS` | Possible but not yet engineered. Needs at least a measurable_input and a falsifier before it can be promoted. | PROPOSED |
+| `REJECTED` | Pattern fails one of the gating conditions. Kept as a negative reference. | REJECTED |
+
+The validator refuses `FACT` claim_tier in PR-1 entirely, by virtue of
+the requirement that an IMPLEMENTED status accompany it. Module PRs
+will introduce IMPLEMENTED status one pattern at a time.
+
+## Running
+
+```bash
+# Validate the shipping translation matrix against the shipping source pack:
+python tools/research/validate_physics_2026_translation.py
+
+# Custom paths:
+python tools/research/validate_physics_2026_translation.py \
+    --translation .claude/research/PHYSICS_2026_TRANSLATION.yaml \
+    --source-pack docs/research/physics_2026/source_pack.yaml \
+    --output /tmp/geosync_physics2026_translation_validation.json
+
+# Tests:
+python -m pytest tests/research/test_validate_physics_2026_translation.py -q
+```
+
+Exit code is `0` on a clean translation, non-zero otherwise. The JSON
+report is written even on failure.
+
+## Adding a pattern
+
+1. Confirm at least one source in the source pack supports the pattern.
+2. Add a new `pattern_id` (shape: `P<digit>_<UPPER_TOKEN>`).
+3. Provide every required key. Keep `claim_tier` at
+   `ENGINEERING_ANALOG` until module + tests + mutation kill exist.
+4. Run the validator.
+5. Open the implementation PR (per the PR-2..PR-7 sequence).
+
+## Promoting a pattern to IMPLEMENTED
+
+When the runtime module ships:
+
+1. Implement the module per the [module template](#module-template-recap)
+   (input dataclass, witness dataclass, pure assess function, six tests).
+2. Set `implementation_status: IMPLEMENTED`.
+3. Add a corresponding entry to the claim ledger
+   (`.claude/claims/CLAIMS.yaml`) with the pattern_id as `claim_id`
+   prefix.
+4. Add a mutation candidate to
+   `.claude/mutation/MUTATION_LEDGER.yaml` and confirm it is killed.
+
+## Rejecting a pattern
+
+If a pattern fails one of the gating conditions during module work:
+
+1. Set `claim_tier: REJECTED` AND `implementation_status: REJECTED`.
+2. Set `rejection_reason` describing the evidence gap.
+3. Do NOT delete the entry. Negative references prevent the same
+   failed pattern from re-emerging under a different name.
+
+## Module template (recap)
+
+Every module that follows from this matrix MUST have:
+
+- module docstring naming `pattern_id`, `engineering analog`, and an
+  explicit non-claim section ("does NOT claim physical equivalence")
+- input dataclass with units, finite validation, no hidden mutable
+  defaults
+- witness dataclass with status / tier / reason / falsifier /
+  evidence_fields / uncertainty
+- assess function: deterministic, pure, no network, no clock, no
+  random, no file mutation
+- tests: positive, negative, boundary, invalid input, falsifier,
+  no-overclaim
+
+## What the matrix explicitly does NOT do
+
+- It does NOT translate physics into product features. The downstream
+  modules are engineering analogs of methodological discipline, not
+  ports of physical phenomena. We borrow the discipline of pair-
+  instability inference, not the gap itself.
+- It does NOT use the word "quantum" in any runtime module name. The
+  validator enforces that against ENGINEERING_ANALOG bodies.
+- It does NOT promote any pattern beyond ENGINEERING_ANALOG. Promotion
+  to FACT requires mutation-killed tests + integration evidence
+  (per the calibration layer's claim ledger rules); that comes later.
+
+## Origin
+
+Physics-2026 integration was authorised after the 2026-04-26 audit
+codified the calibration layer (claim ledger, evidence matrix,
+dependency truth, false-confidence detector, security reachability,
+mutation kill ledger, architecture boundaries, system truth report).
+The translation matrix is the next layer up: how the system imports
+*external* methodological discipline as an independent witness of its
+own engineering blind spots.
+
+The validator is the mechanical guarantee that this discipline is not
+ornamental. Every pattern must pay its falsifier and its test before it
+gets a runtime line.

--- a/tests/research/test_validate_physics_2026_sources.py
+++ b/tests/research/test_validate_physics_2026_sources.py
@@ -1,0 +1,254 @@
+"""Tests for the Physics-2026 source-pack validator.
+
+Three contracts:
+
+1. The shipping pack `docs/research/physics_2026/source_pack.yaml`
+   validates clean: 6 sources, 6 stable IDs, no errors.
+
+2. Each documented failure mode is detected on a synthetic pack:
+   - missing forbidden_overclaim entry
+   - duplicate source_id
+   - forbidden phrase in verified_fact / allowed_translation / title
+   - bad source_id shape
+   - missing required key
+   - empty evidence list
+   - unsupported schema_version
+
+3. The CLI writes deterministic JSON and returns the right exit code.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from textwrap import dedent
+from types import ModuleType
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+VALIDATOR_PATH = REPO_ROOT / "tools" / "research" / "validate_physics_2026_sources.py"
+SHIPPING_PACK = REPO_ROOT / "docs" / "research" / "physics_2026" / "source_pack.yaml"
+
+
+def _load() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("vps", VALIDATOR_PATH)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["vps"] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def vps() -> ModuleType:
+    return _load()
+
+
+def _good_source(**overrides: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "source_id": "S99_FAKE",
+        "title": "Test source",
+        "url": "https://example.org/test",
+        "verified_fact": ["it is a fact"],
+        "allowed_translation": ["abstract pattern"],
+        "forbidden_overclaim": ["do not overclaim"],
+    }
+    base.update(overrides)
+    return base
+
+
+def _write_pack(path: Path, sources: list[dict[str, object]]) -> Path:
+    path.write_text(
+        yaml.safe_dump(
+            {"schema_version": 1, "sources": sources},
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Contract 1 — shipping pack validates clean
+# ---------------------------------------------------------------------------
+
+
+def test_shipping_pack_validates_clean(vps: ModuleType) -> None:
+    report = vps.validate_pack(SHIPPING_PACK)
+    assert report.valid, "shipping pack errors:\n  - " + "\n  - ".join(
+        str(e) for e in report.errors
+    )
+    assert report.source_count == 6
+    assert len(report.source_ids) == 6
+    assert sorted(report.source_ids) == [
+        "S1_GWTC4",
+        "S2_PAIR_INSTABILITY_GAP",
+        "S3_DESI_2026",
+        "S4_KITAEV_PARITY_READOUT",
+        "S5_HELIUM_MOTIONAL_BELL",
+        "S6_LHCB_DOUBLY_CHARMED_BARYON",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Contract 2 — each documented failure mode is detected
+# ---------------------------------------------------------------------------
+
+
+def test_missing_forbidden_overclaim_fails(vps: ModuleType, tmp_path: Path) -> None:
+    bad = _good_source()
+    del bad["forbidden_overclaim"]
+    pack = _write_pack(tmp_path / "pack.yaml", [bad])
+    report = vps.validate_pack(pack)
+    assert not report.valid
+    rules = {e.rule for e in report.errors}
+    assert "MISSING_KEY" in rules
+
+
+def test_empty_forbidden_overclaim_list_fails(vps: ModuleType, tmp_path: Path) -> None:
+    bad = _good_source(forbidden_overclaim=[])
+    pack = _write_pack(tmp_path / "pack.yaml", [bad])
+    report = vps.validate_pack(pack)
+    assert not report.valid
+    assert any(e.rule == "EMPTY_EVIDENCE_LIST" for e in report.errors)
+
+
+def test_duplicate_source_id_fails(vps: ModuleType, tmp_path: Path) -> None:
+    a = _good_source(source_id="S99_FAKE")
+    b = _good_source(source_id="S99_FAKE", title="Different title")
+    pack = _write_pack(tmp_path / "pack.yaml", [a, b])
+    report = vps.validate_pack(pack)
+    assert not report.valid
+    assert any(e.rule == "DUPLICATE_SOURCE_ID" for e in report.errors)
+
+
+@pytest.mark.parametrize(
+    "phrase,key",
+    [
+        ("proves market", "verified_fact"),
+        ("quantum market", "allowed_translation"),
+        ("predicts returns", "verified_fact"),
+        ("universal law", "allowed_translation"),
+        ("physical equivalence", "verified_fact"),
+    ],
+)
+def test_forbidden_phrase_in_inspected_field_fails(
+    vps: ModuleType, tmp_path: Path, phrase: str, key: str
+) -> None:
+    bad = _good_source(**{key: [f"this entry {phrase} sneakily"]})
+    pack = _write_pack(tmp_path / "pack.yaml", [bad])
+    report = vps.validate_pack(pack)
+    assert not report.valid
+    assert any(
+        e.rule == "FORBIDDEN_PHRASE" and phrase in e.detail for e in report.errors
+    ), report.errors
+
+
+def test_forbidden_phrase_inside_forbidden_overclaim_passes(
+    vps: ModuleType, tmp_path: Path
+) -> None:
+    """An entry that *forbids* the phrasing must not be flagged for it."""
+    good = _good_source(
+        forbidden_overclaim=["Do not claim physical equivalence between markets and physics."]
+    )
+    pack = _write_pack(tmp_path / "pack.yaml", [good])
+    report = vps.validate_pack(pack)
+    assert report.valid, [str(e) for e in report.errors]
+
+
+@pytest.mark.parametrize(
+    "bad_id",
+    [
+        "lowercase",
+        "S",
+        "S99",
+        "S99-FAKE",
+        "X1_FAKE",
+        "",
+    ],
+)
+def test_bad_source_id_shape_fails(vps: ModuleType, tmp_path: Path, bad_id: str) -> None:
+    bad = _good_source(source_id=bad_id)
+    pack = _write_pack(tmp_path / "pack.yaml", [bad])
+    report = vps.validate_pack(pack)
+    assert not report.valid
+    rules = {e.rule for e in report.errors}
+    assert {"BAD_SOURCE_ID", "BAD_SOURCE_ID_SHAPE"} & rules, rules
+
+
+def test_missing_required_key_fails(vps: ModuleType, tmp_path: Path) -> None:
+    bad = _good_source()
+    del bad["url"]
+    pack = _write_pack(tmp_path / "pack.yaml", [bad])
+    report = vps.validate_pack(pack)
+    assert not report.valid
+    assert any(e.rule == "MISSING_KEY" and "url" in e.detail for e in report.errors)
+
+
+def test_unsupported_schema_version_fails(vps: ModuleType, tmp_path: Path) -> None:
+    pack = tmp_path / "pack.yaml"
+    pack.write_text(
+        yaml.safe_dump({"schema_version": 99, "sources": []}),
+        encoding="utf-8",
+    )
+    report = vps.validate_pack(pack)
+    assert not report.valid
+    assert any(e.rule == "SCHEMA_VERSION" for e in report.errors)
+
+
+def test_yaml_parse_error_returns_clean_diagnostic(vps: ModuleType, tmp_path: Path) -> None:
+    pack = tmp_path / "pack.yaml"
+    pack.write_text(
+        dedent("""
+            schema_version: 1
+            sources:
+              - source_id: S1_BAD
+                : oops
+            """),
+        encoding="utf-8",
+    )
+    report = vps.validate_pack(pack)
+    assert not report.valid
+    assert any(e.rule == "YAML_PARSE_ERROR" for e in report.errors)
+
+
+def test_missing_pack_file_fails(vps: ModuleType, tmp_path: Path) -> None:
+    report = vps.validate_pack(tmp_path / "absent.yaml")
+    assert not report.valid
+    assert any(e.rule == "PACK_NOT_FOUND" for e in report.errors)
+
+
+# ---------------------------------------------------------------------------
+# Contract 3 — CLI / deterministic JSON
+# ---------------------------------------------------------------------------
+
+
+def test_main_writes_json_and_exits_zero_on_clean_pack(vps: ModuleType, tmp_path: Path) -> None:
+    out = tmp_path / "report.json"
+    rc = vps.main(["--pack", str(SHIPPING_PACK), "--output", str(out)])
+    assert rc == 0
+    assert out.exists()
+    decoded = json.loads(out.read_text(encoding="utf-8"))
+    assert decoded["valid"] is True
+    assert decoded["source_count"] == 6
+
+
+def test_main_exits_nonzero_and_records_errors_on_bad_pack(vps: ModuleType, tmp_path: Path) -> None:
+    pack = _write_pack(tmp_path / "pack.yaml", [_good_source(source_id="bad")])
+    out = tmp_path / "report.json"
+    rc = vps.main(["--pack", str(pack), "--output", str(out)])
+    assert rc == 1
+    decoded = json.loads(out.read_text(encoding="utf-8"))
+    assert decoded["valid"] is False
+    assert decoded["errors"]
+
+
+def test_validate_pack_is_deterministic(vps: ModuleType) -> None:
+    a = vps.validate_pack(SHIPPING_PACK).to_dict()
+    b = vps.validate_pack(SHIPPING_PACK).to_dict()
+    assert json.dumps(a, sort_keys=True) == json.dumps(b, sort_keys=True)

--- a/tests/research/test_validate_physics_2026_translation.py
+++ b/tests/research/test_validate_physics_2026_translation.py
@@ -1,0 +1,331 @@
+"""Tests for the Physics-2026 translation-matrix validator.
+
+Three contracts:
+
+1. The shipping translation `.claude/research/PHYSICS_2026_TRANSLATION.yaml`
+   validates clean against `docs/research/physics_2026/source_pack.yaml`:
+   6 patterns, all references resolve, no errors.
+
+2. Each documented failure mode is detected on a synthetic translation:
+   - missing falsifier
+   - invalid source_id reference
+   - forbidden ENGINEERING_ANALOG phrasing
+   - duplicate proposed_module path
+   - duplicate pattern_id
+   - REJECTED without rejection_reason
+   - missing required key
+   - unsupported schema_version
+
+3. CLI returns the right exit code and writes deterministic JSON.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+VALIDATOR_PATH = REPO_ROOT / "tools" / "research" / "validate_physics_2026_translation.py"
+SHIPPING_TRANSLATION = REPO_ROOT / ".claude" / "research" / "PHYSICS_2026_TRANSLATION.yaml"
+SHIPPING_PACK = REPO_ROOT / "docs" / "research" / "physics_2026" / "source_pack.yaml"
+
+
+def _load() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("vpt", VALIDATOR_PATH)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["vpt"] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def vpt() -> ModuleType:
+    return _load()
+
+
+def _good_pattern(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "pattern_id": "PT_FAKE",
+        "source_ids": ["S99_FAKE"],
+        "source_fact_summary": "summary",
+        "methodological_pattern": "abstract pattern",
+        "geosync_operational_analog": "engineering analog body",
+        "proposed_module": "geosync_hpc/fake/fake_module.py",
+        "claim_tier": "ENGINEERING_ANALOG",
+        "implementation_status": "PROPOSED",
+        "measurable_inputs": ["x"],
+        "output_witness": ["y"],
+        "null_model": "the null is x = 0",
+        "falsifier": "x != 0 fails",
+        "deterministic_tests": ["x = 0 ⇒ y = 0"],
+        "mutation_candidate": "drop the x check",
+        "ledger_entry_required": True,
+    }
+    base.update(overrides)
+    return base
+
+
+def _write_translation(path: Path, patterns: list[dict[str, Any]]) -> Path:
+    path.write_text(
+        yaml.safe_dump({"schema_version": 1, "patterns": patterns}, sort_keys=False),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _write_pack(path: Path, source_ids: list[str]) -> Path:
+    sources = [
+        {
+            "source_id": sid,
+            "title": "stub",
+            "url": "https://example.org",
+            "verified_fact": ["fact"],
+            "allowed_translation": ["pattern"],
+            "forbidden_overclaim": ["do not overclaim"],
+        }
+        for sid in source_ids
+    ]
+    path.write_text(
+        yaml.safe_dump({"schema_version": 1, "sources": sources}, sort_keys=False),
+        encoding="utf-8",
+    )
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Contract 1 — shipping translation validates clean
+# ---------------------------------------------------------------------------
+
+
+def test_shipping_translation_validates_clean(vpt: ModuleType) -> None:
+    report = vpt.validate_translation(SHIPPING_TRANSLATION, SHIPPING_PACK)
+    assert report.valid, "shipping translation errors:\n  - " + "\n  - ".join(
+        str(e) for e in report.errors
+    )
+    assert report.pattern_count == 6
+    assert sorted(report.pattern_ids) == [
+        "P1_POPULATION_EVENT_CATALOG",
+        "P2_STRUCTURED_ABSENCE_INFERENCE",
+        "P3_DYNAMIC_NULL_MODEL",
+        "P4_GLOBAL_PARITY_WITNESS",
+        "P5_MOTIONAL_CORRELATION_WITNESS",
+        "P6_COMPOSITE_BINDING_STRUCTURE",
+    ]
+
+
+def test_every_referenced_source_exists_in_shipping_pack(
+    vpt: ModuleType,
+) -> None:
+    report = vpt.validate_translation(SHIPPING_TRANSLATION, SHIPPING_PACK)
+    expected = {
+        "S1_GWTC4",
+        "S2_PAIR_INSTABILITY_GAP",
+        "S3_DESI_2026",
+        "S4_KITAEV_PARITY_READOUT",
+        "S5_HELIUM_MOTIONAL_BELL",
+        "S6_LHCB_DOUBLY_CHARMED_BARYON",
+    }
+    assert set(report.referenced_source_ids) == expected
+
+
+# ---------------------------------------------------------------------------
+# Contract 2 — failure-mode injection
+# ---------------------------------------------------------------------------
+
+
+def test_missing_falsifier_fails(vpt: ModuleType, tmp_path: Path) -> None:
+    pack = _write_pack(tmp_path / "pack.yaml", ["S99_FAKE"])
+    bad = _good_pattern(falsifier="")
+    trans = _write_translation(tmp_path / "trans.yaml", [bad])
+    report = vpt.validate_translation(trans, pack)
+    assert not report.valid
+    assert any(e.rule == "EMPTY_FALSIFIER" for e in report.errors)
+
+
+def test_invalid_source_id_fails(vpt: ModuleType, tmp_path: Path) -> None:
+    pack = _write_pack(tmp_path / "pack.yaml", ["S99_FAKE"])
+    bad = _good_pattern(source_ids=["S77_DOES_NOT_EXIST"])
+    trans = _write_translation(tmp_path / "trans.yaml", [bad])
+    report = vpt.validate_translation(trans, pack)
+    assert not report.valid
+    assert any(e.rule == "UNKNOWN_SOURCE_ID" for e in report.errors)
+
+
+@pytest.mark.parametrize(
+    "phrase,key",
+    [
+        ("physical equivalence", "geosync_operational_analog"),
+        ("quantum market", "methodological_pattern"),
+        ("universal", "null_model"),
+        ("predicts returns", "falsifier"),
+    ],
+)
+def test_forbidden_engineering_analog_phrase_fails(
+    vpt: ModuleType, tmp_path: Path, phrase: str, key: str
+) -> None:
+    pack = _write_pack(tmp_path / "pack.yaml", ["S99_FAKE"])
+    bad = _good_pattern(**{key: f"this is fine but {phrase} sneaks in"})
+    trans = _write_translation(tmp_path / "trans.yaml", [bad])
+    report = vpt.validate_translation(trans, pack)
+    assert not report.valid
+    assert any(e.rule == "FORBIDDEN_ANALOG_PHRASE" and phrase in e.detail for e in report.errors)
+
+
+def test_forbidden_phrase_in_source_fact_summary_passes(vpt: ModuleType, tmp_path: Path) -> None:
+    """source_fact_summary may legitimately quote source phrasings (e.g.
+    'universal' as it appears in a paper title). It is NOT scanned for
+    forbidden analog phrases."""
+    pack = _write_pack(tmp_path / "pack.yaml", ["S99_FAKE"])
+    good = _good_pattern(
+        source_fact_summary=("The cited paper uses the word universal in its title.")
+    )
+    trans = _write_translation(tmp_path / "trans.yaml", [good])
+    report = vpt.validate_translation(trans, pack)
+    assert report.valid, [str(e) for e in report.errors]
+
+
+def test_duplicate_module_path_fails(vpt: ModuleType, tmp_path: Path) -> None:
+    pack = _write_pack(tmp_path / "pack.yaml", ["S99_FAKE"])
+    a = _good_pattern(pattern_id="P_A")
+    b = _good_pattern(pattern_id="P_B")
+    trans = _write_translation(tmp_path / "trans.yaml", [a, b])
+    report = vpt.validate_translation(trans, pack)
+    assert not report.valid
+    assert any(e.rule == "DUPLICATE_MODULE_PATH" for e in report.errors)
+
+
+def test_duplicate_pattern_id_fails(vpt: ModuleType, tmp_path: Path) -> None:
+    pack = _write_pack(tmp_path / "pack.yaml", ["S99_FAKE"])
+    a = _good_pattern(pattern_id="P_DUP", proposed_module="m/a.py")
+    b = _good_pattern(pattern_id="P_DUP", proposed_module="m/b.py")
+    trans = _write_translation(tmp_path / "trans.yaml", [a, b])
+    report = vpt.validate_translation(trans, pack)
+    assert not report.valid
+    assert any(e.rule == "DUPLICATE_PATTERN_ID" for e in report.errors)
+
+
+def test_rejected_without_reason_fails(vpt: ModuleType, tmp_path: Path) -> None:
+    pack = _write_pack(tmp_path / "pack.yaml", ["S99_FAKE"])
+    bad = _good_pattern(claim_tier="REJECTED", implementation_status="REJECTED")
+    trans = _write_translation(tmp_path / "trans.yaml", [bad])
+    report = vpt.validate_translation(trans, pack)
+    assert not report.valid
+    assert any(e.rule == "REJECTED_NO_REASON" for e in report.errors)
+
+
+def test_rejected_with_reason_passes(vpt: ModuleType, tmp_path: Path) -> None:
+    pack = _write_pack(tmp_path / "pack.yaml", ["S99_FAKE"])
+    bad = _good_pattern(
+        claim_tier="REJECTED",
+        implementation_status="REJECTED",
+        rejection_reason="evidence gap: no measurable input",
+    )
+    trans = _write_translation(tmp_path / "trans.yaml", [bad])
+    report = vpt.validate_translation(trans, pack)
+    assert report.valid, [str(e) for e in report.errors]
+
+
+def test_missing_required_key_fails(vpt: ModuleType, tmp_path: Path) -> None:
+    pack = _write_pack(tmp_path / "pack.yaml", ["S99_FAKE"])
+    bad = _good_pattern()
+    del bad["null_model"]
+    trans = _write_translation(tmp_path / "trans.yaml", [bad])
+    report = vpt.validate_translation(trans, pack)
+    assert not report.valid
+    assert any(e.rule == "MISSING_KEY" and "null_model" in e.detail for e in report.errors)
+
+
+def test_unknown_claim_tier_fails(vpt: ModuleType, tmp_path: Path) -> None:
+    pack = _write_pack(tmp_path / "pack.yaml", ["S99_FAKE"])
+    bad = _good_pattern(claim_tier="ASTROLOGICAL")
+    trans = _write_translation(tmp_path / "trans.yaml", [bad])
+    report = vpt.validate_translation(trans, pack)
+    assert not report.valid
+    assert any(e.rule == "BAD_CLAIM_TIER" for e in report.errors)
+
+
+def test_unsupported_schema_version_fails(vpt: ModuleType, tmp_path: Path) -> None:
+    pack = _write_pack(tmp_path / "pack.yaml", ["S99_FAKE"])
+    trans = tmp_path / "trans.yaml"
+    trans.write_text(
+        yaml.safe_dump({"schema_version": 99, "patterns": []}),
+        encoding="utf-8",
+    )
+    report = vpt.validate_translation(trans, pack)
+    assert not report.valid
+    assert any(e.rule == "SCHEMA_VERSION" for e in report.errors)
+
+
+def test_missing_translation_file_fails(vpt: ModuleType, tmp_path: Path) -> None:
+    pack = _write_pack(tmp_path / "pack.yaml", ["S99_FAKE"])
+    report = vpt.validate_translation(tmp_path / "absent.yaml", pack)
+    assert not report.valid
+    assert any(e.rule == "TRANSLATION_NOT_FOUND" for e in report.errors)
+
+
+def test_empty_source_pack_fails(vpt: ModuleType, tmp_path: Path) -> None:
+    pack = _write_pack(tmp_path / "pack.yaml", [])
+    bad = _good_pattern()
+    trans = _write_translation(tmp_path / "trans.yaml", [bad])
+    report = vpt.validate_translation(trans, pack)
+    assert not report.valid
+    assert any(e.rule == "SOURCE_PACK_UNAVAILABLE" for e in report.errors)
+
+
+# ---------------------------------------------------------------------------
+# Contract 3 — CLI / determinism
+# ---------------------------------------------------------------------------
+
+
+def test_main_writes_json_and_exits_zero_on_clean(vpt: ModuleType, tmp_path: Path) -> None:
+    out = tmp_path / "report.json"
+    rc = vpt.main(
+        [
+            "--translation",
+            str(SHIPPING_TRANSLATION),
+            "--source-pack",
+            str(SHIPPING_PACK),
+            "--output",
+            str(out),
+        ]
+    )
+    assert rc == 0
+    decoded = json.loads(out.read_text(encoding="utf-8"))
+    assert decoded["valid"] is True
+    assert decoded["pattern_count"] == 6
+
+
+def test_main_exits_nonzero_on_bad_translation(vpt: ModuleType, tmp_path: Path) -> None:
+    pack = _write_pack(tmp_path / "pack.yaml", ["S99_FAKE"])
+    bad = _good_pattern(falsifier="")
+    trans = _write_translation(tmp_path / "trans.yaml", [bad])
+    out = tmp_path / "report.json"
+    rc = vpt.main(
+        [
+            "--translation",
+            str(trans),
+            "--source-pack",
+            str(pack),
+            "--output",
+            str(out),
+        ]
+    )
+    assert rc == 1
+    decoded = json.loads(out.read_text(encoding="utf-8"))
+    assert decoded["valid"] is False
+    assert decoded["errors"]
+
+
+def test_validate_translation_is_deterministic(vpt: ModuleType) -> None:
+    a = vpt.validate_translation(SHIPPING_TRANSLATION, SHIPPING_PACK).to_dict()
+    b = vpt.validate_translation(SHIPPING_TRANSLATION, SHIPPING_PACK).to_dict()
+    assert json.dumps(a, sort_keys=True) == json.dumps(b, sort_keys=True)

--- a/tools/research/validate_physics_2026_sources.py
+++ b/tools/research/validate_physics_2026_sources.py
@@ -1,0 +1,307 @@
+"""Source-pack validator for the GeoSync Physics-2026 evidence rail.
+
+Validates `docs/research/physics_2026/source_pack.yaml` against six
+mechanical contracts:
+
+  1. The file parses as YAML and declares schema_version: 1.
+  2. Every source has the required keys:
+        source_id, title, url, verified_fact, allowed_translation,
+        forbidden_overclaim
+  3. Every source has at least one entry in each of the three
+     evidence lists (verified_fact / allowed_translation /
+     forbidden_overclaim).
+  4. No source's prose contains forbidden overclaim phrasings:
+        "proves market", "quantum market", "predicts returns",
+        "universal law", "physical equivalence"
+  5. source_id values are non-empty, unique, and stable
+     (`S<digit>_<UPPERCASE_TOKEN>` shape).
+  6. Output is deterministic JSON written to:
+        /tmp/geosync_physics2026_source_validation.json
+
+Exit code is non-zero when any contract is violated.
+
+The validator is stdlib + PyYAML only. No project imports.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_SOURCE_PACK = REPO_ROOT / "docs" / "research" / "physics_2026" / "source_pack.yaml"
+DEFAULT_OUTPUT = Path("/tmp/geosync_physics2026_source_validation.json")
+
+REQUIRED_KEYS: tuple[str, ...] = (
+    "source_id",
+    "title",
+    "url",
+    "verified_fact",
+    "allowed_translation",
+    "forbidden_overclaim",
+)
+
+# Phrasings that must NEVER appear in the source pack body, regardless of
+# which key they sit under. They are the calibration-layer's red lines:
+# the source pack is an evidence rail, not a marketing document.
+FORBIDDEN_PHRASES: tuple[str, ...] = (
+    "proves market",
+    "quantum market",
+    "predicts returns",
+    "universal law",
+    "physical equivalence",
+)
+
+# Stable shape: S followed by one or more digits, an underscore, and an
+# UPPERCASE token (letters + digits + underscores).
+_SOURCE_ID_SHAPE = re.compile(r"^S\d+_[A-Z][A-Z0-9_]*$")
+
+
+@dataclass(frozen=True)
+class ValidationError:
+    where: str
+    rule: str
+    detail: str
+
+    def __str__(self) -> str:
+        return f"[{self.rule}] {self.where}: {self.detail}"
+
+
+@dataclass
+class ValidationReport:
+    source_count: int = 0
+    valid: bool = True
+    errors: list[ValidationError] = field(default_factory=list)
+    warnings: list[ValidationError] = field(default_factory=list)
+    source_ids: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "source_count": self.source_count,
+            "valid": self.valid,
+            "errors": [str(e) for e in self.errors],
+            "warnings": [str(w) for w in self.warnings],
+            "source_ids": sorted(self.source_ids),
+        }
+
+
+def _check_required_keys(source: dict[str, Any]) -> list[ValidationError]:
+    errors: list[ValidationError] = []
+    sid = str(source.get("source_id") or "<missing>")
+    for key in REQUIRED_KEYS:
+        if key not in source:
+            errors.append(ValidationError(sid, "MISSING_KEY", f"required key absent: {key}"))
+            continue
+        value = source[key]
+        if key in {"verified_fact", "allowed_translation", "forbidden_overclaim"}:
+            if not isinstance(value, list) or not value:
+                errors.append(
+                    ValidationError(
+                        sid,
+                        "EMPTY_EVIDENCE_LIST",
+                        f"{key} must be a non-empty list",
+                    )
+                )
+        else:
+            if not isinstance(value, str) or not value.strip():
+                errors.append(
+                    ValidationError(
+                        sid,
+                        "EMPTY_SCALAR",
+                        f"{key} must be a non-empty string",
+                    )
+                )
+    return errors
+
+
+def _walk_strings(obj: Any) -> Iterable[str]:
+    """Yield every string in a nested dict/list structure."""
+    if isinstance(obj, str):
+        yield obj
+    elif isinstance(obj, dict):
+        for v in obj.values():
+            yield from _walk_strings(v)
+    elif isinstance(obj, list):
+        for v in obj:
+            yield from _walk_strings(v)
+
+
+def _check_forbidden_phrases(source: dict[str, Any]) -> list[ValidationError]:
+    """Scan every string in the source for forbidden phrasings.
+
+    The check is case-insensitive but otherwise a literal substring match.
+    Documenting a forbidden phrase by quoting it (e.g. in `forbidden_overclaim`)
+    is allowed: the phrase scanner is applied to ALL keys including
+    `forbidden_overclaim`, but only the `verified_fact`, `allowed_translation`,
+    `title`, and free prose strings count for failure. This way an entry can
+    explicitly forbid the phrasing without tripping the gate.
+    """
+    errors: list[ValidationError] = []
+    sid = str(source.get("source_id") or "<missing>")
+    inspected_keys = ("title", "verified_fact", "allowed_translation")
+    for key in inspected_keys:
+        value = source.get(key)
+        if value is None:
+            continue
+        for text in _walk_strings(value):
+            lower = text.lower()
+            for phrase in FORBIDDEN_PHRASES:
+                if phrase in lower:
+                    errors.append(
+                        ValidationError(
+                            sid,
+                            "FORBIDDEN_PHRASE",
+                            f"{key} contains forbidden phrasing: {phrase!r}",
+                        )
+                    )
+    return errors
+
+
+def _check_source_id_shape(source: dict[str, Any]) -> list[ValidationError]:
+    sid = source.get("source_id")
+    if not isinstance(sid, str) or not sid.strip():
+        return [ValidationError("<unknown>", "BAD_SOURCE_ID", "missing source_id")]
+    if not _SOURCE_ID_SHAPE.match(sid):
+        return [
+            ValidationError(
+                sid,
+                "BAD_SOURCE_ID_SHAPE",
+                f"source_id {sid!r} does not match S<digits>_<UPPER_TOKEN>",
+            )
+        ]
+    return []
+
+
+def _check_unique_ids(sources: list[dict[str, Any]]) -> list[ValidationError]:
+    errors: list[ValidationError] = []
+    seen: dict[str, int] = {}
+    for source in sources:
+        sid = source.get("source_id")
+        if not isinstance(sid, str):
+            continue
+        seen[sid] = seen.get(sid, 0) + 1
+    for sid, count in seen.items():
+        if count > 1:
+            errors.append(
+                ValidationError(
+                    sid,
+                    "DUPLICATE_SOURCE_ID",
+                    f"source_id appears {count} times",
+                )
+            )
+    return errors
+
+
+def validate_pack(pack_path: Path) -> ValidationReport:
+    if not pack_path.exists():
+        return ValidationReport(
+            valid=False,
+            errors=[ValidationError("<pack>", "PACK_NOT_FOUND", str(pack_path))],
+        )
+    raw_text = pack_path.read_text(encoding="utf-8")
+    try:
+        data = yaml.safe_load(raw_text) or {}
+    except yaml.YAMLError as exc:
+        return ValidationReport(
+            valid=False,
+            errors=[ValidationError("<pack>", "YAML_PARSE_ERROR", str(exc))],
+        )
+    if not isinstance(data, dict):
+        return ValidationReport(
+            valid=False,
+            errors=[ValidationError("<pack>", "PACK_SHAPE", "top-level must be a mapping")],
+        )
+    if data.get("schema_version") != 1:
+        return ValidationReport(
+            valid=False,
+            errors=[
+                ValidationError(
+                    "<pack>",
+                    "SCHEMA_VERSION",
+                    f"unsupported schema_version: {data.get('schema_version')!r}",
+                )
+            ],
+        )
+    sources = data.get("sources") or []
+    if not isinstance(sources, list):
+        return ValidationReport(
+            valid=False,
+            errors=[ValidationError("<pack>", "SOURCES_SHAPE", "sources must be a list")],
+        )
+
+    errors: list[ValidationError] = []
+    for source in sources:
+        if not isinstance(source, dict):
+            errors.append(
+                ValidationError(
+                    "<unknown>",
+                    "SOURCE_SHAPE",
+                    f"source entry must be a mapping: {source!r}",
+                )
+            )
+            continue
+        errors.extend(_check_source_id_shape(source))
+        errors.extend(_check_required_keys(source))
+        errors.extend(_check_forbidden_phrases(source))
+    errors.extend(_check_unique_ids(sources))
+
+    source_ids = [
+        str(s.get("source_id"))
+        for s in sources
+        if isinstance(s, dict) and isinstance(s.get("source_id"), str)
+    ]
+
+    return ValidationReport(
+        source_count=len(sources),
+        valid=not errors,
+        errors=errors,
+        warnings=[],
+        source_ids=source_ids,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate the GeoSync Physics-2026 source pack",
+    )
+    parser.add_argument(
+        "--pack",
+        type=Path,
+        default=DEFAULT_SOURCE_PACK,
+        help="path to source_pack.yaml",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_OUTPUT,
+        help="path to write JSON report",
+    )
+    args = parser.parse_args(argv)
+    report = validate_pack(args.pack)
+    payload = json.dumps(report.to_dict(), indent=2, sort_keys=True)
+    args.output.write_text(payload + "\n", encoding="utf-8")
+    if not report.valid:
+        print(
+            f"FAIL: source pack has {len(report.errors)} validation error(s):",
+            file=sys.stderr,
+        )
+        for err in report.errors:
+            print(f"  - {err}", file=sys.stderr)
+        return 1
+    print(
+        f"OK: source pack validated "
+        f"({report.source_count} sources, {len(report.source_ids)} unique IDs)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/research/validate_physics_2026_translation.py
+++ b/tools/research/validate_physics_2026_translation.py
@@ -1,0 +1,532 @@
+"""Translation-matrix validator for the GeoSync Physics-2026 evidence rail.
+
+Validates `.claude/research/PHYSICS_2026_TRANSLATION.yaml` against the
+translation contract defined by the Physics-2026 protocol:
+
+  1. The file parses as YAML and declares schema_version: 1.
+
+  2. Every pattern entry has the required keys:
+        pattern_id, source_ids, source_fact_summary,
+        methodological_pattern, geosync_operational_analog,
+        proposed_module, claim_tier, implementation_status,
+        measurable_inputs, output_witness, null_model, falsifier,
+        deterministic_tests, mutation_candidate, ledger_entry_required
+
+  3. Every source_id referenced by a pattern exists in the source pack.
+
+  4. Every pattern with implementation_status != REJECTED has at least
+     one measurable_input, one output_witness, a non-empty null_model,
+     a non-empty falsifier, and at least one deterministic_test.
+
+  5. ENGINEERING_ANALOG patterns must NOT use forbidden phrasings:
+        "physical equivalence", "quantum market", "universal", "predicts returns"
+     anywhere in the body.
+
+  6. HYPOTHESIS patterns must NOT be marked FACT.
+
+  7. REJECTED patterns must include `rejection_reason`.
+
+  8. proposed_module paths are unique across all patterns.
+
+  9. claim_tier is one of:
+        FACT / ENGINEERING_ANALOG / HYPOTHESIS / REJECTED
+
+ 10. implementation_status is one of:
+        PROPOSED / IMPLEMENTED / REJECTED
+
+The validator is stdlib + PyYAML only. Output is deterministic JSON
+written to /tmp/geosync_physics2026_translation_validation.json.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_TRANSLATION = REPO_ROOT / ".claude" / "research" / "PHYSICS_2026_TRANSLATION.yaml"
+DEFAULT_SOURCE_PACK = REPO_ROOT / "docs" / "research" / "physics_2026" / "source_pack.yaml"
+DEFAULT_OUTPUT = Path("/tmp/geosync_physics2026_translation_validation.json")
+
+REQUIRED_KEYS: tuple[str, ...] = (
+    "pattern_id",
+    "source_ids",
+    "source_fact_summary",
+    "methodological_pattern",
+    "geosync_operational_analog",
+    "proposed_module",
+    "claim_tier",
+    "implementation_status",
+    "measurable_inputs",
+    "output_witness",
+    "null_model",
+    "falsifier",
+    "deterministic_tests",
+    "mutation_candidate",
+    "ledger_entry_required",
+)
+
+VALID_CLAIM_TIERS = frozenset({"FACT", "ENGINEERING_ANALOG", "HYPOTHESIS", "REJECTED"})
+VALID_IMPLEMENTATION_STATUS = frozenset({"PROPOSED", "IMPLEMENTED", "REJECTED"})
+
+# Phrasings that must never appear inside an ENGINEERING_ANALOG body.
+# These are the calibration-layer red lines: ENGINEERING_ANALOG must not
+# inflate into either physical equivalence or predictive overclaim.
+FORBIDDEN_PHRASES_IN_ANALOG: tuple[str, ...] = (
+    "physical equivalence",
+    "quantum market",
+    "universal",
+    "predicts returns",
+)
+
+
+@dataclass(frozen=True)
+class ValidationError:
+    where: str
+    rule: str
+    detail: str
+
+    def __str__(self) -> str:
+        return f"[{self.rule}] {self.where}: {self.detail}"
+
+
+@dataclass
+class ValidationReport:
+    pattern_count: int = 0
+    valid: bool = True
+    errors: list[ValidationError] = field(default_factory=list)
+    warnings: list[ValidationError] = field(default_factory=list)
+    pattern_ids: list[str] = field(default_factory=list)
+    referenced_source_ids: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "pattern_count": self.pattern_count,
+            "valid": self.valid,
+            "errors": [str(e) for e in self.errors],
+            "warnings": [str(w) for w in self.warnings],
+            "pattern_ids": sorted(self.pattern_ids),
+            "referenced_source_ids": sorted(self.referenced_source_ids),
+        }
+
+
+def _load_known_source_ids(pack_path: Path) -> set[str]:
+    if not pack_path.exists():
+        return set()
+    try:
+        data = yaml.safe_load(pack_path.read_text(encoding="utf-8")) or {}
+    except yaml.YAMLError:
+        return set()
+    sources = data.get("sources") or []
+    if not isinstance(sources, list):
+        return set()
+    return {
+        str(s.get("source_id"))
+        for s in sources
+        if isinstance(s, dict) and isinstance(s.get("source_id"), str)
+    }
+
+
+def _walk_strings(obj: Any) -> Iterable[str]:
+    if isinstance(obj, str):
+        yield obj
+    elif isinstance(obj, dict):
+        for v in obj.values():
+            yield from _walk_strings(v)
+    elif isinstance(obj, list):
+        for v in obj:
+            yield from _walk_strings(v)
+
+
+def _check_required_keys(pattern: dict[str, Any]) -> list[ValidationError]:
+    errors: list[ValidationError] = []
+    pid = str(pattern.get("pattern_id") or "<unknown>")
+    for key in REQUIRED_KEYS:
+        if key not in pattern:
+            errors.append(ValidationError(pid, "MISSING_KEY", f"required key absent: {key}"))
+    return errors
+
+
+def _check_source_refs(
+    pattern: dict[str, Any], known_source_ids: set[str]
+) -> list[ValidationError]:
+    errors: list[ValidationError] = []
+    pid = str(pattern.get("pattern_id") or "<unknown>")
+    refs = pattern.get("source_ids") or []
+    if not isinstance(refs, list) or not refs:
+        errors.append(
+            ValidationError(
+                pid,
+                "EMPTY_SOURCE_IDS",
+                "source_ids must be a non-empty list",
+            )
+        )
+        return errors
+    for ref in refs:
+        if not isinstance(ref, str):
+            errors.append(ValidationError(pid, "BAD_SOURCE_ID_SHAPE", f"non-string entry: {ref!r}"))
+            continue
+        if ref not in known_source_ids:
+            errors.append(
+                ValidationError(
+                    pid,
+                    "UNKNOWN_SOURCE_ID",
+                    f"source_id {ref!r} not present in source pack",
+                )
+            )
+    return errors
+
+
+def _check_claim_tier(pattern: dict[str, Any]) -> list[ValidationError]:
+    errors: list[ValidationError] = []
+    pid = str(pattern.get("pattern_id") or "<unknown>")
+    tier = pattern.get("claim_tier")
+    if tier not in VALID_CLAIM_TIERS:
+        errors.append(ValidationError(pid, "BAD_CLAIM_TIER", f"unknown claim_tier: {tier!r}"))
+    return errors
+
+
+def _check_implementation_status(
+    pattern: dict[str, Any],
+) -> list[ValidationError]:
+    errors: list[ValidationError] = []
+    pid = str(pattern.get("pattern_id") or "<unknown>")
+    status = pattern.get("implementation_status")
+    if status not in VALID_IMPLEMENTATION_STATUS:
+        errors.append(
+            ValidationError(
+                pid,
+                "BAD_IMPLEMENTATION_STATUS",
+                f"unknown implementation_status: {status!r}",
+            )
+        )
+    return errors
+
+
+def _check_evidence_payload(pattern: dict[str, Any]) -> list[ValidationError]:
+    """For any pattern that is NOT REJECTED, the evidence payload must be
+    non-empty: at least one measurable_input, one output_witness, a
+    non-empty null_model, a non-empty falsifier, and at least one
+    deterministic_test."""
+    errors: list[ValidationError] = []
+    pid = str(pattern.get("pattern_id") or "<unknown>")
+    if pattern.get("implementation_status") == "REJECTED":
+        return errors
+    if pattern.get("claim_tier") == "REJECTED":
+        return errors
+
+    list_fields = (
+        ("measurable_inputs", "EMPTY_MEASURABLE_INPUTS"),
+        ("output_witness", "EMPTY_OUTPUT_WITNESS"),
+        ("deterministic_tests", "EMPTY_DETERMINISTIC_TESTS"),
+    )
+    for key, rule in list_fields:
+        value = pattern.get(key)
+        if not isinstance(value, list) or not value:
+            errors.append(
+                ValidationError(
+                    pid, rule, f"{key} must be a non-empty list for non-REJECTED pattern"
+                )
+            )
+    string_fields = (
+        ("null_model", "EMPTY_NULL_MODEL"),
+        ("falsifier", "EMPTY_FALSIFIER"),
+    )
+    for key, rule in string_fields:
+        value = pattern.get(key)
+        if not isinstance(value, str) or not value.strip():
+            errors.append(
+                ValidationError(
+                    pid,
+                    rule,
+                    f"{key} must be a non-empty string for non-REJECTED pattern",
+                )
+            )
+    return errors
+
+
+def _check_engineering_analog_phrasing(
+    pattern: dict[str, Any],
+) -> list[ValidationError]:
+    errors: list[ValidationError] = []
+    pid = str(pattern.get("pattern_id") or "<unknown>")
+    if pattern.get("claim_tier") != "ENGINEERING_ANALOG":
+        return errors
+    # Inspect the analog body. We DO NOT scan source_fact_summary because it
+    # may legitimately quote the source description (e.g. "universal").
+    inspected_keys = (
+        "geosync_operational_analog",
+        "methodological_pattern",
+        "null_model",
+        "falsifier",
+    )
+    for key in inspected_keys:
+        value = pattern.get(key)
+        if value is None:
+            continue
+        for text in _walk_strings(value):
+            lower = text.lower()
+            for phrase in FORBIDDEN_PHRASES_IN_ANALOG:
+                if phrase in lower:
+                    errors.append(
+                        ValidationError(
+                            pid,
+                            "FORBIDDEN_ANALOG_PHRASE",
+                            f"{key} contains forbidden phrasing: {phrase!r}",
+                        )
+                    )
+    return errors
+
+
+def _check_hypothesis_not_fact(
+    pattern: dict[str, Any],
+) -> list[ValidationError]:
+    """Belt-and-braces. If the pattern is a HYPOTHESIS but somewhere
+    declares itself FACT (e.g. via a stray field or a status mismatch),
+    refuse it. This catches the easiest path for claim inflation."""
+    errors: list[ValidationError] = []
+    pid = str(pattern.get("pattern_id") or "<unknown>")
+    tier = pattern.get("claim_tier")
+    # Cross-check explicit `claim_tier` against any contradicting marker.
+    legacy_tier = pattern.get("legacy_claim_tier")
+    if tier == "HYPOTHESIS" and legacy_tier == "FACT":
+        errors.append(
+            ValidationError(
+                pid,
+                "HYPOTHESIS_MARKED_FACT",
+                "claim_tier is HYPOTHESIS but legacy_claim_tier is FACT",
+            )
+        )
+    return errors
+
+
+def _check_rejected_has_reason(
+    pattern: dict[str, Any],
+) -> list[ValidationError]:
+    errors: list[ValidationError] = []
+    pid = str(pattern.get("pattern_id") or "<unknown>")
+    if (
+        pattern.get("claim_tier") == "REJECTED"
+        or pattern.get("implementation_status") == "REJECTED"
+    ):
+        reason = pattern.get("rejection_reason")
+        if not isinstance(reason, str) or not reason.strip():
+            errors.append(
+                ValidationError(
+                    pid,
+                    "REJECTED_NO_REASON",
+                    "REJECTED pattern must include a non-empty rejection_reason",
+                )
+            )
+    return errors
+
+
+def _check_unique_module_paths(
+    patterns: list[dict[str, Any]],
+) -> list[ValidationError]:
+    errors: list[ValidationError] = []
+    seen: dict[str, str] = {}
+    for pattern in patterns:
+        path = pattern.get("proposed_module")
+        if not isinstance(path, str):
+            continue
+        pid = str(pattern.get("pattern_id") or "<unknown>")
+        if path in seen:
+            errors.append(
+                ValidationError(
+                    pid,
+                    "DUPLICATE_MODULE_PATH",
+                    f"proposed_module {path!r} also used by {seen[path]}",
+                )
+            )
+        else:
+            seen[path] = pid
+    return errors
+
+
+def _check_unique_pattern_ids(
+    patterns: list[dict[str, Any]],
+) -> list[ValidationError]:
+    errors: list[ValidationError] = []
+    counts: dict[str, int] = {}
+    for pattern in patterns:
+        pid = pattern.get("pattern_id")
+        if not isinstance(pid, str):
+            continue
+        counts[pid] = counts.get(pid, 0) + 1
+    for pid, count in counts.items():
+        if count > 1:
+            errors.append(
+                ValidationError(
+                    pid,
+                    "DUPLICATE_PATTERN_ID",
+                    f"pattern_id appears {count} times",
+                )
+            )
+    return errors
+
+
+def validate_translation(
+    translation_path: Path,
+    source_pack_path: Path | None = None,
+) -> ValidationReport:
+    if not translation_path.exists():
+        return ValidationReport(
+            valid=False,
+            errors=[
+                ValidationError(
+                    "<translation>",
+                    "TRANSLATION_NOT_FOUND",
+                    str(translation_path),
+                )
+            ],
+        )
+    try:
+        data = yaml.safe_load(translation_path.read_text(encoding="utf-8")) or {}
+    except yaml.YAMLError as exc:
+        return ValidationReport(
+            valid=False,
+            errors=[ValidationError("<translation>", "YAML_PARSE_ERROR", str(exc))],
+        )
+    if not isinstance(data, dict):
+        return ValidationReport(
+            valid=False,
+            errors=[
+                ValidationError(
+                    "<translation>",
+                    "TRANSLATION_SHAPE",
+                    "top-level must be a mapping",
+                )
+            ],
+        )
+    if data.get("schema_version") != 1:
+        return ValidationReport(
+            valid=False,
+            errors=[
+                ValidationError(
+                    "<translation>",
+                    "SCHEMA_VERSION",
+                    f"unsupported schema_version: {data.get('schema_version')!r}",
+                )
+            ],
+        )
+    patterns = data.get("patterns") or []
+    if not isinstance(patterns, list):
+        return ValidationReport(
+            valid=False,
+            errors=[
+                ValidationError(
+                    "<translation>",
+                    "PATTERNS_SHAPE",
+                    "patterns must be a list",
+                )
+            ],
+        )
+
+    pack = source_pack_path or DEFAULT_SOURCE_PACK
+    known_source_ids = _load_known_source_ids(pack)
+    if not known_source_ids:
+        return ValidationReport(
+            valid=False,
+            errors=[
+                ValidationError(
+                    "<translation>",
+                    "SOURCE_PACK_UNAVAILABLE",
+                    f"could not load any source ids from {pack}",
+                )
+            ],
+        )
+
+    errors: list[ValidationError] = []
+    for pattern in patterns:
+        if not isinstance(pattern, dict):
+            errors.append(
+                ValidationError(
+                    "<unknown>",
+                    "PATTERN_SHAPE",
+                    f"pattern entry must be a mapping: {pattern!r}",
+                )
+            )
+            continue
+        errors.extend(_check_required_keys(pattern))
+        errors.extend(_check_claim_tier(pattern))
+        errors.extend(_check_implementation_status(pattern))
+        errors.extend(_check_source_refs(pattern, known_source_ids))
+        errors.extend(_check_evidence_payload(pattern))
+        errors.extend(_check_engineering_analog_phrasing(pattern))
+        errors.extend(_check_hypothesis_not_fact(pattern))
+        errors.extend(_check_rejected_has_reason(pattern))
+    errors.extend(_check_unique_module_paths(patterns))
+    errors.extend(_check_unique_pattern_ids(patterns))
+
+    pattern_ids: list[str] = []
+    referenced: set[str] = set()
+    for pattern in patterns:
+        if not isinstance(pattern, dict):
+            continue
+        pid = pattern.get("pattern_id")
+        if isinstance(pid, str):
+            pattern_ids.append(pid)
+        for ref in pattern.get("source_ids") or []:
+            if isinstance(ref, str):
+                referenced.add(ref)
+
+    return ValidationReport(
+        pattern_count=len(patterns),
+        valid=not errors,
+        errors=errors,
+        warnings=[],
+        pattern_ids=pattern_ids,
+        referenced_source_ids=sorted(referenced),
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate the GeoSync Physics-2026 translation matrix",
+    )
+    parser.add_argument(
+        "--translation",
+        type=Path,
+        default=DEFAULT_TRANSLATION,
+        help="path to PHYSICS_2026_TRANSLATION.yaml",
+    )
+    parser.add_argument(
+        "--source-pack",
+        type=Path,
+        default=DEFAULT_SOURCE_PACK,
+        help="path to source_pack.yaml (used to verify source_id refs)",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_OUTPUT,
+    )
+    args = parser.parse_args(argv)
+    report = validate_translation(args.translation, args.source_pack)
+    payload = json.dumps(report.to_dict(), indent=2, sort_keys=True)
+    args.output.write_text(payload + "\n", encoding="utf-8")
+    if not report.valid:
+        print(
+            f"FAIL: translation has {len(report.errors)} validation error(s):",
+            file=sys.stderr,
+        )
+        for err in report.errors:
+            print(f"  - {err}", file=sys.stderr)
+        return 1
+    print(
+        f"OK: translation matrix validated "
+        f"({report.pattern_count} patterns, {len(report.referenced_source_ids)} source refs)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

PR-1 of the Physics-2026 integration ships ONLY the **evidence rail**: source pack, translation matrix, two validators, two test suites. **NO runtime modules.** **NO market claims.** **NO predictive claims.**

This is the discipline-import layer. It refuses metaphor by mechanical contract:

> If the source is not validated, do not translate.
> If the translation has no measurable input, reject.
> If the module has no falsifier, reject.
> If the test cannot fail, delete it.
> If the claim sounds stronger than the evidence, downgrade it.

## Six 2026 physics primary sources

| ID | Source | Methodological pattern imported |
|---|---|---|
| `S1_GWTC4` | LIGO/Virgo/KAGRA — GWTC-4.0 | population-scale event catalog |
| `S2_PAIR_INSTABILITY_GAP` | Nature 2026 — pair-instability gap | structured-absence inference |
| `S3_DESI_2026` | DESI/LBNL — mapping milestone | dynamic null model with bounded drift |
| `S4_KITAEV_PARITY_READOUT` | Nature 2025 — Kitaev parity readout | global witness for state invisible to local probes |
| `S5_HELIUM_MOTIONAL_BELL` | Nat. Comm. 2026 — helium motional Bell | trajectory correlation distinct from static |
| `S6_LHCB_DOUBLY_CHARMED_BARYON` | CERN/LHCb — doubly-charmed baryon | composite binding distinct from transient correlation |

Each entry carries `verified_fact`, `allowed_translation`, `forbidden_overclaim`. The validator enforces all three.

## Six engineering-analog patterns

All at `claim_tier: ENGINEERING_ANALOG`, `implementation_status: PROPOSED`.

| Pattern | Source | Module path (PROPOSED) |
|---|---|---|
| `P1_POPULATION_EVENT_CATALOG` | S1 | `geosync_hpc/regimes/population_event_catalog.py` |
| `P2_STRUCTURED_ABSENCE_INFERENCE` | S2 | `geosync_hpc/regimes/structured_absence.py` |
| `P3_DYNAMIC_NULL_MODEL` | S3 | `geosync_hpc/nulls/dynamic_null_model.py` |
| `P4_GLOBAL_PARITY_WITNESS` | S4 | `geosync_hpc/coherence/global_parity_witness.py` |
| `P5_MOTIONAL_CORRELATION_WITNESS` | S5 | `geosync_hpc/dynamics/motional_correlation_witness.py` |
| `P6_COMPOSITE_BINDING_STRUCTURE` | S6 | `geosync_hpc/coherence/composite_binding_structure.py` |

Every pattern declares `measurable_inputs`, `output_witness`, `null_model`, `falsifier`, `deterministic_tests`, `mutation_candidate`. The validator refuses any pattern that omits even one.

## What the validators refuse

### Source validator (6 contracts)
- schema parse / required keys / non-empty evidence lists
- forbidden phrasings (`proves market`, `quantum market`, `predicts returns`, `universal law`, `physical equivalence`) in `title` / `verified_fact` / `allowed_translation`
- non-stable / non-unique `source_id`
- (forbidden phrasings INSIDE `forbidden_overclaim` are allowed — that field exists to forbid them by quoting them)

### Translation validator (10 contracts)
- schema parse / required keys
- every `source_ids` reference resolves in the source pack
- non-REJECTED patterns must carry full evidence payload (≥1 input, ≥1 witness field, non-empty null + falsifier, ≥1 deterministic test)
- `ENGINEERING_ANALOG` body refuses `physical equivalence` / `quantum market` / `universal` / `predicts returns`
- HYPOTHESIS cannot be marked FACT
- REJECTED requires `rejection_reason`
- unique `proposed_module` paths
- unique `pattern_id` values
- valid `claim_tier` and `implementation_status` enum values

## Files

```
docs/research/physics_2026/source_pack.yaml          (6 sources)
docs/research/physics_2026/source_validation.md      (protocol doc)
docs/research/physics_2026/translation_matrix.md     (protocol doc)
.claude/research/PHYSICS_2026_TRANSLATION.yaml       (6 patterns)
tools/research/validate_physics_2026_sources.py      (source validator)
tools/research/validate_physics_2026_translation.py  (translation validator)
tests/research/test_validate_physics_2026_sources.py     (23 tests)
tests/research/test_validate_physics_2026_translation.py (21 tests)
```

44 new tests total. Both validators stdlib + PyYAML only.

## Verification (local)

```
ruff check / black --check / mypy --strict on all 4 Python files  → clean
pytest tests/research/test_validate_physics_2026_*                → 44 passed
python tools/research/validate_physics_2026_sources.py            → exit 0
python tools/research/validate_physics_2026_translation.py        → exit 0
```

## What this PR does NOT do

- No runtime modules. PRs 2..7 will implement one pattern at a time.
- No claim ledger entries (those land alongside each module PR).
- No dependency changes.
- No `quantum` / `universal` / `physical equivalence` in any engineering analog body.
- No market correspondences. Translations import **methodological discipline**, not physical entities.

## PR sequence

| PR | Subject | Status |
|---|---|---|
| **PR-1** | **Evidence rail (this PR)** | **OPEN** |
| PR-2 | `population_event_catalog` (P1) | TODO |
| PR-3 | `structured_absence` (P2) | TODO |
| PR-4 | `dynamic_null_model` (P3) | TODO |
| PR-5 | `global_parity_witness` (P4) | TODO |
| PR-6 | `motional_correlation_witness` (P5) | TODO |
| PR-7 | `composite_binding_structure` (P6) | TODO |

Each module PR will land:
1. module (per the §8 template: input dataclass, witness dataclass, pure assess function)
2. unit tests + boundary tests + invalid-input tests + falsifier test + no-overclaim test
3. claim ledger entry (`.claude/claims/CLAIMS.yaml`) tagged with the pattern_id
4. mutation candidate added to `.claude/mutation/MUTATION_LEDGER.yaml`
5. translation matrix `implementation_status: PROPOSED → IMPLEMENTED`

If any pattern fails one of the gating conditions during module work, it will be marked `REJECTED` with a `rejection_reason` and remain in the matrix as a negative reference.

## Test plan

- [ ] CI `python-quality` green
- [ ] CI `python-fast-tests` green (44 new tests collected)
- [ ] CI `frontend-gate` green (no JS/TS files)
- [ ] CI `secrets-supply-chain` green (no manifest changes)
- [ ] After merge: open PR-2 (`population_event_catalog`)

## Origin

The 2026-04-26 audit established that GeoSync's strongest historical failure mode is **claim inflation through metaphor** — borrowing a physics word to describe an engineering behaviour without paying the falsifier and the test. This PR refuses that path mechanically: every translation is gated by a verified source, every runtime module that follows will be gated by the translation matrix, and every claim that follows the runtime module will be gated by the existing claim ledger.

The Physics-2026 sources are imported as **independent witnesses** of methodological discipline GeoSync has historically lacked — *not* as physical models the runtime simulates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)