### PR TITLE
feat(regimes): structured-absence inference (P2)

### DIFF
--- a/.claude/research/PHYSICS_2026_TRANSLATION.yaml
+++ b/.claude/research/PHYSICS_2026_TRANSLATION.yaml
@@ -105,7 +105,8 @@ patterns:
       or INSUFFICIENT_COVERAGE or UNKNOWN.
     proposed_module: geosync_hpc/regimes/structured_absence.py
     claim_tier: ENGINEERING_ANALOG
-    implementation_status: PROPOSED
+    implementation_status: IMPLEMENTED
+    implemented_at: "2026-04-26"
     measurable_inputs:
       - observed_state_space
       - candidate_empty_region

--- a/geosync_hpc/regimes/structured_absence.py
+++ b/geosync_hpc/regimes/structured_absence.py
@@ -1,0 +1,333 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""Structured-absence inference — engineering analog of pair-instability-gap discipline.
+
+pattern_id:        P2_STRUCTURED_ABSENCE_INFERENCE
+source_id:         S2_PAIR_INSTABILITY_GAP
+claim_tier:        ENGINEERING_ANALOG
+implementation:    PR #454 (this module)
+
+Engineering analog
+==================
+
+The pair-instability-gap result (Nature 2026) demonstrates that an
+empty region of state space can be claimed as a TRUE_ABSENCE only
+when (a) coverage of that region is sufficient and (b) selection
+bias has been classified. An empty bin in a survey is not the same
+as a region that is genuinely empty: it can be empty because nothing
+was looked for, or because what was there was filtered out, or
+because the sample is too small to populate it.
+
+This module imports that *inference discipline*, not the physics. A
+GeoSync regime / market-state inference is allowed to declare an
+"absent" region only when it satisfies the same three conditions:
+
+    1. sample_count is positive and above a documented minimum
+    2. coverage_ratio is at or above a declared threshold
+    3. no active selection_bias_flag is set
+    AND
+    4. the candidate empty region was actually observed as empty
+
+Any failure of any condition produces a different status:
+
+    INSUFFICIENT_COVERAGE    sample_count == 0 OR coverage < threshold
+    SELECTION_BIAS           any selection_bias_flag is active
+    UNKNOWN                  candidate region contains observations
+                             (so it is not actually empty), or any
+                             other ambiguous shape
+    TRUE_ABSENCE             all four conditions hold
+
+Status is ordinal in name only. The witness's `accepted_as_absence`
+boolean is True if and only if status == TRUE_ABSENCE.
+
+Explicit non-claims
+===================
+
+This module does NOT claim:
+  - that an absence in the data implies an absence in reality without
+    the four conditions
+  - any forecast / signal / actionable-output use of absence
+  - any one-to-one correspondence with cosmological-survey reasoning
+
+It imports the inference discipline only. Its outputs are
+classified-status records.
+
+Determinism contract
+====================
+
+  - assess_absence(...) is pure: no I/O, no clock, no random, no
+    global state.
+  - Identical inputs produce byte-identical witness outputs.
+  - Invalid inputs (NaN coverage, threshold outside [0, 1], negative
+    sample_count, non-finite values) raise at construction or at
+    assess time — never produce a misleading classification.
+  - There is no module-level mutable state.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field
+from enum import Enum
+from types import MappingProxyType
+from typing import Any
+
+__all__ = [
+    "AbsenceStatus",
+    "AbsenceInput",
+    "AbsenceWitness",
+    "assess_absence",
+]
+
+
+# Stable structured reasons. Strings are the API surface — do not
+# rephrase without bumping the contract.
+_REASON_TRUE_ABSENCE = "OK_TRUE_ABSENCE"
+_REASON_INSUFFICIENT_SAMPLES = "INSUFFICIENT_SAMPLES"
+_REASON_INSUFFICIENT_COVERAGE = "COVERAGE_BELOW_THRESHOLD"
+_REASON_SELECTION_BIAS = "SELECTION_BIAS_ACTIVE"
+_REASON_REGION_NOT_EMPTY = "REGION_NOT_EMPTY"
+
+
+class AbsenceStatus(str, Enum):
+    """Outcome of an absence-inference attempt."""
+
+    TRUE_ABSENCE = "TRUE_ABSENCE"
+    SELECTION_BIAS = "SELECTION_BIAS"
+    INSUFFICIENT_COVERAGE = "INSUFFICIENT_COVERAGE"
+    UNKNOWN = "UNKNOWN"
+
+
+@dataclass(frozen=True)
+class AbsenceInput:
+    """Single absence-inference question.
+
+    `observed_state_space` lists the points (any hashable) actually
+    observed during the survey window. The presence of a point in this
+    set means it was observed at least once.
+
+    `candidate_empty_region` is the predicate / set the caller wants
+    to classify as empty. If any element of `observed_state_space`
+    lies inside `candidate_empty_region`, the region is not empty and
+    cannot be a TRUE_ABSENCE; the witness returns UNKNOWN with reason
+    REGION_NOT_EMPTY.
+
+    `coverage_ratio` is a float in `[0.0, 1.0]` describing how much of
+    the candidate region was observable during the survey. 1.0 means
+    full coverage; 0.0 means nothing was observable.
+
+    `selection_bias_flags` is a tuple of stable string identifiers for
+    bias modes that may apply. Empty tuple means no active bias.
+
+    `sample_count` is the total number of independent samples
+    contributing to the survey. Zero or negative means
+    INSUFFICIENT_COVERAGE regardless of `coverage_ratio`.
+
+    `minimum_coverage_threshold` is the floor below which
+    `coverage_ratio` cannot support TRUE_ABSENCE. The contract is
+    `coverage_ratio >= minimum_coverage_threshold`; equality passes.
+    """
+
+    observed_state_space: frozenset[Any]
+    candidate_empty_region: frozenset[Any]
+    coverage_ratio: float
+    selection_bias_flags: tuple[str, ...]
+    sample_count: int
+    minimum_coverage_threshold: float
+
+    def __post_init__(self) -> None:
+        # observed_state_space + candidate_empty_region — must be frozensets
+        # of hashable elements; the dataclass annotation is only
+        # advisory, so we coerce defensively.
+        if not isinstance(self.observed_state_space, frozenset):
+            raise TypeError(
+                "observed_state_space must be a frozenset; convert "
+                "via frozenset(...) at the call site"
+            )
+        if not isinstance(self.candidate_empty_region, frozenset):
+            raise TypeError(
+                "candidate_empty_region must be a frozenset; convert "
+                "via frozenset(...) at the call site"
+            )
+
+        # coverage_ratio: finite float in [0, 1].
+        if not isinstance(self.coverage_ratio, (int, float)) or isinstance(
+            self.coverage_ratio, bool
+        ):
+            raise TypeError("coverage_ratio must be a finite float in [0, 1]")
+        cov = float(self.coverage_ratio)
+        if not math.isfinite(cov):
+            raise ValueError(f"coverage_ratio must be finite (got {cov!r})")
+        if not 0.0 <= cov <= 1.0:
+            raise ValueError(f"coverage_ratio must be in [0.0, 1.0] (got {cov!r})")
+
+        # selection_bias_flags: tuple of non-empty strings.
+        if not isinstance(self.selection_bias_flags, tuple):
+            raise TypeError("selection_bias_flags must be a tuple of strings")
+        for flag in self.selection_bias_flags:
+            if not isinstance(flag, str) or not flag.strip():
+                raise ValueError("selection_bias_flags entries must be non-empty strings")
+
+        # sample_count: non-negative int (not bool).
+        if not isinstance(self.sample_count, int) or isinstance(self.sample_count, bool):
+            raise TypeError("sample_count must be a non-negative int")
+        if self.sample_count < 0:
+            raise ValueError(f"sample_count must be >= 0 (got {self.sample_count!r})")
+
+        # minimum_coverage_threshold: finite float in [0, 1].
+        if not isinstance(self.minimum_coverage_threshold, (int, float)) or isinstance(
+            self.minimum_coverage_threshold, bool
+        ):
+            raise TypeError("minimum_coverage_threshold must be a finite float in [0, 1]")
+        thr = float(self.minimum_coverage_threshold)
+        if not math.isfinite(thr):
+            raise ValueError(f"minimum_coverage_threshold must be finite (got {thr!r})")
+        if not 0.0 <= thr <= 1.0:
+            raise ValueError(f"minimum_coverage_threshold must be in [0.0, 1.0] " f"(got {thr!r})")
+
+
+@dataclass(frozen=True)
+class AbsenceWitness:
+    """Outcome of one assessment.
+
+    `status` is the structural verdict; `accepted_as_absence` is True
+    iff `status == TRUE_ABSENCE`. `reason` is a stable structured tag
+    callers may pattern-match on. `falsifier` is a human-readable
+    description of what would make this witness wrong.
+    """
+
+    status: AbsenceStatus
+    accepted_as_absence: bool
+    reason: str
+    coverage_ratio: float
+    selection_bias_present: bool
+    sample_count: int
+    falsifier: str
+    evidence_fields: Mapping[str, Any] = field(default_factory=lambda: MappingProxyType({}))
+
+
+# ---------------------------------------------------------------------------
+# Pure assessment function
+# ---------------------------------------------------------------------------
+
+
+_FALSIFIER_TEXT = (
+    "TRUE_ABSENCE was returned but at least one of the following held: "
+    "sample_count == 0; coverage_ratio < minimum_coverage_threshold; "
+    "selection_bias_flags non-empty; the observed_state_space contained "
+    "points inside candidate_empty_region."
+)
+
+
+def _region_observed_to_be_empty(input_: AbsenceInput) -> bool:
+    """Return True iff candidate_empty_region contains zero observed points.
+
+    The check is set-intersection. The candidate region is empty in the
+    observed state space when it shares no element with the observed set.
+    """
+    return not (input_.observed_state_space & input_.candidate_empty_region)
+
+
+def assess_absence(input_: AbsenceInput) -> AbsenceWitness:
+    """Classify the absence-inference question carried by ``input_``.
+
+    Pure function. Reads only the input dataclass; no I/O, no clock,
+    no global state. Returns one ``AbsenceWitness`` describing the
+    structural verdict.
+
+    Priority order (the first failing condition wins):
+
+        1. sample_count == 0           → INSUFFICIENT_COVERAGE
+        2. selection_bias_flags        → SELECTION_BIAS
+        3. coverage < threshold        → INSUFFICIENT_COVERAGE
+        4. region observed not empty   → UNKNOWN (REGION_NOT_EMPTY)
+        5. otherwise                   → TRUE_ABSENCE
+    """
+    bias_present = bool(input_.selection_bias_flags)
+    cov = float(input_.coverage_ratio)
+    thr = float(input_.minimum_coverage_threshold)
+    region_empty = _region_observed_to_be_empty(input_)
+
+    evidence = MappingProxyType(
+        dict(
+            {
+                "coverage_ratio": cov,
+                "minimum_coverage_threshold": thr,
+                "sample_count": input_.sample_count,
+                "selection_bias_flags": tuple(input_.selection_bias_flags),
+                "observed_count_in_region": len(
+                    input_.observed_state_space & input_.candidate_empty_region
+                ),
+            }
+        )
+    )
+
+    if input_.sample_count == 0:
+        return AbsenceWitness(
+            status=AbsenceStatus.INSUFFICIENT_COVERAGE,
+            accepted_as_absence=False,
+            reason=_REASON_INSUFFICIENT_SAMPLES,
+            coverage_ratio=cov,
+            selection_bias_present=bias_present,
+            sample_count=input_.sample_count,
+            falsifier=_FALSIFIER_TEXT,
+            evidence_fields=evidence,
+        )
+
+    if bias_present:
+        return AbsenceWitness(
+            status=AbsenceStatus.SELECTION_BIAS,
+            accepted_as_absence=False,
+            reason=_REASON_SELECTION_BIAS,
+            coverage_ratio=cov,
+            selection_bias_present=True,
+            sample_count=input_.sample_count,
+            falsifier=_FALSIFIER_TEXT,
+            evidence_fields=evidence,
+        )
+
+    if cov < thr:
+        return AbsenceWitness(
+            status=AbsenceStatus.INSUFFICIENT_COVERAGE,
+            accepted_as_absence=False,
+            reason=_REASON_INSUFFICIENT_COVERAGE,
+            coverage_ratio=cov,
+            selection_bias_present=False,
+            sample_count=input_.sample_count,
+            falsifier=_FALSIFIER_TEXT,
+            evidence_fields=evidence,
+        )
+
+    if not region_empty:
+        return AbsenceWitness(
+            status=AbsenceStatus.UNKNOWN,
+            accepted_as_absence=False,
+            reason=_REASON_REGION_NOT_EMPTY,
+            coverage_ratio=cov,
+            selection_bias_present=False,
+            sample_count=input_.sample_count,
+            falsifier=_FALSIFIER_TEXT,
+            evidence_fields=evidence,
+        )
+
+    return AbsenceWitness(
+        status=AbsenceStatus.TRUE_ABSENCE,
+        accepted_as_absence=True,
+        reason=_REASON_TRUE_ABSENCE,
+        coverage_ratio=cov,
+        selection_bias_present=False,
+        sample_count=input_.sample_count,
+        falsifier=_FALSIFIER_TEXT,
+        evidence_fields=evidence,
+    )
+
+
+def assess_many(inputs: Iterable[AbsenceInput]) -> tuple[AbsenceWitness, ...]:
+    """Apply ``assess_absence`` to a sequence of inputs.
+
+    Returned tuple preserves input order. Provided as a convenience for
+    callers that batch many region inferences; behaviour is exactly
+    equivalent to mapping ``assess_absence`` over the iterable.
+    """
+    return tuple(assess_absence(i) for i in inputs)

--- a/tests/unit/regimes/test_structured_absence.py
+++ b/tests/unit/regimes/test_structured_absence.py
@@ -1,0 +1,485 @@
+"""Tests for ``geosync_hpc.regimes.structured_absence`` (P2).
+
+Contract under test:
+
+  Absence becomes evidence only when coverage is sufficient AND
+  selection bias is absent AND the region is actually observed empty.
+
+  "missing data = true absence" is the lie this module blocks.
+
+This file ships the ten tests required by the PR-#454 brief plus a
+small group of structural assertions that protect the contract from
+drift:
+
+   1.  full coverage + no bias + empty region → TRUE_ABSENCE
+   2.  low coverage → INSUFFICIENT_COVERAGE
+   3.  active selection bias → SELECTION_BIAS
+   4.  zero sample count → INSUFFICIENT_COVERAGE
+   5.  non-empty candidate region cannot be TRUE_ABSENCE (UNKNOWN)
+   6.  coverage exactly at threshold → TRUE_ABSENCE (>=, not >)
+   7.  coverage just below threshold → INSUFFICIENT_COVERAGE
+   8.  NaN / inf rejected at construction
+   9.  invalid threshold rejected at construction
+  10.  no-overclaim: module/docstring contains no
+        "law", "prediction", "physical equivalence",
+        "market physics fact"
+"""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+
+import pytest
+
+from geosync_hpc.regimes import structured_absence
+from geosync_hpc.regimes.structured_absence import (
+    AbsenceInput,
+    AbsenceStatus,
+    AbsenceWitness,
+    assess_absence,
+    assess_many,
+)
+
+# ---------------------------------------------------------------------------
+# Builder helpers
+# ---------------------------------------------------------------------------
+
+
+def _input(
+    *,
+    observed_state_space: frozenset[object] = frozenset({"a", "b", "c"}),
+    candidate_empty_region: frozenset[object] = frozenset({"x", "y"}),
+    coverage_ratio: float = 0.95,
+    selection_bias_flags: tuple[str, ...] = (),
+    sample_count: int = 100,
+    minimum_coverage_threshold: float = 0.80,
+) -> AbsenceInput:
+    return AbsenceInput(
+        observed_state_space=observed_state_space,
+        candidate_empty_region=candidate_empty_region,
+        coverage_ratio=coverage_ratio,
+        selection_bias_flags=selection_bias_flags,
+        sample_count=sample_count,
+        minimum_coverage_threshold=minimum_coverage_threshold,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. full coverage + no bias + empty region → TRUE_ABSENCE
+# ---------------------------------------------------------------------------
+
+
+def test_true_absence_when_all_conditions_satisfied() -> None:
+    witness = assess_absence(_input(coverage_ratio=1.0))
+    assert witness.status is AbsenceStatus.TRUE_ABSENCE
+    assert witness.accepted_as_absence is True
+    assert witness.reason == "OK_TRUE_ABSENCE"
+    assert witness.selection_bias_present is False
+    assert witness.coverage_ratio == 1.0
+
+
+# ---------------------------------------------------------------------------
+# 2. low coverage → INSUFFICIENT_COVERAGE
+# ---------------------------------------------------------------------------
+
+
+def test_low_coverage_returns_insufficient_coverage() -> None:
+    witness = assess_absence(_input(coverage_ratio=0.40, minimum_coverage_threshold=0.80))
+    assert witness.status is AbsenceStatus.INSUFFICIENT_COVERAGE
+    assert witness.accepted_as_absence is False
+    assert witness.reason == "COVERAGE_BELOW_THRESHOLD"
+
+
+# ---------------------------------------------------------------------------
+# 3. active selection bias → SELECTION_BIAS
+# ---------------------------------------------------------------------------
+
+
+def test_active_selection_bias_returns_selection_bias() -> None:
+    witness = assess_absence(_input(selection_bias_flags=("survivorship",)))
+    assert witness.status is AbsenceStatus.SELECTION_BIAS
+    assert witness.accepted_as_absence is False
+    assert witness.reason == "SELECTION_BIAS_ACTIVE"
+    assert witness.selection_bias_present is True
+
+
+def test_selection_bias_takes_precedence_over_low_coverage() -> None:
+    """Bias is louder than low coverage in the priority order. Even if
+    coverage is bad, the bias signal must surface — otherwise an
+    operator might fix coverage and falsely conclude the absence is
+    valid while bias still applies."""
+    witness = assess_absence(
+        _input(
+            coverage_ratio=0.10,
+            selection_bias_flags=("look-ahead",),
+            minimum_coverage_threshold=0.80,
+        )
+    )
+    assert witness.status is AbsenceStatus.SELECTION_BIAS
+
+
+# ---------------------------------------------------------------------------
+# 4. zero sample count → INSUFFICIENT_COVERAGE
+# ---------------------------------------------------------------------------
+
+
+def test_zero_sample_count_returns_insufficient_coverage() -> None:
+    witness = assess_absence(_input(sample_count=0))
+    assert witness.status is AbsenceStatus.INSUFFICIENT_COVERAGE
+    assert witness.reason == "INSUFFICIENT_SAMPLES"
+    assert witness.accepted_as_absence is False
+
+
+def test_zero_sample_count_overrides_other_signals() -> None:
+    """No data = no inference, regardless of any other field."""
+    witness = assess_absence(
+        _input(
+            sample_count=0,
+            coverage_ratio=1.0,
+            selection_bias_flags=("survivorship",),
+        )
+    )
+    assert witness.status is AbsenceStatus.INSUFFICIENT_COVERAGE
+    assert witness.reason == "INSUFFICIENT_SAMPLES"
+
+
+# ---------------------------------------------------------------------------
+# 5. non-empty candidate region cannot be TRUE_ABSENCE
+# ---------------------------------------------------------------------------
+
+
+def test_non_empty_region_returns_unknown_not_true_absence() -> None:
+    """Observed points within the candidate empty region falsify
+    emptiness directly. The witness MUST return UNKNOWN with reason
+    REGION_NOT_EMPTY rather than TRUE_ABSENCE."""
+    witness = assess_absence(
+        _input(
+            observed_state_space=frozenset({"a", "b", "x"}),
+            candidate_empty_region=frozenset({"x", "y"}),
+            coverage_ratio=1.0,
+        )
+    )
+    assert witness.status is AbsenceStatus.UNKNOWN
+    assert witness.reason == "REGION_NOT_EMPTY"
+    assert witness.accepted_as_absence is False
+
+
+# ---------------------------------------------------------------------------
+# 6. coverage exactly at threshold follows documented contract (>=, passes)
+# ---------------------------------------------------------------------------
+
+
+def test_coverage_at_threshold_passes() -> None:
+    witness = assess_absence(_input(coverage_ratio=0.80, minimum_coverage_threshold=0.80))
+    assert witness.status is AbsenceStatus.TRUE_ABSENCE
+
+
+# ---------------------------------------------------------------------------
+# 7. coverage just below threshold fails
+# ---------------------------------------------------------------------------
+
+
+def test_coverage_just_below_threshold_fails() -> None:
+    witness = assess_absence(
+        _input(
+            coverage_ratio=0.7999999999,
+            minimum_coverage_threshold=0.80,
+        )
+    )
+    assert witness.status is AbsenceStatus.INSUFFICIENT_COVERAGE
+
+
+# ---------------------------------------------------------------------------
+# 8. NaN / inf rejected
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "bad_value",
+    [float("nan"), float("inf"), float("-inf")],
+)
+def test_nan_inf_coverage_rejected(bad_value: float) -> None:
+    with pytest.raises(ValueError, match="coverage_ratio must be finite"):
+        _input(coverage_ratio=bad_value)
+
+
+@pytest.mark.parametrize(
+    "bad_value",
+    [float("nan"), float("inf"), float("-inf")],
+)
+def test_nan_inf_threshold_rejected(bad_value: float) -> None:
+    with pytest.raises(ValueError, match="minimum_coverage_threshold must be finite"):
+        _input(minimum_coverage_threshold=bad_value)
+
+
+def test_negative_sample_count_rejected() -> None:
+    with pytest.raises(ValueError, match="sample_count must be >= 0"):
+        _input(sample_count=-1)
+
+
+def test_non_int_sample_count_rejected() -> None:
+    with pytest.raises(TypeError, match="sample_count must be"):
+        AbsenceInput(
+            observed_state_space=frozenset({"a"}),
+            candidate_empty_region=frozenset({"x"}),
+            coverage_ratio=0.9,
+            selection_bias_flags=(),
+            sample_count=3.5,  # type: ignore[arg-type]
+            minimum_coverage_threshold=0.8,
+        )
+
+
+def test_boolean_sample_count_rejected() -> None:
+    """Booleans are subclasses of int in Python; accept-on-purpose
+    surfaces a typo-class regression."""
+    with pytest.raises(TypeError):
+        AbsenceInput(
+            observed_state_space=frozenset({"a"}),
+            candidate_empty_region=frozenset({"x"}),
+            coverage_ratio=0.9,
+            selection_bias_flags=(),
+            sample_count=True,
+            minimum_coverage_threshold=0.8,
+        )
+
+
+# ---------------------------------------------------------------------------
+# 9. invalid threshold / coverage range rejected
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("bad", [-0.01, -1.0, 1.01, 2.0, 100.0])
+def test_invalid_threshold_rejected(bad: float) -> None:
+    with pytest.raises(ValueError, match="minimum_coverage_threshold must be in"):
+        _input(minimum_coverage_threshold=bad)
+
+
+@pytest.mark.parametrize("bad", [-0.01, -1.0, 1.01, 2.0, 100.0])
+def test_invalid_coverage_rejected(bad: float) -> None:
+    with pytest.raises(ValueError, match="coverage_ratio must be in"):
+        _input(coverage_ratio=bad)
+
+
+def test_empty_string_bias_flag_rejected() -> None:
+    with pytest.raises(ValueError, match="selection_bias_flags entries"):
+        _input(selection_bias_flags=("",))
+
+
+def test_observed_state_space_must_be_frozenset() -> None:
+    with pytest.raises(TypeError, match="observed_state_space must be"):
+        AbsenceInput(
+            observed_state_space=["a", "b"],  # type: ignore[arg-type]
+            candidate_empty_region=frozenset({"x"}),
+            coverage_ratio=0.9,
+            selection_bias_flags=(),
+            sample_count=10,
+            minimum_coverage_threshold=0.8,
+        )
+
+
+# ---------------------------------------------------------------------------
+# 10. no-overclaim: module text contains no forbidden phrasing
+# ---------------------------------------------------------------------------
+
+
+_MODULE_PATH = Path(structured_absence.__file__)
+
+# Brief-required forbidden phrases — exactly four. Substring match,
+# case-insensitive. "law" needs word-boundary semantics because innocent
+# words (lawful, lawyer) legitimately contain it.
+_FORBIDDEN_PHRASES: tuple[str, ...] = (
+    "law",
+    "prediction",
+    "physical equivalence",
+    "market physics fact",
+)
+
+
+@pytest.mark.parametrize("phrase", _FORBIDDEN_PHRASES)
+def test_module_body_has_no_overclaim_phrasing(phrase: str) -> None:
+    """The module's source MUST NOT contain any of the brief's
+    forbidden phrasings — neither in code nor in docstring."""
+    text = _MODULE_PATH.read_text(encoding="utf-8").lower()
+    if phrase == "law":
+        import re
+
+        pattern = re.compile(r"\blaw\b")
+        assert not pattern.search(text), (
+            "module contains forbidden standalone word 'law'; "
+            "rephrase or move out of the runtime module."
+        )
+    else:
+        assert phrase not in text, f"module contains forbidden phrasing: {phrase!r}"
+
+
+# ---------------------------------------------------------------------------
+# Auxiliary structural tests
+# ---------------------------------------------------------------------------
+
+
+def test_witness_is_frozen() -> None:
+    """A returned witness must be immutable so callers cannot
+    retroactively edit a verdict."""
+    witness = assess_absence(_input())
+    with pytest.raises(Exception):
+        witness.status = AbsenceStatus.UNKNOWN  # type: ignore[misc]
+
+
+def test_pure_function_no_side_effects_across_calls() -> None:
+    """Calling assess_absence twice on the same input must produce
+    structurally identical witnesses."""
+    inp = _input()
+    a = assess_absence(inp)
+    b = assess_absence(inp)
+    # Compare field-by-field; dataclass eq does not work because the
+    # MappingProxyType evidence_fields are equal-by-value but pickled
+    # differently. We assert explicit field equality below.
+    assert a.status == b.status
+    assert a.reason == b.reason
+    assert a.accepted_as_absence == b.accepted_as_absence
+    assert a.coverage_ratio == b.coverage_ratio
+    assert a.selection_bias_present == b.selection_bias_present
+    assert a.sample_count == b.sample_count
+    assert dict(a.evidence_fields) == dict(b.evidence_fields)
+
+
+def test_assess_many_preserves_order() -> None:
+    inputs = [
+        _input(coverage_ratio=1.0),
+        _input(coverage_ratio=0.1, minimum_coverage_threshold=0.8),
+        _input(selection_bias_flags=("look-ahead",)),
+    ]
+    witnesses = assess_many(inputs)
+    assert len(witnesses) == 3
+    assert witnesses[0].status is AbsenceStatus.TRUE_ABSENCE
+    assert witnesses[1].status is AbsenceStatus.INSUFFICIENT_COVERAGE
+    assert witnesses[2].status is AbsenceStatus.SELECTION_BIAS
+
+
+def test_witness_carries_no_prediction_class_field() -> None:
+    """The absence-inference contract: a witness is evidence
+    classification, not a prediction. The witness MUST NOT carry any
+    field name that would let a downstream consumer mistake absence
+    for a trading signal."""
+    forbidden_field_names = {
+        "prediction",
+        "predicted",
+        "signal",
+        "forecast",
+        "score",
+        "direction",
+        "recommendation",
+        "side",
+        "trade",
+        "trade_signal",
+        "buy",
+        "sell",
+        "alpha",
+        "expected_return",
+    }
+    from dataclasses import fields
+
+    actual = {f.name for f in fields(AbsenceWitness)}
+    overlap = actual & forbidden_field_names
+    assert not overlap, f"AbsenceWitness leaks prediction-class fields: {overlap}"
+
+
+def test_evidence_fields_are_immutable() -> None:
+    witness = assess_absence(_input())
+    with pytest.raises(TypeError):
+        witness.evidence_fields["new"] = "x"  # type: ignore[index]
+
+
+def test_module_does_not_import_market_or_trading_modules() -> None:
+    """Defensive: the structured-absence module must not pull in any
+    market / trading module at import time. If it does, the engineering
+    analog has leaked into business logic — exactly the inflation this
+    module is supposed to prevent."""
+    text = _MODULE_PATH.read_text(encoding="utf-8")
+    forbidden_imports = (
+        "from execution",
+        "from backtest",
+        "from analytics.signals",
+        "from core.strategies",
+        "import execution",
+        "import backtest",
+    )
+    for stmt in forbidden_imports:
+        assert stmt not in text, (
+            f"structured_absence.py imports {stmt!r}; the engineering "
+            f"analog must stay decoupled from market / trading layers."
+        )
+
+
+def test_zero_observed_state_space_with_full_coverage_passes() -> None:
+    """A region cannot contain anything if there are no observations,
+    AND coverage is full, AND samples are present. That is the
+    canonical TRUE_ABSENCE shape — most extreme case."""
+    witness = assess_absence(
+        _input(
+            observed_state_space=frozenset(),
+            candidate_empty_region=frozenset({"x"}),
+            coverage_ratio=1.0,
+            sample_count=42,
+        )
+    )
+    assert witness.status is AbsenceStatus.TRUE_ABSENCE
+
+
+def test_falsifier_text_is_present_in_every_witness() -> None:
+    for witness in assess_many(
+        [
+            _input(coverage_ratio=1.0),
+            _input(sample_count=0),
+            _input(selection_bias_flags=("x",)),
+            _input(coverage_ratio=0.1, minimum_coverage_threshold=0.5),
+            _input(
+                observed_state_space=frozenset({"x"}),
+                candidate_empty_region=frozenset({"x"}),
+            ),
+        ]
+    ):
+        assert witness.falsifier
+        assert "TRUE_ABSENCE" in witness.falsifier
+
+
+def test_evidence_fields_record_observed_count_in_region() -> None:
+    """The witness exposes the actual count of observed points inside
+    the candidate region. This is the load-bearing evidence the rule
+    'non-empty region cannot be TRUE_ABSENCE' rests on."""
+    witness = assess_absence(
+        _input(
+            observed_state_space=frozenset({"a", "x", "y"}),
+            candidate_empty_region=frozenset({"x", "y", "z"}),
+            coverage_ratio=1.0,
+        )
+    )
+    assert witness.status is AbsenceStatus.UNKNOWN
+    assert witness.evidence_fields["observed_count_in_region"] == 2
+
+
+def test_finite_threshold_zero_is_admissible() -> None:
+    """A threshold of 0.0 means 'any coverage qualifies'. Edge case;
+    any non-trivial coverage passes."""
+    witness = assess_absence(_input(coverage_ratio=0.0, minimum_coverage_threshold=0.0))
+    # coverage 0.0 >= threshold 0.0, no bias, region empty → TRUE_ABSENCE
+    assert witness.status is AbsenceStatus.TRUE_ABSENCE
+
+
+def test_threshold_one_demands_perfect_coverage() -> None:
+    """A threshold of 1.0 means 'only perfect coverage counts'."""
+    near = assess_absence(_input(coverage_ratio=0.999999, minimum_coverage_threshold=1.0))
+    perfect = assess_absence(_input(coverage_ratio=1.0, minimum_coverage_threshold=1.0))
+    assert near.status is AbsenceStatus.INSUFFICIENT_COVERAGE
+    assert perfect.status is AbsenceStatus.TRUE_ABSENCE
+
+
+def test_non_finite_value_through_arithmetic_blocked() -> None:
+    """Even when coverage_ratio is computed (e.g. division), passing a
+    non-finite result must fail at construction. This test plants
+    `0.0 / 0.0` which yields nan, and asserts the input rejects it."""
+    bad = float("nan")
+    assert math.isnan(bad)
+    with pytest.raises(ValueError, match="coverage_ratio must be finite"):
+        _input(coverage_ratio=bad)


### PR DESCRIPTION
Re-opens after cascade closure of #454. Single commit on main (rail + P1 already merged).

Lie blocked: "missing data = true absence". Only P2 translation status flipped.

Falsifier was executed in original PR #454; tests still pass on rebased branch (46/46).

Quality gates: ruff/black/mypy --strict clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)