### PR TITLE
test(physics): tighten 7 P0 invariants to falsifying companion form

### DIFF
--- a/.claude/commit_acceptors/physics-invariant-tightening.yaml
+++ b/.claude/commit_acceptors/physics-invariant-tightening.yaml
@@ -1,0 +1,82 @@
+# Diff-bound acceptor for the physics-invariant tightening pass.
+#
+# Adds 70 falsifying tests (69 default + 1 heavy_math) that
+# strengthen seven P0 invariants from CLAUDE.md to algebraic /
+# Hypothesis-fuzz / boundary-bit-pattern level. No production code
+# is touched — every change is an additive test under
+# tests/unit/physics/.
+
+id: physics-invariant-tightening
+status: ACTIVE
+claim_type: correctness
+promise: >-
+  Seven P0 invariants from CLAUDE.md (INV-OA2, INV-FE1, INV-LE1,
+  INV-RC1, INV-DRO1, INV-CB1, INV-K2) gain falsifying tests at the
+  strongest available form: algebraic exact at machine epsilon,
+  Hypothesis property fuzz over input space, boundary-bit-pattern
+  identity, or finite-size sweep with 1/√N scaling. All seven
+  pass, all assertions follow the 5-field error format, every
+  test references its INV-* ID.
+diff_scope:
+  changed_files:
+    - path: ".claude/commit_acceptors/physics-invariant-tightening.yaml"
+    - path: "docs/reports/physics_invariant_tightening.md"
+    - path: "newsfragments/physics-invariant-tightening.feature.md"
+    - path: "tests/unit/physics/test_T10_ricci_universal_upper_bound.py"
+    - path: "tests/unit/physics/test_T13_free_energy_monotonicity.py"
+    - path: "tests/unit/physics/test_T17_cryptobiosis_exact_zero.py"
+    - path: "tests/unit/physics/test_T22_lyapunov_robustness.py"
+    - path: "tests/unit/physics/test_T23_ott_antonsen_algebraic.py"
+    - path: "tests/unit/physics/test_T_dro1_gamma_algebraic.py"
+    - path: "tests/unit/physics/test_T9_kuramoto_finite_size_sweep.py"
+  forbidden_paths:
+    - "trading/"
+    - "execution/"
+    - "forecast/"
+    - "policy/"
+required_python_symbols: []
+expected_signal: >-
+  All 69 default-marked tests pass under pytest; the 1 heavy_math
+  test (1/√N scaling) passes under the heavy_math marker; physics
+  validator reports zero L1 / L2 / L4 issues across all seven new
+  files; mypy --strict and ruff clean.
+measurement_command: >-
+  python -m pytest tests/unit/physics/test_T10_ricci_universal_upper_bound.py
+  tests/unit/physics/test_T13_free_energy_monotonicity.py
+  tests/unit/physics/test_T17_cryptobiosis_exact_zero.py
+  tests/unit/physics/test_T22_lyapunov_robustness.py
+  tests/unit/physics/test_T23_ott_antonsen_algebraic.py
+  tests/unit/physics/test_T_dro1_gamma_algebraic.py
+  tests/unit/physics/test_T9_kuramoto_finite_size_sweep.py
+  -v -m "not heavy_math"
+signal_artifact: "tmp/physics_invariant_tightening_pytest.log"
+falsifier:
+  command: >-
+    python -m pytest tests/unit/physics/test_T23_ott_antonsen_algebraic.py
+    -v -k "test_inv_oa2_fixed_point_residual_at_machine_epsilon"
+  description: >-
+    Probe runs the strongest individual test of the pack — INV-OA2
+    fixed-point residual at machine epsilon. The test evaluates the
+    Ott-Antonsen ODE right-hand side at the analytical fixed point
+    R_∞ = √(1 − 2Δ/K) and asserts |dz/dt| < 1e-13 across 10
+    parameter cells. A residual above the round-off floor would
+    prove the OttAntonsenEngine implementation has drifted from
+    the formula. Existing integration-tolerance test (1e-3) would
+    NOT catch a sign or factor drift; this one would.
+rollback_command: >-
+  git checkout HEAD~1 -- tests/unit/physics/test_T10_ricci_universal_upper_bound.py
+  tests/unit/physics/test_T13_free_energy_monotonicity.py
+  tests/unit/physics/test_T17_cryptobiosis_exact_zero.py
+  tests/unit/physics/test_T22_lyapunov_robustness.py
+  tests/unit/physics/test_T23_ott_antonsen_algebraic.py
+  tests/unit/physics/test_T_dro1_gamma_algebraic.py
+  tests/unit/physics/test_T9_kuramoto_finite_size_sweep.py
+  .claude/commit_acceptors/physics-invariant-tightening.yaml
+  docs/reports/physics_invariant_tightening.md
+  newsfragments/physics-invariant-tightening.feature.md
+rollback_verification_command: >-
+  git diff --exit-code tests/unit/physics/
+memory_update_type: append
+ledger_path: ".claude/commit_acceptors/physics-invariant-tightening.yaml"
+report_path: "docs/reports/physics_invariant_tightening.md"
+evidence: []

--- a/docs/reports/physics_invariant_tightening.md
+++ b/docs/reports/physics_invariant_tightening.md
@@ -1,0 +1,77 @@
+# Physics-Invariant Tightening — Seven P0 Companions
+
+Acceptor: `.claude/commit_acceptors/physics-invariant-tightening.yaml`
+Branch: `feat/physics-invariant-tightening`
+
+## Promise
+
+Seven P0 invariants from CLAUDE.md gain a *companion* test file that
+strengthens existing coverage to the strongest practical form:
+algebraic exact at machine epsilon, Hypothesis property fuzz over
+input space, boundary-bit-pattern identity, or finite-size sweep
+with `1/√N` scaling. No production code is touched — every change
+is an additive test under `tests/unit/physics/`.
+
+## Tightening per invariant
+
+| INV | File | Existing form | Companion form | Tests |
+|---|---|---|---|---|
+| **OA2** (algebraic) | `test_T23_ott_antonsen_algebraic.py` | RK4 1e-3 tolerance via integration | Direct evaluation of `_dz_dt` at the analytical fixed point `R_∞ = √(1 − 2Δ/K)`; asserts `|dz/dt| < 1e-13` across 10 parameter cells | 13 |
+| **FE1** (monotonic) | `test_T13_free_energy_monotonicity.py` | INV-FE2 components only | Per-decision contract (`allowed ⟹ ΔF ≤ 0` algebraic, contrapositive `rejected ⟹ ΔF > 0` strict, `ΔF == F_after − F_before` to ULP) over 200 random scenarios × 5 seeds | 11 |
+| **LE1** (universal) | `test_T22_lyapunov_robustness.py` | 5 hand-picked input families | Adversarial corpus (single huge spike, two-value alternation, linear ramp, near-overflow, bimodal clusters, ±0 mixture, short-minimal) plus Hypothesis fuzz over `(seed, n, dim, tau, scale)` | 9 |
+| **RC1** (universal) | `test_T10_ricci_universal_upper_bound.py` | Cycle / complete / path graphs | Hypothesis fuzz over Erdős–Rényi, Watts–Strogatz, Barabási–Albert random graphs; asserts `κ ≤ 1 + 1e-9` on every edge of every connected sample, plus star/path extremal cases | 6 |
+| **DRO1** (algebraic) | `test_T_dro1_gamma_algebraic.py` | H-recovery focus | Tightens `γ = 2H + 1` algebraic identity to documented 1e-5 tolerance across 8 random walks, 4 deterministic trends, Hypothesis fuzz over `(seed, n, sigma)` | 14 |
+| **CB1** (universal) | `test_T17_cryptobiosis_exact_zero.py` | Single hand-driven path with `==` | Hypothesis fuzz over distress sequences asserting `multiplier == 0.0` AND IEEE-754 byte-pattern identity to canonical `+0.0` (catches `-0.0` and denormals); re-entry after rehydration; 20-tick repeated DORMANT update | 4 |
+| **K2** (asymptotic) | `test_T9_kuramoto_finite_size_sweep.py` | Single point `(N=512, K=0.3·K_c)` | Sweep over `(N ∈ {64,128,256}) × (k_ratio ∈ {0.1, 0.3}) × seed ∈ {7, 42}` plus heavy_math `1/√N` scaling test (`R_128 / R_512 ≈ 2`) | 13 |
+
+**Total**: 70 new tests (69 default + 1 heavy_math).
+
+## What's stronger
+
+* **Algebraic vs integration**: OA2 was tested with 1e-3 RK4 tolerance.
+  A sign flip in one of the four RHS terms would not be caught at
+  that tolerance. The new test catches it at 1e-13.
+* **Property vs hand-picked**: LE1 covered five input families. The
+  new Hypothesis fuzz spans ~80 randomized scenarios per pytest
+  run with widely-varying scales, lengths, and embedding params —
+  including pathologies that strain the Rosenstein nearest-neighbor
+  algorithm (bimodal zero-distance neighbors, near-overflow
+  magnitudes, ±0 sign-bit edge cases).
+* **Bit-pattern vs `==`**: CB1 used `multiplier == 0.0`, which
+  passes for `-0.0` and denormals. The new test packs to raw
+  bytes and asserts canonical `+0.0` exactly. Catches a class of
+  bug where downstream BLAS / GPU multiplication semantics would
+  diverge.
+* **Sweep vs single point**: K2 checked one cell; the new sweep
+  exercises the `1/√N` scaling itself and falsifies the floor on
+  a 12-cell grid.
+
+## What is *not* changed
+
+* No production code touched.
+* No existing tests modified (companions, not replacements).
+* No new dependencies added.
+* No CI workflow changes — the new tests fall under existing
+  `python-fast-tests` (default) and `python-heavy-tests`
+  (heavy_math) gates.
+
+## Quality gates
+
+| Gate | Status |
+|---|---|
+| `black --check` (7 files) | clean |
+| `ruff check` (7 files) | clean |
+| `mypy --strict` (7 files) | clean |
+| `pytest -m "not heavy_math"` | 69/69 passed |
+| `pytest -m heavy_math` (scaling test) | 1/1 passed |
+| `.claude/physics/validate_tests.py` | 0 L1, 0 L2, 0 L4 issues; 100% physics grounding |
+
+## Falsifier
+
+The acceptor's `falsifier.command` runs the single strongest test —
+INV-OA2 fixed-point residual at machine epsilon. A residual above
+`1e-13` on any of the 10 parameter cells would prove
+`OttAntonsenEngine._dz_dt` has drifted from the formula
+`dz/dt = -(Δ + iω₀)z + (K/2)(z̄ − z|z|²)`. The existing 1e-3
+integration test would not catch a sign or factor drift;
+this one would.

--- a/newsfragments/physics-invariant-tightening.feature.md
+++ b/newsfragments/physics-invariant-tightening.feature.md
@@ -1,0 +1,1 @@
+Tightened seven P0 physics invariants (INV-OA2, INV-FE1, INV-LE1, INV-RC1, INV-DRO1, INV-CB1, INV-K2) with companion test files that strengthen existing coverage to algebraic exact at machine epsilon, Hypothesis property fuzz, IEEE-754 bit-pattern identity, or finite-size sweep with `1/√N` scaling. 70 new tests, no production code changed, all gates clean.

--- a/tests/unit/physics/test_T10_ricci_universal_upper_bound.py
+++ b/tests/unit/physics/test_T10_ricci_universal_upper_bound.py
@@ -1,0 +1,142 @@
+# SPDX-License-Identifier: MIT
+"""T10 (universal upper bound) — INV-RC1 Hypothesis fuzz battery.
+
+The companion file (`test_T10_ricci_bounds.py`) verifies INV-RC1
+(κ ≤ 1, universal) and INV-RC3 (κ ∈ [−1, 1] on price graphs) on
+hand-picked graphs (cycles, complete graphs, paths). INV-RC1 is
+universal — it must hold for **every** edge of **every** connected
+graph, not just the canonical ones.
+
+This file closes the gap with a Hypothesis-driven fuzz across
+three families of random graphs:
+
+* **Erdős–Rényi G(n, p)** — random edge inclusion at varied p.
+* **Watts–Strogatz small-world** — ring lattice with rewiring.
+* **Barabási–Albert preferential attachment** — scale-free.
+
+For every connected sample, every edge is checked against
+``κ ≤ 1 + ε``. A single violation falsifies INV-RC1 — and would
+indicate either a bug in the Wasserstein-1 kernel (negative W₁,
+violating the metric axiom) or a divisor ``d(x, y) = 0`` slipping
+past the connectedness guard.
+
+Why Hypothesis fuzz over hand-picked sweeps
+-------------------------------------------
+
+Hand-picked graphs catch bugs in topologies *the author thought of*.
+Hypothesis catches bugs in topologies that emerge from the
+joint distribution over (n, p, seed) — including pathological
+examples (single edges, near-disconnected graphs, dense graphs
+with high-degree hubs) that exercise the W₁ kernel in regimes
+the canonical tests miss.
+"""
+
+from __future__ import annotations
+
+import networkx as nx
+from hypothesis import HealthCheck, assume, given, settings
+from hypothesis import strategies as st
+
+from core.indicators.ricci import ricci_curvature_edge
+
+# ULP slack on the upper bound. Any κ > 1 + this is a real violation.
+_UPPER_BOUND_SLACK: float = 1e-9
+
+
+def _assert_all_edges_bounded(label: str, G: nx.Graph, **params: object) -> None:
+    """Iterate every edge and assert κ ≤ 1 + ε."""
+    if G.number_of_edges() == 0:
+        return
+    for u, v in G.edges():
+        kappa = ricci_curvature_edge(G, u, v)
+        assert kappa <= 1.0 + _UPPER_BOUND_SLACK, (
+            f"INV-RC1 VIOLATED on {label}: κ({u}, {v}) = {kappa:.6e} > "
+            f"1 + ε ({_UPPER_BOUND_SLACK:.0e}). "
+            f"Observed at params={params}, edges={G.number_of_edges()}, "
+            f"nodes={G.number_of_nodes()}. "
+            "Physical reasoning: κ = 1 − W₁/d. Since W₁ ≥ 0 by the "
+            "metric axiom and d > 0 on connected graphs, κ ≤ 1 always. "
+            "Violation implies either negative W₁ (kernel bug) or "
+            "d ≤ 0 (connectedness guard failed)."
+        )
+
+
+@given(
+    n=st.integers(min_value=4, max_value=20),
+    p=st.floats(min_value=0.2, max_value=0.95, allow_nan=False, allow_infinity=False),
+    seed=st.integers(min_value=0, max_value=10_000),
+)
+@settings(
+    max_examples=60,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow, HealthCheck.filter_too_much],
+)
+def test_inv_rc1_erdos_renyi_random_graphs(n: int, p: float, seed: int) -> None:
+    """INV-RC1: κ ≤ 1 on every edge of every connected G(n, p)."""
+    G = nx.erdos_renyi_graph(n, p, seed=seed)
+    assume(nx.is_connected(G))
+    _assert_all_edges_bounded("erdos_renyi", G, n=n, p=p, seed=seed)
+
+
+@given(
+    n=st.integers(min_value=6, max_value=20),
+    k=st.integers(min_value=2, max_value=4),
+    p=st.floats(min_value=0.0, max_value=0.5, allow_nan=False, allow_infinity=False),
+    seed=st.integers(min_value=0, max_value=10_000),
+)
+@settings(
+    max_examples=60,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow, HealthCheck.filter_too_much],
+)
+def test_inv_rc1_watts_strogatz_small_world(n: int, k: int, p: float, seed: int) -> None:
+    """INV-RC1: κ ≤ 1 on every edge of every connected Watts-Strogatz graph."""
+    # Watts-Strogatz requires k < n and k even-or-odd, both ok via constructor.
+    assume(k < n)
+    G = nx.watts_strogatz_graph(n, k, p, seed=seed)
+    assume(nx.is_connected(G))
+    _assert_all_edges_bounded("watts_strogatz", G, n=n, k=k, p=p, seed=seed)
+
+
+@given(
+    n=st.integers(min_value=6, max_value=20),
+    m=st.integers(min_value=1, max_value=4),
+    seed=st.integers(min_value=0, max_value=10_000),
+)
+@settings(
+    max_examples=60,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow, HealthCheck.filter_too_much],
+)
+def test_inv_rc1_barabasi_albert_scale_free(n: int, m: int, seed: int) -> None:
+    """INV-RC1: κ ≤ 1 on every edge of every Barabási-Albert graph."""
+    assume(m < n)
+    G = nx.barabasi_albert_graph(n, m, seed=seed)
+    assume(nx.is_connected(G))
+    _assert_all_edges_bounded("barabasi_albert", G, n=n, m=m, seed=seed)
+
+
+def test_inv_rc1_path_graph_extremal_case() -> None:
+    """Path graph: degree-2 interior nodes, degree-1 endpoints.
+
+    Endpoint edges are the extremal case for INV-RC1 — high
+    asymmetry in neighborhood structure. Verify κ ≤ 1 holds.
+    """
+    G = nx.path_graph(20)
+    _assert_all_edges_bounded("path_graph_20", G, n=20)
+
+
+def test_inv_rc1_complete_graph_uniform_curvature() -> None:
+    """Complete K_n: every edge has identical κ; bound must hold."""
+    G = nx.complete_graph(8)
+    _assert_all_edges_bounded("complete_graph_8", G, n=8)
+
+
+def test_inv_rc1_star_graph_extremal_hub_curvature() -> None:
+    """Star graph K_{1,n}: maximally asymmetric degree distribution.
+
+    Center node is degree n; leaves are degree 1. The center–leaf
+    edges stress the W₁ kernel hardest.
+    """
+    G = nx.star_graph(15)
+    _assert_all_edges_bounded("star_graph_15", G, n=15)

--- a/tests/unit/physics/test_T13_free_energy_monotonicity.py
+++ b/tests/unit/physics/test_T13_free_energy_monotonicity.py
@@ -1,0 +1,160 @@
+# SPDX-License-Identifier: MIT
+"""T13 (monotonicity companion) — INV-FE1 per-decision tightening.
+
+The companion file (`test_T13_free_energy_components.py`) verifies
+INV-FE2 — every Helmholtz component (U, T, S) stays non-negative on
+each gate evaluation.
+
+INV-FE1 reads "F non-increasing under active inference." The gate
+implementation in :mod:`core.physics.free_energy_trading_gate`
+enforces this per-decision via the hard rule
+``allowed = (delta_F <= 0.0)`` — every *accepted* move lowers (or
+holds) F. This file pins that per-decision invariant as a property,
+and adds the contrapositive: any non-allowed decision must have
+``delta_F > 0`` (strict). Two complementary directions of the same
+contract; together they fence the gate against silent loosening.
+
+Why this is stronger than the existing component test
+-----------------------------------------------------
+
+INV-FE2 catches drift in U/T/S sub-routines. INV-FE1 catches drift
+in the *gate policy itself*: if a future refactor introduces a
+hysteresis band, an "accept on tie", or a probabilistic accept,
+this test fails immediately without depending on integration timing
+or numerical tolerances. The acceptance rule is algebraic; the test
+matches that algebra.
+
+Across-step trajectory testing is *not* feasible here: the gate's
+``F_before`` depends on the current step's ``recent_returns``, which
+typically vary, so the inter-step F sequence drifts from environment
+shocks rather than from policy. The per-decision contract is the
+right granularity for INV-FE1 in this codebase.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from core.physics.free_energy_trading_gate import FreeEnergyTradingGate
+
+
+@pytest.mark.parametrize("seed", [13, 42, 101, 2024, 9999])
+def test_inv_fe1_every_allowed_decision_has_non_positive_delta_f(seed: int) -> None:
+    """INV-FE1: any decision with allowed=True must satisfy delta_F ≤ 0.
+
+    Drives the gate with 200 random (before, after, returns) triples,
+    then sweeps every produced decision and asserts the per-decision
+    contract. Tolerance is ULP-only — the gate's rule is algebraic.
+    """
+    rng = np.random.default_rng(seed=seed)
+    gate = FreeEnergyTradingGate(T_base=0.60, q=1.5, vol_reference=0.01)
+    ulp_tolerance = 1e-12
+
+    decisions = []
+    for _ in range(200):
+        n_assets = int(rng.integers(2, 8))
+        pos_before = rng.uniform(0.0, 5.0, size=n_assets)
+        pos_after = rng.uniform(0.0, 5.0, size=n_assets)
+        returns = rng.uniform(-0.05, 0.05, size=n_assets)
+        decisions.append(
+            gate.check(
+                positions_before=pos_before,
+                positions_after=pos_after,
+                recent_returns=returns,
+            )
+        )
+
+    allowed_count = sum(1 for d in decisions if d.allowed)
+    assert allowed_count > 0, (
+        f"degenerate fixture at seed={seed}: 0 / 200 allowed decisions; "
+        "the FE1 invariant is vacuous on a fully-rejecting gate, "
+        "and the test would not exercise the contract."
+    )
+
+    for idx, d in enumerate(decisions):
+        if not d.allowed:
+            continue
+        assert d.delta_F <= ulp_tolerance, (
+            f"INV-FE1 VIOLATED on decision {idx}/200 at seed={seed}: "
+            f"allowed=True but delta_F = {d.delta_F:.6e} > "
+            f"ULP tolerance {ulp_tolerance:.0e}. "
+            f"F_before={d.F_before:.6e}, F_after={d.F_after:.6e}. "
+            "Physical reasoning: the gate's policy is "
+            "`allowed = (delta_F <= 0)` — any accepted decision with "
+            "positive delta_F means the policy was loosened or the "
+            "delta_F arithmetic drifted from the F values it summarises."
+        )
+
+
+@pytest.mark.parametrize("seed", [13, 42, 101, 2024, 9999])
+def test_inv_fe1_every_rejected_decision_has_strictly_positive_delta_f(seed: int) -> None:
+    """INV-FE1 contrapositive: allowed=False ⟹ delta_F > 0 (strictly).
+
+    Reject-on-ties would be a silent loosening. This test asserts the
+    rejection set is exactly ``delta_F > 0``.
+    """
+    rng = np.random.default_rng(seed=seed)
+    gate = FreeEnergyTradingGate(T_base=0.60, q=1.5, vol_reference=0.01)
+
+    rejected = []
+    for _ in range(200):
+        n_assets = int(rng.integers(2, 8))
+        pos_before = rng.uniform(0.0, 5.0, size=n_assets)
+        pos_after = rng.uniform(0.0, 5.0, size=n_assets)
+        returns = rng.uniform(-0.05, 0.05, size=n_assets)
+        d = gate.check(
+            positions_before=pos_before,
+            positions_after=pos_after,
+            recent_returns=returns,
+        )
+        if not d.allowed:
+            rejected.append(d)
+
+    assert len(rejected) > 0, (
+        f"degenerate fixture at seed={seed}: 0 rejections; "
+        "the contrapositive is vacuous and the test would not exercise "
+        "the rejection rule."
+    )
+
+    for idx, d in enumerate(rejected):
+        assert d.delta_F > 0.0, (
+            f"INV-FE1 contrapositive VIOLATED on rejected decision "
+            f"{idx} at seed={seed}: allowed=False but "
+            f"delta_F = {d.delta_F:.6e} ≤ 0. "
+            "Physical reasoning: a gate that rejects a non-positive "
+            "delta_F is over-restrictive — INV-FE1 only mandates "
+            "rejection when F would rise."
+        )
+
+
+def test_inv_fe1_delta_f_equals_f_after_minus_f_before_exactly() -> None:
+    """INV-FE1 lemma: delta_F == F_after − F_before to machine precision.
+
+    The decision dataclass exposes all three fields — drift between
+    them would silently break any downstream consumer that consumes
+    delta_F instead of recomputing.
+    """
+    rng = np.random.default_rng(seed=271828)
+    gate = FreeEnergyTradingGate(T_base=0.60, q=1.5, vol_reference=0.01)
+    ulp_tolerance = 1e-12
+
+    for _ in range(50):
+        n_assets = int(rng.integers(2, 6))
+        pos_before = rng.uniform(0.0, 4.0, size=n_assets)
+        pos_after = rng.uniform(0.0, 4.0, size=n_assets)
+        returns = rng.uniform(-0.04, 0.04, size=n_assets)
+        d = gate.check(
+            positions_before=pos_before,
+            positions_after=pos_after,
+            recent_returns=returns,
+        )
+        residual = abs(d.delta_F - (d.F_after - d.F_before))
+        assert residual < ulp_tolerance, (
+            f"INV-FE1 lemma VIOLATED: delta_F={d.delta_F:.6e} "
+            f"!= F_after − F_before = {d.F_after - d.F_before:.6e}, "
+            f"residual={residual:.3e} > {ulp_tolerance:.0e}. "
+            "Physical reasoning: a downstream consumer that gates on "
+            "delta_F instead of recomputing the difference would draw "
+            "wrong conclusions from a drifted field."
+        )

--- a/tests/unit/physics/test_T17_cryptobiosis_exact_zero.py
+++ b/tests/unit/physics/test_T17_cryptobiosis_exact_zero.py
@@ -1,0 +1,180 @@
+# SPDX-License-Identifier: MIT
+"""T17 (exact-zero companion) — INV-CB1 universal property + bit-pattern witness.
+
+The companion file (`test_T17_cryptobiosis.py`) verifies INV-CB1 on
+a single hand-driven path (ACTIVE → VITRIFYING → DORMANT) using
+``result["multiplier"] == 0.0``. INV-CB1 is universal: **every**
+state transition that lands in DORMANT must yield ``multiplier ==
+0.0`` exactly — bitwise, not approximately.
+
+This file closes the gap with three orthogonal probes:
+
+1. **Hypothesis fuzz over distress sequences** — random T-trajectories
+   that drive the controller through arbitrary state sequences. At
+   every tick where ``state == DORMANT``, assert
+   ``multiplier == 0.0`` and the IEEE-754 byte pattern is the
+   canonical positive-zero (no negative zero, no denormal).
+2. **Re-entry after rehydration** — drive into DORMANT, partially
+   rehydrate, force back into DORMANT, assert exactness preserved.
+3. **Bit-pattern witness** — pack the multiplier into 8 raw bytes
+   and assert all are 0x00. This catches a subtle class of bug
+   where ``-0.0`` or denormal-tiny values would compare equal to
+   ``0.0`` under ``==`` but break downstream multiplication
+   semantics on edge platforms.
+"""
+
+from __future__ import annotations
+
+import struct
+
+import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from core.neuro.cryptobiosis import (
+    CryptobiosisConfig,
+    CryptobiosisController,
+    CryptobiosisState,
+)
+
+_POSITIVE_ZERO_BYTES: bytes = struct.pack("<d", 0.0)
+
+
+def _assert_exact_positive_zero(label: str, multiplier: float, **params: object) -> None:
+    """Assert multiplier is bitwise +0.0, not just == 0.0.
+
+    Catches: -0.0 (which compares == 0.0 but has different sign bit),
+    denormals (compare > 0 but underflow), and platform-specific
+    representations.
+    """
+    raw = struct.pack("<d", multiplier)
+    assert raw == _POSITIVE_ZERO_BYTES, (
+        f"INV-CB1 BIT-PATTERN VIOLATED on {label}: "
+        f"multiplier={multiplier!r} packs to {raw.hex()}, "
+        f"expected canonical +0.0 = {_POSITIVE_ZERO_BYTES.hex()}. "
+        f"Observed at params={params}. "
+        "Physical reasoning: -0.0 or denormal multipliers compare == "
+        "0.0 in Python but produce different products in BLAS / GPU "
+        "kernels. Safety mandates the IEEE canonical positive zero."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Hypothesis fuzz: every DORMANT tick has exact zero
+# ---------------------------------------------------------------------------
+
+
+@given(
+    seed=st.integers(min_value=0, max_value=2**31 - 1),
+    n_ticks=st.integers(min_value=10, max_value=200),
+    high_distress_prob=st.floats(
+        min_value=0.0, max_value=1.0, allow_nan=False, allow_infinity=False
+    ),
+)
+@settings(
+    max_examples=80,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow],
+)
+def test_inv_cb1_property_every_dormant_tick_exactly_zero(
+    seed: int, n_ticks: int, high_distress_prob: float
+) -> None:
+    """INV-CB1: at every tick where state == DORMANT, multiplier == +0.0 exactly."""
+    import numpy as np
+
+    rng = np.random.default_rng(seed=seed)
+    ctrl = CryptobiosisController()
+    distresses = np.where(
+        rng.uniform(0.0, 1.0, size=n_ticks) < high_distress_prob,
+        rng.uniform(0.85, 1.0, size=n_ticks),  # high distress → DORMANT
+        rng.uniform(0.0, 0.4, size=n_ticks),  # low distress → ACTIVE/REHYDRATING
+    )
+    for tick, T in enumerate(distresses.tolist()):
+        result = ctrl.update(T=float(T))
+        if ctrl.state == CryptobiosisState.DORMANT:
+            assert result["multiplier"] == 0.0, (
+                f"INV-CB1 VIOLATED at tick {tick}: state=DORMANT but "
+                f"multiplier={result['multiplier']!r} ≠ 0.0. "
+                f"Observed at seed={seed}, n_ticks={n_ticks}, "
+                f"high_distress_prob={high_distress_prob}, T={T}."
+            )
+            _assert_exact_positive_zero(
+                "fuzz",
+                result["multiplier"],
+                tick=tick,
+                seed=seed,
+                T=T,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Re-entry: rehydrate then re-enter DORMANT
+# ---------------------------------------------------------------------------
+
+
+def test_inv_cb1_re_entry_after_rehydration_preserves_exact_zero() -> None:
+    """Drive DORMANT → REHYDRATING → DORMANT; second DORMANT also exact zero."""
+    cfg = CryptobiosisConfig()
+    ctrl = CryptobiosisController(cfg)
+
+    # First entry into DORMANT
+    ctrl.update(T=0.95)  # VITRIFYING
+    result = ctrl.update(T=0.95)  # DORMANT
+    assert ctrl.state == CryptobiosisState.DORMANT
+    _assert_exact_positive_zero("first_dormant", result["multiplier"])
+
+    # Begin rehydration with low distress
+    ctrl.update(T=0.0)  # REHYDRATING (or ACTIVE depending on hysteresis)
+
+    # Force re-entry: high distress again
+    for _ in range(3):
+        result = ctrl.update(T=0.99)
+        if ctrl.state == CryptobiosisState.DORMANT:
+            _assert_exact_positive_zero("re_entered_dormant", result["multiplier"])
+            return
+
+    pytest.skip(
+        "Could not force re-entry to DORMANT under default config; "
+        "test is conditional on hysteresis/rehydration parameters."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Direct multiplier-property exact-zero check
+# ---------------------------------------------------------------------------
+
+
+def test_inv_cb1_property_returns_canonical_positive_zero_when_dormant() -> None:
+    """The :attr:`multiplier` property must return canonical +0.0 in DORMANT."""
+    ctrl = CryptobiosisController()
+    ctrl.update(T=0.99)  # VITRIFYING
+    ctrl.update(T=0.99)  # DORMANT
+    assert ctrl.state == CryptobiosisState.DORMANT
+    multiplier = ctrl.multiplier
+    _assert_exact_positive_zero("property_access_in_dormant", multiplier)
+    # Sanity: also check via the dict that the public update() returns.
+    state_dict = ctrl.update(T=0.99)
+    if ctrl.state == CryptobiosisState.DORMANT:
+        _assert_exact_positive_zero("update_dict_in_dormant", state_dict["multiplier"])
+
+
+def test_inv_cb1_zero_is_immutable_under_repeated_dormant_updates() -> None:
+    """20 repeated high-distress updates from inside DORMANT keep multiplier == +0.0."""
+    ctrl = CryptobiosisController()
+    ctrl.update(T=0.99)
+    ctrl.update(T=0.99)
+    assert ctrl.state == CryptobiosisState.DORMANT
+    for tick in range(20):
+        result = ctrl.update(T=0.99)
+        # Even if state transitions out, the contract is conditional
+        # on DORMANT — only check there.
+        if ctrl.state == CryptobiosisState.DORMANT:
+            assert result["multiplier"] == 0.0, (
+                f"INV-CB1 VIOLATED at tick {tick}: repeated high-distress "
+                f"update produced multiplier={result['multiplier']!r}."
+            )
+            _assert_exact_positive_zero(
+                "repeated_dormant_update",
+                result["multiplier"],
+                tick=tick,
+            )

--- a/tests/unit/physics/test_T22_lyapunov_robustness.py
+++ b/tests/unit/physics/test_T22_lyapunov_robustness.py
@@ -1,0 +1,169 @@
+# SPDX-License-Identifier: MIT
+"""T22 (robustness companion) — INV-LE1 adversarial finiteness battery.
+
+The companion file (`test_T22_lyapunov_spectral.py`) sweeps five
+hand-picked input families (white noise, constant, sine, random
+walk, step) and asserts MLE finiteness on each. INV-LE1 reads
+"MLE is finite for **any** bounded finite input series" — the
+universal claim is stronger than any hand-picked sweep.
+
+This file closes that gap with two fixtures:
+
+1. **Adversarial corpus** — explicitly constructed pathological
+   inputs that strain the Rosenstein nearest-neighbor algorithm:
+   single huge spikes, near-degenerate two-value series, ramps,
+   alternating extremes, near-overflow magnitudes. Each must
+   yield a finite MLE.
+2. **Hypothesis fuzz** — randomly generated bounded series with
+   widely-varying length, embedding dimension, and tau. The MLE
+   must remain finite across the input space.
+
+Why this matters
+----------------
+
+INV-LE1 is universal (P0). A single non-finite MLE in a downstream
+pipeline propagates as NaN through Kelly sizing and risk gating,
+silently disabling the entire trading loop. Catching it at the
+estimator boundary is cheaper than catching it at the order-book.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from core.physics.lyapunov_exponent import maximal_lyapunov_exponent
+
+
+def _assert_finite_mle(label: str, mle: float, **params: object) -> None:
+    assert math.isfinite(mle), (
+        f"INV-LE1 VIOLATED on {label}: MLE = {mle} is not finite. "
+        f"Expected finite real for any bounded finite input. "
+        f"Observed at params={params}. "
+        "Physical reasoning: Rosenstein nearest-neighbor divergence "
+        "on a bounded series cannot diverge to ±∞ in finite steps; "
+        "non-finite output means a degenerate divisor (zero-distance "
+        "neighbors) was not guarded."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Adversarial corpus
+# ---------------------------------------------------------------------------
+
+
+def test_inv_le1_single_huge_spike() -> None:
+    """One enormous outlier in an otherwise calm series."""
+    n = 600
+    series = np.zeros(n, dtype=np.float64)
+    series[n // 2] = 1e6
+    mle = maximal_lyapunov_exponent(series, dim=3, tau=1)
+    _assert_finite_mle("single_huge_spike", mle, n=n, dim=3, tau=1)
+
+
+def test_inv_le1_two_value_alternating() -> None:
+    """Near-degenerate alternation: only two unique values."""
+    n = 600
+    series = np.tile([0.0, 1.0], n // 2).astype(np.float64)
+    mle = maximal_lyapunov_exponent(series, dim=3, tau=1)
+    _assert_finite_mle("two_value_alternating", mle, n=n, dim=3, tau=1)
+
+
+def test_inv_le1_linear_ramp() -> None:
+    """Pure linear ramp — perfectly predictable, zero divergence."""
+    n = 600
+    series = np.linspace(-1.0, 1.0, n, dtype=np.float64)
+    mle = maximal_lyapunov_exponent(series, dim=3, tau=1)
+    _assert_finite_mle("linear_ramp", mle, n=n, dim=3, tau=1)
+
+
+def test_inv_le1_extreme_alternation() -> None:
+    """Alternating ±1e6 — extreme magnitude, predictable structure."""
+    n = 600
+    series = np.tile([-1e6, 1e6], n // 2).astype(np.float64)
+    mle = maximal_lyapunov_exponent(series, dim=3, tau=1)
+    _assert_finite_mle("extreme_alternation", mle, n=n, dim=3, tau=1)
+
+
+def test_inv_le1_near_overflow_magnitudes() -> None:
+    """Series in the upper IEEE-754 double range — risks float overflow
+    in pairwise distance computations."""
+    n = 600
+    rng = np.random.default_rng(seed=11)
+    series = rng.normal(0.0, 1e150, size=n)
+    mle = maximal_lyapunov_exponent(series, dim=3, tau=1)
+    _assert_finite_mle("near_overflow_magnitudes", mle, n=n, dim=3, tau=1)
+
+
+def test_inv_le1_short_minimal_series() -> None:
+    """Short series at the lower bound of where embedding makes sense.
+
+    With dim=3, tau=1 the embedding consumes the first 2 samples,
+    so a 50-sample series is the minimum non-vacuous fixture.
+    """
+    n = 50
+    rng = np.random.default_rng(seed=7)
+    series = rng.normal(0.0, 1.0, size=n)
+    mle = maximal_lyapunov_exponent(series, dim=3, tau=1)
+    _assert_finite_mle("short_minimal_series", mle, n=n, dim=3, tau=1)
+
+
+def test_inv_le1_bimodal_clusters() -> None:
+    """Two tight clusters far apart — many zero-distance neighbors."""
+    n = 600
+    rng = np.random.default_rng(seed=23)
+    cluster_a = rng.normal(0.0, 1e-6, size=n // 2)
+    cluster_b = rng.normal(1e3, 1e-6, size=n // 2)
+    series = np.concatenate([cluster_a, cluster_b])
+    rng.shuffle(series)
+    mle = maximal_lyapunov_exponent(series, dim=3, tau=1)
+    _assert_finite_mle("bimodal_clusters", mle, n=n, dim=3, tau=1)
+
+
+def test_inv_le1_negative_zero_mixture() -> None:
+    """Series with both +0.0 and −0.0 — IEEE-754 sign edge case."""
+    n = 600
+    series = np.zeros(n, dtype=np.float64)
+    series[::2] = -0.0
+    series[1::2] = 0.0
+    series[100] = 1.0  # one non-zero point so embedding has structure
+    mle = maximal_lyapunov_exponent(series, dim=3, tau=1)
+    _assert_finite_mle("negative_zero_mixture", mle, n=n, dim=3, tau=1)
+
+
+# ---------------------------------------------------------------------------
+# Hypothesis fuzz
+# ---------------------------------------------------------------------------
+
+
+@given(
+    seed=st.integers(min_value=0, max_value=2**31 - 1),
+    n=st.integers(min_value=80, max_value=400),
+    dim=st.integers(min_value=2, max_value=5),
+    tau=st.integers(min_value=1, max_value=4),
+    scale=st.floats(min_value=1e-12, max_value=1e6, allow_nan=False, allow_infinity=False),
+)
+@settings(
+    max_examples=80,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow],
+)
+def test_inv_le1_hypothesis_fuzz_keeps_mle_finite(
+    seed: int, n: int, dim: int, tau: int, scale: float
+) -> None:
+    """INV-LE1 universal: fuzz the input space, MLE always finite."""
+    rng = np.random.default_rng(seed=seed)
+    series = rng.normal(0.0, scale, size=n)
+    mle = maximal_lyapunov_exponent(series, dim=dim, tau=tau)
+    _assert_finite_mle(
+        "hypothesis_fuzz",
+        mle,
+        seed=seed,
+        n=n,
+        dim=dim,
+        tau=tau,
+        scale=scale,
+    )

--- a/tests/unit/physics/test_T23_ott_antonsen_algebraic.py
+++ b/tests/unit/physics/test_T23_ott_antonsen_algebraic.py
@@ -1,0 +1,162 @@
+# SPDX-License-Identifier: MIT
+"""T23 (algebraic companion) — Ott-Antonsen fixed-point at machine epsilon.
+
+The companion test file (`test_T23_ott_antonsen_chimera.py`) verifies
+INV-OA2 by integrating the ODE for T=100 and comparing the long-time
+limit with `√(1 − 2Δ/K)`. Because that test goes through RK4 at
+``dt=0.01``, its tolerance is bounded by the integrator (≈ 1e-3) — a
+loosening of the underlying invariant which is, per CLAUDE.md
+("INV-OA2 ... Analytical — CAN test to float precision"), exact at
+the algebraic level.
+
+These tests close that gap. They do *not* integrate. They evaluate
+the Ott-Antonsen ODE right-hand side directly at the analytical
+fixed point ``z = R_∞ + 0j`` (with ω₀ = 0) and assert
+``|dz/dt| < 1e-13`` — i.e., the formula and the implementation
+agree to within IEEE-754 double-precision arithmetic noise on a
+single ``_dz_dt`` evaluation.
+
+Why this is the strongest possible test for INV-OA2
+---------------------------------------------------
+
+INV-OA2 is an *algebraic* invariant: at the supercritical fixed
+point ``z = R_∞`` (real, ω₀ = 0), the right-hand side reduces to::
+
+    dz/dt = -Δ·R_∞ + (K/2)·(R_∞ − R_∞³)
+          = R_∞·[(K/2)·(1 − R_∞²) − Δ]
+          = R_∞·[(K/2)·(2Δ/K) − Δ]    (substitute R_∞² = 1 − 2Δ/K)
+          = R_∞·[Δ − Δ]
+          = 0.
+
+So at the analytical R_∞, ``_dz_dt`` should return exactly zero
+modulo IEEE-754 round-off. Any deviation larger than ~10·eps
+proves the implementation has drifted from the formula. The
+existing 1e-3 RK4 test would not catch a sign error in one of the
+RHS terms; this one would.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from core.kuramoto.ott_antonsen import OttAntonsenEngine
+
+# Machine epsilon ≈ 2.22e-16; allow ~50·eps for accumulated round-off
+# across the multiplication / subtraction chain in _dz_dt. Empirically
+# the residual stays under 1e-14 across the parameter sweep.
+_ALGEBRAIC_TOL: float = 1e-13
+
+
+@pytest.mark.parametrize(
+    ("K", "delta"),
+    [
+        (1.5, 0.5),  # K/K_c = 1.5  → R_∞ ≈ 0.577
+        (2.0, 0.5),  # K/K_c = 2.0  → R_∞ ≈ 0.707
+        (3.0, 0.5),  # K/K_c = 3.0  → R_∞ ≈ 0.816
+        (5.0, 0.5),  # K/K_c = 5.0  → R_∞ ≈ 0.894
+        (10.0, 0.5),  # K/K_c = 10.0 → R_∞ ≈ 0.949
+        (100.0, 0.5),  # extreme: R_∞ → 1
+        (1.01, 0.5),  # near critical: R_∞ ≈ 0.099 (tight test of the formula)
+        (4.0, 1.0),  # different Δ
+        (0.4, 0.1),  # smaller scale
+        (200.0, 0.05),  # extreme: R_∞ → 1, very small Δ
+    ],
+)
+def test_inv_oa2_fixed_point_residual_at_machine_epsilon(K: float, delta: float) -> None:
+    """INV-OA2 (algebraic): _dz_dt(R_∞ + 0j) == 0 to machine precision.
+
+    Evaluates the right-hand side at the analytical fixed point and
+    asserts the residual is below ``1e-13``. This is the strongest
+    possible test for INV-OA2 because it does not depend on a
+    numerical integrator — only on the formula's algebraic
+    correctness.
+    """
+    engine = OttAntonsenEngine(K=K, delta=delta, omega0=0.0)
+    R_inf = math.sqrt(1.0 - 2.0 * delta / K)
+    z_fixed = complex(R_inf, 0.0)
+    dz = engine._dz_dt(z_fixed)  # noqa: SLF001 — algebraic invariant probe
+    residual = abs(dz)
+    assert residual < _ALGEBRAIC_TOL, (
+        f"INV-OA2 ALGEBRAIC VIOLATED: |dz/dt| at the analytical "
+        f"fixed point R_∞ = √(1 − 2Δ/K) is {residual:.3e}, "
+        f"expected < {_ALGEBRAIC_TOL:.0e}. "
+        f"Observed at K={K}, Δ={delta}, K_c={2 * delta}, R_∞={R_inf:.16f}, "
+        f"dz/dt = {dz!r}. "
+        "Physical reasoning: at the supercritical fixed point the "
+        "drift terms exactly cancel — any residual above the "
+        "round-off floor implies a sign or factor drift in _dz_dt "
+        "that the integration-tolerance test (1e-3) would miss."
+    )
+
+
+def test_inv_oa2_subcritical_zero_is_also_a_fixed_point() -> None:
+    """INV-OA2 / INV-OA3: z = 0 is *always* a fixed point (sub- and supercritical).
+
+    For both K < K_c and K > K_c the incoherent state z = 0 is a
+    fixed point of the ODE. Subcritically it is the *only* stable
+    one; supercritically it is unstable but still a fixed point.
+    Either way, ``_dz_dt(0)`` must be exactly ``0+0j``.
+    """
+    for K, delta in [(0.5, 0.5), (1.0, 0.5), (2.0, 0.5), (10.0, 0.5)]:
+        engine = OttAntonsenEngine(K=K, delta=delta)
+        dz = engine._dz_dt(complex(0.0, 0.0))  # noqa: SLF001
+        assert dz == 0j, (
+            f"INV-OA2/3 VIOLATED: z=0 must yield dz/dt == 0+0j exactly; "
+            f"got {dz!r} at K={K}, delta={delta}. "
+            "Any non-zero result would imply spurious drift terms in _dz_dt."
+        )
+
+
+def test_inv_oa2_critical_point_zero_residual() -> None:
+    """INV-OA2 (boundary) — at K = K_c the only fixed point is z = 0; R_∞ formula returns 0.
+
+    Verifies that :attr:`OttAntonsenEngine.R_steady` returns exactly
+    ``0.0`` at the bifurcation point (no pseudo-supercritical drift),
+    and that ``_dz_dt(0)`` agrees.
+    """
+    delta = 0.7
+    K_c = 2.0 * delta
+    engine = OttAntonsenEngine(K=K_c, delta=delta)
+    assert engine.R_steady == 0.0, (
+        f"INV-OA2 boundary: at K = K_c the steady-state magnitude must "
+        f"be exactly 0.0; got R_steady={engine.R_steady!r} at K={K_c}, "
+        f"delta={delta}. The formula √(1 − K_c/K) evaluates to 0 here, "
+        "but a sloppy implementation could return √eps."
+    )
+    dz = engine._dz_dt(complex(0.0, 0.0))  # noqa: SLF001
+    assert dz == 0j, (
+        f"INV-OA2 boundary VIOLATED: _dz_dt(0) at K = K_c "
+        f"observed = {dz!r}, expected = 0+0j. "
+        f"Parameters: K={K_c}, delta={delta}, K_c=2·delta={2 * delta}. "
+        "Physical reasoning: at the bifurcation point K = K_c the "
+        "incoherent fixed point z = 0 is marginally stable; the ODE "
+        "right-hand side must still vanish there exactly by symmetry."
+    )
+
+
+def test_inv_oa2_residual_grows_with_perturbation_size() -> None:
+    """INV-OA2 (discriminative-power probe) — verify the algebraic test is non-vacuous.
+
+    Demonstrates that ``_dz_dt`` is sensitive to perturbations off
+    the fixed point, so the at-fixed-point residual being below
+    ``1e-13`` is a real falsification of any drift in INV-OA2 — not
+    an artifact of a degenerate (e.g., constantly-zero) function.
+    The residual at ``z = R_∞ + ε`` must grow at least linearly
+    with ε for small ε.
+    """
+    K, delta = 3.0, 0.5
+    engine = OttAntonsenEngine(K=K, delta=delta)
+    R_inf = math.sqrt(1.0 - 2.0 * delta / K)
+    base = abs(engine._dz_dt(complex(R_inf, 0.0)))  # noqa: SLF001
+    perturbed = abs(engine._dz_dt(complex(R_inf + 1e-6, 0.0)))  # noqa: SLF001
+    assert perturbed > base * 1e6, (
+        f"INV-OA2 discriminative-power probe failed: "
+        f"observed perturbed-residual = {perturbed:.3e}, "
+        f"expected ≥ base × 1e6 = {base * 1e6:.3e} (base = {base:.3e}). "
+        f"Parameters: K={K}, delta={delta}, R_inf={R_inf:.6f}, perturbation=1e-6. "
+        "Physical reasoning: if _dz_dt is suspiciously flat near the "
+        "fixed point, the algebraic test cannot catch implementation "
+        "drift and INV-OA2 would be vacuously satisfied."
+    )

--- a/tests/unit/physics/test_T9_kuramoto_finite_size_sweep.py
+++ b/tests/unit/physics/test_T9_kuramoto_finite_size_sweep.py
@@ -1,0 +1,114 @@
+# SPDX-License-Identifier: MIT
+"""T9 (finite-size companion) — INV-K2 sweep across N and K ratios.
+
+The companion file (`test_T9_kuramoto_transitions.py`) tests INV-K2
+at one fixed ``(N=512, K=0.3·K_c, seed=42)``. INV-K2 is a *family*
+of asymptotic claims:
+
+    K < K_c ⟹ R(t→∞) → 0   with finite-size floor  ε = C/√N, C ∈ [2, 3].
+
+A single-point check leaves the ``1/√N`` scaling untested. This
+file widens the cell grid:
+
+* ``N ∈ {64, 128, 256}`` — covers an octave-and-a-half of the
+  ``1/√N`` law; default cells are kept compute-light so the suite
+  remains under the standard test budget.
+* ``k_ratio ∈ {0.1, 0.3}`` — two depths into the subcritical
+  regime.
+* Two seeds per cell — protects against a lucky-seed pass without
+  blowing the runtime budget.
+
+The bound asserted is ``R_final ≤ 3/√N`` (the upper end of the
+catalog's ``[2, 3]`` epsilon range). A failure on a single cell
+falsifies INV-K2.
+
+The ``1/√N`` scaling test (which runs an N=512 simulation) is
+gated behind ``@pytest.mark.heavy_math``.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from core.kuramoto.config import KuramotoConfig
+from core.kuramoto.engine import KuramotoEngine
+
+_SIGMA_OMEGA: float = 1.0
+_DT: float = 0.01
+_STEPS: int = 1500
+
+
+def _critical_coupling_gaussian(sigma: float) -> float:
+    """K_c = 2·σ·√(2π)/π for a Gaussian frequency density."""
+    return 2.0 * sigma * math.sqrt(2.0 * math.pi) / math.pi
+
+
+def _run_R_tail_mean(N: int, coupling: float, seed: int) -> float:
+    rng = np.random.default_rng(seed)
+    omega = rng.normal(loc=0.0, scale=_SIGMA_OMEGA, size=N)
+    theta0 = rng.uniform(-math.pi, math.pi, size=N)
+    cfg = KuramotoConfig(
+        N=N,
+        K=coupling,
+        omega=omega,
+        theta0=theta0,
+        dt=_DT,
+        steps=_STEPS,
+        seed=seed,
+    )
+    result = KuramotoEngine(cfg).run()
+    tail = result.order_parameter[-(_STEPS // 3) :]
+    return float(np.mean(tail))
+
+
+@pytest.mark.parametrize("N", [64, 128, 256])
+@pytest.mark.parametrize("k_ratio", [0.1, 0.3])
+@pytest.mark.parametrize("seed", [7, 42])
+def test_inv_k2_finite_size_floor(N: int, k_ratio: float, seed: int) -> None:
+    """INV-K2: subcritical R_final ≤ 3/√N for every (N, k_ratio, seed) cell."""
+    K_c = _critical_coupling_gaussian(_SIGMA_OMEGA)
+    K = k_ratio * K_c
+    floor_epsilon = 3.0 / math.sqrt(N)
+    R_tail = _run_R_tail_mean(N=N, coupling=K, seed=seed)
+    assert R_tail <= floor_epsilon, (
+        f"INV-K2 VIOLATED on cell (N={N}, K/K_c={k_ratio}, seed={seed}): "
+        f"R_tail={R_tail:.4f} > 3/√N = {floor_epsilon:.4f}. "
+        f"Expected subcritical R bounded by finite-size noise floor "
+        f"ε = 3/√N (catalog INV-K2). "
+        f"Observed at sigma={_SIGMA_OMEGA}, K_c={K_c:.4f}, K={K:.4f}, "
+        f"steps={_STEPS}, dt={_DT}. "
+        "Physical reasoning: below K_c the only stable state is the "
+        "incoherent fixed point; finite-N fluctuations leave R at the "
+        "1/√N noise floor, not above it."
+    )
+
+
+@pytest.mark.heavy_math
+def test_inv_k2_floor_scales_with_one_over_sqrt_n() -> None:
+    """Verify the 1/√N scaling: R_final at N=128 ≈ 2× R_final at N=512.
+
+    This is a stronger property than any individual cell — it tests
+    the *scaling law* itself. The ratio of tail-means across N
+    should track the 1/√N prediction within a factor ≈ 2.
+
+    Marked ``heavy_math`` because the N=512 simulation pushes the
+    test runtime over the default per-test budget.
+    """
+    K_c = _critical_coupling_gaussian(_SIGMA_OMEGA)
+    K = 0.3 * K_c
+    seed = 42
+    R_128 = _run_R_tail_mean(N=128, coupling=K, seed=seed)
+    R_512 = _run_R_tail_mean(N=512, coupling=K, seed=seed)
+    expected_ratio = math.sqrt(512.0 / 128.0)  # = 2.0
+    measured_ratio = R_128 / max(R_512, 1e-12)
+    assert 0.5 * expected_ratio <= measured_ratio <= 2.0 * expected_ratio, (
+        f"INV-K2 SCALING VIOLATED: R(N=128)/R(N=512) = {measured_ratio:.3f}, "
+        f"expected ≈ {expected_ratio:.3f} ± factor 2. "
+        f"R_128={R_128:.4e}, R_512={R_512:.4e}. "
+        "Physical reasoning: subcritical R follows the 1/√N "
+        "finite-size law to leading order; deviation by more than a "
+        "factor of 2 implies the engine's noise floor scales wrongly."
+    )

--- a/tests/unit/physics/test_T_dro1_gamma_algebraic.py
+++ b/tests/unit/physics/test_T_dro1_gamma_algebraic.py
@@ -1,0 +1,121 @@
+# SPDX-License-Identifier: MIT
+"""T-DRO1 (algebraic) — `γ = 2·H + 1` to documented precision.
+
+INV-DRO1 (universal, P0) reads::
+
+    γ = 2·H + 1 to float precision; tolerance |γ − (2H+1)| < 1e-5.
+
+The implementation in :func:`core.dro_ara.engine.derive_gamma`
+returns ``(round(2H+1, 6), round(H, 6), round(r2, 6))``. By
+construction the rounding to 6 decimal places keeps the residual
+``|γ − (2H+1)|`` strictly below ``5e-7`` — well inside the
+``1e-5`` ceiling of the invariant — but only if the *internal*
+computation is correct. The point of this test is to pin the
+relationship across a sweep of inputs (synthetic and stochastic),
+so any future refactor that decouples ``γ`` from ``H`` (e.g., via
+a separate estimator) is caught immediately.
+
+Why a separate file from ``test_dfa_gamma_estimator.py``
+--------------------------------------------------------
+
+The existing test focuses on Hurst-exponent recovery accuracy on
+synthetic fractional Brownian motion. INV-DRO1 is a different
+claim: it pins the *algebraic identity* between the two returned
+fields. The two tests are complementary; this one falsifies a
+specific class of bug (γ and H drift apart) that an H-recovery
+test cannot.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from core.dro_ara.engine import derive_gamma
+
+# Documented tolerance from the INV-DRO1 spec.
+_GAMMA_H_TOL: float = 1e-5
+
+
+def _assert_gamma_equals_2h_plus_1(label: str, gamma: float, H: float, **params: object) -> None:
+    residual = abs(gamma - (2.0 * H + 1.0))
+    assert residual < _GAMMA_H_TOL, (
+        f"INV-DRO1 VIOLATED on {label}: "
+        f"|γ − (2H+1)| = {residual:.3e} > {_GAMMA_H_TOL:.0e}. "
+        f"γ={gamma!r}, H={H!r}, params={params}. "
+        "Physical reasoning: γ and H come from the same DFA estimator; "
+        "the algebraic relation is the contract — drift implies the "
+        "two fields were computed from divergent intermediate states."
+    )
+
+
+@pytest.mark.parametrize("seed", [0, 1, 7, 42, 101, 314, 2024, 9999])
+def test_inv_dro1_random_walk_input(seed: int) -> None:
+    """INV-DRO1 on random-walk inputs: γ and H must satisfy 2H+1."""
+    rng = np.random.default_rng(seed=seed)
+    n = 1024
+    series = np.cumsum(rng.normal(0.0, 1.0, size=n))
+    gamma, H, r2 = derive_gamma(series)
+    assert math.isfinite(gamma) and math.isfinite(H), (
+        f"derive_gamma returned non-finite (γ={gamma}, H={H}) at seed={seed}; "
+        "DFA on a random walk must yield finite γ and H."
+    )
+    _assert_gamma_equals_2h_plus_1("random_walk", gamma, H, seed=seed, n=n)
+
+
+@pytest.mark.parametrize("slope", [0.001, 0.01, 0.05, 0.1])
+def test_inv_dro1_linear_trend_input(slope: float) -> None:
+    """INV-DRO1 on a deterministic linear trend.
+
+    Linear trend yields trivial DFA fluctuation; whatever (H, γ) the
+    estimator returns, the algebraic identity must hold.
+    """
+    n = 1024
+    series = slope * np.arange(n, dtype=np.float64)
+    gamma, H, r2 = derive_gamma(series)
+    if not (math.isfinite(gamma) and math.isfinite(H)):
+        # A degenerate input may produce a sentinel; that is acceptable.
+        # The invariant is conditional on finiteness of both fields.
+        return
+    _assert_gamma_equals_2h_plus_1("linear_trend", gamma, H, slope=slope, n=n)
+
+
+@given(
+    seed=st.integers(min_value=0, max_value=2**31 - 1),
+    n=st.integers(min_value=256, max_value=2048),
+    sigma=st.floats(min_value=1e-3, max_value=1e3, allow_nan=False, allow_infinity=False),
+)
+@settings(
+    max_examples=50,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow],
+)
+def test_inv_dro1_hypothesis_random_walk_invariance(seed: int, n: int, sigma: float) -> None:
+    """INV-DRO1 fuzz: identity holds across (seed, n, sigma) configurations."""
+    rng = np.random.default_rng(seed=seed)
+    series = np.cumsum(rng.normal(0.0, sigma, size=n))
+    gamma, H, _r2 = derive_gamma(series)
+    if not (math.isfinite(gamma) and math.isfinite(H)):
+        return
+    _assert_gamma_equals_2h_plus_1("hypothesis_walk", gamma, H, seed=seed, n=n, sigma=sigma)
+
+
+def test_inv_dro1_known_exact_relation_for_pure_brownian() -> None:
+    """Pure Brownian motion has H = 0.5 ⟹ γ = 2.
+
+    The DFA estimator on a long enough Brownian path should
+    recover H ≈ 0.5 ± ~0.1 for n=4096; whatever H it returns,
+    γ must equal 2H+1 within the spec tolerance.
+    """
+    rng = np.random.default_rng(seed=12345)
+    n = 4096
+    increments = rng.normal(0.0, 1.0, size=n)
+    series = np.cumsum(increments)
+    gamma, H, r2 = derive_gamma(series)
+    _assert_gamma_equals_2h_plus_1("pure_brownian_n4096", gamma, H, n=n)
+    # Sanity: r2 should indicate a clean linear fit on Brownian.
+    assert math.isfinite(r2)


### PR DESCRIPTION
## Summary

Adds seven *companion* test files that strengthen existing coverage of P0 invariants from CLAUDE.md to the strongest practical falsifying form. No production code is touched — every change is under `tests/unit/physics/`.

| INV | Existing | Companion (this PR) | New tests |
|---|---|---|---|
| **OA2** (algebraic) | RK4 1e-3 integration tolerance | `_dz_dt` evaluated at analytical fixed point `R_∞ = √(1−2Δ/K)`; asserts `< 1e-13` | 13 |
| **FE1** (monotonic) | INV-FE2 components only | Per-decision `allowed ⟹ ΔF ≤ 0` algebraic + contrapositive + ULP lemma | 11 |
| **LE1** (universal) | 5 hand-picked inputs | Adversarial corpus + Hypothesis fuzz | 9 |
| **RC1** (universal) | Cycle/complete/path | Erdős–Rényi, Watts–Strogatz, Barabási–Albert random-graph fuzz | 6 |
| **DRO1** (algebraic) | H-recovery focus | `γ = 2H+1` algebraic to spec'd 1e-5 | 14 |
| **CB1** (universal) | Single path with `==` | Hypothesis fuzz + IEEE-754 bit-pattern `+0.0` identity | 4 |
| **K2** (asymptotic) | Single point `(N=512, K=0.3·K_c)` | Sweep `(N × k_ratio × seed)` + heavy_math `1/√N` scaling | 13 |

**Total: 70 tests** (69 default + 1 heavy_math).

## What's stronger

* **Algebraic vs integration**: OA2 was 1e-3 RK4. A sign flip in one of the four RHS terms would not be caught at that floor. The new test catches drift at 1e-13.
* **Property vs hand-picked**: LE1 covered five hand-picked families. The new Hypothesis fuzz spans ~80 randomised scenarios per run including bimodal zero-distance neighbors, near-overflow magnitudes, ±0 sign-bit edge cases.
* **Bit-pattern vs equality**: CB1 used `multiplier == 0.0` — passes for `-0.0` and denormals. The new test packs to raw bytes and asserts canonical `+0.0` exactly.
* **Sweep vs single point**: K2 checked one cell; the new sweep exercises the `1/√N` scaling itself and falsifies the floor on a 12-cell grid.

## What is *not* changed

* No production code touched.
* No existing tests modified (companions, not replacements).
* No new dependencies added.
* No CI workflow changes.

## Quality gates (local)

* `black --check` (7 files): ✓ clean
* `ruff check` (7 files): ✓ clean
* `mypy --strict` (7 files): ✓ clean
* `pytest -m "not heavy_math"`: 69/69 passed
* `pytest -m heavy_math`: 1/1 passed (scaling test)
* `.claude/physics/validate_tests.py`: 0 L1, 0 L2, 0 L4 issues; 100% physics grounding (every test references its INV-* ID)

## Governance

Acceptor `.claude/commit_acceptors/physics-invariant-tightening.yaml` binds all 10 changed files (7 test files + acceptor + report + newsfragment). Falsifier filters to the OA2 algebraic test — the strongest individual probe of the pack.

## Test plan

- [x] All 69 default tests pass locally
- [x] heavy_math scaling test passes locally
- [x] mypy --strict clean
- [x] black + ruff clean
- [x] physics-validator: 0 L1/L2/L4
- [ ] CI: physics-invariants
- [ ] CI: physics-test-validation
- [ ] CI: python-fast-tests
- [ ] CI: commit-acceptor-validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)