### PR TITLE
feat(coherence): add claim gauge witness (P10)

### DIFF
--- a/.claude/research/PHYSICS_2026_TRANSLATION.yaml
+++ b/.claude/research/PHYSICS_2026_TRANSLATION.yaml
@@ -521,7 +521,8 @@ patterns:
       local-symmetry constraint is satisfied.
     proposed_module: geosync_hpc/coherence/claim_gauge_witness.py
     claim_tier: ENGINEERING_ANALOG
-    implementation_status: PROPOSED
+    implementation_status: IMPLEMENTED
+    implemented_at: "2026-04-27"
     measurable_inputs:
       - claim_id
       - local_constraints

--- a/geosync_hpc/coherence/claim_gauge_witness.py
+++ b/geosync_hpc/coherence/claim_gauge_witness.py
@@ -1,0 +1,181 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""Claim gauge witness — engineering analog of S10 local-consistency gauging.
+
+pattern_id:        P10_CLAIM_GAUGE_WITNESS
+source_id:         S10_LOGICAL_GAUGING_LOCAL_SYMMETRY
+claim_tier:        ENGINEERING_ANALOG
+
+A claim about a global property must be gauged against the local-
+consistency constraints it implies. The named lie blocked here is
+"a single local check is a global proof". A claim is GAUGE_PASS only
+when every required local-consistency constraint is satisfied.
+
+Statuses:
+    GAUGE_PASS                every required constraint is satisfied
+    GAUGE_REFUSED             at least one required constraint reports
+                              unsatisfied; ``failing_constraints`` lists
+                              the offenders
+    UNKNOWN_CONSTRAINT         a required constraint is missing from
+                              the satisfaction map
+    INVALID_INPUT             malformed constraint shape
+
+Non-claims: no one-to-one correspondence with logical-gauging physics;
+no forecast / signal / trading interpretation; the witness reports a
+boolean AND over named local surfaces.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from enum import Enum
+from types import MappingProxyType
+from typing import Any
+
+__all__ = [
+    "GaugeStatus",
+    "GaugeInput",
+    "GaugeWitness",
+    "assess_claim_gauge",
+]
+
+
+_FALSIFIER_TEXT = (
+    "GAUGE_PASS was returned but at least one required local-consistency "
+    "constraint reported unsatisfied. OR: the required-constraints set "
+    "was silently emptied or its intersection with the satisfaction map "
+    "was bypassed. OR: a missing required constraint was treated as "
+    "satisfied."
+)
+
+
+class GaugeStatus(str, Enum):
+    GAUGE_PASS = "GAUGE_PASS"
+    GAUGE_REFUSED = "GAUGE_REFUSED"
+    UNKNOWN_CONSTRAINT = "UNKNOWN_CONSTRAINT"
+    INVALID_INPUT = "INVALID_INPUT"
+
+
+@dataclass(frozen=True)
+class GaugeInput:
+    """One claim-gauge question.
+
+    ``claim_id`` is a stable identifier for the global claim under
+    test. ``local_constraints`` is the full set of constraint names the
+    caller has measured. ``constraint_satisfaction`` maps each constraint
+    name to a bool. ``required_constraints`` is the subset the gauge
+    enforces; it must be a non-empty subset of ``local_constraints``.
+    """
+
+    claim_id: str
+    local_constraints: tuple[str, ...]
+    constraint_satisfaction: Mapping[str, bool]
+    required_constraints: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.claim_id, str) or not self.claim_id.strip():
+            raise ValueError("claim_id must be a non-empty string")
+
+        if not isinstance(self.local_constraints, tuple):
+            raise TypeError("local_constraints must be a tuple of strings")
+        if len(self.local_constraints) == 0:
+            raise ValueError("local_constraints must be non-empty")
+        for i, c in enumerate(self.local_constraints):
+            if not isinstance(c, str) or not c.strip():
+                raise ValueError(f"local_constraints[{i}] must be a non-empty string")
+
+        if not isinstance(self.constraint_satisfaction, Mapping):
+            raise TypeError("constraint_satisfaction must be a Mapping[str, bool]")
+        for k, v in self.constraint_satisfaction.items():
+            if not isinstance(k, str) or not k.strip():
+                raise ValueError("constraint_satisfaction keys must be non-empty strings")
+            if not isinstance(v, bool):
+                raise TypeError(f"constraint_satisfaction[{k!r}] must be a bool")
+
+        if not isinstance(self.required_constraints, tuple):
+            raise TypeError("required_constraints must be a tuple of strings")
+        if len(self.required_constraints) == 0:
+            raise ValueError("required_constraints must be non-empty")
+        for i, c in enumerate(self.required_constraints):
+            if not isinstance(c, str) or not c.strip():
+                raise ValueError(f"required_constraints[{i}] must be a non-empty string")
+
+        local_set = set(self.local_constraints)
+        for c in self.required_constraints:
+            if c not in local_set:
+                raise ValueError(
+                    f"required constraint {c!r} not present in local_constraints; "
+                    "every required constraint must be declared as local first"
+                )
+
+
+@dataclass(frozen=True)
+class GaugeWitness:
+    """One claim-gauge verdict."""
+
+    status: GaugeStatus
+    claim_id: str
+    failing_constraints: tuple[str, ...]
+    missing_constraints: tuple[str, ...]
+    reason: str
+    falsifier: str
+    evidence_fields: Mapping[str, Any] = field(default_factory=lambda: MappingProxyType({}))
+
+
+def assess_claim_gauge(input_: GaugeInput) -> GaugeWitness:
+    """Pure local-consistency gauge.
+
+    Priority (first failing condition wins):
+        1. any required constraint missing from satisfaction map
+                                          → UNKNOWN_CONSTRAINT
+        2. any required constraint False  → GAUGE_REFUSED
+        3. otherwise                       → GAUGE_PASS
+    """
+    sat = input_.constraint_satisfaction
+    required = input_.required_constraints
+
+    missing: list[str] = [c for c in required if c not in sat]
+    failing: list[str] = [c for c in required if c in sat and not sat[c]]
+
+    evidence = MappingProxyType(
+        {
+            "claim_id": input_.claim_id,
+            "local_count": len(input_.local_constraints),
+            "required_count": len(required),
+            "missing_count": len(missing),
+            "failing_count": len(failing),
+            "missing_constraints": tuple(missing),
+            "failing_constraints": tuple(failing),
+        }
+    )
+
+    if missing:
+        return GaugeWitness(
+            status=GaugeStatus.UNKNOWN_CONSTRAINT,
+            claim_id=input_.claim_id,
+            failing_constraints=tuple(failing),
+            missing_constraints=tuple(missing),
+            reason="REQUIRED_CONSTRAINT_NOT_MEASURED",
+            falsifier=_FALSIFIER_TEXT,
+            evidence_fields=evidence,
+        )
+    if failing:
+        return GaugeWitness(
+            status=GaugeStatus.GAUGE_REFUSED,
+            claim_id=input_.claim_id,
+            failing_constraints=tuple(failing),
+            missing_constraints=(),
+            reason="REQUIRED_CONSTRAINT_UNSATISFIED",
+            falsifier=_FALSIFIER_TEXT,
+            evidence_fields=evidence,
+        )
+    return GaugeWitness(
+        status=GaugeStatus.GAUGE_PASS,
+        claim_id=input_.claim_id,
+        failing_constraints=(),
+        missing_constraints=(),
+        reason="OK_ALL_REQUIRED_CONSTRAINTS_SATISFIED",
+        falsifier=_FALSIFIER_TEXT,
+        evidence_fields=evidence,
+    )

--- a/tests/unit/coherence/test_claim_gauge_witness.py
+++ b/tests/unit/coherence/test_claim_gauge_witness.py
@@ -1,0 +1,260 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""Tests for geosync_hpc.coherence.claim_gauge_witness."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from pathlib import Path
+
+import pytest
+
+from geosync_hpc.coherence.claim_gauge_witness import (
+    GaugeInput,
+    GaugeStatus,
+    GaugeWitness,
+    assess_claim_gauge,
+)
+
+
+def _input(
+    *,
+    claim_id: str = "claim-test",
+    local_constraints: tuple[str, ...] = ("a", "b", "c"),
+    constraint_satisfaction: dict[str, bool] | None = None,
+    required_constraints: tuple[str, ...] = ("a", "b", "c"),
+) -> GaugeInput:
+    if constraint_satisfaction is None:
+        constraint_satisfaction = {"a": True, "b": True, "c": True}
+    return GaugeInput(
+        claim_id=claim_id,
+        local_constraints=local_constraints,
+        constraint_satisfaction=constraint_satisfaction,
+        required_constraints=required_constraints,
+    )
+
+
+def test_all_required_satisfied_passes() -> None:
+    """1. Every required constraint satisfied → GAUGE_PASS."""
+    witness = assess_claim_gauge(_input())
+    assert witness.status is GaugeStatus.GAUGE_PASS
+    assert witness.failing_constraints == ()
+    assert witness.missing_constraints == ()
+
+
+def test_one_required_violated_refuses() -> None:
+    """2. One required constraint reports False → GAUGE_REFUSED.
+
+    This is the test the falsifier must break.
+    """
+    witness = assess_claim_gauge(
+        _input(
+            constraint_satisfaction={"a": True, "b": False, "c": True},
+        )
+    )
+    assert witness.status is GaugeStatus.GAUGE_REFUSED
+    assert "b" in witness.failing_constraints
+
+
+def test_missing_required_constraint_unknown() -> None:
+    """3. Required constraint missing from satisfaction map → UNKNOWN_CONSTRAINT."""
+    witness = assess_claim_gauge(
+        _input(
+            constraint_satisfaction={"a": True, "c": True},  # b missing
+        )
+    )
+    assert witness.status is GaugeStatus.UNKNOWN_CONSTRAINT
+    assert "b" in witness.missing_constraints
+
+
+def test_required_not_in_local_rejected() -> None:
+    """4. required_constraints must be subset of local_constraints."""
+    with pytest.raises(ValueError, match="not present in local_constraints"):
+        GaugeInput(
+            claim_id="x",
+            local_constraints=("a",),
+            constraint_satisfaction={"a": True},
+            required_constraints=("a", "b"),
+        )
+
+
+def test_empty_required_rejected() -> None:
+    with pytest.raises(ValueError, match="required_constraints must be non-empty"):
+        GaugeInput(
+            claim_id="x",
+            local_constraints=("a",),
+            constraint_satisfaction={"a": True},
+            required_constraints=(),
+        )
+
+
+def test_empty_local_rejected() -> None:
+    with pytest.raises(ValueError, match="local_constraints must be non-empty"):
+        GaugeInput(
+            claim_id="x",
+            local_constraints=(),
+            constraint_satisfaction={},
+            required_constraints=("a",),
+        )
+
+
+def test_empty_claim_id_rejected() -> None:
+    with pytest.raises(ValueError, match="claim_id must be a non-empty string"):
+        GaugeInput(
+            claim_id="",
+            local_constraints=("a",),
+            constraint_satisfaction={"a": True},
+            required_constraints=("a",),
+        )
+    with pytest.raises(ValueError, match="claim_id must be a non-empty string"):
+        GaugeInput(
+            claim_id="   ",
+            local_constraints=("a",),
+            constraint_satisfaction={"a": True},
+            required_constraints=("a",),
+        )
+
+
+def test_non_bool_satisfaction_rejected() -> None:
+    with pytest.raises(TypeError, match="must be a bool"):
+        GaugeInput(
+            claim_id="x",
+            local_constraints=("a",),
+            constraint_satisfaction={"a": 1},  # type: ignore[dict-item]
+            required_constraints=("a",),
+        )
+
+
+def test_non_string_satisfaction_key_rejected() -> None:
+    with pytest.raises(ValueError, match="constraint_satisfaction keys"):
+        GaugeInput(
+            claim_id="x",
+            local_constraints=("a",),
+            constraint_satisfaction={"": True},
+            required_constraints=("a",),
+        )
+
+
+def test_non_tuple_local_rejected() -> None:
+    with pytest.raises(TypeError, match="local_constraints must be a tuple"):
+        GaugeInput(
+            claim_id="x",
+            local_constraints=["a"],  # type: ignore[arg-type]
+            constraint_satisfaction={"a": True},
+            required_constraints=("a",),
+        )
+
+
+def test_non_mapping_satisfaction_rejected() -> None:
+    with pytest.raises(TypeError, match="must be a Mapping"):
+        GaugeInput(
+            claim_id="x",
+            local_constraints=("a",),
+            constraint_satisfaction=[("a", True)],  # type: ignore[arg-type]
+            required_constraints=("a",),
+        )
+
+
+def test_empty_local_member_name_rejected() -> None:
+    with pytest.raises(ValueError, match=r"local_constraints\[0\] must be a non-empty string"):
+        GaugeInput(
+            claim_id="x",
+            local_constraints=("",),
+            constraint_satisfaction={"": True},
+            required_constraints=("",),
+        )
+
+
+def test_subset_required_passes() -> None:
+    """Required can be a strict subset; non-required failures don't trip the gauge."""
+    witness = assess_claim_gauge(
+        _input(
+            local_constraints=("a", "b", "c"),
+            constraint_satisfaction={"a": True, "b": False, "c": True},
+            required_constraints=("a", "c"),
+        )
+    )
+    assert witness.status is GaugeStatus.GAUGE_PASS
+
+
+def test_multiple_failures_listed_in_order() -> None:
+    """failing_constraints preserves required-tuple order."""
+    witness = assess_claim_gauge(
+        _input(
+            constraint_satisfaction={"a": False, "b": False, "c": True},
+            required_constraints=("a", "b", "c"),
+        )
+    )
+    assert witness.status is GaugeStatus.GAUGE_REFUSED
+    assert witness.failing_constraints == ("a", "b")
+
+
+def test_deterministic_repeated_calls_equal() -> None:
+    inp = _input(
+        constraint_satisfaction={"a": True, "b": False, "c": True},
+        required_constraints=("a", "b", "c"),
+    )
+    a = assess_claim_gauge(inp)
+    b = assess_claim_gauge(inp)
+    assert a == b
+    assert a.status is b.status
+    assert a.evidence_fields == b.evidence_fields
+
+
+def test_witness_is_frozen() -> None:
+    witness = assess_claim_gauge(_input())
+    with pytest.raises(Exception):  # noqa: B017
+        witness.status = GaugeStatus.INVALID_INPUT  # type: ignore[misc]
+
+
+def test_evidence_fields_immutable() -> None:
+    witness = assess_claim_gauge(_input())
+    assert isinstance(witness.evidence_fields, Mapping)
+    with pytest.raises(TypeError):
+        witness.evidence_fields["x"] = 1  # type: ignore[index]
+
+
+def test_witness_carries_no_prediction_class_field() -> None:
+    forbidden = {"prediction", "signal", "forecast", "target_price", "recommended_action"}
+    fields = set(GaugeWitness.__dataclass_fields__.keys())
+    assert fields.isdisjoint(forbidden)
+
+
+def test_no_numeric_score_fields_exist() -> None:
+    forbidden = {"score", "health_score", "health_index", "confidence", "percent", "ratio"}
+    fields = set(GaugeWitness.__dataclass_fields__.keys())
+    assert fields.isdisjoint(forbidden)
+
+
+def test_falsifier_text_non_empty() -> None:
+    witness = assess_claim_gauge(_input())
+    assert isinstance(witness.falsifier, str)
+    assert len(witness.falsifier) > 80
+
+
+_MODULE_PATH = (
+    Path(__file__).resolve().parents[3] / "geosync_hpc" / "coherence" / "claim_gauge_witness.py"
+)
+
+
+def test_module_does_not_use_predictive_or_universal_language() -> None:
+    text = _MODULE_PATH.read_text(encoding="utf-8").lower()
+    forbidden = (
+        r"\bprediction\b",
+        r"\buniversal\b",
+        r"physical equivalence",
+        r"new law of physics",
+    )
+    for pattern in forbidden:
+        assert re.search(pattern, text) is None, f"forbidden phrase {pattern!r} present"
+
+
+def test_module_does_not_import_market_or_trading_modules() -> None:
+    text = _MODULE_PATH.read_text(encoding="utf-8")
+    for tainted in (
+        "from geosync_hpc.execution",
+        "from geosync_hpc.policy",
+        "from geosync_hpc.application",
+    ):
+        assert tainted not in text, f"{tainted!r} would couple this witness to runtime layers"


### PR DESCRIPTION
Lie blocked: "a single local check is a global proof".

Module: `geosync_hpc/coherence/claim_gauge_witness.py`. Pure deterministic, frozen dataclasses. Statuses: GAUGE_PASS / GAUGE_REFUSED / UNKNOWN_CONSTRAINT / INVALID_INPUT. GAUGE_PASS requires every required local-consistency constraint satisfied; missing required constraint → fail-closed UNKNOWN_CONSTRAINT.

Tests: 22/22 pass. Falsifier: replaced failing-constraint scan with empty list; 2 tests FAILED (one_violated_refuses + multiple_failures_listed_in_order); restored clean.

Translation: P10 only flipped to IMPLEMENTED, implemented_at 2026-04-27. P1-P9 untouched.

Quality gates: ruff/black/mypy --strict clean, validator OK (10/10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)