### PR TITLE
ci: fix physics-2026 gate dependency bootstrap

### DIFF
--- a/.github/workflows/physics-2026-gate.yml
+++ b/.github/workflows/physics-2026-gate.yml
@@ -107,10 +107,15 @@ jobs:
       - name: Install minimal test dependencies
         run: |
           set -euo pipefail
+          # tests/conftest.py imports pandas + pytest + yaml at module
+          # level. Pandas is part of the project's runtime contract
+          # (requirements.txt pins pandas>=2.3.3); the minimal install
+          # below mirrors that pin so pytest collection succeeds.
           python -m pip install --upgrade pip
           python -m pip install \
             'pytest>=8.4' \
             'numpy>=2.3.3' \
+            'pandas>=2.3.3' \
             'PyYAML>=6.0.3'
 
       - name: Run physics-2026 unit suites
@@ -148,10 +153,16 @@ jobs:
       - name: Install minimal integration dependencies
         run: |
           set -euo pipefail
+          # tests/conftest.py imports pandas + pytest + yaml at module
+          # level. The integration suite also needs numpy. Pandas is
+          # pinned by the project (requirements.txt: pandas>=2.3.3); we
+          # mirror that pin here.
           python -m pip install --upgrade pip
           python -m pip install \
             'pytest>=8.4' \
-            'numpy>=2.3.3'
+            'numpy>=2.3.3' \
+            'pandas>=2.3.3' \
+            'PyYAML>=6.0.3'
 
       - name: Run physics-2026 reality chain
         run: |


### PR DESCRIPTION
## Summary
Lie blocked: **\"CI failure is harmless because local validation passed\"**.

Adds `pandas>=2.3.3` to both pytest-running jobs in `.github/workflows/physics-2026-gate.yml`, and `PyYAML>=6.0.3` to integration-chain. `tests/conftest.py` imports pandas + pytest + yaml at module level; without them pytest collection fails with `ImportError while loading conftest`.

## Diff
- `unit-tests` job: install list gains `'pandas>=2.3.3'`
- `integration-chain` job: install list gains `'pandas>=2.3.3'` and `'PyYAML>=6.0.3'`

Pins mirror `requirements.txt` (canonical project contract). No torch / no full requirements install — workflow stays lean.

## Falsifier (executed locally)
1. Created `/tmp/_no_pandas_stub/pandas.py` whose body raises `ModuleNotFoundError`.
2. Ran `PYTHONPATH=/tmp/_no_pandas_stub:$PYTHONPATH python -m pytest tests/unit/regimes/test_population_event_catalog.py --collect-only`.
3. Result: same error chain as CI failure (`ImportError while loading conftest → import pandas as pd → ModuleNotFoundError`).
4. Removed stub. Same command collects cleanly with pandas restored.

## Local workflow-equivalent validation
| Command | Result |
|---|---|
| `import pandas, numpy, yaml, pytest` | pandas 2.3.3, numpy 2.4.3, PyYAML 6.0.3, pytest 8.4.2 |
| `pytest <7 unit-test files>` | 202 passed |
| `pytest tests/integration/test_physics_2026_reality_chain.py` | 13 passed |
| `validate_physics_2026_sources.py` | OK 10/10 |
| `validate_physics_2026_translation.py` | OK 10/10 |

## Workflow invariants
- `permissions: contents: read` (unchanged)
- all actions pinned by 40-char SHA
- no `pull_request_target`
- YAML parses cleanly

## Scope
- no runtime module touched
- no test changed
- no validators broadened
- only the two failing jobs' install steps modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)