### PR TITLE
feat(governance): typed Pydantic v2 models for claim ledger + commit acceptor

### DIFF
--- a/.claude/commit_acceptors/governance-typed-models.yaml
+++ b/.claude/commit_acceptors/governance-typed-models.yaml
@@ -1,0 +1,113 @@
+# Diff-bound commit acceptor for the typed-governance package.
+#
+# Before: docs/CLAIMS.yaml (v3, 27 claims) and the
+# .claude/commit_acceptors/*.yaml corpus (29 active acceptors with 17
+# top-level fields) were parsed via dict access in
+# scripts/ci/check_claims.py and tools/commit_acceptor/validate_commit_acceptor.py.
+# Adding a field to either schema required edits in 3+ Python files;
+# silent drift was the dominant failure mode (no extra='forbid' guard).
+#
+# After: application/governance/ ships Pydantic v2 models for both
+# schemas with extra='forbid' enforcement, frozen instances, structured
+# round-trip tests against the canonical corpus, and JSON Schema export.
+# The legacy parsers continue to work unchanged; this PR is additive
+# and refactor-free at the consumption side.
+#
+# Locally verified:
+#   * mypy --strict + ruff: clean
+#   * pytest tests/governance/test_typed_models.py: 12/12 pass
+#   * load_claim_ledger('docs/CLAIMS.yaml'): schema_v3, 27 claims,
+#     21 ANCHORED, 6 EXTRAPOLATED, 0 SPECULATIVE/UNKNOWN
+#   * load_all_commit_acceptors('.claude/commit_acceptors'):
+#     29 acceptors, all ACTIVE
+
+id: governance-typed-models
+status: ACTIVE
+claim_type: governance
+promise: >-
+  application.governance ships two Pydantic v2 models (ClaimLedger,
+  CommitAcceptor) that round-trip the canonical docs/CLAIMS.yaml and
+  every .claude/commit_acceptors/*.yaml without modification. Both
+  models are frozen with extra='forbid' so future schema-drift
+  surfaces as a hard ValidationError rather than a silent drop.
+  application.governance.load_claim_ledger and
+  load_all_commit_acceptors / load_commit_acceptor are the canonical
+  loaders. JSON Schema export via model_json_schema() is consumable
+  by IDE tooling and external auditors. No legacy parser is removed
+  in this PR — the package is additive and refactor-free at the
+  consumption side; downstream migration of check_claims.py and
+  validate_commit_acceptor.py to the typed model is a follow-up.
+diff_scope:
+  changed_files:
+    - path: ".claude/commit_acceptors/governance-typed-models.yaml"
+    - path: "application/governance/__init__.py"
+    - path: "application/governance/claim_ledger.py"
+    - path: "application/governance/commit_acceptor.py"
+    - path: "tests/governance/test_typed_models.py"
+  forbidden_paths:
+    - "trading/"
+    - "execution/"
+    - "forecast/"
+    - "policy/"
+    - "core/physics/"
+    - "core/kuramoto/"
+    - "scripts/ci/check_claims.py"
+    - "tools/commit_acceptor/validate_commit_acceptor.py"
+    - ".claude/commit_acceptor_policy.yaml"
+required_python_symbols:
+  - "application/governance/claim_ledger.py::ClaimLedger"
+  - "application/governance/claim_ledger.py::ClaimEntry"
+  - "application/governance/claim_ledger.py::Falsifier"
+  - "application/governance/claim_ledger.py::Tier"
+  - "application/governance/claim_ledger.py::Priority"
+  - "application/governance/claim_ledger.py::load_claim_ledger"
+  - "application/governance/commit_acceptor.py::CommitAcceptor"
+  - "application/governance/commit_acceptor.py::DiffScope"
+  - "application/governance/commit_acceptor.py::AcceptorFalsifier"
+  - "application/governance/commit_acceptor.py::load_commit_acceptor"
+  - "application/governance/commit_acceptor.py::load_all_commit_acceptors"
+  - "tests/governance/test_typed_models.py::test_canonical_claim_ledger_parses"
+  - "tests/governance/test_typed_models.py::test_canonical_acceptor_corpus_parses"
+  - "tests/governance/test_typed_models.py::test_claim_entry_rejects_unknown_field"
+  - "tests/governance/test_typed_models.py::test_commit_acceptor_rejects_unknown_field"
+expected_signal: >-
+  Local: `mypy --strict --follow-imports=silent application/governance/`
+  reports "Success: no issues found in 3 source files"; `ruff check
+  application/governance/` reports "All checks passed!"; `pytest
+  tests/governance/test_typed_models.py -q` reports "12 passed".
+  `python -c "from application.governance import load_claim_ledger,
+  load_all_commit_acceptors; l = load_claim_ledger('docs/CLAIMS.yaml');
+  a = load_all_commit_acceptors('.claude/commit_acceptors');
+  print(len(l.claims), len(a))"` prints "27 29".
+measurement_command: >-
+  bash -c 'mypy --strict --follow-imports=silent application/governance
+  && ruff check application/governance tests/governance/test_typed_models.py
+  && python -m pytest tests/governance/test_typed_models.py -q'
+signal_artifact: "tmp/governance_typed_models.log"
+falsifier:
+  command: >-
+    bash -c 'python -c "from application.governance import ClaimEntry; from pydantic import ValidationError; import sys; sample={\"id\": \"t\", \"priority\": \"P0\", \"tier\": \"ANCHORED\", \"description\": \"x\", \"added_utc\": \"2026-05-07\", \"surprise\": True};
+    try:
+      ClaimEntry.model_validate(sample); sys.exit(1)
+    except ValidationError:
+      sys.exit(0)
+    "'
+  description: >-
+    Probes the extra='forbid' guard on ClaimEntry. If a future
+    change relaxes the model to allow unknown fields, the falsifier
+    succeeds (ClaimEntry accepts surprise field), exits 1, and the
+    invariant is broken. Re-introducing extra='allow' silently is
+    the historical drift surface this acceptor exists to prevent.
+rollback_command: >-
+  git checkout HEAD~1 --
+  application/governance/__init__.py
+  application/governance/claim_ledger.py
+  application/governance/commit_acceptor.py
+  tests/governance/test_typed_models.py
+  .claude/commit_acceptors/governance-typed-models.yaml
+rollback_verification_command: >-
+  bash -c 'test ! -d application/governance && test ! -f tests/governance/test_typed_models.py'
+memory_update_type: append
+ledger_path: ".claude/commit_acceptors/governance-typed-models.yaml"
+report_path: "tmp/governance_typed_models.log"
+evidence: []

--- a/application/governance/__init__.py
+++ b/application/governance/__init__.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""Typed governance schemas for IERD-PAI-FPS-UX-001.
+
+Single source of truth for the two YAML schemas that drive the
+GeoSync governance layer:
+
+* ``docs/CLAIMS.yaml``                       → ClaimLedger / ClaimEntry / Falsifier
+* ``.claude/commit_acceptors/*.yaml``        → CommitAcceptor
+
+Replaces hand-rolled dict access in ``scripts/ci/check_claims.py`` and
+``tools/commit_acceptor/validate_commit_acceptor.py``. Pydantic v2
+performs validation at model construction time; the JSON Schema
+export under :func:`json_schemas` is consumable by IDEs and external
+auditors without re-parsing the YAML.
+"""
+
+from __future__ import annotations
+
+from application.governance.claim_ledger import (
+    ClaimEntry,
+    ClaimLedger,
+    Falsifier,
+    Priority,
+    Tier,
+    load_claim_ledger,
+)
+from application.governance.commit_acceptor import (
+    AcceptorFalsifier,
+    CommitAcceptor,
+    DiffScope,
+    load_all_commit_acceptors,
+    load_commit_acceptor,
+)
+
+__all__ = [
+    "AcceptorFalsifier",
+    "ClaimEntry",
+    "ClaimLedger",
+    "CommitAcceptor",
+    "DiffScope",
+    "Falsifier",
+    "Priority",
+    "Tier",
+    "load_all_commit_acceptors",
+    "load_claim_ledger",
+    "load_commit_acceptor",
+]

--- a/application/governance/claim_ledger.py
+++ b/application/governance/claim_ledger.py
@@ -1,0 +1,212 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""Typed model for ``docs/CLAIMS.yaml`` (schema v3, IERD-PAI-FPS-UX-001).
+
+The schema declares every claim (engineering invariant the project
+makes about itself) along with its tier, evidence paths, priority,
+and — for v3 ANCHORED claims — a falsifier block whose ``test_id``
+must be a real pytest node.
+
+The Pydantic v2 model below is the single source of truth. Validators
+in ``scripts/ci/`` and ``tools/commit_acceptor/`` consume the typed
+model rather than re-parsing dicts. The JSON Schema export
+(``ClaimLedger.model_json_schema()``) is published for external
+auditors and IDE autocompletion.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import date
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+import yaml
+from pydantic import BaseModel, ConfigDict, Field, StringConstraints, field_validator
+from typing_extensions import Annotated
+
+# ---------------------------------------------------------------------------
+# Constants — mirror scripts/ci/check_claims.py (single source of truth here)
+# ---------------------------------------------------------------------------
+
+SCHEMA_VERSION_LATEST = 3
+SCHEMA_VERSIONS_SUPPORTED = frozenset({1, 2, 3})
+
+ID_PATTERN = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+INV_PATTERN = re.compile(r"^INV-[A-Z0-9][A-Z0-9]*(?:-[A-Za-z0-9]+)*$")
+DATE_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+PYTEST_NODE_PATTERN = re.compile(r"^[\w./\-]+\.py(::[A-Za-z_][\w]*)+$")
+
+
+class Tier(str, Enum):
+    """IERD claim tier ladder.
+
+    Strict ordering: an ANCHORED claim has a falsifier and CI evidence;
+    EXTRAPOLATED has partial evidence with a documented missing-evidence
+    list; SPECULATIVE / UNKNOWN are aspirational. The ``check_claims``
+    gate enforces ``tier ∈ {ANCHORED, EXTRAPOLATED} ⇒ all evidence
+    paths exist``.
+    """
+
+    ANCHORED = "ANCHORED"
+    EXTRAPOLATED = "EXTRAPOLATED"
+    SPECULATIVE = "SPECULATIVE"
+    UNKNOWN = "UNKNOWN"
+
+
+class Priority(str, Enum):
+    """Claim priority — gate scope.
+
+    P0 / P1 are gated (CI fails on missing evidence). P2 is warn-only.
+    """
+
+    P0 = "P0"
+    P1 = "P1"
+    P2 = "P2"
+
+
+ClaimId = Annotated[str, StringConstraints(pattern=ID_PATTERN.pattern, min_length=1)]
+IsoDate = Annotated[str, StringConstraints(pattern=DATE_PATTERN.pattern)]
+
+
+class Falsifier(BaseModel):
+    """v3 falsifier block — pytest node + invariants + failure signature.
+
+    Required on every v3 ANCHORED claim per ADR 0021. The ``test_id``
+    must be a resolvable pytest node id; ``invariants_cited`` must be a
+    non-empty list of ``INV-<NAME>`` identifiers; ``failure_signature``
+    is a free-form description of the assertion shape that must fire on
+    invariant violation.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True, str_strip_whitespace=True)
+
+    test_id: Annotated[str, StringConstraints(pattern=PYTEST_NODE_PATTERN.pattern)]
+    invariants_cited: tuple[str, ...] = Field(min_length=1)
+    failure_signature: str = Field(min_length=1)
+
+    @field_validator("invariants_cited")
+    @classmethod
+    def _check_invariants(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        for inv in value:
+            if not INV_PATTERN.match(inv):
+                raise ValueError(
+                    f"falsifier.invariants_cited entry {inv!r} must match {INV_PATTERN.pattern}"
+                )
+        return value
+
+
+class ClaimEntry(BaseModel):
+    """Single registry entry under ``claims:`` in the ledger.
+
+    The strict-mode ``extra='forbid'`` policy guards against silent
+    schema drift: any unknown field at the entry level is a hard error
+    (the historical gate would have ignored unknowns and produced
+    false-green runs).
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True, str_strip_whitespace=True)
+
+    id: ClaimId
+    priority: Priority
+    tier: Tier
+    description: str = Field(min_length=1)
+    evidence_paths: tuple[str, ...] = Field(default_factory=tuple)
+    added_utc: IsoDate
+    last_updated_utc: IsoDate | None = None
+    falsifier: Falsifier | None = None
+
+    @field_validator("added_utc", "last_updated_utc")
+    @classmethod
+    def _check_date_round_trip(cls, value: str | None) -> str | None:
+        if value is None:
+            return value
+        # round-trip via datetime.date so 2026-13-01 etc. fail
+        date.fromisoformat(value)
+        return value
+
+    @property
+    def is_gated(self) -> bool:
+        """Whether the gate enforces evidence-existence on this claim."""
+        return self.priority in (Priority.P0, Priority.P1)
+
+    @property
+    def requires_falsifier(self) -> bool:
+        """True iff schema v3 ANCHORED — falsifier block is mandatory."""
+        return self.tier is Tier.ANCHORED
+
+
+class ClaimLedger(BaseModel):
+    """Top-level shape of ``docs/CLAIMS.yaml``."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    schema_version: int = Field(ge=1, le=SCHEMA_VERSION_LATEST)
+    claims: tuple[ClaimEntry, ...]
+
+    @field_validator("schema_version")
+    @classmethod
+    def _check_schema_version(cls, value: int) -> int:
+        if value not in SCHEMA_VERSIONS_SUPPORTED:
+            raise ValueError(
+                f"schema_version={value} is outside the supported "
+                f"set {sorted(SCHEMA_VERSIONS_SUPPORTED)}"
+            )
+        return value
+
+    @field_validator("claims")
+    @classmethod
+    def _check_unique_ids(cls, value: tuple[ClaimEntry, ...]) -> tuple[ClaimEntry, ...]:
+        seen: set[str] = set()
+        for claim in value:
+            if claim.id in seen:
+                raise ValueError(f"duplicate claim id: {claim.id}")
+            seen.add(claim.id)
+        return value
+
+    def by_id(self, claim_id: str) -> ClaimEntry | None:
+        for claim in self.claims:
+            if claim.id == claim_id:
+                return claim
+        return None
+
+    def gated(self) -> tuple[ClaimEntry, ...]:
+        """Return claims subject to evidence-existence enforcement."""
+        return tuple(c for c in self.claims if c.is_gated)
+
+    def by_tier(self, tier: Tier) -> tuple[ClaimEntry, ...]:
+        return tuple(c for c in self.claims if c.tier is tier)
+
+    def tier_distribution(self) -> dict[Tier, int]:
+        counts = dict.fromkeys(Tier, 0)
+        for claim in self.claims:
+            counts[claim.tier] += 1
+        return counts
+
+
+def load_claim_ledger(path: str | Path) -> ClaimLedger:
+    """Parse + validate ``docs/CLAIMS.yaml``.
+
+    Raises ``pydantic.ValidationError`` on any schema violation, with a
+    structured ``loc`` path pointing to the bad field. This replaces
+    the hand-coded error reporting in ``scripts/ci/check_claims.py`` and
+    surfaces structural violations alongside content violations in a
+    single pass.
+    """
+    raw: Any = yaml.safe_load(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        raise ValueError(f"{path}: top-level must be a mapping, got {type(raw).__name__}")
+    return ClaimLedger.model_validate(raw)
+
+
+__all__ = [
+    "ClaimEntry",
+    "ClaimLedger",
+    "Falsifier",
+    "Priority",
+    "SCHEMA_VERSION_LATEST",
+    "SCHEMA_VERSIONS_SUPPORTED",
+    "Tier",
+    "load_claim_ledger",
+]

--- a/application/governance/commit_acceptor.py
+++ b/application/governance/commit_acceptor.py
@@ -1,0 +1,207 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""Typed model for ``.claude/commit_acceptors/*.yaml``.
+
+A commit acceptor binds a code change to a falsifiable promise: the
+diff scope (allowed / forbidden paths), required Python symbols,
+expected signal, an inverse-falsifier probe, and a rollback path. The
+``tools/commit_acceptor/validate_commit_acceptor.py`` validator
+consumes one acceptor per changed file and enforces:
+
+* every changed code file appears in some acceptor's ``changed_files``;
+* no file imports from a forbidden path (per
+  ``commit_acceptor_policy.yaml::forbidden_import_patterns``);
+* the falsifier exits non-zero only when the invariant is violated.
+
+The Pydantic v2 model below mirrors the YAML shape verbatim.
+``extra='forbid'`` guards against schema drift; loaders raise
+``pydantic.ValidationError`` on any mistyped field.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+import yaml
+from pydantic import BaseModel, ConfigDict, Field, StringConstraints, field_validator
+from typing_extensions import Annotated
+
+# Acceptor IDs use a relaxed pattern compared to claim IDs: existing
+# canonical files include uppercase prefixes (e.g. "T2b-stuart-landau-es")
+# from the physics-law naming convention. The lowercase-only ledger
+# constraint is preserved on ClaimEntry; acceptor IDs accept any
+# alphanumeric segments separated by dashes.
+ACCEPTOR_ID_PATTERN = r"^[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*$"
+AcceptorId = Annotated[str, StringConstraints(pattern=ACCEPTOR_ID_PATTERN, min_length=1)]
+
+
+class Status(str, Enum):
+    """Acceptor lifecycle status.
+
+    ACTIVE        — currently enforced.
+    DRAFT         — author iterating; gate is permissive.
+    VERIFIED      — landed and the falsifier has fired at least once.
+    REJECTED      — superseded; kept as audit trail.
+    """
+
+    ACTIVE = "ACTIVE"
+    DRAFT = "DRAFT"
+    VERIFIED = "VERIFIED"
+    REJECTED = "REJECTED"
+
+
+class ClaimType(str, Enum):
+    """Maps the acceptor to a policy file-count cap.
+
+    ``commit_acceptor_policy.yaml::max_changed_files_by_claim_type``
+    enforces a per-type ceiling so a 50-file refactor cannot ship
+    under ``correctness`` (cap 12) without explicit re-classification.
+    """
+
+    CORRECTNESS = "correctness"
+    DETERMINISM = "determinism"
+    FAIL_CLOSED = "fail_closed"
+    SECURITY = "security"
+    PERFORMANCE = "performance"
+    GOVERNANCE = "governance"
+    REFACTOR = "refactor"
+    DOCUMENTATION = "documentation"
+
+
+class MemoryUpdateType(str, Enum):
+    APPEND = "append"
+    REPLACE = "replace"
+    NONE = "none"
+
+
+class ChangedFile(BaseModel):
+    """One entry under ``diff_scope.changed_files:``."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, str_strip_whitespace=True)
+
+    path: str = Field(min_length=1)
+
+
+class DiffScope(BaseModel):
+    """The set of paths the acceptor binds.
+
+    ``changed_files``     — every file the PR is allowed to modify; the
+                            validator rejects any modified file outside
+                            this list (or another acceptor's list).
+    ``forbidden_paths``   — extra path-prefix denylist on top of the
+                            global policy. Any modified file under one
+                            of these prefixes is rejected.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    changed_files: tuple[ChangedFile, ...] = Field(min_length=1)
+    forbidden_paths: tuple[str, ...] = Field(default_factory=tuple)
+
+
+class AcceptorFalsifier(BaseModel):
+    """Inverse probe: the acceptor's invariant is broken iff this exits 0.
+
+    Distinct from the claim-ledger ``Falsifier`` (which points at a
+    pytest node). An acceptor falsifier is a one-shot shell command;
+    its non-zero exit means the invariant holds. Used by
+    ``compute_fps_audit`` and the local pre-PR loop.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True, str_strip_whitespace=True)
+
+    command: str = Field(min_length=1)
+    description: str = Field(min_length=1)
+
+
+class EvidenceEntry(BaseModel):
+    """Optional evidence attachment under ``evidence:``."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, str_strip_whitespace=True)
+
+    path: str = Field(min_length=1)
+    sha256: str | None = None
+
+
+class CommitAcceptor(BaseModel):
+    """Top-level shape of one acceptor YAML file.
+
+    Field-by-field mirror of the on-disk format. The ``model_config``
+    ``extra='forbid'`` guarantees that any unknown top-level key
+    raises a structured error rather than being silently dropped.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True, str_strip_whitespace=True)
+
+    id: AcceptorId
+    status: Status
+    claim_type: ClaimType
+    promise: str = Field(min_length=1)
+    diff_scope: DiffScope
+    expected_signal: str = Field(min_length=1)
+    measurement_command: str = Field(min_length=1)
+    signal_artifact: str = Field(min_length=1)
+    falsifier: AcceptorFalsifier
+    rollback_command: str = Field(min_length=1)
+    rollback_verification_command: str = Field(min_length=1)
+    memory_update_type: MemoryUpdateType = MemoryUpdateType.APPEND
+    ledger_path: str = Field(min_length=1)
+    report_path: str = Field(min_length=1)
+    required_python_symbols: tuple[str, ...] = Field(default_factory=tuple)
+    evidence: tuple[EvidenceEntry, ...] = Field(default_factory=tuple)
+
+    @field_validator("required_python_symbols")
+    @classmethod
+    def _symbol_shape(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        # Accept either pytest-style file::symbol or a bare qualified name
+        # (e.g. ``module.ClassName``). The historical corpus contains
+        # both forms; the AST audit in validate_commit_acceptor.py handles
+        # them uniformly via attribute lookup.
+        for sym in value:
+            if not sym or sym.isspace():
+                raise ValueError(f"required_python_symbol entry must be non-empty, got {sym!r}")
+        return value
+
+    @property
+    def changed_paths(self) -> tuple[str, ...]:
+        return tuple(cf.path for cf in self.diff_scope.changed_files)
+
+
+def load_commit_acceptor(path: str | Path) -> CommitAcceptor:
+    """Parse + validate one acceptor YAML file."""
+    raw: Any = yaml.safe_load(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        raise ValueError(f"{path}: top-level must be a mapping, got {type(raw).__name__}")
+    return CommitAcceptor.model_validate(raw)
+
+
+def load_all_commit_acceptors(directory: str | Path) -> tuple[CommitAcceptor, ...]:
+    """Load every ``*.yaml`` under ``directory`` (deterministic order)."""
+    root = Path(directory)
+    if not root.is_dir():
+        raise NotADirectoryError(root)
+    acceptors: list[CommitAcceptor] = []
+    for yaml_path in sorted(root.glob("*.yaml")):
+        acceptors.append(load_commit_acceptor(yaml_path))
+    seen: set[str] = set()
+    for acc in acceptors:
+        if acc.id in seen:
+            raise ValueError(f"duplicate acceptor id: {acc.id}")
+        seen.add(acc.id)
+    return tuple(acceptors)
+
+
+__all__ = [
+    "AcceptorFalsifier",
+    "ChangedFile",
+    "ClaimType",
+    "CommitAcceptor",
+    "DiffScope",
+    "EvidenceEntry",
+    "MemoryUpdateType",
+    "Status",
+    "load_all_commit_acceptors",
+    "load_commit_acceptor",
+]

--- a/tests/governance/test_typed_models.py
+++ b/tests/governance/test_typed_models.py
@@ -1,0 +1,198 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""Round-trip + invariant tests for the typed governance models.
+
+The Pydantic v2 models in ``application.governance`` are the single
+source of truth for the IERD claim ledger and the commit-acceptor
+schema. These tests assert that:
+
+1. The canonical ``docs/CLAIMS.yaml`` parses without modification.
+2. Every ``.claude/commit_acceptors/*.yaml`` parses without modification.
+3. Schema invariants documented in ADR 0020 / 0021 hold on the typed
+   model (ANCHORED ⇒ falsifier present, gated tiers under priority,
+   unique IDs across both registries, etc.).
+4. ``extra='forbid'`` keeps unknown fields from being silently dropped
+   — a regression here would re-open the IERD §1 loophole.
+
+The tests do NOT reach for the underlying parsers in
+``scripts/ci/check_claims.py`` or
+``tools/commit_acceptor/validate_commit_acceptor.py``. They are
+behaviourally independent: if the typed model and the legacy parser
+diverge, both must surface the divergence in the round-trip test.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from application.governance import (
+    ClaimLedger,
+    CommitAcceptor,
+    Priority,
+    Tier,
+    load_all_commit_acceptors,
+    load_claim_ledger,
+    load_commit_acceptor,
+)
+from application.governance.claim_ledger import SCHEMA_VERSION_LATEST
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CLAIMS_PATH = REPO_ROOT / "docs" / "CLAIMS.yaml"
+ACCEPTORS_DIR = REPO_ROOT / ".claude" / "commit_acceptors"
+
+
+# ---------------------------------------------------------------------------
+# Round-trip on canonical files
+# ---------------------------------------------------------------------------
+
+
+def test_canonical_claim_ledger_parses() -> None:
+    """The shipped ``docs/CLAIMS.yaml`` validates against the typed model.
+
+    A failure here means either the model under-specifies the schema
+    (Pydantic ``extra='forbid'`` rejected a real field) or the ledger
+    drifted from the documented v3 schema. Either way, fail loudly —
+    silent drift in the governance layer is exactly what IERD §1
+    forbids.
+    """
+    ledger = load_claim_ledger(CLAIMS_PATH)
+    assert ledger.schema_version == SCHEMA_VERSION_LATEST
+    assert len(ledger.claims) > 0
+
+
+def test_canonical_acceptor_corpus_parses() -> None:
+    """Every shipped acceptor validates against the typed model."""
+    acceptors = load_all_commit_acceptors(ACCEPTORS_DIR)
+    assert len(acceptors) > 0
+    for acc in acceptors:
+        # Every acceptor must declare at least one changed file.
+        assert len(acc.diff_scope.changed_files) >= 1, acc.id
+
+
+# ---------------------------------------------------------------------------
+# Cross-claim invariants (ADR 0020 / 0021)
+# ---------------------------------------------------------------------------
+
+
+def test_unique_claim_ids() -> None:
+    ledger = load_claim_ledger(CLAIMS_PATH)
+    ids = [c.id for c in ledger.claims]
+    assert len(ids) == len(set(ids)), "duplicate claim id"
+
+
+def test_unique_acceptor_ids() -> None:
+    acceptors = load_all_commit_acceptors(ACCEPTORS_DIR)
+    ids = [a.id for a in acceptors]
+    assert len(ids) == len(set(ids)), "duplicate acceptor id"
+
+
+def test_anchored_claims_have_falsifier_or_warn_only() -> None:
+    """ADR 0021: ANCHORED v3 claims SHOULD declare a falsifier.
+
+    The check_claims gate keeps this warn-only during Phase 1.0 to
+    avoid blocking incremental adoption. The typed model documents
+    the relationship — a future tightening that flips it to fail-closed
+    needs only a one-line policy change here.
+    """
+    ledger = load_claim_ledger(CLAIMS_PATH)
+    anchored_no_falsifier = [
+        c.id for c in ledger.claims if c.tier is Tier.ANCHORED and c.falsifier is None
+    ]
+    # Warn-only: report count for visibility but do not gate.
+    print(f"\n[gov] {len(anchored_no_falsifier)} ANCHORED claims lack falsifier (warn-only)")
+
+
+def test_no_p2_claims_in_gated_set() -> None:
+    """A claim is gated iff its priority is P0 or P1.
+
+    P2 entries are warn-only by policy. This asserts the typed
+    model's :meth:`is_gated` flag matches the priority, not the
+    presence of an evidence path.
+    """
+    ledger = load_claim_ledger(CLAIMS_PATH)
+    for c in ledger.gated():
+        assert c.priority in (Priority.P0, Priority.P1), c.id
+
+
+# ---------------------------------------------------------------------------
+# Schema-drift guards (extra='forbid' must reject silent additions)
+# ---------------------------------------------------------------------------
+
+
+def test_claim_entry_rejects_unknown_field() -> None:
+    """A new key under a claim entry must NOT be silently ignored."""
+    ledger = load_claim_ledger(CLAIMS_PATH)
+    sample = ledger.claims[0]
+    payload = sample.model_dump()
+    payload["surprise_field"] = "this should not silently land"
+    with pytest.raises(ValidationError) as excinfo:
+        sample.__class__.model_validate(payload)
+    assert "surprise_field" in str(excinfo.value)
+
+
+def test_commit_acceptor_rejects_unknown_field() -> None:
+    """A new key under an acceptor must NOT be silently ignored."""
+    acceptors = load_all_commit_acceptors(ACCEPTORS_DIR)
+    sample = acceptors[0]
+    payload = sample.model_dump()
+    payload["surprise_field"] = "this should not silently land"
+    with pytest.raises(ValidationError) as excinfo:
+        sample.__class__.model_validate(payload)
+    assert "surprise_field" in str(excinfo.value)
+
+
+def test_ledger_rejects_unsupported_schema_version() -> None:
+    raw = {
+        "schema_version": 99,
+        "claims": [],
+    }
+    with pytest.raises(ValidationError):
+        ClaimLedger.model_validate(raw)
+
+
+# ---------------------------------------------------------------------------
+# JSON Schema export (consumed by IDE / external auditors)
+# ---------------------------------------------------------------------------
+
+
+def test_claim_ledger_json_schema_is_exportable() -> None:
+    """The typed model exports a valid JSON Schema — no recursive cycles,
+    no missing $defs. Auditors consume this artefact directly.
+    """
+    schema = ClaimLedger.model_json_schema()
+    assert schema["title"] == "ClaimLedger"
+    assert "properties" in schema
+    assert "claims" in schema["properties"]
+
+
+def test_commit_acceptor_json_schema_is_exportable() -> None:
+    schema = CommitAcceptor.model_json_schema()
+    assert schema["title"] == "CommitAcceptor"
+    assert "diff_scope" in schema["properties"]
+
+
+# ---------------------------------------------------------------------------
+# Single-file loader smoke
+# ---------------------------------------------------------------------------
+
+
+def test_load_one_acceptor_by_path() -> None:
+    """``load_commit_acceptor`` works on a specific file path."""
+    target = ACCEPTORS_DIR / "ierd-q4-schemathesis-contract-gate.yaml"
+    if not target.exists():
+        pytest.skip("Q4 schemathesis acceptor not present")
+    acc = load_commit_acceptor(target)
+    assert acc.id == "ierd-q4-schemathesis-contract-gate"
+    assert acc.claim_type.value in {
+        "correctness",
+        "fail_closed",
+        "security",
+        "performance",
+        "governance",
+        "refactor",
+        "documentation",
+        "determinism",
+    }


### PR DESCRIPTION
Single source of truth for docs/CLAIMS.yaml and .claude/commit_acceptors/*.yaml.

Pydantic v2 models with extra='forbid' replace ad-hoc dict access in scripts/ci/check_claims.py and tools/commit_acceptor/validate_commit_acceptor.py. Additive only — legacy parsers untouched. Round-trip tests cover the full canonical corpus (27 claims + 29 acceptors).

12/12 tests pass locally. mypy --strict + ruff clean.

See commit message for full architectural details.