### PR TITLE
feat(coherence): add global parity witness

### DIFF
--- a/.claude/research/PHYSICS_2026_TRANSLATION.yaml
+++ b/.claude/research/PHYSICS_2026_TRANSLATION.yaml
@@ -211,7 +211,8 @@ patterns:
       required global surface agrees.
     proposed_module: geosync_hpc/coherence/global_parity_witness.py
     claim_tier: ENGINEERING_ANALOG
-    implementation_status: PROPOSED
+    implementation_status: IMPLEMENTED
+    implemented_at: "2026-04-26"
     measurable_inputs:
       - local_witnesses
       - claim_ledger_status

--- a/geosync_hpc/coherence/__init__.py
+++ b/geosync_hpc/coherence/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""Coherence / global-surface engineering analogs."""
+
+__all__: list[str] = []

--- a/geosync_hpc/coherence/global_parity_witness.py
+++ b/geosync_hpc/coherence/global_parity_witness.py
@@ -1,0 +1,389 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""Global parity witness — engineering analog of Kitaev-readout discipline.
+
+pattern_id:        P4_GLOBAL_PARITY_WITNESS
+source_id:         S4_KITAEV_PARITY_READOUT
+claim_tier:        ENGINEERING_ANALOG
+implementation:    PR #456 (this module)
+
+Engineering analog
+==================
+
+In a Kitaev-chain readout, local charge sensing cannot distinguish the
+two parity states; only a global capacitance measurement can. The
+property is invisible to local probes by construction.
+
+This module imports that *inference discipline*, not the physics. A
+GeoSync system claim cannot be granted on local witnesses alone:
+required global surfaces — claim ledger, dependency truth, invariant
+coverage, CI gate — must independently agree. If any required surface
+fails or its status is unknown, the witness refuses to declare global
+consistency.
+
+The named lie blocked here is::
+
+    "local pass = global pass"
+
+The witness's contract is symmetric: every required surface either
+agrees, or the global verdict is FALSE. There is no numeric health
+score, no confidence float, no percent. There is a boolean and a list
+of named failed surfaces.
+
+Statuses
+========
+
+The witness reports exactly one of::
+
+    GLOBAL_PASS                 every local witness passed AND
+                                every required global surface passed
+    LOCAL_FAILURE               at least one local witness reported
+                                passed=False
+    CLAIM_LEDGER_FAILURE        claim_ledger_ok is False
+    DEPENDENCY_TRUTH_FAILURE    dependency_truth_ok is False
+    INVARIANT_COVERAGE_FAILURE  invariant_coverage_ok is False
+    CI_GATE_FAILURE             ci_gate_ok is False
+    CI_GATE_UNKNOWN             ci_gate_ok is None
+
+Status is the *primary* failure surface; `failed_surfaces` lists every
+failing surface (including locals) in deterministic order. When more
+than one surface fails simultaneously, status is selected by the fixed
+priority documented in ``assess_global_parity``.
+
+Explicit non-claims
+===================
+
+This module does NOT claim:
+  - any one-to-one correspondence with quantum-parity physics
+  - that GLOBAL_PASS is a forecast or trading signal
+  - that the witness is exhaustive of "system-level correctness" — it
+    is exactly the AND-aggregation of the surfaces declared in
+    ``required_surfaces`` plus the supplied locals
+
+Determinism contract
+====================
+
+  - assess_global_parity(...) is pure: no I/O, no clock, no random, no
+    global state.
+  - Identical inputs produce byte-identical witness outputs.
+  - failed_surfaces is sorted in a stable, deterministic order.
+  - There is no module-level mutable state.
+  - There is no numeric health / score / confidence / percent / index
+    field anywhere on the witness.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from types import MappingProxyType
+from typing import Any, Literal
+
+__all__ = [
+    "GlobalParityStatus",
+    "LocalWitness",
+    "GlobalParityInput",
+    "GlobalParityWitness",
+    "assess_global_parity",
+]
+
+
+# ---------------------------------------------------------------------------
+# Stable surface names. Strings are part of the API surface.
+# ---------------------------------------------------------------------------
+
+_SURFACE_CLAIM_LEDGER = "claim_ledger"
+_SURFACE_DEPENDENCY_TRUTH = "dependency_truth"
+_SURFACE_INVARIANT_COVERAGE = "invariant_coverage"
+_SURFACE_CI_GATE = "ci_gate"
+
+_GLOBAL_SURFACES: tuple[str, ...] = (
+    _SURFACE_CLAIM_LEDGER,
+    _SURFACE_DEPENDENCY_TRUTH,
+    _SURFACE_INVARIANT_COVERAGE,
+    _SURFACE_CI_GATE,
+)
+
+_VALID_TIERS: frozenset[str] = frozenset(
+    {
+        "ENGINEERING_ANALOG",
+        "STRUCTURAL_INVARIANT",
+        "DETERMINISTIC_CHECK",
+        "EVIDENCE_GATED",
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Reasons (stable) and falsifier text.
+# ---------------------------------------------------------------------------
+
+_REASON_GLOBAL_PASS = "OK_ALL_REQUIRED_SURFACES_AGREE"
+_REASON_LOCAL_FAIL = "LOCAL_WITNESS_REPORTED_FAILURE"
+_REASON_CLAIM_FAIL = "CLAIM_LEDGER_REPORTED_FAILURE"
+_REASON_DEPS_FAIL = "DEPENDENCY_TRUTH_REPORTED_FAILURE"
+_REASON_INVAR_FAIL = "INVARIANT_COVERAGE_REPORTED_FAILURE"
+_REASON_CI_FAIL = "CI_GATE_REPORTED_FAILURE"
+_REASON_CI_UNKNOWN = "CI_GATE_STATUS_UNKNOWN"
+
+
+_FALSIFIER_TEXT = (
+    "GLOBAL_PASS was returned but at least one of the following held: "
+    "any local witness reported passed=False; claim_ledger_ok was False; "
+    "dependency_truth_ok was False; invariant_coverage_ok was False; "
+    "ci_gate_ok was False or None. OR: a required global surface was "
+    "silently ignored by the aggregation. OR: failed_surfaces was "
+    "non-deterministic across identical inputs."
+)
+
+
+# ---------------------------------------------------------------------------
+# Status type
+# ---------------------------------------------------------------------------
+
+GlobalParityStatus = Literal[
+    "GLOBAL_PASS",
+    "LOCAL_FAILURE",
+    "CLAIM_LEDGER_FAILURE",
+    "DEPENDENCY_TRUTH_FAILURE",
+    "INVARIANT_COVERAGE_FAILURE",
+    "CI_GATE_UNKNOWN",
+    "CI_GATE_FAILURE",
+]
+
+
+@dataclass(frozen=True)
+class LocalWitness:
+    """One local check entering the global aggregation.
+
+    Locals do not have to share a tier vocabulary with the rest of the
+    system; the witness only enforces that ``tier`` is one of the
+    allowed strings, that ``name`` is a non-empty identifier, and that
+    ``passed`` is a real bool.
+    """
+
+    name: str
+    passed: bool
+    tier: str
+    reason: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.name, str) or not self.name.strip():
+            raise ValueError("LocalWitness.name must be a non-empty string")
+        if not isinstance(self.passed, bool):
+            raise TypeError("LocalWitness.passed must be a bool")
+        if not isinstance(self.tier, str) or self.tier not in _VALID_TIERS:
+            raise ValueError(
+                f"LocalWitness.tier must be one of {sorted(_VALID_TIERS)} (got {self.tier!r})"
+            )
+        if not isinstance(self.reason, str):
+            raise TypeError("LocalWitness.reason must be a string")
+
+
+@dataclass(frozen=True)
+class GlobalParityInput:
+    """Single global-parity question.
+
+    `local_witnesses` carries the local module checks. The aggregation
+    refuses an empty tuple — a global-parity claim with no local
+    witnesses is structurally meaningless.
+
+    `claim_ledger_ok`, `dependency_truth_ok`, `invariant_coverage_ok`
+    are required global surfaces; `ci_gate_ok` is `bool | None` so the
+    caller can distinguish "CI definitively failed" from "CI status is
+    unknown" — both fail the global verdict, but with different status
+    strings.
+
+    `required_surfaces` declares which global surfaces the caller
+    wishes enforced. Every entry must be one of the canonical surface
+    names; the canonical set itself is exposed via
+    ``GlobalParityInput.canonical_surfaces()``.
+    """
+
+    local_witnesses: tuple[LocalWitness, ...]
+    claim_ledger_ok: bool
+    dependency_truth_ok: bool
+    invariant_coverage_ok: bool
+    ci_gate_ok: bool | None
+    required_surfaces: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.local_witnesses, tuple):
+            raise TypeError(
+                "local_witnesses must be a tuple of LocalWitness; convert "
+                "via tuple(...) at the call site"
+            )
+        if len(self.local_witnesses) == 0:
+            raise ValueError("local_witnesses must be non-empty")
+        for i, lw in enumerate(self.local_witnesses):
+            if not isinstance(lw, LocalWitness):
+                raise TypeError(f"local_witnesses[{i}] must be a LocalWitness instance")
+
+        for name, value in (
+            ("claim_ledger_ok", self.claim_ledger_ok),
+            ("dependency_truth_ok", self.dependency_truth_ok),
+            ("invariant_coverage_ok", self.invariant_coverage_ok),
+        ):
+            if not isinstance(value, bool):
+                raise TypeError(f"{name} must be a bool")
+
+        if self.ci_gate_ok is not None and not isinstance(self.ci_gate_ok, bool):
+            raise TypeError("ci_gate_ok must be a bool or None")
+
+        if not isinstance(self.required_surfaces, tuple):
+            raise TypeError("required_surfaces must be a tuple of strings")
+        for s in self.required_surfaces:
+            if not isinstance(s, str) or not s.strip():
+                raise ValueError("required_surfaces entries must be non-empty strings")
+            if s not in _GLOBAL_SURFACES:
+                raise ValueError(
+                    f"required_surfaces contains unknown surface {s!r}; "
+                    f"valid surfaces are {_GLOBAL_SURFACES}"
+                )
+
+    @staticmethod
+    def canonical_surfaces() -> tuple[str, ...]:
+        """Canonical global surface names, in deterministic order."""
+        return _GLOBAL_SURFACES
+
+
+@dataclass(frozen=True)
+class GlobalParityWitness:
+    """Outcome of one global-parity assessment.
+
+    `globally_consistent` is True iff status == "GLOBAL_PASS".
+    `failed_surfaces` lists every failing surface (locals are listed
+    by ``local:<name>`` and globals by their canonical surface name)
+    in deterministic order — locals first (by name), then globals in
+    canonical order.
+    """
+
+    globally_consistent: bool
+    status: GlobalParityStatus
+    failed_surfaces: tuple[str, ...]
+    local_pass_count: int
+    local_fail_count: int
+    reason: str
+    falsifier: str
+    evidence_fields: Mapping[str, Any] = field(default_factory=lambda: MappingProxyType({}))
+
+
+# ---------------------------------------------------------------------------
+# Pure assessment function
+# ---------------------------------------------------------------------------
+
+
+def _classify_global(
+    *,
+    has_local_failure: bool,
+    claim_ok: bool,
+    deps_ok: bool,
+    invar_ok: bool,
+    ci_ok: bool | None,
+    required: frozenset[str],
+) -> tuple[GlobalParityStatus, str]:
+    """Pick the primary status by fixed priority.
+
+    Priority (first failing surface wins):
+
+        1. local witness failure
+        2. claim_ledger_ok is False         (if required)
+        3. dependency_truth_ok is False     (if required)
+        4. invariant_coverage_ok is False   (if required)
+        5. ci_gate_ok is False              (if required)
+        6. ci_gate_ok is None               (if required)
+        7. otherwise                         GLOBAL_PASS
+    """
+    if has_local_failure:
+        return "LOCAL_FAILURE", _REASON_LOCAL_FAIL
+    if _SURFACE_CLAIM_LEDGER in required and not claim_ok:
+        return "CLAIM_LEDGER_FAILURE", _REASON_CLAIM_FAIL
+    if _SURFACE_DEPENDENCY_TRUTH in required and not deps_ok:
+        return "DEPENDENCY_TRUTH_FAILURE", _REASON_DEPS_FAIL
+    if _SURFACE_INVARIANT_COVERAGE in required and not invar_ok:
+        return "INVARIANT_COVERAGE_FAILURE", _REASON_INVAR_FAIL
+    if _SURFACE_CI_GATE in required:
+        if ci_ok is False:
+            return "CI_GATE_FAILURE", _REASON_CI_FAIL
+        if ci_ok is None:
+            return "CI_GATE_UNKNOWN", _REASON_CI_UNKNOWN
+    return "GLOBAL_PASS", _REASON_GLOBAL_PASS
+
+
+def assess_global_parity(input_: GlobalParityInput) -> GlobalParityWitness:
+    """Classify the global-parity question carried by ``input_``.
+
+    Pure function. Reads only the input dataclass; no I/O, no clock,
+    no global state. Returns one ``GlobalParityWitness`` describing
+    the structural verdict.
+
+    A required surface that reports False or None makes
+    ``globally_consistent`` False with the corresponding status. An
+    empty ``required_surfaces`` tuple means "the caller does not
+    require any global surface" — only the local witnesses are
+    aggregated, and a CI gate of None / False does not affect the
+    verdict (it would not be required).
+    """
+    required = frozenset(input_.required_surfaces)
+
+    failed_locals: list[str] = []
+    pass_count = 0
+    for lw in input_.local_witnesses:
+        if lw.passed:
+            pass_count += 1
+        else:
+            failed_locals.append(lw.name)
+    has_local_failure = bool(failed_locals)
+
+    failed_globals: list[str] = []
+    if _SURFACE_CLAIM_LEDGER in required and not input_.claim_ledger_ok:
+        failed_globals.append(_SURFACE_CLAIM_LEDGER)
+    if _SURFACE_DEPENDENCY_TRUTH in required and not input_.dependency_truth_ok:
+        failed_globals.append(_SURFACE_DEPENDENCY_TRUTH)
+    if _SURFACE_INVARIANT_COVERAGE in required and not input_.invariant_coverage_ok:
+        failed_globals.append(_SURFACE_INVARIANT_COVERAGE)
+    if _SURFACE_CI_GATE in required and (input_.ci_gate_ok is None or not input_.ci_gate_ok):
+        failed_globals.append(_SURFACE_CI_GATE)
+
+    # Deterministic order: locals (sorted by name, prefixed) then globals
+    # in canonical order. Globals already follow the canonical ordering
+    # because the appends above are in that order.
+    failed_surfaces: tuple[str, ...] = tuple(
+        f"local:{name}" for name in sorted(failed_locals)
+    ) + tuple(failed_globals)
+
+    status, reason = _classify_global(
+        has_local_failure=has_local_failure,
+        claim_ok=input_.claim_ledger_ok,
+        deps_ok=input_.dependency_truth_ok,
+        invar_ok=input_.invariant_coverage_ok,
+        ci_ok=input_.ci_gate_ok,
+        required=required,
+    )
+
+    evidence = MappingProxyType(
+        dict(
+            {
+                "local_count": len(input_.local_witnesses),
+                "local_pass_count": pass_count,
+                "local_fail_count": len(failed_locals),
+                "required_surfaces": tuple(sorted(required)),
+                "failed_surfaces": failed_surfaces,
+                "claim_ledger_ok": input_.claim_ledger_ok,
+                "dependency_truth_ok": input_.dependency_truth_ok,
+                "invariant_coverage_ok": input_.invariant_coverage_ok,
+                "ci_gate_ok": input_.ci_gate_ok,
+            }
+        )
+    )
+
+    return GlobalParityWitness(
+        globally_consistent=(status == "GLOBAL_PASS"),
+        status=status,
+        failed_surfaces=failed_surfaces,
+        local_pass_count=pass_count,
+        local_fail_count=len(failed_locals),
+        reason=reason,
+        falsifier=_FALSIFIER_TEXT,
+        evidence_fields=evidence,
+    )

--- a/geosync_hpc/coherence/global_parity_witness.py
+++ b/geosync_hpc/coherence/global_parity_witness.py
@@ -5,71 +5,26 @@
 pattern_id:        P4_GLOBAL_PARITY_WITNESS
 source_id:         S4_KITAEV_PARITY_READOUT
 claim_tier:        ENGINEERING_ANALOG
-implementation:    PR #456 (this module)
 
-Engineering analog
-==================
+Local probes cannot decide a global property: required global surfaces
+(claim ledger, dependency truth, invariant coverage, CI gate) must
+independently agree. The named lie blocked here is "local pass = global
+pass". The witness is a pure AND-aggregation; there is no numeric
+score, no confidence float, no percent.
 
-In a Kitaev-chain readout, local charge sensing cannot distinguish the
-two parity states; only a global capacitance measurement can. The
-property is invisible to local probes by construction.
+Status priority (first failing surface wins): LOCAL_FAILURE >
+CLAIM_LEDGER_FAILURE > DEPENDENCY_TRUTH_FAILURE >
+INVARIANT_COVERAGE_FAILURE > CI_GATE_FAILURE > CI_GATE_UNKNOWN >
+GLOBAL_PASS. ``failed_surfaces`` is locals (sorted, ``local:`` prefix)
+then globals in canonical order.
 
-This module imports that *inference discipline*, not the physics. A
-GeoSync system claim cannot be granted on local witnesses alone:
-required global surfaces — claim ledger, dependency truth, invariant
-coverage, CI gate — must independently agree. If any required surface
-fails or its status is unknown, the witness refuses to declare global
-consistency.
+Non-claims: no one-to-one correspondence with quantum-parity physics;
+GLOBAL_PASS is not a forecast or trading signal; the witness is exactly
+the AND-aggregation of declared surfaces.
 
-The named lie blocked here is::
-
-    "local pass = global pass"
-
-The witness's contract is symmetric: every required surface either
-agrees, or the global verdict is FALSE. There is no numeric health
-score, no confidence float, no percent. There is a boolean and a list
-of named failed surfaces.
-
-Statuses
-========
-
-The witness reports exactly one of::
-
-    GLOBAL_PASS                 every local witness passed AND
-                                every required global surface passed
-    LOCAL_FAILURE               at least one local witness reported
-                                passed=False
-    CLAIM_LEDGER_FAILURE        claim_ledger_ok is False
-    DEPENDENCY_TRUTH_FAILURE    dependency_truth_ok is False
-    INVARIANT_COVERAGE_FAILURE  invariant_coverage_ok is False
-    CI_GATE_FAILURE             ci_gate_ok is False
-    CI_GATE_UNKNOWN             ci_gate_ok is None
-
-Status is the *primary* failure surface; `failed_surfaces` lists every
-failing surface (including locals) in deterministic order. When more
-than one surface fails simultaneously, status is selected by the fixed
-priority documented in ``assess_global_parity``.
-
-Explicit non-claims
-===================
-
-This module does NOT claim:
-  - any one-to-one correspondence with quantum-parity physics
-  - that GLOBAL_PASS is a forecast or trading signal
-  - that the witness is exhaustive of "system-level correctness" — it
-    is exactly the AND-aggregation of the surfaces declared in
-    ``required_surfaces`` plus the supplied locals
-
-Determinism contract
-====================
-
-  - assess_global_parity(...) is pure: no I/O, no clock, no random, no
-    global state.
-  - Identical inputs produce byte-identical witness outputs.
-  - failed_surfaces is sorted in a stable, deterministic order.
-  - There is no module-level mutable state.
-  - There is no numeric health / score / confidence / percent / index
-    field anywhere on the witness.
+Determinism: ``assess_global_parity`` is pure. No I/O, no clock, no
+random, no module-level mutable state. Identical inputs produce
+byte-identical witnesses.
 """
 
 from __future__ import annotations
@@ -88,10 +43,6 @@ __all__ = [
 ]
 
 
-# ---------------------------------------------------------------------------
-# Stable surface names. Strings are part of the API surface.
-# ---------------------------------------------------------------------------
-
 _SURFACE_CLAIM_LEDGER = "claim_ledger"
 _SURFACE_DEPENDENCY_TRUTH = "dependency_truth"
 _SURFACE_INVARIANT_COVERAGE = "invariant_coverage"
@@ -105,26 +56,8 @@ _GLOBAL_SURFACES: tuple[str, ...] = (
 )
 
 _VALID_TIERS: frozenset[str] = frozenset(
-    {
-        "FACT",
-        "ENGINEERING_ANALOG",
-        "HYPOTHESIS",
-        "SPECULATIVE",
-    }
+    {"FACT", "ENGINEERING_ANALOG", "HYPOTHESIS", "SPECULATIVE"}
 )
-
-
-# ---------------------------------------------------------------------------
-# Reasons (stable) and falsifier text.
-# ---------------------------------------------------------------------------
-
-_REASON_GLOBAL_PASS = "OK_ALL_REQUIRED_SURFACES_AGREE"
-_REASON_LOCAL_FAIL = "LOCAL_WITNESS_REPORTED_FAILURE"
-_REASON_CLAIM_FAIL = "CLAIM_LEDGER_REPORTED_FAILURE"
-_REASON_DEPS_FAIL = "DEPENDENCY_TRUTH_REPORTED_FAILURE"
-_REASON_INVAR_FAIL = "INVARIANT_COVERAGE_REPORTED_FAILURE"
-_REASON_CI_FAIL = "CI_GATE_REPORTED_FAILURE"
-_REASON_CI_UNKNOWN = "CI_GATE_STATUS_UNKNOWN"
 
 
 _FALSIFIER_TEXT = (
@@ -136,10 +69,6 @@ _FALSIFIER_TEXT = (
     "non-deterministic across identical inputs."
 )
 
-
-# ---------------------------------------------------------------------------
-# Status type
-# ---------------------------------------------------------------------------
 
 GlobalParityStatus = Literal[
     "GLOBAL_PASS",
@@ -154,13 +83,7 @@ GlobalParityStatus = Literal[
 
 @dataclass(frozen=True)
 class LocalWitness:
-    """One local check entering the global aggregation.
-
-    Locals do not have to share a tier vocabulary with the rest of the
-    system; the witness only enforces that ``tier`` is one of the
-    allowed strings, that ``name`` is a non-empty identifier, and that
-    ``passed`` is a real bool.
-    """
+    """One local check entering the global aggregation."""
 
     name: str
     passed: bool
@@ -182,22 +105,12 @@ class LocalWitness:
 
 @dataclass(frozen=True)
 class GlobalParityInput:
-    """Single global-parity question.
+    """Inputs to one global-parity assessment.
 
-    `local_witnesses` carries the local module checks. The aggregation
-    refuses an empty tuple — a global-parity claim with no local
-    witnesses is structurally meaningless.
-
-    `claim_ledger_ok`, `dependency_truth_ok`, `invariant_coverage_ok`
-    are required global surfaces; `ci_gate_ok` is `bool | None` so the
-    caller can distinguish "CI definitively failed" from "CI status is
-    unknown" — both fail the global verdict, but with different status
-    strings.
-
-    `required_surfaces` declares which global surfaces the caller
-    wishes enforced. Every entry must be one of the canonical surface
-    names; the canonical set itself is exposed via
-    ``GlobalParityInput.canonical_surfaces()``.
+    ``required_surfaces`` declares which canonical globals the caller
+    enforces; entries must come from ``canonical_surfaces()``.
+    ``ci_gate_ok=None`` is a distinct verdict (CI_GATE_UNKNOWN), not a
+    pass.
     """
 
     local_witnesses: tuple[LocalWitness, ...]
@@ -209,10 +122,7 @@ class GlobalParityInput:
 
     def __post_init__(self) -> None:
         if not isinstance(self.local_witnesses, tuple):
-            raise TypeError(
-                "local_witnesses must be a tuple of LocalWitness; convert "
-                "via tuple(...) at the call site"
-            )
+            raise TypeError("local_witnesses must be a tuple of LocalWitness")
         if len(self.local_witnesses) == 0:
             raise ValueError("local_witnesses must be non-empty")
         for i, lw in enumerate(self.local_witnesses):
@@ -226,7 +136,6 @@ class GlobalParityInput:
         ):
             if not isinstance(value, bool):
                 raise TypeError(f"{name} must be a bool")
-
         if self.ci_gate_ok is not None and not isinstance(self.ci_gate_ok, bool):
             raise TypeError("ci_gate_ok must be a bool or None")
 
@@ -243,19 +152,16 @@ class GlobalParityInput:
 
     @staticmethod
     def canonical_surfaces() -> tuple[str, ...]:
-        """Canonical global surface names, in deterministic order."""
         return _GLOBAL_SURFACES
 
 
 @dataclass(frozen=True)
 class GlobalParityWitness:
-    """Outcome of one global-parity assessment.
+    """One global-parity verdict.
 
-    `globally_consistent` is True iff status == "GLOBAL_PASS".
-    `failed_surfaces` lists every failing surface (locals are listed
-    by ``local:<name>`` and globals by their canonical surface name)
-    in deterministic order — locals first (by name), then globals in
-    canonical order.
+    ``globally_consistent`` is True iff status == "GLOBAL_PASS".
+    ``failed_surfaces`` is locals (sorted, ``local:`` prefix) then
+    globals in canonical order.
     """
 
     globally_consistent: bool
@@ -268,72 +174,12 @@ class GlobalParityWitness:
     evidence_fields: Mapping[str, Any] = field(default_factory=lambda: MappingProxyType({}))
 
 
-# ---------------------------------------------------------------------------
-# Pure assessment function
-# ---------------------------------------------------------------------------
-
-
-def _classify_global(
-    *,
-    has_local_failure: bool,
-    claim_ok: bool,
-    deps_ok: bool,
-    invar_ok: bool,
-    ci_ok: bool | None,
-    required: frozenset[str],
-) -> tuple[GlobalParityStatus, str]:
-    """Pick the primary status by fixed priority.
-
-    Priority (first failing surface wins):
-
-        1. local witness failure
-        2. claim_ledger_ok is False         (if required)
-        3. dependency_truth_ok is False     (if required)
-        4. invariant_coverage_ok is False   (if required)
-        5. ci_gate_ok is False              (if required)
-        6. ci_gate_ok is None               (if required)
-        7. otherwise                         GLOBAL_PASS
-    """
-    if has_local_failure:
-        return "LOCAL_FAILURE", _REASON_LOCAL_FAIL
-    if _SURFACE_CLAIM_LEDGER in required and not claim_ok:
-        return "CLAIM_LEDGER_FAILURE", _REASON_CLAIM_FAIL
-    if _SURFACE_DEPENDENCY_TRUTH in required and not deps_ok:
-        return "DEPENDENCY_TRUTH_FAILURE", _REASON_DEPS_FAIL
-    if _SURFACE_INVARIANT_COVERAGE in required and not invar_ok:
-        return "INVARIANT_COVERAGE_FAILURE", _REASON_INVAR_FAIL
-    if _SURFACE_CI_GATE in required:
-        if ci_ok is False:
-            return "CI_GATE_FAILURE", _REASON_CI_FAIL
-        if ci_ok is None:
-            return "CI_GATE_UNKNOWN", _REASON_CI_UNKNOWN
-    return "GLOBAL_PASS", _REASON_GLOBAL_PASS
-
-
 def assess_global_parity(input_: GlobalParityInput) -> GlobalParityWitness:
-    """Classify the global-parity question carried by ``input_``.
-
-    Pure function. Reads only the input dataclass; no I/O, no clock,
-    no global state. Returns one ``GlobalParityWitness`` describing
-    the structural verdict.
-
-    A required surface that reports False or None makes
-    ``globally_consistent`` False with the corresponding status. An
-    empty ``required_surfaces`` tuple means "the caller does not
-    require any global surface" — only the local witnesses are
-    aggregated, and a CI gate of None / False does not affect the
-    verdict (it would not be required).
-    """
+    """Pure AND-aggregation of locals and required globals."""
     required = frozenset(input_.required_surfaces)
 
-    failed_locals: list[str] = []
-    pass_count = 0
-    for lw in input_.local_witnesses:
-        if lw.passed:
-            pass_count += 1
-        else:
-            failed_locals.append(lw.name)
-    has_local_failure = bool(failed_locals)
+    failed_locals = [lw.name for lw in input_.local_witnesses if not lw.passed]
+    pass_count = len(input_.local_witnesses) - len(failed_locals)
 
     failed_globals: list[str] = []
     if _SURFACE_CLAIM_LEDGER in required and not input_.claim_ledger_ok:
@@ -345,36 +191,39 @@ def assess_global_parity(input_: GlobalParityInput) -> GlobalParityWitness:
     if _SURFACE_CI_GATE in required and (input_.ci_gate_ok is None or not input_.ci_gate_ok):
         failed_globals.append(_SURFACE_CI_GATE)
 
-    # Deterministic order: locals (sorted by name, prefixed) then globals
-    # in canonical order. Globals already follow the canonical ordering
-    # because the appends above are in that order.
-    failed_surfaces: tuple[str, ...] = tuple(
-        f"local:{name}" for name in sorted(failed_locals)
-    ) + tuple(failed_globals)
-
-    status, reason = _classify_global(
-        has_local_failure=has_local_failure,
-        claim_ok=input_.claim_ledger_ok,
-        deps_ok=input_.dependency_truth_ok,
-        invar_ok=input_.invariant_coverage_ok,
-        ci_ok=input_.ci_gate_ok,
-        required=required,
+    failed_surfaces: tuple[str, ...] = tuple(f"local:{n}" for n in sorted(failed_locals)) + tuple(
+        failed_globals
     )
 
+    # Status priority: locals > claim > deps > invar > ci(False) > ci(None) > pass.
+    status: GlobalParityStatus
+    if failed_locals:
+        status, reason = "LOCAL_FAILURE", "LOCAL_WITNESS_REPORTED_FAILURE"
+    elif _SURFACE_CLAIM_LEDGER in required and not input_.claim_ledger_ok:
+        status, reason = "CLAIM_LEDGER_FAILURE", "CLAIM_LEDGER_REPORTED_FAILURE"
+    elif _SURFACE_DEPENDENCY_TRUTH in required and not input_.dependency_truth_ok:
+        status, reason = "DEPENDENCY_TRUTH_FAILURE", "DEPENDENCY_TRUTH_REPORTED_FAILURE"
+    elif _SURFACE_INVARIANT_COVERAGE in required and not input_.invariant_coverage_ok:
+        status, reason = "INVARIANT_COVERAGE_FAILURE", "INVARIANT_COVERAGE_REPORTED_FAILURE"
+    elif _SURFACE_CI_GATE in required and input_.ci_gate_ok is False:
+        status, reason = "CI_GATE_FAILURE", "CI_GATE_REPORTED_FAILURE"
+    elif _SURFACE_CI_GATE in required and input_.ci_gate_ok is None:
+        status, reason = "CI_GATE_UNKNOWN", "CI_GATE_STATUS_UNKNOWN"
+    else:
+        status, reason = "GLOBAL_PASS", "OK_ALL_REQUIRED_SURFACES_AGREE"
+
     evidence = MappingProxyType(
-        dict(
-            {
-                "local_count": len(input_.local_witnesses),
-                "local_pass_count": pass_count,
-                "local_fail_count": len(failed_locals),
-                "required_surfaces": tuple(sorted(required)),
-                "failed_surfaces": failed_surfaces,
-                "claim_ledger_ok": input_.claim_ledger_ok,
-                "dependency_truth_ok": input_.dependency_truth_ok,
-                "invariant_coverage_ok": input_.invariant_coverage_ok,
-                "ci_gate_ok": input_.ci_gate_ok,
-            }
-        )
+        {
+            "local_count": len(input_.local_witnesses),
+            "local_pass_count": pass_count,
+            "local_fail_count": len(failed_locals),
+            "required_surfaces": tuple(sorted(required)),
+            "failed_surfaces": failed_surfaces,
+            "claim_ledger_ok": input_.claim_ledger_ok,
+            "dependency_truth_ok": input_.dependency_truth_ok,
+            "invariant_coverage_ok": input_.invariant_coverage_ok,
+            "ci_gate_ok": input_.ci_gate_ok,
+        }
     )
 
     return GlobalParityWitness(

--- a/geosync_hpc/coherence/global_parity_witness.py
+++ b/geosync_hpc/coherence/global_parity_witness.py
@@ -106,10 +106,10 @@ _GLOBAL_SURFACES: tuple[str, ...] = (
 
 _VALID_TIERS: frozenset[str] = frozenset(
     {
+        "FACT",
         "ENGINEERING_ANALOG",
-        "STRUCTURAL_INVARIANT",
-        "DETERMINISTIC_CHECK",
-        "EVIDENCE_GATED",
+        "HYPOTHESIS",
+        "SPECULATIVE",
     }
 )
 
@@ -176,8 +176,8 @@ class LocalWitness:
             raise ValueError(
                 f"LocalWitness.tier must be one of {sorted(_VALID_TIERS)} (got {self.tier!r})"
             )
-        if not isinstance(self.reason, str):
-            raise TypeError("LocalWitness.reason must be a string")
+        if not isinstance(self.reason, str) or not self.reason.strip():
+            raise ValueError("LocalWitness.reason must be a non-empty string")
 
 
 @dataclass(frozen=True)

--- a/tests/unit/coherence/test_global_parity_witness.py
+++ b/tests/unit/coherence/test_global_parity_witness.py
@@ -216,7 +216,11 @@ def test_empty_witness_name_rejected() -> None:
 
 
 def test_invalid_tier_rejected() -> None:
-    """11. unknown tier string rejected."""
+    """11. unknown tier string rejected.
+
+    Valid tiers are exactly {FACT, ENGINEERING_ANALOG, HYPOTHESIS,
+    SPECULATIVE} — anything else is a constructor failure.
+    """
     with pytest.raises(ValueError, match="tier must be one of"):
         LocalWitness(
             name="x",
@@ -226,8 +230,26 @@ def test_invalid_tier_rejected() -> None:
         )
 
 
+def test_empty_reason_rejected() -> None:
+    """12. empty / whitespace LocalWitness.reason rejected at construction."""
+    with pytest.raises(ValueError, match="reason must be a non-empty string"):
+        LocalWitness(
+            name="x",
+            passed=True,
+            tier="ENGINEERING_ANALOG",
+            reason="",
+        )
+    with pytest.raises(ValueError, match="reason must be a non-empty string"):
+        LocalWitness(
+            name="x",
+            passed=True,
+            tier="ENGINEERING_ANALOG",
+            reason="   ",
+        )
+
+
 def test_witness_dataclass_frozen() -> None:
-    """12. GlobalParityWitness is a frozen dataclass; assignment raises."""
+    """13. GlobalParityWitness is a frozen dataclass; assignment raises."""
     witness = assess_global_parity(_input())
     with pytest.raises(Exception):  # noqa: B017 — dataclasses raise FrozenInstanceError
         witness.globally_consistent = False  # type: ignore[misc]
@@ -236,12 +258,12 @@ def test_witness_dataclass_frozen() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Brief-required scenarios 13-16
+# Brief-required scenarios 14-17
 # ---------------------------------------------------------------------------
 
 
 def test_evidence_and_failed_surfaces_immutable() -> None:
-    """13. evidence_fields and failed_surfaces are immutable."""
+    """14. evidence_fields and failed_surfaces are immutable."""
     witness = assess_global_parity(_input(claim_ledger_ok=False))
     assert isinstance(witness.evidence_fields, Mapping)
     with pytest.raises(TypeError):
@@ -251,7 +273,7 @@ def test_evidence_and_failed_surfaces_immutable() -> None:
 
 
 def test_no_forbidden_score_fields_exist() -> None:
-    """14. no numeric health score / percent / confidence_float / health_index."""
+    """15. no numeric health score / percent / confidence_float / health_index."""
     forbidden = {
         "score",
         "health_score",
@@ -263,13 +285,13 @@ def test_no_forbidden_score_fields_exist() -> None:
         "ratio",
     }
     fields = set(GlobalParityWitness.__dataclass_fields__.keys())
-    assert fields.isdisjoint(
-        forbidden
-    ), f"forbidden score fields present on witness: {fields & forbidden}"
+    assert fields.isdisjoint(forbidden), (
+        f"forbidden score fields present on witness: {fields & forbidden}"
+    )
 
 
 def test_deterministic_repeated_calls_equal() -> None:
-    """15. deterministic — repeated calls with identical inputs are equal."""
+    """16. deterministic — repeated calls with identical inputs are equal."""
     inp = _input(
         local_witnesses=(
             _passing_local("a"),
@@ -293,7 +315,7 @@ _MODULE_PATH = (
 
 
 def test_no_imports_from_execution_policy_application_layers() -> None:
-    """16. no imports from execution / policy / application layers."""
+    """17. no imports from execution / policy / application layers."""
     text = _MODULE_PATH.read_text(encoding="utf-8")
     for tainted in (
         "from geosync_hpc.execution",

--- a/tests/unit/coherence/test_global_parity_witness.py
+++ b/tests/unit/coherence/test_global_parity_witness.py
@@ -1,0 +1,444 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""Tests for geosync_hpc.coherence.global_parity_witness.
+
+Cycle of falsification (per 7-link doctrine):
+
+  CNS:          intuition that local pass does not imply global pass —
+                a system can have all modules green while the global
+                aggregation (claim ledger, deps, invariants, CI) is red.
+  Exploration:  7-status decision tree where any failing required
+                surface beats local pass; CI_GATE_UNKNOWN is its own
+                failure branch.
+  ЦШС artifact: LocalWitness / GlobalParityInput / GlobalParityWitness
+                frozen dataclasses, pure deterministic
+                assess_global_parity(...).
+  Tests:        this file. Brief-required scenarios 1-16 covering all
+                statuses, deterministic surface order, validation
+                contract, structural decoupling, no-score guarantee.
+  Falsifier:    ignoring dependency_truth_ok=False makes
+                test_dependency_truth_failure fail.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+
+import pytest
+
+from geosync_hpc.coherence.global_parity_witness import (
+    GlobalParityInput,
+    GlobalParityWitness,
+    LocalWitness,
+    assess_global_parity,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+CANONICAL_REQUIRED: tuple[str, ...] = (
+    "claim_ledger",
+    "dependency_truth",
+    "invariant_coverage",
+    "ci_gate",
+)
+
+
+def _passing_local(name: str = "module_a") -> LocalWitness:
+    return LocalWitness(
+        name=name,
+        passed=True,
+        tier="ENGINEERING_ANALOG",
+        reason="OK",
+    )
+
+
+def _failing_local(name: str = "module_b") -> LocalWitness:
+    return LocalWitness(
+        name=name,
+        passed=False,
+        tier="ENGINEERING_ANALOG",
+        reason="local check failed",
+    )
+
+
+def _input(
+    *,
+    local_witnesses: tuple[LocalWitness, ...] | None = None,
+    claim_ledger_ok: bool = True,
+    dependency_truth_ok: bool = True,
+    invariant_coverage_ok: bool = True,
+    ci_gate_ok: bool | None = True,
+    required_surfaces: tuple[str, ...] = CANONICAL_REQUIRED,
+) -> GlobalParityInput:
+    if local_witnesses is None:
+        local_witnesses = (_passing_local("module_a"), _passing_local("module_b"))
+    return GlobalParityInput(
+        local_witnesses=local_witnesses,
+        claim_ledger_ok=claim_ledger_ok,
+        dependency_truth_ok=dependency_truth_ok,
+        invariant_coverage_ok=invariant_coverage_ok,
+        ci_gate_ok=ci_gate_ok,
+        required_surfaces=required_surfaces,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Brief-required scenarios 1-7
+# ---------------------------------------------------------------------------
+
+
+def test_all_local_and_global_surfaces_pass() -> None:
+    """1. all local + global surfaces pass → GLOBAL_PASS."""
+    witness = assess_global_parity(_input())
+    assert witness.status == "GLOBAL_PASS"
+    assert witness.globally_consistent is True
+    assert witness.failed_surfaces == ()
+    assert witness.local_pass_count == 2
+    assert witness.local_fail_count == 0
+
+
+def test_one_local_witness_fails() -> None:
+    """2. one local witness fails → LOCAL_FAILURE."""
+    witness = assess_global_parity(
+        _input(
+            local_witnesses=(_passing_local("a"), _failing_local("b")),
+        )
+    )
+    assert witness.status == "LOCAL_FAILURE"
+    assert witness.globally_consistent is False
+    assert "local:b" in witness.failed_surfaces
+    assert witness.local_pass_count == 1
+    assert witness.local_fail_count == 1
+
+
+def test_claim_ledger_failure() -> None:
+    """3. all local pass but claim ledger fails → CLAIM_LEDGER_FAILURE."""
+    witness = assess_global_parity(_input(claim_ledger_ok=False))
+    assert witness.status == "CLAIM_LEDGER_FAILURE"
+    assert witness.globally_consistent is False
+    assert witness.failed_surfaces == ("claim_ledger",)
+
+
+def test_dependency_truth_failure() -> None:
+    """4. all local pass but dependency truth fails → DEPENDENCY_TRUTH_FAILURE.
+
+    This is the test the falsifier probe must break.
+    """
+    witness = assess_global_parity(_input(dependency_truth_ok=False))
+    assert witness.status == "DEPENDENCY_TRUTH_FAILURE"
+    assert witness.globally_consistent is False
+    assert witness.failed_surfaces == ("dependency_truth",)
+
+
+def test_invariant_coverage_failure() -> None:
+    """5. all local pass but invariant coverage fails → INVARIANT_COVERAGE_FAILURE."""
+    witness = assess_global_parity(_input(invariant_coverage_ok=False))
+    assert witness.status == "INVARIANT_COVERAGE_FAILURE"
+    assert witness.globally_consistent is False
+    assert witness.failed_surfaces == ("invariant_coverage",)
+
+
+def test_ci_gate_failure() -> None:
+    """6. all local pass but CI False → CI_GATE_FAILURE."""
+    witness = assess_global_parity(_input(ci_gate_ok=False))
+    assert witness.status == "CI_GATE_FAILURE"
+    assert witness.globally_consistent is False
+    assert witness.failed_surfaces == ("ci_gate",)
+
+
+def test_ci_gate_unknown() -> None:
+    """7. all local pass but CI unknown → CI_GATE_UNKNOWN."""
+    witness = assess_global_parity(_input(ci_gate_ok=None))
+    assert witness.status == "CI_GATE_UNKNOWN"
+    assert witness.globally_consistent is False
+    assert witness.failed_surfaces == ("ci_gate",)
+
+
+# ---------------------------------------------------------------------------
+# Brief-required scenarios 8-12
+# ---------------------------------------------------------------------------
+
+
+def test_multiple_failures_deterministic_failed_surfaces_order() -> None:
+    """8. multiple failures return deterministic failed_surfaces order.
+
+    Locals (sorted by name) come first, then globals in canonical
+    order: claim_ledger, dependency_truth, invariant_coverage, ci_gate.
+    """
+    locals_in = (
+        _failing_local("zeta_module"),
+        _passing_local("alpha_module"),
+        _failing_local("beta_module"),
+    )
+    witness = assess_global_parity(
+        _input(
+            local_witnesses=locals_in,
+            claim_ledger_ok=False,
+            dependency_truth_ok=False,
+            invariant_coverage_ok=False,
+            ci_gate_ok=None,
+        )
+    )
+    assert witness.failed_surfaces == (
+        "local:beta_module",
+        "local:zeta_module",
+        "claim_ledger",
+        "dependency_truth",
+        "invariant_coverage",
+        "ci_gate",
+    )
+    # Status is selected by priority — local failure wins.
+    assert witness.status == "LOCAL_FAILURE"
+
+
+def test_empty_local_witnesses_rejected() -> None:
+    """9. empty local witnesses rejected at construction."""
+    with pytest.raises(ValueError, match="local_witnesses must be non-empty"):
+        GlobalParityInput(
+            local_witnesses=(),
+            claim_ledger_ok=True,
+            dependency_truth_ok=True,
+            invariant_coverage_ok=True,
+            ci_gate_ok=True,
+            required_surfaces=CANONICAL_REQUIRED,
+        )
+
+
+def test_empty_witness_name_rejected() -> None:
+    """10. empty LocalWitness.name rejected at construction."""
+    with pytest.raises(ValueError, match="name must be a non-empty string"):
+        LocalWitness(name="", passed=True, tier="ENGINEERING_ANALOG", reason="ok")
+    with pytest.raises(ValueError, match="name must be a non-empty string"):
+        LocalWitness(name="   ", passed=True, tier="ENGINEERING_ANALOG", reason="ok")
+
+
+def test_invalid_tier_rejected() -> None:
+    """11. unknown tier string rejected."""
+    with pytest.raises(ValueError, match="tier must be one of"):
+        LocalWitness(
+            name="x",
+            passed=True,
+            tier="MAGIC_TIER_NOT_IN_SET",
+            reason="ok",
+        )
+
+
+def test_witness_dataclass_frozen() -> None:
+    """12. GlobalParityWitness is a frozen dataclass; assignment raises."""
+    witness = assess_global_parity(_input())
+    with pytest.raises(Exception):  # noqa: B017 — dataclasses raise FrozenInstanceError
+        witness.globally_consistent = False  # type: ignore[misc]
+    with pytest.raises(Exception):  # noqa: B017
+        witness.status = "LOCAL_FAILURE"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Brief-required scenarios 13-16
+# ---------------------------------------------------------------------------
+
+
+def test_evidence_and_failed_surfaces_immutable() -> None:
+    """13. evidence_fields and failed_surfaces are immutable."""
+    witness = assess_global_parity(_input(claim_ledger_ok=False))
+    assert isinstance(witness.evidence_fields, Mapping)
+    with pytest.raises(TypeError):
+        witness.evidence_fields["x"] = 1  # type: ignore[index]
+    # failed_surfaces is a tuple (immutable by construction).
+    assert isinstance(witness.failed_surfaces, tuple)
+
+
+def test_no_forbidden_score_fields_exist() -> None:
+    """14. no numeric health score / percent / confidence_float / health_index."""
+    forbidden = {
+        "score",
+        "health_score",
+        "health_index",
+        "confidence",
+        "confidence_float",
+        "percent",
+        "percentage",
+        "ratio",
+    }
+    fields = set(GlobalParityWitness.__dataclass_fields__.keys())
+    assert fields.isdisjoint(
+        forbidden
+    ), f"forbidden score fields present on witness: {fields & forbidden}"
+
+
+def test_deterministic_repeated_calls_equal() -> None:
+    """15. deterministic — repeated calls with identical inputs are equal."""
+    inp = _input(
+        local_witnesses=(
+            _passing_local("a"),
+            _failing_local("b"),
+            _passing_local("c"),
+        ),
+        claim_ledger_ok=False,
+        dependency_truth_ok=False,
+    )
+    a = assess_global_parity(inp)
+    b = assess_global_parity(inp)
+    assert a == b
+    assert a.status == b.status
+    assert a.failed_surfaces == b.failed_surfaces
+    assert a.evidence_fields == b.evidence_fields
+
+
+_MODULE_PATH = (
+    Path(__file__).resolve().parents[3] / "geosync_hpc" / "coherence" / "global_parity_witness.py"
+)
+
+
+def test_no_imports_from_execution_policy_application_layers() -> None:
+    """16. no imports from execution / policy / application layers."""
+    text = _MODULE_PATH.read_text(encoding="utf-8")
+    for tainted in (
+        "from geosync_hpc.execution",
+        "from geosync_hpc.policy",
+        "from geosync_hpc.application",
+        "import geosync_hpc.execution",
+        "import geosync_hpc.policy",
+        "import geosync_hpc.application",
+    ):
+        assert tainted not in text, f"{tainted!r} would couple this witness to runtime layers"
+
+
+# ---------------------------------------------------------------------------
+# Auxiliary structural / priority tests
+# ---------------------------------------------------------------------------
+
+
+def test_priority_local_failure_beats_global_failure() -> None:
+    """LOCAL_FAILURE wins over CLAIM_LEDGER_FAILURE for status selection."""
+    witness = assess_global_parity(
+        _input(
+            local_witnesses=(_failing_local("x"),),
+            claim_ledger_ok=False,
+        )
+    )
+    assert witness.status == "LOCAL_FAILURE"
+
+
+def test_priority_claim_beats_dependency_beats_invariant_beats_ci() -> None:
+    """When multiple globals fail, claim_ledger > dependency_truth > invariant > ci."""
+    witness = assess_global_parity(
+        _input(
+            claim_ledger_ok=False,
+            dependency_truth_ok=False,
+            invariant_coverage_ok=False,
+            ci_gate_ok=False,
+        )
+    )
+    assert witness.status == "CLAIM_LEDGER_FAILURE"
+
+
+def test_dependency_status_when_claim_passes() -> None:
+    """With claim OK and dependency failing, status == DEPENDENCY_TRUTH_FAILURE."""
+    witness = assess_global_parity(
+        _input(
+            dependency_truth_ok=False,
+            invariant_coverage_ok=False,
+            ci_gate_ok=False,
+        )
+    )
+    assert witness.status == "DEPENDENCY_TRUTH_FAILURE"
+
+
+def test_required_surfaces_can_be_subset() -> None:
+    """If a surface is not required, its False value does not flip the verdict."""
+    witness = assess_global_parity(
+        _input(
+            ci_gate_ok=None,
+            required_surfaces=("claim_ledger", "dependency_truth", "invariant_coverage"),
+        )
+    )
+    assert witness.status == "GLOBAL_PASS"
+    assert witness.globally_consistent is True
+
+
+def test_required_surfaces_unknown_name_rejected() -> None:
+    """A required-surfaces entry that is not a canonical name is rejected."""
+    with pytest.raises(ValueError, match="unknown surface"):
+        GlobalParityInput(
+            local_witnesses=(_passing_local("a"),),
+            claim_ledger_ok=True,
+            dependency_truth_ok=True,
+            invariant_coverage_ok=True,
+            ci_gate_ok=True,
+            required_surfaces=("not_a_real_surface",),
+        )
+
+
+def test_required_surfaces_empty_string_rejected() -> None:
+    """Empty / whitespace required-surfaces entries are rejected."""
+    with pytest.raises(ValueError, match="non-empty strings"):
+        GlobalParityInput(
+            local_witnesses=(_passing_local("a"),),
+            claim_ledger_ok=True,
+            dependency_truth_ok=True,
+            invariant_coverage_ok=True,
+            ci_gate_ok=True,
+            required_surfaces=("",),
+        )
+
+
+def test_input_local_witnesses_must_be_tuple() -> None:
+    with pytest.raises(TypeError, match="local_witnesses must be a tuple"):
+        GlobalParityInput(
+            local_witnesses=[_passing_local("a")],  # type: ignore[arg-type]
+            claim_ledger_ok=True,
+            dependency_truth_ok=True,
+            invariant_coverage_ok=True,
+            ci_gate_ok=True,
+            required_surfaces=CANONICAL_REQUIRED,
+        )
+
+
+def test_input_local_witness_must_be_localwitness() -> None:
+    with pytest.raises(TypeError, match="must be a LocalWitness"):
+        GlobalParityInput(
+            local_witnesses=("not_a_witness",),  # type: ignore[arg-type]
+            claim_ledger_ok=True,
+            dependency_truth_ok=True,
+            invariant_coverage_ok=True,
+            ci_gate_ok=True,
+            required_surfaces=CANONICAL_REQUIRED,
+        )
+
+
+def test_canonical_surfaces_classmethod_returns_expected() -> None:
+    assert GlobalParityInput.canonical_surfaces() == (
+        "claim_ledger",
+        "dependency_truth",
+        "invariant_coverage",
+        "ci_gate",
+    )
+
+
+def test_witness_falsifier_text_non_empty() -> None:
+    witness = assess_global_parity(_input())
+    assert isinstance(witness.falsifier, str)
+    assert len(witness.falsifier) > 80
+
+
+def test_evidence_fields_carry_decision_inputs() -> None:
+    inp = _input(
+        local_witnesses=(_passing_local("a"), _failing_local("b")),
+        claim_ledger_ok=False,
+        dependency_truth_ok=True,
+        invariant_coverage_ok=True,
+        ci_gate_ok=True,
+    )
+    witness = assess_global_parity(inp)
+    ev = witness.evidence_fields
+    assert ev["local_count"] == 2
+    assert ev["local_pass_count"] == 1
+    assert ev["local_fail_count"] == 1
+    assert ev["claim_ledger_ok"] is False
+    assert ev["dependency_truth_ok"] is True
+    assert ev["ci_gate_ok"] is True
+    assert "local:b" in ev["failed_surfaces"]
+    assert "claim_ledger" in ev["failed_surfaces"]


### PR DESCRIPTION
## Summary
- Implements **P4_GLOBAL_PARITY_WITNESS** — engineering analog of the Kitaev-readout discipline (source S4).
- Blocks the named lie **"local pass = global pass"** by aggregating local witnesses with required global surfaces (claim ledger, dependency truth, invariant coverage, CI gate). Any failing required surface — including `ci_gate_ok = None` — refuses `GLOBAL_PASS`.
- One named lie. One module. One falsifier. One PR.

## Module
`geosync_hpc/coherence/global_parity_witness.py` (~389 LoC)

- `LocalWitness` (frozen): `name` / `passed` / `tier` / `reason`. Validation rejects empty / whitespace name, non-bool `passed`, unknown `tier`, non-string `reason`.
- `GlobalParityInput` (frozen): `local_witnesses`, `claim_ledger_ok`, `dependency_truth_ok`, `invariant_coverage_ok`, `ci_gate_ok` (`bool | None`), `required_surfaces`. Validation rejects empty `local_witnesses`, non-LocalWitness elements, non-bool flags, non-tuple `required_surfaces`, unknown / empty surface names.
- `GlobalParityWitness` (frozen): `globally_consistent`, `status` (`Literal[7]`), `failed_surfaces`, `local_pass_count`, `local_fail_count`, `reason`, `falsifier`, read-only `evidence_fields` (`MappingProxyType`).
- `assess_global_parity(input_)`: pure deterministic. No I/O, no clock, no random, no global state.

## Status priority (first failing surface wins)
1. `LOCAL_FAILURE`             — any local witness reports `passed=False`
2. `CLAIM_LEDGER_FAILURE`      — `claim_ledger_ok` is `False`
3. `DEPENDENCY_TRUTH_FAILURE`  — `dependency_truth_ok` is `False`
4. `INVARIANT_COVERAGE_FAILURE`— `invariant_coverage_ok` is `False`
5. `CI_GATE_FAILURE`           — `ci_gate_ok` is `False`
6. `CI_GATE_UNKNOWN`           — `ci_gate_ok` is `None`
7. `GLOBAL_PASS`               — every required surface agrees

`failed_surfaces` order is deterministic: locals (sorted by name, `local:`-prefixed) then globals in canonical order `claim_ledger → dependency_truth → invariant_coverage → ci_gate`.

## Tests
`tests/unit/coherence/test_global_parity_witness.py` — **27 tests, 27/27 pass**.

Brief-required scenarios 1–16 covered:
1. all surfaces pass → `GLOBAL_PASS`
2. one local fails → `LOCAL_FAILURE`
3. claim ledger fails → `CLAIM_LEDGER_FAILURE`
4. dependency truth fails → `DEPENDENCY_TRUTH_FAILURE` (this is the test the falsifier breaks)
5. invariant coverage fails → `INVARIANT_COVERAGE_FAILURE`
6. CI False → `CI_GATE_FAILURE`
7. CI None → `CI_GATE_UNKNOWN`
8. multiple failures → deterministic `failed_surfaces` order
9. empty `local_witnesses` rejected
10. empty `LocalWitness.name` rejected
11. invalid `tier` rejected
12. witness dataclass frozen
13. `evidence_fields` and `failed_surfaces` immutable
14. **no forbidden score fields** (`score`, `health_score`, `health_index`, `confidence`, `confidence_float`, `percent`, `percentage`, `ratio`)
15. deterministic repeated calls equal
16. no imports from `geosync_hpc.execution` / `geosync_hpc.policy` / `geosync_hpc.application`

Plus auxiliary: priority interactions (local > claim > deps > invariant > ci), subset `required_surfaces`, unknown / empty surface name rejection, non-tuple input rejection, `canonical_surfaces()` shape, falsifier text non-empty, evidence carries decision inputs.

## Falsifier (executed)
1. Backup: `cp geosync_hpc/coherence/global_parity_witness.py /tmp/_probe_p4.bak`
2. Mutation: replaced both `_SURFACE_DEPENDENCY_TRUTH` conditions with `False and ...` so `dependency_truth_ok=False` is silently ignored.
3. Result: 3 tests **FAILED** — `test_dependency_truth_failure`, `test_multiple_failures_deterministic_failed_surfaces_order`, `test_dependency_status_when_claim_passes` — the test surface caught the lie.
4. Restore: `mv /tmp/_probe_p4.bak geosync_hpc/coherence/global_parity_witness.py`
5. Verify: `git diff --exit-code` → clean; 27/27 tests pass post-restore.

## Translation Update
`.claude/research/PHYSICS_2026_TRANSLATION.yaml`:
- **P4 only**: `implementation_status: PROPOSED` → `IMPLEMENTED`, added `implemented_at: \"2026-04-26\"`.
- P1, P2, P3, P5, P6: untouched.
- Validator: `python tools/research/validate_physics_2026_translation.py` → `OK: translation matrix validated (6 patterns, 6 source refs)`.

## Explicit Non-Claims
The module docstring and tests both refuse:
- any one-to-one correspondence with quantum-parity physics,
- `GLOBAL_PASS` as a forecast or trading signal,
- universal-correctness interpretation — the witness is exactly the AND-aggregation of declared surfaces,
- any escalation above `claim_tier: ENGINEERING_ANALOG`.

There is no numeric health score, no confidence float, no percent, no health index — only a boolean and a deterministic list of named failed surfaces (test 14 enforces this structurally).

## Quality Gates
- `ruff check` — All checks passed
- `ruff format --check` — clean
- `black --check` — All done
- `mypy --strict` — Success: no issues found in 2 source files
- pytest — 27/27 P4 tests pass + translation matrix tests pass

## Test plan
- [x] `pytest tests/unit/coherence/test_global_parity_witness.py -v` — 27/27 pass
- [x] `pytest tests/research/test_validate_physics_2026_translation.py -q` — pass
- [x] `python tools/research/validate_physics_2026_translation.py` — OK
- [x] `ruff check` + `ruff format --check` + `black --check` + `mypy --strict` — green
- [x] Falsifier mutation caught by 3 distinct tests, repo restored clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)