### PR TITLE
feat(governance): evidence-decay engine (#476)

### DIFF
--- a/tests/governance/test_evidence_decay.py
+++ b/tests/governance/test_evidence_decay.py
@@ -1,0 +1,190 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""Tests for tools/governance/evidence_decay.py."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from tools.governance.evidence_decay import (
+    POLICY_BY_CLASS,
+    DecayClass,
+    DecayStatus,
+    EvidenceRecord,
+    assess_decay,
+)
+
+
+def _record(
+    *,
+    decay_class: DecayClass = DecayClass.SECURITY_HIGH_DECAY,
+    last_verified_at: datetime | None = None,
+) -> EvidenceRecord:
+    if last_verified_at is None:
+        last_verified_at = datetime(2026, 4, 27, tzinfo=timezone.utc)
+    return EvidenceRecord(
+        evidence_id="ev-1",
+        evidence_type="security-advisory",
+        last_verified_at=last_verified_at,
+        decay_class=decay_class,
+        revalidate_command="python tools/research/validate_physics_2026_sources.py",
+    )
+
+
+def test_fresh_security_evidence_is_valid() -> None:
+    record = _record(last_verified_at=datetime(2026, 4, 27, tzinfo=timezone.utc))
+    witness = assess_decay(record, now=datetime(2026, 4, 28, tzinfo=timezone.utc))
+    assert witness.status is DecayStatus.VALID
+
+
+def test_security_evidence_eight_days_old_is_stale() -> None:
+    """SECURITY_HIGH_DECAY: stale_after = 7d.
+
+    This is the test the falsifier must break.
+    """
+    record = _record(last_verified_at=datetime(2026, 4, 1, tzinfo=timezone.utc))
+    witness = assess_decay(record, now=datetime(2026, 4, 9, tzinfo=timezone.utc))
+    assert witness.status is DecayStatus.STALE
+
+
+def test_security_evidence_thirty_one_days_old_is_expired() -> None:
+    """SECURITY_HIGH_DECAY: expired_after = 30d."""
+    record = _record(last_verified_at=datetime(2026, 4, 1, tzinfo=timezone.utc))
+    witness = assess_decay(record, now=datetime(2026, 5, 2, tzinfo=timezone.utc))
+    assert witness.status is DecayStatus.EXPIRED
+
+
+def test_market_data_one_day_old_is_valid_two_days_stale_eight_days_expired() -> None:
+    base = datetime(2026, 4, 1, tzinfo=timezone.utc)
+    record = _record(
+        decay_class=DecayClass.MARKET_DATA_HIGH_DECAY,
+        last_verified_at=base,
+    )
+    assert assess_decay(record, now=base + timedelta(hours=12)).status is DecayStatus.VALID
+    assert assess_decay(record, now=base + timedelta(days=2)).status is DecayStatus.STALE
+    assert assess_decay(record, now=base + timedelta(days=8)).status is DecayStatus.EXPIRED
+
+
+def test_ci_state_immediate_decay_thresholds() -> None:
+    base = datetime(2026, 4, 27, 12, tzinfo=timezone.utc)
+    record = _record(
+        decay_class=DecayClass.CI_STATE_IMMEDIATE_DECAY,
+        last_verified_at=base,
+    )
+    assert assess_decay(record, now=base + timedelta(minutes=30)).status is DecayStatus.VALID
+    assert assess_decay(record, now=base + timedelta(hours=2)).status is DecayStatus.STALE
+    assert assess_decay(record, now=base + timedelta(hours=25)).status is DecayStatus.EXPIRED
+
+
+def test_static_low_decay_long_thresholds() -> None:
+    base = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    record = _record(
+        decay_class=DecayClass.STATIC_LOW_DECAY,
+        last_verified_at=base,
+    )
+    assert assess_decay(record, now=base + timedelta(days=100)).status is DecayStatus.VALID
+    assert assess_decay(record, now=base + timedelta(days=200)).status is DecayStatus.STALE
+    assert assess_decay(record, now=base + timedelta(days=800)).status is DecayStatus.EXPIRED
+
+
+def test_dependency_medium_decay_thresholds() -> None:
+    base = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    record = _record(
+        decay_class=DecayClass.DEPENDENCY_MEDIUM_DECAY,
+        last_verified_at=base,
+    )
+    assert assess_decay(record, now=base + timedelta(days=10)).status is DecayStatus.VALID
+    assert assess_decay(record, now=base + timedelta(days=45)).status is DecayStatus.STALE
+    assert assess_decay(record, now=base + timedelta(days=120)).status is DecayStatus.EXPIRED
+
+
+def test_future_last_verified_returns_revalidation_required() -> None:
+    """Clock-drift defence: last_verified_at in the future → revalidate."""
+    record = _record(last_verified_at=datetime(2027, 1, 1, tzinfo=timezone.utc))
+    witness = assess_decay(record, now=datetime(2026, 4, 27, tzinfo=timezone.utc))
+    assert witness.status is DecayStatus.REVALIDATION_REQUIRED
+
+
+def test_naive_datetime_rejected() -> None:
+    with pytest.raises(ValueError, match="timezone-aware"):
+        EvidenceRecord(
+            evidence_id="x",
+            evidence_type="t",
+            last_verified_at=datetime(2026, 4, 27),  # naive
+            decay_class=DecayClass.STATIC_LOW_DECAY,
+            revalidate_command="echo refresh",
+        )
+
+
+def test_naive_now_rejected() -> None:
+    with pytest.raises(ValueError, match="timezone-aware"):
+        assess_decay(_record(), now=datetime(2026, 4, 27))  # naive
+
+
+def test_empty_id_rejected() -> None:
+    with pytest.raises(ValueError, match="evidence_id"):
+        EvidenceRecord(
+            evidence_id="",
+            evidence_type="t",
+            last_verified_at=datetime(2026, 4, 27, tzinfo=timezone.utc),
+            decay_class=DecayClass.STATIC_LOW_DECAY,
+            revalidate_command="echo refresh",
+        )
+
+
+def test_empty_revalidate_command_rejected() -> None:
+    with pytest.raises(ValueError, match="revalidate_command"):
+        EvidenceRecord(
+            evidence_id="x",
+            evidence_type="t",
+            last_verified_at=datetime(2026, 4, 27, tzinfo=timezone.utc),
+            decay_class=DecayClass.STATIC_LOW_DECAY,
+            revalidate_command="",
+        )
+
+
+def test_policy_invariant_expired_greater_than_stale() -> None:
+    for cls, policy in POLICY_BY_CLASS.items():
+        assert policy.expired_after > policy.stale_after, cls
+
+
+def test_witness_is_frozen() -> None:
+    record = _record()
+    witness = assess_decay(record, now=datetime(2026, 4, 28, tzinfo=timezone.utc))
+    with pytest.raises(Exception):  # noqa: B017
+        witness.status = DecayStatus.EXPIRED  # type: ignore[misc]
+
+
+def test_witness_evidence_fields_immutable() -> None:
+    from collections.abc import Mapping
+
+    record = _record()
+    witness = assess_decay(record, now=datetime(2026, 4, 28, tzinfo=timezone.utc))
+    assert isinstance(witness.evidence_fields, Mapping)
+    with pytest.raises(TypeError):
+        witness.evidence_fields["x"] = 1  # type: ignore[index]
+
+
+def test_falsifier_text_present() -> None:
+    record = _record()
+    witness = assess_decay(record, now=datetime(2026, 4, 28, tzinfo=timezone.utc))
+    assert isinstance(witness.falsifier, str)
+    assert len(witness.falsifier) > 80
+
+
+def test_witness_carries_no_prediction_class_field() -> None:
+    from tools.governance.evidence_decay import DecayWitness
+
+    forbidden = {"prediction", "signal", "forecast", "score", "confidence"}
+    fields = set(DecayWitness.__dataclass_fields__.keys())
+    assert fields.isdisjoint(forbidden)
+
+
+def test_deterministic_at_same_inputs() -> None:
+    record = _record()
+    now = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    a = assess_decay(record, now=now)
+    b = assess_decay(record, now=now)
+    assert a == b

--- a/tools/governance/evidence_decay.py
+++ b/tools/governance/evidence_decay.py
@@ -1,0 +1,226 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""Evidence-decay engine.
+
+Lie blocked:
+    "old evidence remains true forever"
+
+Evidence is dated. A claim that rests on a security advisory checked
+six months ago is not the same as a claim that rests on the same
+advisory checked yesterday. This module classifies an evidence record
+into one of {VALID, STALE, EXPIRED, REVALIDATION_REQUIRED} given its
+type-specific decay policy and the current clock.
+
+Decay classes (max age in seconds before STALE / EXPIRED):
+
+    STATIC_LOW_DECAY            stale=180d   expired=730d
+    DEPENDENCY_MEDIUM_DECAY     stale=30d    expired=90d
+    SECURITY_HIGH_DECAY         stale=7d     expired=30d
+    MARKET_DATA_HIGH_DECAY      stale=1d     expired=7d
+    CI_STATE_IMMEDIATE_DECAY    stale=1h     expired=24h
+
+Determinism: classification is a pure function of (now, last_verified_at,
+decay_class). The clock is injected; no module-level time-of-day reads.
+
+Non-claims:
+    - the engine does not refresh evidence; it only classifies it
+    - it does not run revalidate_command; it records the command for
+      a caller to invoke
+    - decay thresholds are policy, not law; they reduce false-confidence
+      at known cadences but do not certify any specific freshness level
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from enum import Enum
+from types import MappingProxyType
+from typing import Any
+
+__all__ = [
+    "DecayClass",
+    "DecayStatus",
+    "EvidenceRecord",
+    "DecayPolicy",
+    "DecayWitness",
+    "POLICY_BY_CLASS",
+    "assess_decay",
+]
+
+
+class DecayClass(str, Enum):
+    STATIC_LOW_DECAY = "STATIC_LOW_DECAY"
+    DEPENDENCY_MEDIUM_DECAY = "DEPENDENCY_MEDIUM_DECAY"
+    SECURITY_HIGH_DECAY = "SECURITY_HIGH_DECAY"
+    MARKET_DATA_HIGH_DECAY = "MARKET_DATA_HIGH_DECAY"
+    CI_STATE_IMMEDIATE_DECAY = "CI_STATE_IMMEDIATE_DECAY"
+
+
+class DecayStatus(str, Enum):
+    VALID = "VALID"
+    STALE = "STALE"
+    EXPIRED = "EXPIRED"
+    REVALIDATION_REQUIRED = "REVALIDATION_REQUIRED"
+
+
+@dataclass(frozen=True)
+class DecayPolicy:
+    """Policy for one decay class."""
+
+    decay_class: DecayClass
+    stale_after: timedelta
+    expired_after: timedelta
+
+    def __post_init__(self) -> None:
+        if self.stale_after.total_seconds() <= 0:
+            raise ValueError("stale_after must be a positive duration")
+        if self.expired_after <= self.stale_after:
+            raise ValueError("expired_after must be strictly greater than stale_after")
+
+
+POLICY_BY_CLASS: Mapping[DecayClass, DecayPolicy] = MappingProxyType(
+    {
+        DecayClass.STATIC_LOW_DECAY: DecayPolicy(
+            DecayClass.STATIC_LOW_DECAY,
+            timedelta(days=180),
+            timedelta(days=730),
+        ),
+        DecayClass.DEPENDENCY_MEDIUM_DECAY: DecayPolicy(
+            DecayClass.DEPENDENCY_MEDIUM_DECAY,
+            timedelta(days=30),
+            timedelta(days=90),
+        ),
+        DecayClass.SECURITY_HIGH_DECAY: DecayPolicy(
+            DecayClass.SECURITY_HIGH_DECAY,
+            timedelta(days=7),
+            timedelta(days=30),
+        ),
+        DecayClass.MARKET_DATA_HIGH_DECAY: DecayPolicy(
+            DecayClass.MARKET_DATA_HIGH_DECAY,
+            timedelta(days=1),
+            timedelta(days=7),
+        ),
+        DecayClass.CI_STATE_IMMEDIATE_DECAY: DecayPolicy(
+            DecayClass.CI_STATE_IMMEDIATE_DECAY,
+            timedelta(hours=1),
+            timedelta(hours=24),
+        ),
+    }
+)
+
+
+@dataclass(frozen=True)
+class EvidenceRecord:
+    """One piece of dated evidence."""
+
+    evidence_id: str
+    evidence_type: str
+    last_verified_at: datetime
+    decay_class: DecayClass
+    revalidate_command: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.evidence_id, str) or not self.evidence_id.strip():
+            raise ValueError("evidence_id must be a non-empty string")
+        if not isinstance(self.evidence_type, str) or not self.evidence_type.strip():
+            raise ValueError("evidence_type must be a non-empty string")
+        if not isinstance(self.last_verified_at, datetime):
+            raise TypeError("last_verified_at must be a datetime")
+        if self.last_verified_at.tzinfo is None:
+            raise ValueError("last_verified_at must be timezone-aware")
+        if not isinstance(self.decay_class, DecayClass):
+            raise TypeError("decay_class must be a DecayClass member")
+        if not isinstance(self.revalidate_command, str) or not self.revalidate_command.strip():
+            raise ValueError("revalidate_command must be a non-empty string")
+
+
+@dataclass(frozen=True)
+class DecayWitness:
+    """One decay-classification verdict."""
+
+    evidence_id: str
+    status: DecayStatus
+    decay_class: DecayClass
+    age_seconds: float
+    stale_threshold_seconds: float
+    expired_threshold_seconds: float
+    revalidate_command: str
+    reason: str
+    falsifier: str
+    evidence_fields: Mapping[str, Any] = field(default_factory=lambda: MappingProxyType({}))
+
+
+_FALSIFIER_TEXT = (
+    "VALID was returned for an evidence record whose age exceeds the "
+    "decay-class stale_after threshold. OR: EXPIRED evidence was "
+    "treated as VALID because the decay policy was bypassed. OR: the "
+    "clock was read from system state instead of the injected `now`."
+)
+
+
+def assess_decay(record: EvidenceRecord, *, now: datetime) -> DecayWitness:
+    """Pure decay classifier.
+
+    Priority (first matching condition wins):
+        1. age >= expired_after   → EXPIRED (REVALIDATION_REQUIRED if
+                                    revalidate_command is non-empty;
+                                    otherwise EXPIRED only)
+        2. age >= stale_after     → STALE
+        3. age <  0 (future)      → REVALIDATION_REQUIRED
+        4. otherwise              → VALID
+    """
+    if not isinstance(now, datetime):
+        raise TypeError("now must be a datetime")
+    if now.tzinfo is None:
+        raise ValueError("now must be timezone-aware")
+
+    policy = POLICY_BY_CLASS[record.decay_class]
+    delta = now - record.last_verified_at
+    age = delta.total_seconds()
+    stale = policy.stale_after.total_seconds()
+    expired = policy.expired_after.total_seconds()
+
+    if age < 0:
+        status = DecayStatus.REVALIDATION_REQUIRED
+        reason = "LAST_VERIFIED_IN_FUTURE_CLOCK_DRIFT"
+    elif age >= expired:
+        status = DecayStatus.EXPIRED
+        reason = "AGE_EXCEEDS_EXPIRED_THRESHOLD"
+    elif age >= stale:
+        status = DecayStatus.STALE
+        reason = "AGE_EXCEEDS_STALE_THRESHOLD"
+    else:
+        status = DecayStatus.VALID
+        reason = "OK_WITHIN_STALE_THRESHOLD"
+
+    evidence = MappingProxyType(
+        {
+            "evidence_id": record.evidence_id,
+            "evidence_type": record.evidence_type,
+            "decay_class": record.decay_class.value,
+            "last_verified_at": record.last_verified_at.isoformat(),
+            "now": now.isoformat(),
+            "age_seconds": age,
+            "stale_threshold_seconds": stale,
+            "expired_threshold_seconds": expired,
+        }
+    )
+    return DecayWitness(
+        evidence_id=record.evidence_id,
+        status=status,
+        decay_class=record.decay_class,
+        age_seconds=age,
+        stale_threshold_seconds=stale,
+        expired_threshold_seconds=expired,
+        revalidate_command=record.revalidate_command,
+        reason=reason,
+        falsifier=_FALSIFIER_TEXT,
+        evidence_fields=evidence,
+    )
+
+
+def _utcnow_for_doctest() -> datetime:
+    """Stable UTC-now wrapper kept out of assess_decay for determinism."""
+    return datetime.now(tz=timezone.utc)


### PR DESCRIPTION
Lie blocked: 'old evidence remains true forever'.

Pure classifier; clock injected. 5 decay classes, 4 statuses. 18/18 tests pass. Falsifier wrapped stale/expired branches in False → 6 tests FAILED across every policy class; restored clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)