### PR TITLE
fix(shadow): honest DP3 recovery test (FIX-3)

### DIFF
--- a/.claude/commit_acceptors/dp3-honest-test.yaml
+++ b/.claude/commit_acceptors/dp3-honest-test.yaml
@@ -1,0 +1,84 @@
+# Diff-bound acceptor for FIX-3: honest DP3 (snapshot-staleness) recovery test.
+#
+# The earlier informal claim was: "manual tick refreshed paper-state →
+# Sharpe rose from −6.82 → −4.68; therefore DP3 staleness explains 31 %
+# of the deficit." That claim conflated a *causal* recovery with a
+# *mechanical* small-n effect: at n=14 returns, simply appending one
+# positive bar moves the annualised Sharpe by O(1/sqrt(N)) regardless
+# of whether the new bar carries any signal about staleness.
+#
+# This module installs a registered protocol: the observed Δ Sharpe
+# from bar N−1 to bar N is compared against the mechanical small-n
+# distribution produced by appending a random draw from the prior
+# return distribution (999 permutations). Verdict is BINARY:
+# REJECT if |Δ| < 2 × std(mechanical null), else CONFIRMED with
+# p-value. AMBIGUOUS / PARTIAL labels are explicitly forbidden by spec.
+
+id: dp3-honest-test
+status: ACTIVE
+claim_type: correctness
+promise: >-
+  `python -m geosync.dp3_test --honest [--bar N]` reads paper-state
+  equity.csv, computes annualised Sharpe at bars N-1 and N, runs a
+  999-path mechanical-null permutation (append a random draw from the
+  prior return distribution and recompute the Δ), and emits a strictly
+  binary REJECT / CONFIRMED label plus the two-sided p-value over the
+  null. The acceptance band is BAND_K=2.0 standard deviations of the
+  mechanical null. Tested invariants: (i) zero-novel-signal data
+  (last bar = prior mean) yields REJECT; (ii) large-n prior + extreme
+  outlier yields CONFIRMED with p<0.05; (iii) label is strictly
+  REJECT|CONFIRMED, never AMBIGUOUS; (iv) bar<3 raises ValueError;
+  (v) missing paper-state raises FileNotFoundError. The earlier
+  informal "31 %% recovery" claim is hereby retracted as
+  NULL_PENDING_TEST until the live trajectory accumulates enough
+  bars for this protocol to fire CONFIRMED.
+diff_scope:
+  changed_files:
+    - path: ".claude/commit_acceptors/dp3-honest-test.yaml"
+    - path: "INVENTORY.json"
+    - path: "geosync/dp3_test.py"
+    - path: "tests/scripts/test_dp3_test.py"
+  forbidden_paths:
+    - "trading/"
+    - "execution/"
+    - "forecast/"
+    - "policy/"
+    - "core/physics/"
+    - "scripts/evaluate_cross_asset_kuramoto_shadow.py"
+required_python_symbols:
+  - "geosync/dp3_test.py::evaluate"
+  - "geosync/dp3_test.py::DP3Result"
+  - "geosync/dp3_test.py::BAND_K"
+expected_signal: >-
+  Locally on bar 15 of the live shadow trajectory:
+  `python -m geosync.dp3_test --honest` →
+  "DP3 BAR 15 | Sharpe(N-1)=-5.8895 → Sharpe(N)=-3.9154 |
+  Δ=+1.9741 | band(2σ)=2.0469 | p=0.0741 | LABEL REJECT |
+  n_returns=14". Confirms that the +1.97 ΔSharpe between bars 14
+  and 15 is INSIDE the mechanical small-n null at this sample size —
+  the earlier "31 %% recovery" attribution was a false positive on
+  n=1 anecdotal evidence.
+measurement_command: >-
+  bash -c 'python -m geosync.dp3_test --honest --json | python -c "import json,sys; d=json.loads(sys.stdin.read()); print(d[\"label\"]); sys.exit(0 if d[\"label\"] in {\"REJECT\",\"CONFIRMED\"} else 1)"'
+signal_artifact: "tmp/dp3_honest_test.log"
+falsifier:
+  command: >-
+    bash -c 'python -m geosync.dp3_test 2>&1 | grep -q -- "--honest" && exit 0 || exit 1'
+  description: >-
+    Probe runs the module without the --honest flag. If the module
+    silently accepts the call and emits a verdict, the contract is
+    broken — callers can re-emit the informal claim without explicitly
+    acknowledging the protocol replacement. The --honest flag must be
+    required.
+rollback_command: >-
+  git checkout HEAD~1 --
+  geosync/dp3_test.py
+  tests/scripts/test_dp3_test.py
+  .claude/commit_acceptors/dp3-honest-test.yaml
+  INVENTORY.json
+rollback_verification_command: >-
+  git diff --exit-code geosync/dp3_test.py
+memory_update_type: append
+ledger_path: ".claude/commit_acceptors/dp3-honest-test.yaml"
+report_path: "geosync/dp3_test.py"
+evidence: []

--- a/geosync/dp3_test.py
+++ b/geosync/dp3_test.py
@@ -1,0 +1,238 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""FIX-3: honest DP3 (snapshot-staleness) recovery test.
+
+The earlier informal claim was: "manual tick refreshed paper-state →
+Sharpe rose from −6.82 → −4.68; therefore DP3 staleness explains 31 %
+of the deficit." That claim conflates a *causal* recovery with a
+*mechanical* small-n effect: at n=14 returns, simply appending one
+positive bar moves the annualised Sharpe by O(1/sqrt(N)) ≈ 1.0–2.0
+SD-units regardless of whether the new bar carries any signal about
+staleness. n=1 datapoint, confounded.
+
+This module replaces the informal claim with a registered protocol:
+
+    H0  observed ΔSharpe between bar N−1 and bar N is
+        indistinguishable from the mechanical small-n distribution
+        produced by appending a random draw from the prior return
+        distribution.
+    H1  observed |ΔSharpe| > 2 × SE_of_mechanical_distribution.
+
+If H0 is not rejected → label REJECT (no DP3 effect detectable beyond
+mechanics). If observed exceeds the band, emit CONFIRMED with the
+two-sided permutation p-value over the mechanical null.
+
+Pre-registered thresholds:
+    band  = 2 × std(mechanical_distribution)
+    p     = mean(|mech_delta| >= |observed_delta|)
+    label = REJECT if |observed_delta| < band, else CONFIRMED
+
+The output is BINARY by design (REJECT / CONFIRMED) with explicit
+p-value. ``ambiguous`` / ``promising`` / ``partial`` are forbidden —
+the test answers a yes/no question.
+
+Falsification gate (FIX-3): on a synthetic series whose final bar is
+exactly the prior-mean (zero novel signal), the test MUST give
+REJECT. The test in tests/scripts/test_dp3_test.py asserts this.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+from numpy.typing import NDArray
+
+REPO = Path(__file__).resolve().parents[1]
+PAPER_EQUITY = Path.home() / "spikes" / "cross_asset_sync_regime" / "paper_state" / "equity.csv"
+
+BARS_PER_YEAR: float = 252.0
+DEFAULT_N_PERM: int = 999
+DEFAULT_SEED: int = 20260506
+BAND_K: float = 2.0  # 2 × std-of-mechanical-null
+
+
+@dataclass(frozen=True, slots=True)
+class DP3Result:
+    bar: int
+    sharpe_full: float
+    sharpe_prior: float
+    delta_observed: float
+    band: float
+    p_value: float
+    label: str
+    n_returns: int
+
+
+def _load_returns_up_to_bar(bar: int, equity_path: Path = PAPER_EQUITY) -> NDArray[np.float64]:
+    """Same canonical loader used by geosync.verdict — derive log-rets from equity."""
+    if not equity_path.is_file():
+        raise FileNotFoundError(
+            f"paper-state ledger not found at {equity_path}. "
+            f"Run paper_trader.py --tick to populate."
+        )
+    df = pd.read_csv(equity_path, parse_dates=["date"])
+    for col in ("equity", "day_n", "date"):
+        if col not in df.columns:
+            raise ValueError(
+                f"paper-state {equity_path} missing required {col!r} column. "
+                f"Got columns: {list(df.columns)}."
+            )
+    df = df.sort_values(["date", "day_n"]).drop_duplicates("date", keep="last")
+    df = df.reset_index(drop=True)
+    if bar < 2:
+        raise ValueError(f"DP3 test requires bar >= 2 (need >=1 prior return); got {bar}")
+    if bar > len(df):
+        raise ValueError(f"bar {bar} exceeds available live bars ({len(df)} unique dates)")
+    equity = df["equity"].to_numpy(dtype=np.float64)[:bar]
+    log_rets = np.diff(np.log(np.maximum(equity, 1e-12)))
+    return log_rets[np.isfinite(log_rets)]
+
+
+def _sharpe_annualised(returns: NDArray[np.float64]) -> float:
+    if returns.size < 2:
+        return float("nan")
+    mu = float(returns.mean()) * BARS_PER_YEAR
+    sd = float(returns.std(ddof=1)) * float(np.sqrt(BARS_PER_YEAR))
+    if sd <= 0.0 or not np.isfinite(sd):
+        return float("nan")
+    return mu / sd
+
+
+def evaluate(
+    bar: int,
+    *,
+    equity_path: Path = PAPER_EQUITY,
+    n_perm: int = DEFAULT_N_PERM,
+    seed: int = DEFAULT_SEED,
+) -> DP3Result:
+    full = _load_returns_up_to_bar(bar, equity_path=equity_path)
+    if full.size < 3:
+        raise ValueError(
+            f"DP3 test requires >= 3 returns; got {full.size} from "
+            f"bar={bar}. Wait for more ticks before running this test."
+        )
+    prior = full[:-1]
+    sharpe_full = _sharpe_annualised(full)
+    sharpe_prior = _sharpe_annualised(prior)
+    delta_observed = sharpe_full - sharpe_prior
+
+    rng = np.random.default_rng(seed)
+    mech_deltas = np.empty(n_perm, dtype=np.float64)
+    for i in range(n_perm):
+        synthetic_bar = float(rng.choice(prior))
+        synthetic_full = np.concatenate([prior, np.array([synthetic_bar])])
+        mech_deltas[i] = _sharpe_annualised(synthetic_full) - sharpe_prior
+
+    finite = mech_deltas[np.isfinite(mech_deltas)]
+    if finite.size == 0:
+        raise ValueError("Mechanical null produced no finite deltas; cannot test.")
+    band = float(BAND_K * np.std(finite, ddof=1))
+    p_value = float(np.mean(np.abs(finite) >= abs(delta_observed)))
+    if not np.isfinite(delta_observed) or not np.isfinite(band):
+        raise ValueError(f"Non-finite delta or band: delta={delta_observed}, band={band}")
+    label = "REJECT" if abs(delta_observed) < band else "CONFIRMED"
+
+    return DP3Result(
+        bar=bar,
+        sharpe_full=sharpe_full,
+        sharpe_prior=sharpe_prior,
+        delta_observed=delta_observed,
+        band=band,
+        p_value=p_value,
+        label=label,
+        n_returns=int(full.size),
+    )
+
+
+def _format(r: DP3Result) -> str:
+    return (
+        f"DP3 BAR {r.bar} | "
+        f"Sharpe(N-1)={r.sharpe_prior:+.4f} → "
+        f"Sharpe(N)={r.sharpe_full:+.4f} | "
+        f"Δ={r.delta_observed:+.4f} | "
+        f"band(2σ)={r.band:.4f} | "
+        f"p={r.p_value:.4f} | "
+        f"LABEL {r.label} | "
+        f"n_returns={r.n_returns}"
+    )
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        description=(
+            "Honest DP3 (snapshot-staleness) recovery test: compares "
+            "observed bar-N→N+1 ΔSharpe against the mechanical small-n "
+            "null. Emits REJECT or CONFIRMED."
+        ),
+    )
+    ap.add_argument(
+        "--honest",
+        action="store_true",
+        help=(
+            "Required flag. Ensures callers acknowledge that this test "
+            "replaces the earlier informal '31 %% recovery' claim."
+        ),
+    )
+    ap.add_argument(
+        "--bar",
+        type=int,
+        default=None,
+        help=("Live bar number to test at. Defaults to the latest available bar in paper-state."),
+    )
+    ap.add_argument(
+        "--equity-path",
+        type=Path,
+        default=PAPER_EQUITY,
+        help="Override paper-state equity.csv path.",
+    )
+    ap.add_argument("--n-perm", type=int, default=DEFAULT_N_PERM, help="Permutations.")
+    ap.add_argument("--seed", type=int, default=DEFAULT_SEED, help="RNG seed.")
+    ap.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit JSON instead of human-readable line.",
+    )
+    args = ap.parse_args(list(argv) if argv is not None else None)
+
+    if not args.honest:
+        ap.error(
+            "DP3 test requires --honest flag (acknowledges this replaces "
+            "the earlier informal '31 %% recovery' claim)."
+        )
+
+    bar = args.bar
+    if bar is None:
+        df = pd.read_csv(args.equity_path, parse_dates=["date"])
+        bar = df.sort_values(["date", "day_n"]).drop_duplicates("date", keep="last").shape[0]
+
+    r = evaluate(
+        bar,
+        equity_path=args.equity_path,
+        n_perm=args.n_perm,
+        seed=args.seed,
+    )
+    if args.json:
+        payload = {
+            "bar": r.bar,
+            "sharpe_full": r.sharpe_full,
+            "sharpe_prior": r.sharpe_prior,
+            "delta_observed": r.delta_observed,
+            "band": r.band,
+            "p_value": r.p_value,
+            "label": r.label,
+            "n_returns": r.n_returns,
+        }
+        print(json.dumps(payload, sort_keys=True))
+    else:
+        print(_format(r))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_dp3_test.py
+++ b/tests/scripts/test_dp3_test.py
@@ -1,0 +1,113 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""FIX-3 contract: honest DP3 (snapshot-staleness) recovery test.
+
+Falsification gate: a synthetic series whose final bar is exactly the
+prior-mean (zero novel signal) MUST yield REJECT — confirming the test
+correctly identifies mechanical-only ΔSharpe as null.
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from geosync.dp3_test import evaluate
+
+
+def _equity_csv_from_returns(target: Path, log_rets: np.ndarray) -> Path:
+    """Build a paper-state equity.csv from a log-return series.
+
+    Equity[0] = 1.0; equity[i] = exp(cumsum(log_rets[:i])).
+    """
+    n_bars = len(log_rets) + 1
+    equity = np.concatenate([[1.0], np.exp(np.cumsum(log_rets))])
+    rows = []
+    start = date(2026, 4, 11)
+    for i in range(n_bars):
+        rows.append(
+            {
+                "day_n": i + 1,
+                "date": (start + timedelta(days=i)).isoformat(),
+                "regime": "high_sync",
+                "R": 0.4,
+                "net_ret": float(log_rets[i - 1]) if i > 0 else 0.0,
+                "equity": float(equity[i]),
+                "btc_equity": 1.0,
+            }
+        )
+    pd.DataFrame(rows).to_csv(target, index=False, lineterminator="\n")
+    return target
+
+
+def test_zero_novel_signal_yields_reject(tmp_path: Path) -> None:
+    """Final bar = prior mean → ΔSharpe ≈ mechanical floor → REJECT."""
+    rng = np.random.default_rng(123)
+    prior = rng.normal(loc=-0.005, scale=0.01, size=14)
+    final_bar_zero_novel = float(prior.mean())  # adds the prior mean — no novelty
+    full = np.append(prior, final_bar_zero_novel)
+    eq = _equity_csv_from_returns(tmp_path / "equity.csv", full)
+    r = evaluate(15, equity_path=eq, n_perm=999, seed=42)
+    assert r.label == "REJECT", (
+        f"FIX-3 VIOLATED: synthetic 'no novel signal' (last bar = "
+        f"prior mean) should yield REJECT, got {r.label}. "
+        f"delta={r.delta_observed:+.4f}, band={r.band:.4f}, "
+        f"p={r.p_value:.4f}."
+    )
+    assert r.p_value > 0.05, (
+        f"FIX-3 VIOLATED: p={r.p_value} unexpectedly small for "
+        f"synthetic null. delta={r.delta_observed}, band={r.band}."
+    )
+
+
+def test_strong_novel_signal_yields_confirmed(tmp_path: Path) -> None:
+    """Large-n prior + extreme outlier → ΔSharpe outside mechanical null → CONFIRMED.
+
+    Construction: prior is n=200 i.i.d. normal(0, 0.005). At this n the
+    bootstrap mechanical null is tight (~O(1/√n) Sharpe units). Final bar
+    is a 50σ negative spike (-0.25). |observed Δ| dwarfs mechanical SD.
+    """
+    rng = np.random.default_rng(7)
+    prior = rng.normal(loc=0.0, scale=0.005, size=200)
+    final_bar = -0.25  # 50× prior std
+    full = np.append(prior, final_bar)
+    eq = _equity_csv_from_returns(tmp_path / "equity.csv", full)
+    r = evaluate(201, equity_path=eq, n_perm=999, seed=42)
+    assert r.label == "CONFIRMED", (
+        f"FIX-3 VIOLATED: large-n prior + 50σ outlier should yield "
+        f"CONFIRMED, got {r.label}. delta={r.delta_observed:+.4f}, "
+        f"band={r.band:.4f}, p={r.p_value:.4f}."
+    )
+    assert r.p_value < 0.05, (
+        f"FIX-3 VIOLATED: p={r.p_value} unexpectedly large for outlier "
+        f"signal. delta={r.delta_observed}, band={r.band}."
+    )
+
+
+def test_label_is_strictly_binary(tmp_path: Path) -> None:
+    """Labels must be REJECT or CONFIRMED — never AMBIGUOUS / PENDING / etc."""
+    rng = np.random.default_rng(11)
+    full = rng.normal(loc=0.0, scale=0.01, size=20)
+    eq = _equity_csv_from_returns(tmp_path / "equity.csv", full)
+    r = evaluate(20, equity_path=eq, n_perm=499, seed=42)
+    assert r.label in {
+        "REJECT",
+        "CONFIRMED",
+    }, f"FIX-3 VIOLATED: label must be strictly binary (REJECT or CONFIRMED), got {r.label!r}."
+
+
+def test_too_few_returns_raises(tmp_path: Path) -> None:
+    """Bar=2 → n_returns=1 → cannot run mechanical null → ValueError."""
+    eq = _equity_csv_from_returns(tmp_path / "equity.csv", np.array([0.001, 0.001]))
+    with pytest.raises(ValueError, match=r"requires >= 3 returns"):
+        evaluate(2, equity_path=eq, n_perm=99, seed=42)
+
+
+def test_missing_paper_state_raises(tmp_path: Path) -> None:
+    """Absent paper-state ledger → FileNotFoundError, no silent default."""
+    with pytest.raises(FileNotFoundError):
+        evaluate(15, equity_path=tmp_path / "nonexistent.csv")


### PR DESCRIPTION
## Creator
New `geosync.dp3_test` module replaces the informal "31 % staleness recovery" claim with a registered mechanical-null permutation protocol. Verdict is strictly binary REJECT / CONFIRMED with explicit p-value.

## Critic
- **Edge-case 1** — bootstrap mechanical null collapses if prior returns are degenerate (constant). evaluate() guards via finite-mask + ValueError on empty mech distribution.
- **Edge-case 2** — at very small n the test underpowers (no signal CAN be CONFIRMED). Acceptable: REJECT means "not distinguishable from mechanics", which is the correct epistemic state at n=14.
- **Edge-case 3** — the `--honest` CLI flag is enforced via argparse error, not via Python attribute. A direct `from geosync.dp3_test import evaluate` bypasses the flag — by design (library callers, including the test suite, must opt in to the contract via the test file).
- **Risk** — observed Δ that hugs the band edge could flip on small re-permutations. Mitigated by 999 paths default + fixed seed; the `band` constant is exposed as `BAND_K=2.0` for adversarial tightening.

## Auditor
**Falsification gate (FIX-3):** synthetic series whose final bar is exactly the prior-mean (zero novel signal) MUST yield REJECT. Synthetic series with large-n prior + extreme outlier MUST yield CONFIRMED with p<0.05.

**False-positive avoidance:**
- `test_label_is_strictly_binary` asserts no AMBIGUOUS/PENDING label can leak in.
- The acceptor's falsifier probe ensures the `--honest` flag is required.
- The 999-path bootstrap + 2σ band makes spurious CONFIRMED unlikely without a genuine effect.

## Verifier
\`\`\`
\$ python -m geosync.dp3_test --honest
DP3 BAR 15 | Sharpe(N-1)=-5.8895 → Sharpe(N)=-3.9154 | Δ=+1.9741 | band(2σ)=2.0469 | p=0.0741 | LABEL REJECT | n_returns=14

\$ python -m geosync.dp3_test --honest --json
{\"band\": 2.04..., \"bar\": 15, \"delta_observed\": 1.97..., \"label\": \"REJECT\", \"n_returns\": 14, \"p_value\": 0.0741, \"sharpe_full\": -3.92..., \"sharpe_prior\": -5.89...}

\$ pytest tests/scripts/test_dp3_test.py -x -q
.....                                                            [100%]
5 passed
\`\`\`

The earlier "31 % recovery" attribution is hereby retracted as NULL_PENDING_TEST. The +1.97 Δ is INSIDE the mechanical small-n null (band=2.05) — confirming the user's self-audit that the original claim was false confidence on n=1.