### PR TITLE
fix(governance): bind dogfood JSON to commit-acceptor-layer

### DIFF
--- a/.claude/commit_acceptors/commit-acceptor-layer.yaml
+++ b/.claude/commit_acceptors/commit-acceptor-layer.yaml
@@ -20,6 +20,7 @@ diff_scope:
     - path: "tests/unit/commit_acceptor/test_run_evidence.py"
     - path: ".github/workflows/commit-acceptor-gate.yml"
     - path: "docs/reports/diff_bound_commit_acceptor_layer.md"
+    - path: "tmp/run_evidence_dogfood.json"
   forbidden_paths:
     - "trading/"
     - "execution/"


### PR DESCRIPTION
## Summary

The dogfood JSON `tmp/run_evidence_dogfood.json` committed in #492 has the `.json` extension which the policy treats as code. Without an acceptor binding, the diff-binding CI gate red-lights `feat/commit-acceptor-layer`. This adds the file to the self-acceptor's `diff_scope.changed_files`.

One-line patch.

## Test plan

- [x] `python tools/commit_acceptor/validate_commit_acceptor.py --base-ref origin/main --head-ref HEAD --require-acceptor-for-code-change` exits 0 locally
- [x] pytest 67/67 still green
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)