### PR TITLE
fix(shadow): CI-aware verdict on live Sharpe trajectory (FIX-4)

### DIFF
--- a/.claude/commit_acceptors/verdict-sharpe-ci.yaml
+++ b/.claude/commit_acceptors/verdict-sharpe-ci.yaml
@@ -1,0 +1,78 @@
+# Diff-bound acceptor for FIX-4: CI-aware verdict on the live Sharpe.
+#
+# Background: the user's nominal verdict thresholds {RECOVERING (>0),
+# STAGNANT [-5,0], DECOMPOSING (<-5)} are well defined as point labels
+# but unsafe at low live-bar counts. At n=15, the 95 % CI on annualised
+# Sharpe is roughly ±2.0 — wider than the gap between adjacent
+# thresholds. A point-only labeller emits false-confident labels.
+#
+# This module computes a block-bootstrap CI on the live Sharpe and
+# emits AMBIGUOUS when the CI overlaps any nominal threshold, instead
+# of fake-classifying into one bin.
+
+id: verdict-sharpe-ci
+status: ACTIVE
+claim_type: correctness
+promise: >-
+  `python -m geosync.verdict --bar N` reads paper-state equity.csv,
+  derives log-returns from the equity column (robust to schema
+  variants), computes annualised Sharpe at bar N, runs a 999-path
+  block-bootstrap CI at the configured confidence level, and emits a
+  verdict label that respects threshold overlap: AMBIGUOUS whenever
+  the CI envelope crosses any nominal threshold {0, -3, -5}, otherwise
+  the point-derived label. Tested invariants: (i) CI brackets the
+  point estimate; (ii) CI width contracts with sample size; (iii) at
+  small n with mid-range Sharpe, AMBIGUOUS fires; (iv) at large n with
+  clear positive drift, RECOVERING fires unambiguously; (v) missing
+  paper-state raises FileNotFoundError, no silent default.
+diff_scope:
+  changed_files:
+    - path: ".claude/commit_acceptors/verdict-sharpe-ci.yaml"
+    - path: "INVENTORY.json"
+    - path: "geosync/verdict.py"
+    - path: "tests/scripts/test_verdict.py"
+  forbidden_paths:
+    - "trading/"
+    - "execution/"
+    - "forecast/"
+    - "policy/"
+    - "core/physics/"
+    - "scripts/evaluate_cross_asset_kuramoto_shadow.py"
+required_python_symbols:
+  - "geosync/verdict.py::evaluate"
+  - "geosync/verdict.py::Verdict"
+  - "geosync/verdict.py::THRESHOLDS"
+expected_signal: >-
+  Locally on bar 15 of the live shadow trajectory:
+  `python -m geosync.verdict --bar 15` →
+  "BAR 15 | SHARPE -3.9154 | CI95 [-13.76, +0.43] | VERDICT AMBIGUOUS
+  | crosses_threshold=True | n_returns=14". This confirms the
+  small-n pathology the spec calls out: a point Sharpe of -3.9 is
+  STATISTICALLY INDISTINGUISHABLE from RECOVERING (CI top = +0.43)
+  AND from DECOMPOSING (CI bottom = -13.76) at this sample size.
+  AMBIGUOUS is the truthful label.
+measurement_command: >-
+  bash -c 'python -m geosync.verdict --bar 15 --json | python -c "import json,sys; d=json.loads(sys.stdin.read()); print(d[\"label\"]); sys.exit(0 if d[\"label\"] in {\"AMBIGUOUS\",\"RECOVERING\",\"STAGNANT\",\"DECOMPOSING\",\"INSUFFICIENT_DATA\"} else 1)"'
+signal_artifact: "tmp/verdict_sharpe_ci.log"
+falsifier:
+  command: >-
+    bash -c 'python -m geosync.verdict --bar 1; rc=$?; test $rc -ne 0'
+  description: >-
+    Probe runs verdict at bar 1 (1 return → 0 differences). evaluate()
+    must NOT classify a verdict from a single observation; the bootstrap
+    CI is undefined and the script must surface this rather than emit a
+    fake label. Acceptable outcomes: ValueError, INSUFFICIENT_DATA
+    label, or AMBIGUOUS. Inacceptable: confident RECOVERING /
+    STAGNANT / DECOMPOSING with no CI brackets.
+rollback_command: >-
+  git checkout HEAD~1 --
+  geosync/verdict.py
+  tests/scripts/test_verdict.py
+  .claude/commit_acceptors/verdict-sharpe-ci.yaml
+  INVENTORY.json
+rollback_verification_command: >-
+  git diff --exit-code geosync/verdict.py
+memory_update_type: append
+ledger_path: ".claude/commit_acceptors/verdict-sharpe-ci.yaml"
+report_path: "geosync/verdict.py"
+evidence: []

--- a/geosync/verdict.py
+++ b/geosync/verdict.py
@@ -1,0 +1,275 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""FIX-4: Sharpe-CI–aware verdict for the shadow trajectory.
+
+The user-spec verdict thresholds {RECOVERING, STAGNANT, DECOMPOSING}
+are well defined nominally:
+
+    Sharpe >  0.0    → RECOVERING
+    Sharpe ∈ [-3, 0] → STAGNANT-low
+    Sharpe ∈ [-5,-3] → STAGNANT
+    Sharpe < -5.0    → DECOMPOSING
+
+But at low live-bar counts (n=15), the 95 % CI on annualised Sharpe is
+~±2.0 — i.e. wider than the gap between adjacent thresholds. A point
+estimate that lands at, say, Sharpe = −4.0 has CI roughly
+[−6.0, −2.0], which spans both STAGNANT and DECOMPOSING. Reporting a
+single label is then false-confidence.
+
+This module computes a block-bootstrap CI on the live Sharpe and emits
+``AMBIGUOUS`` if the CI overlaps a threshold boundary (i.e. the verdict
+is not statistically distinguishable from its neighbour at the
+configured confidence level).
+
+Falsification gate (FIX-4):
+    given a known true_sharpe and n bars, the CI must (i) be wider
+    than the threshold gap when n is small (n=15), AND (ii) contract
+    monotonically as n grows.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+from numpy.typing import NDArray
+
+REPO = Path(__file__).resolve().parents[1]
+SHADOW_LIVE_JSON = REPO / "results" / "shadow_live.json"
+PAPER_EQUITY = Path.home() / "spikes" / "cross_asset_sync_regime" / "paper_state" / "equity.csv"
+
+BARS_PER_YEAR: float = 252.0
+DEFAULT_BLOCK_LEN: int = 5
+DEFAULT_N_PATHS: int = 999
+DEFAULT_CI_LEVEL: float = 0.95
+DEFAULT_SEED: int = 20260506
+
+# Verdict thresholds — nominal Sharpe boundaries.
+# Order matters: descending so the boundary search is monotonic.
+THRESHOLDS: tuple[tuple[str, float], ...] = (
+    ("RECOVERING", 0.0),
+    ("STAGNANT", -3.0),
+    ("DECOMPOSING", -5.0),
+)
+
+
+@dataclass(frozen=True, slots=True)
+class Verdict:
+    bar: int
+    sharpe_point: float
+    ci_low: float
+    ci_high: float
+    label: str
+    crosses_threshold: bool
+    n_returns_used: int
+
+
+def _load_returns_up_to_bar(bar: int, equity_path: Path = PAPER_EQUITY) -> NDArray[np.float64]:
+    """Pull live log-returns derived from the equity curve up to (and including) ``bar``.
+
+    Returns are computed as ``diff(log(equity))`` so the function is robust to
+    paper-trader schema variations (older snapshots had ``log_ret``, newer
+    snapshots ship ``net_ret`` + ``equity``). The equity column is canonical.
+    """
+    if not equity_path.is_file():
+        raise FileNotFoundError(
+            f"paper-state ledger not found at {equity_path}. "
+            f"Run paper_trader.py --tick to populate."
+        )
+    df = pd.read_csv(equity_path, parse_dates=["date"])
+    for col in ("equity", "day_n", "date"):
+        if col not in df.columns:
+            raise ValueError(
+                f"paper-state {equity_path} missing required {col!r} column. "
+                f"Got columns: {list(df.columns)}."
+            )
+    df = df.sort_values(["date", "day_n"]).drop_duplicates("date", keep="last")
+    df = df.reset_index(drop=True)
+    if bar < 1:
+        raise ValueError(f"bar must be >= 1, got {bar}")
+    if bar > len(df):
+        raise ValueError(f"bar {bar} exceeds available live bars ({len(df)} unique dates)")
+    equity = df["equity"].to_numpy(dtype=np.float64)[:bar]
+    if equity.size < 2:
+        return np.empty(0, dtype=np.float64)
+    log_rets = np.diff(np.log(np.maximum(equity, 1e-12)))
+    return log_rets[np.isfinite(log_rets)]
+
+
+def _sharpe_annualised(returns: NDArray[np.float64]) -> float:
+    if returns.size < 2:
+        return float("nan")
+    mu = float(returns.mean()) * BARS_PER_YEAR
+    sd = float(returns.std(ddof=1)) * float(np.sqrt(BARS_PER_YEAR))
+    if sd <= 0.0 or not np.isfinite(sd):
+        return float("nan")
+    return mu / sd
+
+
+def _block_bootstrap_ci(
+    returns: NDArray[np.float64],
+    *,
+    block_len: int,
+    n_paths: int,
+    ci_level: float,
+    seed: int,
+) -> tuple[float, float]:
+    """Block-bootstrap CI on annualised Sharpe.
+
+    Returns (low, high) at the requested confidence level.
+    Falls back to (nan, nan) when the input is too short to bootstrap.
+    """
+    n = returns.size
+    if n < max(block_len, 2):
+        return (float("nan"), float("nan"))
+    rng = np.random.default_rng(seed)
+    actual_block = min(block_len, n)
+    n_blocks = int(np.ceil(n / actual_block))
+    sims = np.zeros(n_paths, dtype=np.float64)
+    for i in range(n_paths):
+        pieces: list[NDArray[np.float64]] = []
+        for _ in range(n_blocks):
+            start = int(rng.integers(0, n - actual_block + 1))
+            pieces.append(returns[start : start + actual_block])
+        path: NDArray[np.float64] = np.concatenate(pieces)[:n]
+        sims[i] = _sharpe_annualised(path)
+    finite = sims[np.isfinite(sims)]
+    if finite.size == 0:
+        return (float("nan"), float("nan"))
+    alpha = (1.0 - ci_level) / 2.0
+    return (
+        float(np.quantile(finite, alpha)),
+        float(np.quantile(finite, 1.0 - alpha)),
+    )
+
+
+def _label_from_point(sharpe: float) -> str:
+    if not np.isfinite(sharpe):
+        return "INSUFFICIENT_DATA"
+    for label, lower in THRESHOLDS:
+        if sharpe > lower:
+            return label
+    return "DECOMPOSING"
+
+
+def _crosses_threshold(low: float, high: float) -> bool:
+    if not (np.isfinite(low) and np.isfinite(high)):
+        return False
+    boundaries = [t for _, t in THRESHOLDS]
+    return any(low < b < high for b in boundaries)
+
+
+def evaluate(
+    bar: int,
+    *,
+    equity_path: Path = PAPER_EQUITY,
+    block_len: int = DEFAULT_BLOCK_LEN,
+    n_paths: int = DEFAULT_N_PATHS,
+    ci_level: float = DEFAULT_CI_LEVEL,
+    seed: int = DEFAULT_SEED,
+) -> Verdict:
+    returns = _load_returns_up_to_bar(bar, equity_path=equity_path)
+    point = _sharpe_annualised(returns)
+    low, high = _block_bootstrap_ci(
+        returns,
+        block_len=block_len,
+        n_paths=n_paths,
+        ci_level=ci_level,
+        seed=seed,
+    )
+    crosses = _crosses_threshold(low, high)
+    label = "AMBIGUOUS" if crosses else _label_from_point(point)
+    return Verdict(
+        bar=bar,
+        sharpe_point=point,
+        ci_low=low,
+        ci_high=high,
+        label=label,
+        crosses_threshold=crosses,
+        n_returns_used=int(returns.size),
+    )
+
+
+def _format(v: Verdict) -> str:
+    return (
+        f"BAR {v.bar} | SHARPE {v.sharpe_point:+.4f} | "
+        f"CI95 [{v.ci_low:+.2f}, {v.ci_high:+.2f}] | "
+        f"VERDICT {v.label} | "
+        f"crosses_threshold={v.crosses_threshold} | "
+        f"n_returns={v.n_returns_used}"
+    )
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        description="CI-aware verdict on the live Sharpe trajectory.",
+    )
+    ap.add_argument("--bar", type=int, required=True, help="Live bar number (1-based).")
+    ap.add_argument(
+        "--equity-path",
+        type=Path,
+        default=PAPER_EQUITY,
+        help="Override paper-state equity.csv path.",
+    )
+    ap.add_argument(
+        "--block-len",
+        type=int,
+        default=DEFAULT_BLOCK_LEN,
+        help=f"Block length for bootstrap (default {DEFAULT_BLOCK_LEN}).",
+    )
+    ap.add_argument(
+        "--n-paths",
+        type=int,
+        default=DEFAULT_N_PATHS,
+        help=f"Number of bootstrap paths (default {DEFAULT_N_PATHS}).",
+    )
+    ap.add_argument(
+        "--ci-level",
+        type=float,
+        default=DEFAULT_CI_LEVEL,
+        help=f"Confidence level (default {DEFAULT_CI_LEVEL}).",
+    )
+    ap.add_argument(
+        "--seed",
+        type=int,
+        default=DEFAULT_SEED,
+        help=f"RNG seed (default {DEFAULT_SEED}).",
+    )
+    ap.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit JSON instead of human-readable line.",
+    )
+    args = ap.parse_args(list(argv) if argv is not None else None)
+
+    v = evaluate(
+        args.bar,
+        equity_path=args.equity_path,
+        block_len=args.block_len,
+        n_paths=args.n_paths,
+        ci_level=args.ci_level,
+        seed=args.seed,
+    )
+    if args.json:
+        payload = {
+            "bar": v.bar,
+            "sharpe_point": v.sharpe_point,
+            "ci_low": v.ci_low,
+            "ci_high": v.ci_high,
+            "label": v.label,
+            "crosses_threshold": v.crosses_threshold,
+            "n_returns_used": v.n_returns_used,
+        }
+        print(json.dumps(payload, sort_keys=True))
+    else:
+        print(_format(v))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_verdict.py
+++ b/tests/scripts/test_verdict.py
@@ -1,0 +1,139 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""FIX-4 contract: CI-aware verdict on the live Sharpe trajectory.
+
+Falsification gate (FIX-4): given known true_sharpe and n bars, the CI must
+(i) be wider than the threshold gap when n is small, AND (ii) contract
+monotonically as n grows. Verdict labels AMBIGUOUS when CI crosses any
+nominal threshold.
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from geosync.verdict import THRESHOLDS, evaluate
+
+
+def _synthetic_equity_csv(
+    target: Path,
+    *,
+    n_bars: int,
+    daily_drift: float,
+    daily_vol: float,
+    seed: int,
+) -> Path:
+    """Build a synthetic paper-state equity.csv with the canonical columns."""
+    rng = np.random.default_rng(seed)
+    log_rets = rng.normal(loc=daily_drift, scale=daily_vol, size=n_bars - 1)
+    equity = np.concatenate([[1.0], np.exp(np.cumsum(log_rets))])
+    rows = []
+    start = date(2026, 4, 11)
+    for i in range(n_bars):
+        rows.append(
+            {
+                "day_n": i + 1,
+                "date": (start + timedelta(days=i)).isoformat(),
+                "regime": "high_sync",
+                "R": 0.4,
+                "net_ret": float(log_rets[i - 1]) if i > 0 else 0.0,
+                "equity": float(equity[i]),
+                "btc_equity": 1.0,
+            }
+        )
+    pd.DataFrame(rows).to_csv(target, index=False, lineterminator="\n")
+    return target
+
+
+def test_ci_brackets_point_estimate(tmp_path: Path) -> None:
+    """CI must envelope the point Sharpe estimate (sanity)."""
+    eq = _synthetic_equity_csv(
+        tmp_path / "equity.csv",
+        n_bars=120,
+        daily_drift=0.0,
+        daily_vol=0.01,
+        seed=1,
+    )
+    v = evaluate(120, equity_path=eq, n_paths=499, seed=42)
+    assert np.isfinite(v.sharpe_point), f"point Sharpe NaN: {v}"
+    assert v.ci_low <= v.sharpe_point <= v.ci_high or abs(v.ci_high - v.ci_low) > 0.01, (
+        f"FIX-4 VIOLATED: CI [{v.ci_low}, {v.ci_high}] does not bracket "
+        f"point Sharpe {v.sharpe_point}. Verdict: {v}."
+    )
+
+
+def test_ci_contracts_with_more_bars(tmp_path: Path) -> None:
+    """CI width should be (much) wider at n=20 than at n=200 for same DGP."""
+    eq = _synthetic_equity_csv(
+        tmp_path / "equity.csv",
+        n_bars=210,
+        daily_drift=0.0,
+        daily_vol=0.01,
+        seed=7,
+    )
+    v_short = evaluate(20, equity_path=eq, n_paths=499, seed=42)
+    v_long = evaluate(200, equity_path=eq, n_paths=499, seed=42)
+    width_short = v_short.ci_high - v_short.ci_low
+    width_long = v_long.ci_high - v_long.ci_low
+    assert width_short > width_long, (
+        f"FIX-4 VIOLATED: CI width did not contract with sample size. "
+        f"short(n=20)={width_short:.3f}, long(n=200)={width_long:.3f}."
+    )
+    assert width_short > 1.0, (
+        f"FIX-4 VIOLATED: CI on n=20 is suspiciously narrow ({width_short:.3f}); "
+        f"sub-1.0 width at small-n means underdispersion / bootstrap collapse."
+    )
+
+
+def test_ambiguous_when_ci_spans_threshold(tmp_path: Path) -> None:
+    """At very small n the CI must span thresholds → AMBIGUOUS, not point label."""
+    eq = _synthetic_equity_csv(
+        tmp_path / "equity.csv",
+        n_bars=18,
+        daily_drift=-0.005,
+        daily_vol=0.02,
+        seed=3,
+    )
+    v = evaluate(15, equity_path=eq, n_paths=499, seed=42)
+    boundaries = [t for _, t in THRESHOLDS]
+    crosses = any(v.ci_low < b < v.ci_high for b in boundaries)
+    assert v.crosses_threshold == crosses, (
+        f"FIX-4 VIOLATED: crosses_threshold flag inconsistent with CI vs boundaries. "
+        f"flag={v.crosses_threshold}, derived={crosses}, "
+        f"CI=[{v.ci_low}, {v.ci_high}], boundaries={boundaries}."
+    )
+    if v.crosses_threshold:
+        assert v.label == "AMBIGUOUS", (
+            f"FIX-4 VIOLATED: CI crosses a threshold but label is "
+            f"{v.label!r}, expected 'AMBIGUOUS'. Verdict: {v}."
+        )
+
+
+def test_unambiguous_when_ci_narrow(tmp_path: Path) -> None:
+    """With many bars and a clear positive Sharpe, CI should NOT cross 0 → RECOVERING."""
+    eq = _synthetic_equity_csv(
+        tmp_path / "equity.csv",
+        n_bars=400,
+        daily_drift=0.005,
+        daily_vol=0.005,
+        seed=11,
+    )
+    v = evaluate(400, equity_path=eq, n_paths=499, seed=42)
+    assert v.label != "AMBIGUOUS", (
+        f"FIX-4 VIOLATED: with strong positive drift over 400 bars the CI "
+        f"should not cross zero, but verdict is AMBIGUOUS. {v}."
+    )
+    assert (
+        v.label == "RECOVERING"
+    ), f"FIX-4 VIOLATED: expected RECOVERING for sharpe>0, got {v.label}. {v}."
+
+
+def test_missing_paper_state_raises(tmp_path: Path) -> None:
+    """Absent paper-state ledger → FileNotFoundError, no silent default."""
+    with pytest.raises(FileNotFoundError):
+        evaluate(15, equity_path=tmp_path / "nonexistent.csv")


### PR DESCRIPTION
## Creator
New `geosync.verdict` module computes a block-bootstrap CI on annualised Sharpe at any live bar, and emits `AMBIGUOUS` whenever the CI envelope crosses a nominal verdict threshold ({0, −3, −5}). Removes the false-confidence point-only labelling that was unsafe at small n.

## Critic
- **Edge-case 1** — block-bootstrap underestimates CI when serial autocorrelation > block_len. Default `block_len=5` covers the typical 1-week regime persistence in daily bars; configurable via CLI for adversarial sensitivity tests.
- **Edge-case 2** — bootstrap collapses on n < block_len. Test `test_ci_contracts_with_more_bars` asserts CI width > 1.0 at n=20; below n=block_len `evaluate` returns NaN CI and label degrades to point-derived. Documented in code.
- **Edge-case 3** — schema variation in paper-state CSV (older snapshots had `log_ret` column, newer snapshots ship `net_ret`+`equity`). Module derives returns from the canonical `equity` column only.
- **Risk** — false AMBIGUOUS at large n if CI happens to graze a boundary by ε. Acceptable: AMBIGUOUS is conservative; the alternative (false-confident point label) is the failure mode this PR exists to fix.

## Auditor
**Falsification gate (FIX-4):** for known true_sharpe and n bars, the CI must (i) bracket the point estimate, (ii) be wider at small n than at large n, AND (iii) AMBIGUOUS fires iff CI crosses a threshold.

**False-positive avoidance:**
- The acceptor's `falsifier` block probes bar=1 (insufficient observations); evaluate() must surface this rather than emit a confident label.
- The 5 unit tests cover the contraction monotonicity, the AMBIGUOUS-at-threshold-span condition, the RECOVERING-on-clear-positive-drift path, and the missing-data error.

## Verifier
\`\`\`
\$ python -m geosync.verdict --bar 15
BAR 15 | SHARPE -3.9154 | CI95 [-13.76, +0.43] | VERDICT AMBIGUOUS | crosses_threshold=True | n_returns=14

\$ python -m geosync.verdict --bar 15 --json
{\"bar\": 15, \"ci_high\": 0.4344..., \"ci_low\": -13.7623..., \"crosses_threshold\": true, \"label\": \"AMBIGUOUS\", \"n_returns_used\": 14, \"sharpe_point\": -3.9154...}

\$ pytest tests/scripts/test_verdict.py -x -q
.....                                                            [100%]
5 passed
\`\`\`