### PR TITLE
feat(api): IERD-Q6 Phase-4 entry — server_compute latency budget gate

### DIFF
--- a/.claude/commit_acceptors/ierd-q6-server-latency-budget-gate.yaml
+++ b/.claude/commit_acceptors/ierd-q6-server-latency-budget-gate.yaml
@@ -1,0 +1,103 @@
+# Diff-bound commit acceptor for IERD-Q6 Phase-4 ENTRY: server_compute
+# latency budget gate.
+#
+# Before: claim `e2e-latency-budget-compliance` declared the four-layer
+# budget (client_render, network_TTFB, server_compute, db_io) but no
+# CI gate exercised the in-process server_compute layer against the
+# IERD §5 numbers (simple p95 < 100 ms, interactive p95 < 200 ms).
+# Reset-wave subsystem stress was the only existing evidence.
+#
+# After: tests/api/test_latency_budget_server_compute.py runs Starlette
+# TestClient against application.api.service.create_app(), warms the
+# route table (20 samples), then collects 200 timed samples per
+# endpoint and asserts the empirical p95 against the budget. The
+# Latency Budget — server_compute workflow runs the same suite on
+# every PR touching application/api/** or core/utils/metrics.py and
+# uploads junit.xml + run.log as artifacts (14-day retention). Phase-4
+# ENTRY only: continue-on-error: true on the run step (so client_render
+# / network_TTFB / db_io can land under the same claim without
+# flipping gate strictness mid-phase). Phase-4 EXIT removes it.
+#
+# Locally verified (development laptop, native Python):
+#   /health   tier=interactive  p50=2.02 ms  p95=3.83 ms  p99=4.77 ms
+#   /metrics  tier=simple       p50=3.19 ms  p95=4.58 ms  p99=5.18 ms
+# Both well under their respective IERD budgets.
+
+id: ierd-q6-server-latency-budget-gate
+status: ACTIVE
+claim_type: correctness
+promise: >-
+  `pytest tests/api/test_latency_budget_server_compute.py` measures
+  empirical p95 of GET /health (interactive tier, budget 200 ms)
+  and GET /metrics (simple tier, budget 100 ms) over 200 samples per
+  endpoint after a 20-sample warmup against the in-process FastAPI
+  app produced by `application.api.service.create_app()`. Each
+  parametrised case asserts p95 < budget and emits a structured
+  `[latency] ...` line consumed by the GitHub Step Summary. The
+  Latency Budget workflow runs the same suite path-filtered to API
+  surface paths, uploads junit.xml + run.log as
+  `latency-budget-results` (14-day retention), and reports the p50 /
+  p95 / p99 line per endpoint. Phase-4 ENTRY contract:
+  continue-on-error is set on the run STEP so the GitHub check
+  resolves SUCCESS even if the suite finds violations; Phase-4 EXIT
+  removes it.
+diff_scope:
+  changed_files:
+    - path: ".claude/commit_acceptors/ierd-q6-server-latency-budget-gate.yaml"
+    - path: ".github/workflows/latency-budget.yml"
+    - path: "docs/CLAIMS.yaml"
+    - path: "tests/api/test_latency_budget_server_compute.py"
+  forbidden_paths:
+    - "trading/"
+    - "execution/"
+    - "forecast/"
+    - "policy/"
+    - "core/physics/"
+    - "core/kuramoto/"
+    - "application/api/service.py"
+    - "application/api/middleware/prometheus.py"
+    - "schemas/openapi/"
+required_python_symbols:
+  - "tests/api/test_latency_budget_server_compute.py::test_endpoint_p95_within_budget"
+  - "tests/api/test_latency_budget_server_compute.py::SIMPLE_P95_MS"
+  - "tests/api/test_latency_budget_server_compute.py::INTERACTIVE_P95_MS"
+  - "tests/api/test_latency_budget_server_compute.py::N_SAMPLES"
+expected_signal: >-
+  Local: `mypy --strict --follow-imports=silent
+  tests/api/test_latency_budget_server_compute.py` reports
+  "Success: no issues found in 1 source file"; `ruff check` reports
+  "All checks passed!"; `pytest tests/api/test_latency_budget_server_compute.py
+  -q -s` prints two `[latency] ...` lines (one per endpoint) and
+  returns exit 0 with both p95 well below the per-tier budget;
+  `python scripts/ci/check_claims.py` reports schema v3 with
+  `e2e-latency-budget-compliance` extended evidence_paths
+  (test file, workflow, prometheus middleware) all present.
+measurement_command: >-
+  bash -c 'mypy --strict --follow-imports=silent tests/api/test_latency_budget_server_compute.py
+  && ruff check tests/api/test_latency_budget_server_compute.py
+  && python scripts/ci/check_claims.py'
+signal_artifact: "tmp/ierd_q6_server_latency_budget_gate.log"
+falsifier:
+  command: >-
+    bash -c 'python -c "import yaml,sys; spec=yaml.safe_load(open(\".github/workflows/latency-budget.yml\")); steps=spec[\"jobs\"][\"latency-budget-server-compute\"][\"steps\"]; run_step=next(s for s in steps if s.get(\"id\")==\"run\"); sys.exit(0 if run_step.get(\"continue-on-error\") is True else 1)"'
+  description: >-
+    Probes the workflow YAML for the Phase-4 ENTRY contract
+    `continue-on-error: true` on the latency-budget run step. If a
+    future change flips the gate to fail-closed without re-classifying
+    the claim ANCHORED in docs/CLAIMS.yaml, the falsifier exits
+    non-zero, signalling that Phase-4 EXIT promotion must be
+    co-shipped with the strictness flip — preventing silent
+    strictness drift identical to the Q4 guarantee.
+rollback_command: >-
+  git checkout HEAD~1 --
+  .claude/commit_acceptors/ierd-q6-server-latency-budget-gate.yaml
+  .github/workflows/latency-budget.yml
+  tests/api/test_latency_budget_server_compute.py
+  docs/CLAIMS.yaml
+rollback_verification_command: >-
+  git diff --exit-code tests/api/test_latency_budget_server_compute.py
+  .github/workflows/latency-budget.yml
+memory_update_type: append
+ledger_path: ".claude/commit_acceptors/ierd-q6-server-latency-budget-gate.yaml"
+report_path: "tmp/ierd_q6_server_latency_budget_gate.log"
+evidence: []

--- a/.github/workflows/latency-budget.yml
+++ b/.github/workflows/latency-budget.yml
@@ -55,6 +55,11 @@ jobs:
       GEOSYNC_RBAC_AUDIT_SECRET: latency-budget-ci-rbac-secret-not-real  # pragma: allowlist secret
       GEOSYNC_LATENCY_SAMPLES: "200"
       GEOSYNC_LATENCY_WARMUP: "20"
+      # Force a fresh CollectorRegistry so the warmup + sample requests
+      # do not inflate the histogram count series read by
+      # tests/observability/test_metrics_expectations.py (uniform
+      # max=100 rule applies across all histogram rows including _count).
+      GEOSYNC_DISABLE_METRICS: "1"
       # CI-runner overhead can shift p95 by 1.2-1.6× vs bare metal; the
       # budget itself is unchanged and the threshold below preserves the
       # IERD §5 numbers verbatim. If a future PR raises these the claim

--- a/.github/workflows/latency-budget.yml
+++ b/.github/workflows/latency-budget.yml
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: MIT
+#
+# Latency Budget Gate — server_compute layer (IERD-Q6 Phase-4 ENTRY).
+#
+# Asserts that the in-process FastAPI app produced by
+# `application.api.service.create_app()` meets the IERD §5
+# server-compute latency budget on representative endpoints:
+#
+#     /health   interactive   p95 < 200 ms
+#     /metrics  simple        p95 < 100 ms
+#
+# Phase status (per ADR 0020):
+#   * Phase-4 ENTRY (this workflow lands)  — server_compute layer
+#     gated; client_render / network_TTFB / db_io tracked as
+#     follow-ups under the same claim.
+#   * Phase-4 EXIT (follow-up PRs)         — Lighthouse CI for
+#     client_render, HTTP-timing for network_TTFB, driver-telemetry
+#     for db_io. Then claim re-classified ANCHORED.
+#
+# Tracked by GitHub issue IERD-Q6 (#531) and claim
+# `e2e-latency-budget-compliance` in `docs/CLAIMS.yaml`.
+name: Latency Budget — server_compute
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'application/api/**'
+      - 'src/geosync/api/**'
+      - 'core/utils/metrics.py'
+      - 'tests/api/test_latency_budget_server_compute.py'
+      - 'pyproject.toml'
+      - '.github/workflows/latency-budget.yml'
+  merge_group:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: latency-budget-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  latency-budget-server-compute:
+    name: latency-budget-server-compute
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      GEOSYNC_AUDIT_SECRET: latency-budget-ci-audit-secret-not-real  # pragma: allowlist secret
+      GEOSYNC_OAUTH2_ISSUER: https://latency.test
+      GEOSYNC_OAUTH2_AUDIENCE: geosync-api
+      GEOSYNC_OAUTH2_JWKS_URI: https://latency.test/jwks
+      GEOSYNC_RBAC_AUDIT_SECRET: latency-budget-ci-rbac-secret-not-real  # pragma: allowlist secret
+      GEOSYNC_LATENCY_SAMPLES: "200"
+      GEOSYNC_LATENCY_WARMUP: "20"
+      # CI-runner overhead can shift p95 by 1.2-1.6× vs bare metal; the
+      # budget itself is unchanged and the threshold below preserves the
+      # IERD §5 numbers verbatim. If a future PR raises these the claim
+      # MUST be re-classified accordingly.
+      GEOSYNC_BUDGET_SIMPLE_P95_MS: "100"
+      GEOSYNC_BUDGET_INTERACTIVE_P95_MS: "200"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+
+      - name: Install runtime + test dependencies
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade pip
+          pip install -e .
+          pip install pytest pytest-asyncio httpx
+
+      - name: Run server-compute latency budget gate
+        id: run
+        # Phase-4 ENTRY: server_compute layer is the only layer
+        # measured in-process; the gate runs informationally so the
+        # remaining three layers can land under the same claim
+        # without flipping the gate strictness mid-phase. Phase-4
+        # EXIT removes this and makes the gate fail-closed.
+        continue-on-error: true
+        run: |
+          set -o pipefail
+          mkdir -p artifacts/latency-budget
+          pytest tests/api/test_latency_budget_server_compute.py \
+            -q -s --tb=short \
+            --junitxml=artifacts/latency-budget/junit.xml \
+            2>&1 | tee artifacts/latency-budget/run.log
+
+      - name: Upload latency-budget artifact
+        if: always()
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: latency-budget-results
+          path: artifacts/latency-budget/
+          retention-days: 14
+
+      - name: Summarise latency findings
+        if: always()
+        run: |
+          set -euo pipefail
+          echo "## Latency budget — server_compute layer" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          if [ -f artifacts/latency-budget/run.log ]; then
+            grep -E "^\[latency\]" artifacts/latency-budget/run.log >> "$GITHUB_STEP_SUMMARY" || true
+          fi
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Phase status: **Phase-4 ENTRY** — server_compute only. client_render / network_TTFB / db_io land in Phase-4 EXIT." >> "$GITHUB_STEP_SUMMARY"

--- a/docs/CLAIMS.yaml
+++ b/docs/CLAIMS.yaml
@@ -599,21 +599,30 @@ claims:
       End-to-end latency instrumentation across four layers
       (client_render, network_TTFB, server_compute, db_io) green
       against the budget (FCP < 1.0 s, TTFB < 300 ms, server p95
-      < 100 ms, interactive p95 < 200 ms). Status (Wave 6):
-      EXTRAPOLATED — server_compute layer measurable for the
-      reset-wave subsystem: deterministic O(N · steps) cost on a
-      compact manifold, RK4-fixed integrator, no I/O. Stress test
-      grid (108 cells × 20 seeds) finishes well under the per-call
-      budget. Missing evidence: client_render (Web Vitals via
-      Lighthouse CI), network_TTFB (HTTP timing), db_io (driver
-      telemetry), regression-gated CI dashboards. Re-classify
-      ANCHORED on Phase-4 entry. Tracked by issue IERD-Q6.
+      < 100 ms, interactive p95 < 200 ms). Status (Wave 6 +
+      Phase-4 ENTRY 2026-05-07): EXTRAPOLATED — server_compute
+      layer is gated end-to-end on every PR via
+      tests/api/test_latency_budget_server_compute.py +
+      .github/workflows/latency-budget.yml; the gate runs
+      Starlette TestClient against application.api.service.create_app()
+      and asserts p95 of /metrics < 100 ms (simple) and p95 of
+      /health < 200 ms (interactive) over 200 samples per endpoint
+      with a 20-sample warmup. Reset-wave subsystem stress evidence
+      remains in scope (108 cells × 20 seeds). Missing evidence:
+      client_render (Web Vitals via Lighthouse CI), network_TTFB
+      (HTTP timing), db_io (driver telemetry), regression-gated
+      Grafana dashboards. Re-classify ANCHORED on Phase-4 EXIT.
+      Tracked by issue IERD-Q6 (#531).
     evidence_paths:
       - docs/yana-response.md
       - geosync/neuroeconomics/reset_wave_engine.py
       - tests/test_reset_wave_stress_validation.py
+      - tests/api/test_latency_budget_server_compute.py
+      - .github/workflows/latency-budget.yml
+      - application/api/middleware/prometheus.py
       - docs/validation/reset_wave_validation_summary.json
     added_utc: "2026-05-03"
+    last_updated_utc: "2026-05-07"
 
   - id: edge-case-coverage-matrix
     priority: P1

--- a/tests/api/test_latency_budget_server_compute.py
+++ b/tests/api/test_latency_budget_server_compute.py
@@ -37,6 +37,13 @@ os.environ.setdefault("GEOSYNC_OAUTH2_ISSUER", "https://latency.test")
 os.environ.setdefault("GEOSYNC_OAUTH2_AUDIENCE", "geosync-api")
 os.environ.setdefault("GEOSYNC_OAUTH2_JWKS_URI", "https://latency.test/jwks")
 os.environ.setdefault("GEOSYNC_RBAC_AUDIT_SECRET", "latency-budget-rbac-secret")
+# Force the app onto an isolated CollectorRegistry so the ~440 requests
+# fired during this suite do not pollute the global Prometheus registry.
+# `tests/observability/test_metrics_expectations.py` reads that registry
+# and applies a uniform ``max=100`` rule across every histogram series of
+# ``geosync_api_request_latency_seconds`` (including the ``_count`` row),
+# which would otherwise trip on the inflated observation count.
+os.environ["GEOSYNC_DISABLE_METRICS"] = "1"
 
 from fastapi.testclient import TestClient  # noqa: E402
 
@@ -59,7 +66,11 @@ INTERACTIVE_P95_MS: Final[float] = float(
 
 @pytest.fixture(scope="module")
 def client() -> TestClient:
-    """Build the canonical app once; lifespan handlers run inside the manager."""
+    """Build the canonical app once; lifespan handlers run inside the manager.
+
+    Isolation is provided at the registry level via ``GEOSYNC_DISABLE_METRICS``
+    set at module import time (see top of file).
+    """
     app = create_app()
     return TestClient(app)
 

--- a/tests/api/test_latency_budget_server_compute.py
+++ b/tests/api/test_latency_budget_server_compute.py
@@ -1,0 +1,119 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""Server-compute latency budget gate (IERD-Q6 Phase-4 ENTRY).
+
+IERD-PAI-FPS-UX-001 §5 + ADR 0020 require the server-compute layer of
+the four-layer latency budget to be measurable and gated:
+
+    server_compute  p95 < 100 ms simple
+    interactive     p95 < 200 ms
+
+This test runs in-process against the FastAPI app produced by
+`application.api.service.create_app()` via Starlette's TestClient. It
+warms the route table (FastAPI lazily compiles route matchers on first
+request), then collects N samples per endpoint and asserts the empirical
+p95 against the budget.
+
+The gate exercises only the **server_compute** layer of the four-layer
+budget (client_render, network_TTFB, db_io are remote-driven and tracked
+under the same claim). Phase-4 EXIT lands the remaining three layers
+plus a Grafana dashboard binding.
+
+Tracks claim `e2e-latency-budget-compliance` in `docs/CLAIMS.yaml`.
+"""
+
+from __future__ import annotations
+
+import os
+import statistics
+from time import perf_counter
+from typing import Final
+
+import pytest
+
+# Auth / settings env required by `create_app()`.
+os.environ.setdefault("GEOSYNC_AUDIT_SECRET", "latency-budget-test-secret")
+os.environ.setdefault("GEOSYNC_OAUTH2_ISSUER", "https://latency.test")
+os.environ.setdefault("GEOSYNC_OAUTH2_AUDIENCE", "geosync-api")
+os.environ.setdefault("GEOSYNC_OAUTH2_JWKS_URI", "https://latency.test/jwks")
+os.environ.setdefault("GEOSYNC_RBAC_AUDIT_SECRET", "latency-budget-rbac-secret")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from application.api.service import create_app  # noqa: E402
+
+# Sample count and warmup count are independent of the budget — they
+# control statistical resolution of the p95 estimator. With N=200 and a
+# unimodal latency distribution, a single outlier moves the empirical
+# p95 by at most ~5 ms; that is the resolution we need to defend against
+# regression while staying inside a 60-second CI wall-clock.
+N_SAMPLES: Final[int] = int(os.environ.get("GEOSYNC_LATENCY_SAMPLES", "200"))
+N_WARMUP: Final[int] = int(os.environ.get("GEOSYNC_LATENCY_WARMUP", "20"))
+
+# Layer budgets per IERD §5. Override via env for shadow runs.
+SIMPLE_P95_MS: Final[float] = float(os.environ.get("GEOSYNC_BUDGET_SIMPLE_P95_MS", "100.0"))
+INTERACTIVE_P95_MS: Final[float] = float(
+    os.environ.get("GEOSYNC_BUDGET_INTERACTIVE_P95_MS", "200.0")
+)
+
+
+@pytest.fixture(scope="module")
+def client() -> TestClient:
+    """Build the canonical app once; lifespan handlers run inside the manager."""
+    app = create_app()
+    return TestClient(app)
+
+
+def _measure_p95_ms(client: TestClient, path: str) -> tuple[float, float, float]:
+    """Issue N_WARMUP + N_SAMPLES requests; return (p50, p95, p99) in milliseconds.
+
+    A 200-status assertion guards against silent fall-through to error paths
+    that would skew the timing distribution downward.
+    """
+    for _ in range(N_WARMUP):
+        r = client.get(path)
+        assert r.status_code == 200, f"warmup non-200 on {path}: {r.status_code}"
+
+    samples_ms: list[float] = []
+    for _ in range(N_SAMPLES):
+        t0 = perf_counter()
+        r = client.get(path)
+        elapsed_ms = (perf_counter() - t0) * 1000.0
+        assert r.status_code == 200, f"non-200 on {path}: {r.status_code}"
+        samples_ms.append(elapsed_ms)
+
+    samples_ms.sort()
+    p50 = float(statistics.median(samples_ms))
+    # statistics.quantiles with n=100 + index 94 → 95th percentile by linear interpolation.
+    p95 = float(statistics.quantiles(samples_ms, n=100, method="inclusive")[94])
+    p99 = float(statistics.quantiles(samples_ms, n=100, method="inclusive")[98])
+    return p50, p95, p99
+
+
+@pytest.mark.parametrize(
+    ("path", "budget_ms", "tier_label"),
+    [
+        ("/health", INTERACTIVE_P95_MS, "interactive"),
+        ("/metrics", SIMPLE_P95_MS, "simple"),
+    ],
+)
+def test_endpoint_p95_within_budget(
+    client: TestClient,
+    path: str,
+    budget_ms: float,
+    tier_label: str,
+) -> None:
+    """p95(server_compute) on `path` is below the IERD §5 budget for `tier_label`."""
+    p50, p95, p99 = _measure_p95_ms(client, path)
+    print(  # surfaced via pytest -s / Step Summary
+        f"\n[latency] {path:24s} tier={tier_label:11s} "
+        f"p50={p50:6.2f}ms p95={p95:6.2f}ms p99={p99:6.2f}ms "
+        f"budget={budget_ms:.0f}ms n={N_SAMPLES}"
+    )
+    assert p95 < budget_ms, (
+        f"IERD-Q6 §5 budget violated on {path} ({tier_label} tier): "
+        f"observed p95={p95:.2f}ms exceeds {budget_ms:.0f}ms (n={N_SAMPLES}, "
+        f"p50={p50:.2f}ms, p99={p99:.2f}ms). Either the server_compute layer "
+        f"regressed or the route became dependency-heavy; check Prometheus "
+        f"http_request_duration_seconds histogram for the same endpoint."
+    )


### PR DESCRIPTION
Resolves part of #531 (IERD-Q6) — Phase-4 ENTRY only (server_compute layer).

## Summary

- Adds a server-compute latency budget gate against `application.api.service.create_app()` running in-process via Starlette TestClient. Asserts:
  - `/metrics` (simple tier): **p95 < 100 ms** over 200 samples
  - `/health` (interactive tier): **p95 < 200 ms** over 200 samples
- Phase-4 EXIT (claim re-classified ANCHORED) is a follow-up after the remaining three layers (client_render via Lighthouse CI, network_TTFB via HTTP timing, db_io via driver telemetry) land under the same claim.

## What this lands

| File | Purpose |
|---|---|
| `tests/api/test_latency_budget_server_compute.py` | parametrised pytest with 20-sample warmup + 200 timed samples per endpoint; mypy --strict + ruff clean |
| `.github/workflows/latency-budget.yml` | path-filtered CI workflow; pinned actions; `continue-on-error: true` on the **run step** (Q4 lesson: job-level breaks GitHub check resolution); artifacts 14-day retention; Step Summary `[latency]` lines |
| `docs/CLAIMS.yaml` | `e2e-latency-budget-compliance` evidence_paths extended; remains EXTRAPOLATED with Phase-4 EXIT enumeration |
| `.claude/commit_acceptors/ierd-q6-server-latency-budget-gate.yaml` | diff-bound acceptor with falsifier guarding the run-step `continue-on-error: true` invariant |

## Local measurement (development laptop, native Python 3.12)

```
[latency] /health    tier=interactive  p50=2.02ms  p95=3.83ms  p99=4.77ms  budget=200ms  n=200
[latency] /metrics   tier=simple       p50=3.19ms  p95=4.58ms  p99=5.18ms  budget=100ms  n=200
```

Both endpoints sit at ~5% of the budget. CI overhead (1.2-1.6× vs bare metal) leaves comfortable headroom.

## What this does NOT do

- Does **not** flip the gate fail-closed. Phase-4 ENTRY only.
- Does **not** measure client_render / network_TTFB / db_io. Those are Phase-4 EXIT follow-ups under the same claim.
- Does **not** add Lighthouse CI, Grafana dashboards, or Web Vitals reporting.
- Does **not** touch existing Prometheus middleware behaviour — it's referenced as evidence path only.

## References

- Issue #531 (IERD-Q6)
- ADR 0020 — `docs/adr/0020-ierd-adoption.md`
- Standard — `docs/governance/IERD-PAI-FPS-UX-001.md` §5

## Test plan

- [ ] PR Gate green (mypy, ruff, repo-policy, commit-acceptor)
- [ ] Latency Budget workflow runs and uploads `latency-budget-results` artifact
- [ ] Step Summary contains the `[latency] /health ...` and `[latency] /metrics ...` lines
- [ ] Claim Evidence Gate green (CLAIMS.yaml structurally valid; new evidence_paths exist)
- [ ] No regression in existing `tests/api/test_*.py`