### PR TITLE
feat(coherence): add composite binding structure (P6)

### DIFF
--- a/.claude/research/PHYSICS_2026_TRANSLATION.yaml
+++ b/.claude/research/PHYSICS_2026_TRANSLATION.yaml
@@ -318,7 +318,8 @@ patterns:
       cluster.
     proposed_module: geosync_hpc/coherence/composite_binding_structure.py
     claim_tier: ENGINEERING_ANALOG
-    implementation_status: PROPOSED
+    implementation_status: IMPLEMENTED
+    implemented_at: "2026-04-27"
     measurable_inputs:
       - asset_cluster
       - correlation_matrix

--- a/geosync_hpc/coherence/composite_binding_structure.py
+++ b/geosync_hpc/coherence/composite_binding_structure.py
@@ -1,0 +1,236 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""Composite binding structure — engineering analog of doubly-charmed-baryon discipline.
+
+pattern_id:        P6_COMPOSITE_BINDING_STRUCTURE
+source_id:         S6_LHCB_DOUBLY_CHARMED_BARYON
+claim_tier:        ENGINEERING_ANALOG
+
+A high correlation across an asset cluster is *transient* unless it
+survives both a documented persistence window AND a documented
+perturbation-response check. The named lie blocked here is
+"correlation = binding": clusters that dissolve under perturbation must
+be reported as TRANSIENT_CORRELATION, not as PERSISTENT_BINDING.
+
+Statuses:
+    PERSISTENT_BINDING       relation persists across window AND
+                             survives perturbation
+    TRANSIENT_CORRELATION    relation seen, but it dissolves under
+                             perturbation OR fails to persist
+    INSUFFICIENT_PERSISTENCE relation persists for fewer than the
+                             required window samples
+    UNKNOWN                  degenerate inputs (empty cluster after
+                             validation, all-NaN windows)
+
+Non-claims: no one-to-one correspondence with quantum-baryon physics;
+PERSISTENT_BINDING is not a forecast, signal, or trading instruction.
+Determinism: pure function, no I/O, no clock, no random.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from enum import Enum
+from types import MappingProxyType
+from typing import Any
+
+__all__ = [
+    "BindingStatus",
+    "BindingInput",
+    "BindingWitness",
+    "assess_composite_binding",
+]
+
+
+_FALSIFIER_TEXT = (
+    "PERSISTENT_BINDING was returned but the cluster's correlation "
+    "dissolved under the documented perturbation; OR the relation did "
+    "not survive the persistence window; OR a TRANSIENT_CORRELATION "
+    "case was silently upgraded to PERSISTENT_BINDING because the "
+    "perturbation_response check was bypassed."
+)
+
+
+class BindingStatus(str, Enum):
+    PERSISTENT_BINDING = "PERSISTENT_BINDING"
+    TRANSIENT_CORRELATION = "TRANSIENT_CORRELATION"
+    INSUFFICIENT_PERSISTENCE = "INSUFFICIENT_PERSISTENCE"
+    UNKNOWN = "UNKNOWN"
+
+
+@dataclass(frozen=True)
+class BindingInput:
+    """One composite-binding question.
+
+    ``correlation_window`` is a tuple of correlation values observed at
+    successive time slices for the cluster. ``correlation_threshold``
+    is the floor above which a slice is considered "in cluster".
+    ``persistence_window`` is the minimum number of in-cluster slices
+    required to consider persistence achieved. ``perturbation_response``
+    is a tuple of correlation values observed under the documented
+    perturbation; the binding survives if the median perturbation-
+    response value remains above ``correlation_threshold``.
+    """
+
+    asset_cluster: tuple[str, ...]
+    correlation_window: tuple[float, ...]
+    correlation_threshold: float
+    persistence_window: int
+    perturbation_response: tuple[float, ...]
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.asset_cluster, tuple):
+            raise TypeError("asset_cluster must be a tuple of strings")
+        if len(self.asset_cluster) == 0:
+            raise ValueError("asset_cluster must be non-empty")
+        for i, name in enumerate(self.asset_cluster):
+            if not isinstance(name, str) or not name.strip():
+                raise ValueError(f"asset_cluster[{i}] must be a non-empty string")
+
+        for name, series in (
+            ("correlation_window", self.correlation_window),
+            ("perturbation_response", self.perturbation_response),
+        ):
+            if not isinstance(series, tuple):
+                raise TypeError(f"{name} must be a tuple of floats")
+            for i, v in enumerate(series):
+                if not isinstance(v, (int, float)) or isinstance(v, bool):
+                    raise TypeError(f"{name}[{i}] must be a finite float")
+                if not math.isfinite(float(v)):
+                    raise ValueError(f"{name}[{i}] must be finite (got {v!r})")
+                if not -1.0 <= float(v) <= 1.0:
+                    raise ValueError(
+                        f"{name}[{i}] must be in [-1, 1] (got {v!r}); "
+                        "this witness assumes correlation-coefficient inputs"
+                    )
+
+        if not isinstance(self.correlation_threshold, (int, float)) or isinstance(
+            self.correlation_threshold, bool
+        ):
+            raise TypeError("correlation_threshold must be a finite float in [-1, 1]")
+        if not math.isfinite(float(self.correlation_threshold)):
+            raise ValueError(
+                f"correlation_threshold must be finite (got {self.correlation_threshold!r})"
+            )
+        if not -1.0 <= float(self.correlation_threshold) <= 1.0:
+            raise ValueError(
+                f"correlation_threshold must be in [-1, 1] (got {self.correlation_threshold!r})"
+            )
+
+        if not isinstance(self.persistence_window, int) or isinstance(
+            self.persistence_window, bool
+        ):
+            raise TypeError("persistence_window must be a positive int")
+        if self.persistence_window <= 0:
+            raise ValueError(f"persistence_window must be > 0 (got {self.persistence_window!r})")
+
+
+@dataclass(frozen=True)
+class BindingWitness:
+    """One composite-binding verdict."""
+
+    binding_status: BindingStatus
+    transient_correlation: bool
+    persistent_binding: bool
+    persistent_slice_count: int
+    perturbation_median: float
+    threshold_used: float
+    reason: str
+    falsifier: str
+    evidence_fields: Mapping[str, Any] = field(default_factory=lambda: MappingProxyType({}))
+
+
+def _median(values: tuple[float, ...]) -> float:
+    if not values:
+        return float("nan")
+    s = sorted(values)
+    n = len(s)
+    mid = n // 2
+    if n % 2 == 1:
+        return float(s[mid])
+    return float(0.5 * (s[mid - 1] + s[mid]))
+
+
+def assess_composite_binding(input_: BindingInput) -> BindingWitness:
+    """Pure binding classifier.
+
+    Priority (first failing condition wins):
+        1. correlation_window empty            → UNKNOWN
+        2. perturbation_response empty         → UNKNOWN
+        3. persistent_slice_count < window     → INSUFFICIENT_PERSISTENCE
+        4. perturbation_median < threshold     → TRANSIENT_CORRELATION
+        5. otherwise                           → PERSISTENT_BINDING
+    """
+    threshold = float(input_.correlation_threshold)
+    persistent_count = sum(1 for v in input_.correlation_window if float(v) >= threshold)
+    perturb_median = _median(input_.perturbation_response)
+
+    def _build(
+        status: BindingStatus,
+        *,
+        transient: bool,
+        persistent: bool,
+        reason: str,
+    ) -> BindingWitness:
+        evidence = MappingProxyType(
+            {
+                "asset_cluster": input_.asset_cluster,
+                "correlation_window_len": len(input_.correlation_window),
+                "perturbation_response_len": len(input_.perturbation_response),
+                "persistent_slice_count": persistent_count,
+                "perturbation_median": perturb_median,
+                "correlation_threshold": threshold,
+                "persistence_window": input_.persistence_window,
+            }
+        )
+        return BindingWitness(
+            binding_status=status,
+            transient_correlation=transient,
+            persistent_binding=persistent,
+            persistent_slice_count=persistent_count,
+            perturbation_median=perturb_median,
+            threshold_used=threshold,
+            reason=reason,
+            falsifier=_FALSIFIER_TEXT,
+            evidence_fields=evidence,
+        )
+
+    if len(input_.correlation_window) == 0:
+        return _build(
+            BindingStatus.UNKNOWN,
+            transient=False,
+            persistent=False,
+            reason="EMPTY_CORRELATION_WINDOW",
+        )
+    if len(input_.perturbation_response) == 0:
+        return _build(
+            BindingStatus.UNKNOWN,
+            transient=False,
+            persistent=False,
+            reason="EMPTY_PERTURBATION_RESPONSE",
+        )
+
+    if persistent_count < input_.persistence_window:
+        return _build(
+            BindingStatus.INSUFFICIENT_PERSISTENCE,
+            transient=False,
+            persistent=False,
+            reason="PERSISTENT_SLICES_BELOW_WINDOW",
+        )
+
+    if perturb_median < threshold:
+        return _build(
+            BindingStatus.TRANSIENT_CORRELATION,
+            transient=True,
+            persistent=False,
+            reason="PERTURBATION_DISSOLVED_RELATION",
+        )
+
+    return _build(
+        BindingStatus.PERSISTENT_BINDING,
+        transient=False,
+        persistent=True,
+        reason="OK_RELATION_SURVIVES_PERTURBATION_AND_WINDOW",
+    )

--- a/tests/unit/coherence/test_composite_binding_structure.py
+++ b/tests/unit/coherence/test_composite_binding_structure.py
@@ -1,0 +1,275 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""Tests for geosync_hpc.coherence.composite_binding_structure."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from pathlib import Path
+
+import pytest
+
+from geosync_hpc.coherence.composite_binding_structure import (
+    BindingInput,
+    BindingStatus,
+    BindingWitness,
+    assess_composite_binding,
+)
+
+
+def _input(
+    *,
+    asset_cluster: tuple[str, ...] = ("BTC", "ETH"),
+    correlation_window: tuple[float, ...] = (0.9, 0.85, 0.92, 0.88, 0.91),
+    correlation_threshold: float = 0.7,
+    persistence_window: int = 3,
+    perturbation_response: tuple[float, ...] = (0.82, 0.79, 0.84),
+) -> BindingInput:
+    return BindingInput(
+        asset_cluster=asset_cluster,
+        correlation_window=correlation_window,
+        correlation_threshold=correlation_threshold,
+        persistence_window=persistence_window,
+        perturbation_response=perturbation_response,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Brief-required deterministic scenarios
+# ---------------------------------------------------------------------------
+
+
+def test_persistent_correlation_across_window_returns_persistent_binding() -> None:
+    """1. Persistent correlation across window AND surviving perturbation → PERSISTENT_BINDING."""
+    witness = assess_composite_binding(_input())
+    assert witness.binding_status is BindingStatus.PERSISTENT_BINDING
+    assert witness.persistent_binding is True
+    assert witness.transient_correlation is False
+    assert witness.persistent_slice_count == 5
+    assert witness.perturbation_median >= witness.threshold_used
+
+
+def test_transient_correlation_that_dissolves_under_perturbation() -> None:
+    """2. Persistent in window, dissolves under perturbation → TRANSIENT_CORRELATION.
+
+    This is the test the falsifier must break.
+    """
+    witness = assess_composite_binding(
+        _input(
+            correlation_window=(0.9, 0.85, 0.92, 0.88, 0.91),
+            correlation_threshold=0.7,
+            persistence_window=3,
+            perturbation_response=(0.2, 0.1, 0.15),
+        )
+    )
+    assert witness.binding_status is BindingStatus.TRANSIENT_CORRELATION
+    assert witness.transient_correlation is True
+    assert witness.persistent_binding is False
+    assert witness.perturbation_median < witness.threshold_used
+
+
+def test_insufficient_persistence_slices() -> None:
+    """Window has too few in-cluster slices → INSUFFICIENT_PERSISTENCE."""
+    witness = assess_composite_binding(
+        _input(
+            correlation_window=(0.9, 0.2, 0.3, 0.1, 0.15),
+            correlation_threshold=0.7,
+            persistence_window=3,
+        )
+    )
+    assert witness.binding_status is BindingStatus.INSUFFICIENT_PERSISTENCE
+    assert witness.persistent_slice_count == 1
+
+
+def test_empty_cluster_rejected() -> None:
+    """3. Empty asset_cluster rejected at construction."""
+    with pytest.raises(ValueError, match="asset_cluster must be non-empty"):
+        BindingInput(
+            asset_cluster=(),
+            correlation_window=(0.9,),
+            correlation_threshold=0.7,
+            persistence_window=1,
+            perturbation_response=(0.8,),
+        )
+
+
+def test_empty_correlation_window_returns_unknown() -> None:
+    """Empty correlation_window → UNKNOWN."""
+    witness = assess_composite_binding(_input(correlation_window=(), persistence_window=1))
+    assert witness.binding_status is BindingStatus.UNKNOWN
+
+
+def test_empty_perturbation_response_returns_unknown() -> None:
+    """Empty perturbation_response → UNKNOWN."""
+    witness = assess_composite_binding(_input(perturbation_response=()))
+    assert witness.binding_status is BindingStatus.UNKNOWN
+
+
+def test_correlation_value_outside_unit_range_rejected() -> None:
+    """4. Correlation values outside [-1, 1] rejected (validation by shape)."""
+    with pytest.raises(ValueError, match=r"correlation_window\[0\] must be in"):
+        BindingInput(
+            asset_cluster=("BTC",),
+            correlation_window=(1.5,),
+            correlation_threshold=0.7,
+            persistence_window=1,
+            perturbation_response=(0.8,),
+        )
+    with pytest.raises(ValueError, match=r"perturbation_response\[1\] must be in"):
+        BindingInput(
+            asset_cluster=("BTC",),
+            correlation_window=(0.9,),
+            correlation_threshold=0.7,
+            persistence_window=1,
+            perturbation_response=(0.8, -1.5),
+        )
+
+
+def test_persistence_window_zero_rejected() -> None:
+    """5. persistence_window <= 0 rejected."""
+    with pytest.raises(ValueError, match="persistence_window must be > 0"):
+        BindingInput(
+            asset_cluster=("BTC",),
+            correlation_window=(0.9,),
+            correlation_threshold=0.7,
+            persistence_window=0,
+            perturbation_response=(0.8,),
+        )
+
+
+def test_persistence_window_negative_rejected() -> None:
+    with pytest.raises(ValueError, match="persistence_window must be > 0"):
+        BindingInput(
+            asset_cluster=("BTC",),
+            correlation_window=(0.9,),
+            correlation_threshold=0.7,
+            persistence_window=-1,
+            perturbation_response=(0.8,),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Validation contract
+# ---------------------------------------------------------------------------
+
+
+def test_nan_in_correlation_window_rejected() -> None:
+    with pytest.raises(ValueError, match=r"correlation_window\[1\] must be finite"):
+        BindingInput(
+            asset_cluster=("BTC",),
+            correlation_window=(0.9, float("nan")),
+            correlation_threshold=0.7,
+            persistence_window=1,
+            perturbation_response=(0.8,),
+        )
+
+
+def test_threshold_outside_range_rejected() -> None:
+    with pytest.raises(ValueError, match="correlation_threshold must be in"):
+        BindingInput(
+            asset_cluster=("BTC",),
+            correlation_window=(0.9,),
+            correlation_threshold=1.5,
+            persistence_window=1,
+            perturbation_response=(0.8,),
+        )
+
+
+def test_non_tuple_cluster_rejected() -> None:
+    with pytest.raises(TypeError, match="asset_cluster must be a tuple"):
+        BindingInput(
+            asset_cluster=["BTC"],  # type: ignore[arg-type]
+            correlation_window=(0.9,),
+            correlation_threshold=0.7,
+            persistence_window=1,
+            perturbation_response=(0.8,),
+        )
+
+
+def test_empty_cluster_member_name_rejected() -> None:
+    with pytest.raises(ValueError, match=r"asset_cluster\[0\] must be a non-empty string"):
+        BindingInput(
+            asset_cluster=("",),
+            correlation_window=(0.9,),
+            correlation_threshold=0.7,
+            persistence_window=1,
+            perturbation_response=(0.8,),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Determinism + structural
+# ---------------------------------------------------------------------------
+
+
+def test_deterministic_repeated_calls_equal() -> None:
+    inp = _input(
+        correlation_window=(0.9, 0.4, 0.85, 0.3, 0.91, 0.88),
+        perturbation_response=(0.5, 0.45, 0.6),
+    )
+    a = assess_composite_binding(inp)
+    b = assess_composite_binding(inp)
+    assert a == b
+    assert a.binding_status is b.binding_status
+    assert a.evidence_fields == b.evidence_fields
+
+
+def test_witness_is_frozen() -> None:
+    witness = assess_composite_binding(_input())
+    with pytest.raises(Exception):  # noqa: B017 — FrozenInstanceError
+        witness.binding_status = BindingStatus.UNKNOWN  # type: ignore[misc]
+
+
+def test_evidence_fields_immutable() -> None:
+    witness = assess_composite_binding(_input())
+    assert isinstance(witness.evidence_fields, Mapping)
+    with pytest.raises(TypeError):
+        witness.evidence_fields["x"] = 1  # type: ignore[index]
+
+
+def test_falsifier_text_non_empty() -> None:
+    witness = assess_composite_binding(_input())
+    assert isinstance(witness.falsifier, str)
+    assert len(witness.falsifier) > 80
+
+
+def test_witness_carries_no_prediction_class_field() -> None:
+    forbidden = {"prediction", "signal", "forecast", "target_price", "recommended_action"}
+    fields = set(BindingWitness.__dataclass_fields__.keys())
+    assert fields.isdisjoint(forbidden)
+
+
+# ---------------------------------------------------------------------------
+# No-overclaim guard
+# ---------------------------------------------------------------------------
+
+
+_MODULE_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "geosync_hpc"
+    / "coherence"
+    / "composite_binding_structure.py"
+)
+
+
+def test_module_does_not_use_predictive_or_physics_equivalence_language() -> None:
+    text = _MODULE_PATH.read_text(encoding="utf-8").lower()
+    forbidden = (
+        r"\bprediction\b",
+        r"\buniversal\b",
+        r"physical equivalence",
+        r"market physics fact",
+    )
+    for pattern in forbidden:
+        assert re.search(pattern, text) is None, f"forbidden phrase {pattern!r} present"
+
+
+def test_module_does_not_import_market_or_trading_modules() -> None:
+    text = _MODULE_PATH.read_text(encoding="utf-8")
+    for tainted in (
+        "from geosync_hpc.execution",
+        "from geosync_hpc.policy",
+        "from geosync_hpc.application",
+    ):
+        assert tainted not in text, f"{tainted!r} would couple this witness to runtime layers"


### PR DESCRIPTION
## Summary
- Implements **P6_COMPOSITE_BINDING_STRUCTURE** — engineering analog of doubly-charmed-baryon binding discipline (source S6).
- Blocks the named lie **"correlation = binding"** by gating `PERSISTENT_BINDING` behind both a persistence-window count AND a perturbation-response median test.
- One named lie. One module. One falsifier. One PR.

## Module
`geosync_hpc/coherence/composite_binding_structure.py`

- `BindingStatus`: `PERSISTENT_BINDING` / `TRANSIENT_CORRELATION` / `INSUFFICIENT_PERSISTENCE` / `UNKNOWN`
- `BindingInput` (frozen): `asset_cluster`, `correlation_window`, `correlation_threshold`, `persistence_window`, `perturbation_response`. Validation rejects empty cluster / empty member name / non-tuple / NaN / out-of-[-1,1] correlations / non-positive window.
- `BindingWitness` (frozen): `binding_status`, `transient_correlation`, `persistent_binding`, `persistent_slice_count`, `perturbation_median`, `threshold_used`, `reason`, `falsifier`, immutable `evidence_fields`.
- `assess_composite_binding(input_)`: pure deterministic. No I/O, no clock, no random, no module-level state.

## Decision rule
Priority (first failing condition wins):
1. correlation_window empty → `UNKNOWN`
2. perturbation_response empty → `UNKNOWN`
3. persistent_slice_count < persistence_window → `INSUFFICIENT_PERSISTENCE`
4. perturbation_median < correlation_threshold → `TRANSIENT_CORRELATION`
5. otherwise → `PERSISTENT_BINDING`

## Tests
`tests/unit/coherence/test_composite_binding_structure.py` — **20 tests, 20/20 pass**.

Brief deterministic scenarios:
- persistent correlation across window AND surviving perturbation → `PERSISTENT_BINDING`
- persistent in window but dissolves under perturbation → `TRANSIENT_CORRELATION` (lie surface; falsifier breaks this)
- insufficient slices in window → `INSUFFICIENT_PERSISTENCE`
- empty cluster rejected
- correlation values outside [-1, 1] rejected
- persistence_window <= 0 rejected

Validation contract: NaN in correlation_window, threshold outside range, non-tuple cluster, empty cluster member name. Determinism, frozen witness, immutable evidence_fields, no forecast/signal/forecast field names, no \`prediction\` / \`universal\` / \`physical equivalence\` / \`market physics fact\` in module text, no execution/policy/application imports.

## Falsifier (executed)
1. Backup: \`cp ... /tmp/_probe_p6.bak\`
2. Mutation: wrapped \`if perturb_median < threshold:\` in \`False and ...\` so transient correlations are silently upgraded to bindings.
3. Result: \`test_transient_correlation_that_dissolves_under_perturbation\` **FAILED** — caught the lie.
4. Restore: \`mv /tmp/_probe_p6.bak ...\`. Mutation lines absent. 20/20 pass.

## Translation Update
**P6 only** \`PROPOSED → IMPLEMENTED\` + \`implemented_at: \"2026-04-27\"\`. P1, P2, P3, P4, P5 untouched. Validator OK (6/6).

## Explicit Non-Claims
- no one-to-one correspondence with quantum-baryon physics
- PERSISTENT_BINDING is not a forecast / signal / trading instruction
- claim_tier remains ENGINEERING_ANALOG

🤖 Generated with [Claude Code](https://claude.com/claude-code)