### PR TITLE
fix(coverage): F02 closure — make coverage honest about what it measures

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,69 +1,54 @@
+; F02 closure — honest coverage configuration.
+;
+; The previous .coveragerc declared `source = core, backtest, execution`
+; while [run] omit re-excluded 13 sub-packages of core (accelerators,
+; agent, altdata, config, events, indicators, messaging, metrics, phase,
+; reporting, strategies, utils, data/adapters). The reported coverage
+; number therefore measured roughly two-thirds of the declared source —
+; the classic F02 false-confidence pattern.
+;
+; This file replaces that pattern. Source declares the surfaces this
+; profile observes. Omit excludes ONLY artefacts that are not source
+; (tests, generated stubs, empty package markers). When a sub-package
+; is intentionally not measured by this profile, that decision is
+; expressed by REMOVING it from `source`, not by smuggling it into omit.
+;
+; Subsystems not measured by this profile remain observable:
+; they will be added back to `source` when their dedicated profile / CI
+; job lands. Until then, the coverage number reflects only what is
+; actually instrumented — by design, lower than the previous lying
+; total, but truthful.
+;
+; Rule: every path under `omit` must NOT be a child of any path under
+; `source`. The regression test `tests/audit/test_coverage_honesty.py`
+; enforces this.
+
 [run]
+branch = True
 source =
     core
     backtest
     execution
 omit =
-    **/__init__.py
-    application/**
-    cli/**
-    analytics/**
-    markets/**
-    nfpro/**
     tests/**
-    domain/**
-    observability/**
-    apps/**
-    interfaces/**
-    libs/**
-    scripts/**
-    src/**
-    tools/**
     conftest.py
-    core/accelerators/**
-    core/agent/**
-    core/altdata/**
-    core/config/**
-    core/events/**
-    core/indicators/**
-    core/messaging/**
-    core/metrics/**
-    core/reporting/**
-    core/strategies/**
-    core/utils/**
-    core/phase/**
-    core/data/adapters/**
+    **/__init__.py
+    **/generated/**
+    **/_pb2.py
+    **/_pb2_grpc.py
 
 [report]
 show_missing = True
 precision = 2
+exclude_lines =
+    pragma: no cover
+    def __repr__
+    raise NotImplementedError
+    if TYPE_CHECKING:
 omit =
-    **/__init__.py
-    application/**
-    cli/**
-    analytics/**
-    markets/**
-    nfpro/**
     tests/**
-    domain/**
-    observability/**
-    apps/**
-    interfaces/**
-    libs/**
-    scripts/**
-    src/**
-    tools/**
     conftest.py
-    core/accelerators/**
-    core/agent/**
-    core/altdata/**
-    core/config/**
-    core/events/**
-    core/indicators/**
-    core/messaging/**
-    core/metrics/**
-    core/reporting/**
-    core/strategies/**
-    core/utils/**
-    core/phase/**
-    core/data/adapters/**
+    **/__init__.py
+    **/generated/**
+    **/_pb2.py
+    **/_pb2_grpc.py

--- a/tests/audit/test_coverage_honesty.py
+++ b/tests/audit/test_coverage_honesty.py
@@ -1,0 +1,148 @@
+"""Coverage honesty regression test.
+
+Contract under test:
+
+    A path under [run] omit MUST NOT erase a path declared under
+    [run] source.
+
+This is the structural form of the F02 closure. The companion detector
+class (`C1` in `tools/audit/false_confidence_detector.py`) enforces the
+same rule with structured findings; this test enforces it from the
+opposite end (parses .coveragerc directly, asserts the file is honest).
+
+Both checks block the same lie:
+
+    "coverage number = real coverage"
+
+If the lie returns (someone smuggles a `core/utils/**` back into [run]
+omit), the test below fails AND C1 fires. Two independent witnesses.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+COVERAGERC = REPO_ROOT / ".coveragerc"
+
+
+def _parse_coveragerc_section(text: str, section: str, key: str) -> list[str]:
+    """Return the list-valued entry for `section.key` from a .coveragerc.
+
+    coverage.py uses INI semantics with newline-separated list values; the
+    block below the `key =` line indents continuation entries.
+    """
+    lines = text.splitlines()
+    in_section = False
+    in_key = False
+    out: list[str] = []
+    for raw in lines:
+        stripped = raw.strip()
+        # Strip ; and # comments to a separate variable so we don't lose
+        # the leading-whitespace check below.
+        if not stripped or stripped.startswith(";") or stripped.startswith("#"):
+            continue
+        # Section header.
+        if re.match(r"^\[[^\]]+\]\s*$", stripped):
+            in_section = stripped == f"[{section}]"
+            in_key = False
+            continue
+        if not in_section:
+            continue
+        # Key line.
+        if "=" in raw and raw.lstrip() == raw:
+            this_key, _, value = raw.partition("=")
+            if this_key.strip().lower() == key.lower():
+                in_key = True
+                v = value.strip()
+                if v:
+                    out.append(v)
+            else:
+                in_key = False
+            continue
+        if in_key:
+            entry = stripped
+            if entry:
+                out.append(entry)
+    return out
+
+
+def _omit_erases_source(omit: str, sources: list[str]) -> bool:
+    """An omit pattern erases declared source if its leading path
+    component lies under a source root.
+
+    Treat `**`-prefixed globs as global filters (they don't ERASE a
+    specific source root — they apply uniformly).
+    """
+    head = omit.rstrip("/").rstrip("*").rstrip("/")
+    if not head or head.startswith("**"):
+        return False
+    norm_sources = [s.rstrip("/").rstrip("*").rstrip("/") for s in sources]
+    for src in norm_sources:
+        if head == src:
+            return True
+        if head.startswith(src + "/"):
+            return True
+    return False
+
+
+def test_coveragerc_exists() -> None:
+    assert COVERAGERC.exists(), f".coveragerc not found at {COVERAGERC}"
+
+
+def test_run_source_is_non_empty() -> None:
+    text = COVERAGERC.read_text(encoding="utf-8")
+    sources = _parse_coveragerc_section(text, "run", "source")
+    assert sources, "[run] source must declare at least one path"
+
+
+@pytest.mark.parametrize("section", ["run", "report"])
+def test_no_omit_erases_declared_source(section: str) -> None:
+    """The structural F02 contract.
+
+    Holds for both [run] omit and [report] omit, because both must
+    agree on what counts as source.
+    """
+    text = COVERAGERC.read_text(encoding="utf-8")
+    sources = _parse_coveragerc_section(text, "run", "source")
+    omits = _parse_coveragerc_section(text, section, "omit")
+    erasing = [o for o in omits if _omit_erases_source(o, sources)]
+    assert not erasing, (
+        f"[{section}] omit erases declared source root(s) — F02 has "
+        f"returned. Erasing patterns:\n  - "
+        + "\n  - ".join(erasing)
+        + f"\n\nDeclared source: {sources}\n"
+        "If a sub-package is intentionally not measured by this profile, "
+        "drop it from `source` instead of smuggling it into `omit`."
+    )
+
+
+def test_run_and_report_omit_agree() -> None:
+    """Drift between [run] omit and [report] omit is its own honesty
+    failure: a lie at report time."""
+    text = COVERAGERC.read_text(encoding="utf-8")
+    run_omit = sorted(_parse_coveragerc_section(text, "run", "omit"))
+    report_omit = sorted(_parse_coveragerc_section(text, "report", "omit"))
+    assert run_omit == report_omit, (
+        "[run] omit and [report] omit must match exactly:\n"
+        f"  in [run] only:    {sorted(set(run_omit) - set(report_omit))}\n"
+        f"  in [report] only: {sorted(set(report_omit) - set(run_omit))}"
+    )
+
+
+def test_omit_only_targets_non_source_paths() -> None:
+    """Every omit pattern must be either:
+    - a non-source-root path (e.g. tests/**, conftest.py), OR
+    - a global glob (**/...).
+
+    No exceptions. If a sub-package needs exclusion, it leaves source —
+    it does not get smuggled into omit.
+    """
+    text = COVERAGERC.read_text(encoding="utf-8")
+    sources = _parse_coveragerc_section(text, "run", "source")
+    omits = _parse_coveragerc_section(text, "run", "omit")
+    bad = [o for o in omits if _omit_erases_source(o, sources)]
+    assert not bad, f"omit erases declared source: {bad}"

--- a/tests/audit/test_false_confidence_detector.py
+++ b/tests/audit/test_false_confidence_detector.py
@@ -45,11 +45,23 @@ def fcd() -> ModuleType:
 # ---------------------------------------------------------------------------
 
 
-def test_live_repo_surfaces_c1_coverage_omission(fcd: ModuleType) -> None:
-    """F02 must be visible: .coveragerc omits more than it covers."""
+def test_live_repo_no_longer_surfaces_c1_coverage_omission(fcd: ModuleType) -> None:
+    """F02 closed: .coveragerc no longer hides declared source via omit.
+
+    The detector's tightened C1 rule (omit-erases-declared-source) MUST
+    be silent on the post-F02-fix live tree. If this test fails, the bad
+    pattern (omit list shadowing core/* sub-packages, the original F02)
+    has returned. Promote it to xfail ONLY by also describing how the
+    new live finding is actually different from F02; otherwise fix the
+    config.
+    """
     report = fcd.collect(REPO_ROOT)
     c1 = [f for f in report.findings if f.false_confidence_type == "C1"]
-    assert c1, "C1 (.coveragerc omit inflation) not detected on live tree"
+    assert (
+        not c1
+    ), "C1 (.coveragerc omit-erases-declared-source) fired on live tree:\n  " + "\n  ".join(
+        f"{x.actual_evidence}" for x in c1
+    )
 
 
 def test_live_repo_surfaces_c2_scanner_path_mismatch(fcd: ModuleType) -> None:
@@ -78,7 +90,13 @@ def _make_repo(tmp_path: Path) -> Path:
     return repo
 
 
-def test_c1_synthetic_omit_inflation(fcd: ModuleType, tmp_path: Path) -> None:
+def test_c1_synthetic_omit_erases_declared_source(fcd: ModuleType, tmp_path: Path) -> None:
+    """C1 must fire when omit patterns erase paths under declared source.
+
+    This synthetic case mirrors the original F02: declare `src` as source,
+    then omit five sub-packages of `src`. Each omit pattern is a child of
+    a declared source root → C1 must fire.
+    """
     repo = _make_repo(tmp_path)
     (repo / ".coveragerc").write_text(
         dedent("""
@@ -86,16 +104,63 @@ def test_c1_synthetic_omit_inflation(fcd: ModuleType, tmp_path: Path) -> None:
             source =
                 src
             omit =
-                src/a
-                src/b
-                src/c
-                src/d
-                src/e
+                src/a/**
+                src/b/**
+                src/c/**
+                src/d/**
+                src/e/**
             """),
         encoding="utf-8",
     )
     findings = fcd._detect_c1_coverage_omission(repo)
-    assert findings, "C1 should detect 5x omit inflation"
+    assert findings, "C1 should detect omit patterns erasing declared source"
+    assert findings[0].finding_id == "C1-COVERAGERC-OMIT-ERASES-SOURCE"
+
+
+def test_c1_silent_when_omits_target_non_source(fcd: ModuleType, tmp_path: Path) -> None:
+    """C1 must NOT fire when omit patterns target only non-source paths.
+
+    A legitimate config declares source = src and omits tests, conftest,
+    __init__ markers, generated stubs. None of those are children of any
+    declared source root, so C1 stays silent.
+    """
+    repo = _make_repo(tmp_path)
+    (repo / ".coveragerc").write_text(
+        dedent("""
+            [run]
+            source =
+                src
+            omit =
+                tests/**
+                conftest.py
+                **/__init__.py
+                **/generated/**
+                **/_pb2.py
+            """),
+        encoding="utf-8",
+    )
+    findings = fcd._detect_c1_coverage_omission(repo)
+    assert not findings, "C1 should be silent on legitimate omits; got:\n  " + "\n  ".join(
+        f.actual_evidence for f in findings
+    )
+
+
+def test_c1_silent_when_omit_is_glob_filter(fcd: ModuleType, tmp_path: Path) -> None:
+    """A `**`-prefixed glob is a global filter, not a source eraser."""
+    repo = _make_repo(tmp_path)
+    (repo / ".coveragerc").write_text(
+        dedent("""
+            [run]
+            source =
+                src
+            omit =
+                **/__init__.py
+                **/generated/**
+            """),
+        encoding="utf-8",
+    )
+    findings = fcd._detect_c1_coverage_omission(repo)
+    assert not findings
 
 
 def test_c2_synthetic_dockerfile_unscanned(fcd: ModuleType, tmp_path: Path) -> None:

--- a/tools/audit/false_confidence_detector.py
+++ b/tools/audit/false_confidence_detector.py
@@ -143,34 +143,73 @@ def _detect_c1_coverage_omission(repo_root: Path) -> list[Finding]:
     findings: list[Finding] = []
     if not source:
         return findings
-    omit_count = len(omits)
-    source_count = len(source)
-    # Heuristic: if the omit list is larger than the declared source list,
-    # the configuration is almost certainly excluding more than it covers.
-    if omit_count >= source_count * 2:
+
+    # Precision rule: an omit pattern is a false-confidence signal ONLY when
+    # it erases a path under a declared source root. A bare-name pattern
+    # like `tests/**` is fine when nothing in `source` declares `tests`; it
+    # is the omit-erases-declared-source pattern that produced F02.
+    erasing_omits = _omits_erasing_declared_source(source, omits)
+    if erasing_omits:
         findings.append(
             Finding(
-                finding_id="C1-COVERAGERC-OMIT-INFLATION",
+                finding_id="C1-COVERAGERC-OMIT-ERASES-SOURCE",
                 false_confidence_type="C1",
                 evidence_path=".coveragerc",
                 apparent_claim=(
-                    f"`source =` declares {source_count} target(s) " f"({', '.join(source)})"
+                    f"`source =` declares {len(source)} target(s) ({', '.join(source)})"
                 ),
                 actual_evidence=(
-                    f"`omit =` excludes {omit_count} pattern(s); ratio "
-                    f"{omit_count / max(source_count, 1):.1f}x — coverage "
-                    "is measured on a small subset"
+                    f"`omit =` erases {len(erasing_omits)} pattern(s) under "
+                    f"declared source roots: {sorted(erasing_omits)[:5]}"
+                    f"{'…' if len(erasing_omits) > 5 else ''}"
                 ),
                 risk="CRITICAL",
                 priority="CRITICAL",
                 minimal_repayment_action=(
-                    "rewrite .coveragerc to declare per-subsystem source "
-                    "blocks; remove the wholesale omit list; gate on "
-                    "per-subsystem floors not a single global %"
+                    "remove omit patterns that lie under declared source roots; "
+                    "if a sub-package is intentionally not measured by this "
+                    "profile, drop it from `source` instead of smuggling it "
+                    "into `omit`"
                 ),
             )
         )
     return findings
+
+
+def _omits_erasing_declared_source(source: list[str], omits: list[str]) -> list[str]:
+    """Return the omit patterns that erase a declared source root.
+
+    Both source and omit entries are normalised to a leading-segment
+    representation (no trailing slashes, no `**` suffixes). An omit
+    pattern erases a source root when the omit's leading path component
+    is a strict child of any source root path.
+
+    `tests/**` against `source = core, backtest, execution` returns []
+        (no source root is `tests`).
+    `core/utils/**` against the same `source` returns ['core/utils/**']
+        (it is under the `core` root).
+    `**/__init__.py` matches every package; treated as a global filter,
+        not as erasing-declared-source.
+    """
+    erasing: list[str] = []
+    # Strip trailing `/**` and `/*` suffixes; treat the rest as a path.
+    norm_sources = [s.rstrip("/").rstrip("*").rstrip("/") for s in source]
+    for omit in omits:
+        head = omit.rstrip("/").rstrip("*").rstrip("/")
+        if not head or head.startswith("**"):
+            # Globs like **/__init__.py or **/generated/** are global filters,
+            # not source-root erasers.
+            continue
+        for src in norm_sources:
+            if head == src:
+                # Omit IS the source root — total erasure.
+                erasing.append(omit)
+                break
+            if head.startswith(src + "/"):
+                # Omit is a child of a declared source root.
+                erasing.append(omit)
+                break
+    return erasing
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes **F02** — coverage false-confidence (CRITICAL). The previous `.coveragerc` declared `source = core, backtest, execution` while `[run] omit` re-excluded 13 sub-packages of `core/`. Of 35 sub-directories, 13 were silently erased under the same key that declared core as source. Every coverage % reported in CI / docs / dashboards measured roughly 22 of 35 declared sub-packages. **The number was a lie.**

This PR makes the configuration honest, tightens the detector's C1 rule from a coarse heuristic to a structural one, and adds an independent regression test that parses `.coveragerc` directly.

## What changes

| File | Change |
|---|---|
| `.coveragerc` | 29 omits → 6 (only legitimate non-source globals: `tests/**`, `conftest.py`, `**/__init__.py`, `**/generated/**`, `**/_pb2*.py`). All 13 source-erasing patterns removed. |
| `tools/audit/false_confidence_detector.py` | C1 rule: `omit_count >= source_count * 2` → "any omit pattern that lies under a path declared in source". Finding ID renamed `C1-COVERAGERC-OMIT-INFLATION` → `C1-COVERAGERC-OMIT-ERASES-SOURCE`. |
| `tests/audit/test_false_confidence_detector.py` | Inverted live-tree test (was "F02 visible" → now "F02 closed"). 3 synthetic tests added covering the precision rule. |
| `tests/audit/test_coverage_honesty.py` | NEW — 6 tests parsing `.coveragerc` directly; second independent witness on the same lie. |

## What this PR does NOT do

- No runtime logic touched
- No Physics-2026 P2..P6 implemented
- No new YAML
- No new dashboard / doc-index
- No coverage threshold raised
- No tests added that bless current numbers
- No bypass of the detector for politeness

The coverage number IS lower now. By design. A honest lower number is closer to truth than a lying higher one.

## Probe (mandatory per F02 closure protocol §8)

1. Backed up `.coveragerc`
2. Reintroduced F02 by appending `core/utils/**` to `[run] omit`
3. Detector fired: `C1-COVERAGERC-OMIT-ERASES-SOURCE` listing `core/utils/**` under "declared source roots"
4. Honesty test `test_no_omit_erases_declared_source[run]` failed with `AssertionError: F02 has returned`
5. Restored from backup
6. Detector silent (C1 count = 0)
7. Honesty tests green (6/6)
8. `git diff --exit-code` clean — no `core/utils` residue in any omit section

## Verification

```
python tools/audit/false_confidence_detector.py    → C1 count: 0
python tools/audit/system_truth_report.py
                                                    → false_confidence band
                                                      RED → YELLOW
pytest tests/audit/                                 → 36 passed
ruff check / black --check / mypy --strict          → clean
```

## Stacked on

PR #448 (calibration tasks). Rebases automatically when #448 merges.

## Closure Status: **CLOSED**

- F02 false-confidence no longer active (detector silent on live tree)
- probe executed and restored cleanly
- 36/36 audit tests pass (incl. 6 new honesty + 3 synthetic C1)
- configuration is honest (no source-erasing omit)
- no new ceremony added

🤖 Generated with [Claude Code](https://claude.com/claude-code)