### PR TITLE
chore(audit): close 3 governance debt items from 2026-05-07 audit

### DIFF
--- a/.claude/commit_acceptors/debt-audit-cleanup-2026-05-07.yaml
+++ b/.claude/commit_acceptors/debt-audit-cleanup-2026-05-07.yaml
@@ -1,0 +1,106 @@
+# Diff-bound commit acceptor for the 2026-05-07 audit-debt cleanup.
+#
+# Closes three findings from the codebase audit run after the IERD-Q4
+# Phase-3 EXIT (PR #551) + governance typed models (PR #552):
+#
+# 1. Invariant count drift — README.md badges and table claimed 87
+#    invariants while the registry returned 90 (the body already said
+#    90). The shields and the headline table now match the
+#    `python scripts/count_invariants.py` authority.
+#
+# 2. Workflow self-contradiction — `.github/workflows/commit-acceptor-gate.yml`
+#    used floating action tags (`actions/checkout@v6`, `actions/setup-python@v6`)
+#    while every other workflow pins by 40-char SHA per the repo-policy
+#    rule the gate itself enforces.
+#
+# 3. Test-isolation regression — the latency-budget test set five env
+#    vars at module import time (`os.environ["GEOSYNC_DISABLE_METRICS"] = "1"`
+#    + four `setdefault` calls) which polluted the pytest session for
+#    downstream test modules. Refactored to a module-scoped `client`
+#    fixture that snapshots → applies overrides → yields → restores;
+#    `create_app` is imported lazily through `importlib` inside the
+#    fixture window.
+#
+# Locally verified:
+#   * mypy --strict + ruff: clean on the touched test file
+#   * pytest tests/api/test_latency_budget_server_compute.py
+#       tests/observability/test_metrics_expectations.py: 6/6 pass when
+#     run together (was 3/6 with the leaking module-level env)
+#   * python scripts/count_invariants.py: 90
+
+id: debt-audit-cleanup-2026-05-07
+status: ACTIVE
+claim_type: governance
+promise: >-
+  After this PR lands the README invariant badges (lines 12 and 35)
+  and the headline table (line 175) declare 90, matching
+  `python scripts/count_invariants.py`. The
+  `.github/workflows/commit-acceptor-gate.yml` workflow pins both
+  `actions/checkout` and `actions/setup-python` by 40-char commit SHA
+  (matching the canonical pin used in pr-gate.yml,
+  schemathesis-contract.yml, and latency-budget.yml). The
+  latency-budget test no longer mutates `os.environ` at module
+  import time; the env-var window is bounded to the lifetime of the
+  module-scoped `client` fixture.
+diff_scope:
+  changed_files:
+    - path: ".claude/commit_acceptors/debt-audit-cleanup-2026-05-07.yaml"
+    - path: ".github/workflows/commit-acceptor-gate.yml"
+    - path: "README.md"
+    - path: "tests/api/test_latency_budget_server_compute.py"
+  forbidden_paths:
+    - "trading/"
+    - "execution/"
+    - "forecast/"
+    - "policy/"
+    - "core/physics/"
+    - "core/kuramoto/"
+    - "application/api/service.py"
+    - "application/api/errors.py"
+    - "scripts/ci/check_claims.py"
+    - "tools/commit_acceptor/validate_commit_acceptor.py"
+required_python_symbols:
+  - "tests/api/test_latency_budget_server_compute.py::client"
+  - "tests/api/test_latency_budget_server_compute.py::_REQUIRED_ENV"
+  - "tests/api/test_latency_budget_server_compute.py::test_endpoint_p95_within_budget"
+expected_signal: >-
+  Local: `python scripts/count_invariants.py` returns 90; `grep -E
+  "invariants-(87|90)" README.md` finds only invariants-90 hits;
+  `grep "actions/checkout@v6" .github/workflows/commit-acceptor-gate.yml`
+  is empty (replaced by SHA-pinned form);
+  `pytest tests/api/test_latency_budget_server_compute.py
+  tests/observability/test_metrics_expectations.py -q` exits 0 (was
+  failing before this PR with `AssertionError: expectations failed
+  with issues: [{'code': 'above_max', 'message': 'value 230.0
+  exceeds maximum 100.0', 'metric':
+  'geosync_api_request_latency_seconds'}]`).
+measurement_command: >-
+  bash -c 'python scripts/count_invariants.py
+  && grep -L "invariants-87" README.md
+  && grep -q "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd"
+       .github/workflows/commit-acceptor-gate.yml
+  && python -m pytest tests/api/test_latency_budget_server_compute.py
+       tests/observability/test_metrics_expectations.py -q'
+signal_artifact: "tmp/debt_audit_cleanup_2026_05_07.log"
+falsifier:
+  command: >-
+    bash -c 'grep -q "invariants-87\|@v6\b" README.md
+    .github/workflows/commit-acceptor-gate.yml'
+  description: >-
+    Probes the union of the three remediated artefacts: shields
+    showing `invariants-87` OR a floating `@v6` action tag in the
+    commit-acceptor-gate workflow. If grep finds either pattern,
+    the falsifier exits 0 — drift has reappeared and the PR's
+    governance promise is broken.
+rollback_command: >-
+  git checkout HEAD~1 --
+  README.md
+  .github/workflows/commit-acceptor-gate.yml
+  tests/api/test_latency_budget_server_compute.py
+  .claude/commit_acceptors/debt-audit-cleanup-2026-05-07.yaml
+rollback_verification_command: >-
+  bash -c 'grep -q "invariants-87" README.md'
+memory_update_type: append
+ledger_path: ".claude/commit_acceptors/debt-audit-cleanup-2026-05-07.yaml"
+report_path: "tmp/debt_audit_cleanup_2026_05_07.log"
+evidence: []

--- a/.github/workflows/commit-acceptor-gate.yml
+++ b/.github/workflows/commit-acceptor-gate.yml
@@ -12,10 +12,10 @@ jobs:
       matrix:
         python-version: ["3.11", "3.12"]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <br><br>
 
 [![modules-15](https://img.shields.io/badge/modules-15-blueviolet?style=for-the-badge)](docs/ARCHITECTURE.md)
-[![invariants-87](https://img.shields.io/badge/invariants-87-critical?style=for-the-badge)](CLAUDE.md)
+[![invariants-90](https://img.shields.io/badge/invariants-90-critical?style=for-the-badge)](CLAUDE.md)
 [![tests-11446](https://img.shields.io/badge/tests-11%2C446-brightgreen?style=for-the-badge)](tests/)
 [![indicators-17](https://img.shields.io/badge/indicators-17-gold?style=for-the-badge)](core/indicators/)
 [![ADRs-16](https://img.shields.io/badge/ADRs-16-blue?style=for-the-badge)](docs/adr/)
@@ -32,7 +32,7 @@ Kuramoto synchronization  ·  Ricci curvature flow  ·  Free-energy thermodynami
 [![Formal Verification](https://github.com/neuron7xLab/GeoSync/actions/workflows/formal-verification.yml/badge.svg?branch=main)](https://github.com/neuron7xLab/GeoSync/actions/workflows/formal-verification.yml)
 [![Python](https://img.shields.io/badge/Python-3.11%20%7C%203.12-3776AB?style=flat&logo=python&logoColor=white)](https://www.python.org/)
 [![Security](https://img.shields.io/badge/NIST%20SP%20800--53-aligned-red?style=flat)](docs/security/)
-[![Physics Gate](https://img.shields.io/badge/physics_gate-87_invariants-critical?style=flat)](CLAUDE.md)
+[![Physics Gate](https://img.shields.io/badge/physics_gate-90_invariants-critical?style=flat)](CLAUDE.md)
 [![Coverage](https://img.shields.io/badge/line_coverage-71%25-yellowgreen?style=flat)](BASELINE.md)
 
 </div>
@@ -172,7 +172,7 @@ Control-plane safety properties are additionally **model-checked in TLA⁺** —
 
 | Metric | Value | Source |
 |--------|-------|--------|
-| Physics invariants declared | **87 in `.claude/physics/INVARIANTS.yaml`** (single source of truth) | `python scripts/count_invariants.py` |
+| Physics invariants declared | **90 in `.claude/physics/INVARIANTS.yaml`** (single source of truth) | `python scripts/count_invariants.py` |
 | Physics invariants grounded by tests | tracked in [`BASELINE.md`](BASELINE.md) — **deliberately smaller than declared count**; coverage growth is gated, not assumed | `BASELINE.md` ledger |
 | C1/C2 code audit | **0** undocumented physics clamps in `core/` | `physics-kernel-gate.yml` |
 | CI gates | physics-kernel-gate · invariant-count-sync · formal-verification (TLA⁺) · claims-evidence-gate | `.github/workflows/` |

--- a/tests/api/test_latency_budget_server_compute.py
+++ b/tests/api/test_latency_budget_server_compute.py
@@ -60,11 +60,11 @@ INTERACTIVE_P95_MS: Final[float] = float(
 
 
 _REQUIRED_ENV: Final[dict[str, str]] = {
-    "GEOSYNC_AUDIT_SECRET": "latency-budget-test-secret",
+    "GEOSYNC_AUDIT_SECRET": "latency-budget-test-secret",  # pragma: allowlist secret
     "GEOSYNC_OAUTH2_ISSUER": "https://latency.test",
     "GEOSYNC_OAUTH2_AUDIENCE": "geosync-api",
     "GEOSYNC_OAUTH2_JWKS_URI": "https://latency.test/jwks",
-    "GEOSYNC_RBAC_AUDIT_SECRET": "latency-budget-rbac-secret",
+    "GEOSYNC_RBAC_AUDIT_SECRET": "latency-budget-rbac-secret",  # pragma: allowlist secret
     # Isolated CollectorRegistry — the ~440 GET requests this suite
     # fires must not pollute the global Prometheus REGISTRY read by
     # ``tests/observability/test_metrics_expectations.py``.

--- a/tests/api/test_latency_budget_server_compute.py
+++ b/tests/api/test_latency_budget_server_compute.py
@@ -24,30 +24,25 @@ Tracks claim `e2e-latency-budget-compliance` in `docs/CLAIMS.yaml`.
 
 from __future__ import annotations
 
+import importlib
 import os
 import statistics
+from collections.abc import Iterator
 from time import perf_counter
-from typing import Final
+from typing import TYPE_CHECKING, Final
 
 import pytest
+from fastapi.testclient import TestClient
 
-# Auth / settings env required by `create_app()`.
-os.environ.setdefault("GEOSYNC_AUDIT_SECRET", "latency-budget-test-secret")
-os.environ.setdefault("GEOSYNC_OAUTH2_ISSUER", "https://latency.test")
-os.environ.setdefault("GEOSYNC_OAUTH2_AUDIENCE", "geosync-api")
-os.environ.setdefault("GEOSYNC_OAUTH2_JWKS_URI", "https://latency.test/jwks")
-os.environ.setdefault("GEOSYNC_RBAC_AUDIT_SECRET", "latency-budget-rbac-secret")
-# Force the app onto an isolated CollectorRegistry so the ~440 requests
-# fired during this suite do not pollute the global Prometheus registry.
-# `tests/observability/test_metrics_expectations.py` reads that registry
-# and applies a uniform ``max=100`` rule across every histogram series of
-# ``geosync_api_request_latency_seconds`` (including the ``_count`` row),
-# which would otherwise trip on the inflated observation count.
-os.environ["GEOSYNC_DISABLE_METRICS"] = "1"
+if TYPE_CHECKING:
+    from fastapi import FastAPI
 
-from fastapi.testclient import TestClient  # noqa: E402
-
-from application.api.service import create_app  # noqa: E402
+# Env-var injection deferred to a module-scoped fixture (see
+# ``_isolated_env`` below) so this module no longer mutates ``os.environ``
+# at import time. Previously the unconditional
+# ``os.environ["GEOSYNC_DISABLE_METRICS"] = "1"`` left state behind for
+# downstream tests in the same pytest session, in violation of the
+# IERD test-isolation discipline this very module's claim asserts.
 
 # Sample count and warmup count are independent of the budget — they
 # control statistical resolution of the p95 estimator. With N=200 and a
@@ -64,15 +59,44 @@ INTERACTIVE_P95_MS: Final[float] = float(
 )
 
 
-@pytest.fixture(scope="module")
-def client() -> TestClient:
-    """Build the canonical app once; lifespan handlers run inside the manager.
+_REQUIRED_ENV: Final[dict[str, str]] = {
+    "GEOSYNC_AUDIT_SECRET": "latency-budget-test-secret",
+    "GEOSYNC_OAUTH2_ISSUER": "https://latency.test",
+    "GEOSYNC_OAUTH2_AUDIENCE": "geosync-api",
+    "GEOSYNC_OAUTH2_JWKS_URI": "https://latency.test/jwks",
+    "GEOSYNC_RBAC_AUDIT_SECRET": "latency-budget-rbac-secret",
+    # Isolated CollectorRegistry — the ~440 GET requests this suite
+    # fires must not pollute the global Prometheus REGISTRY read by
+    # ``tests/observability/test_metrics_expectations.py``.
+    "GEOSYNC_DISABLE_METRICS": "1",
+}
 
-    Isolation is provided at the registry level via ``GEOSYNC_DISABLE_METRICS``
-    set at module import time (see top of file).
+
+@pytest.fixture(scope="module")
+def client() -> Iterator[TestClient]:
+    """Build the canonical app inside an isolated env-var window.
+
+    The previous implementation set ``os.environ`` at module import
+    time, leaving every required key in place for the rest of the
+    pytest session. This fixture takes a snapshot, applies overrides,
+    builds the app, yields the TestClient, and restores the snapshot
+    on teardown — the env mutation is bounded to the lifetime of this
+    module's test cases.
     """
-    app = create_app()
-    return TestClient(app)
+    saved: dict[str, str | None] = {key: os.environ.get(key) for key in _REQUIRED_ENV}
+    os.environ.update(_REQUIRED_ENV)
+    try:
+        # Late import so settings (Pydantic, env-driven) resolve under
+        # the overrides above, not under whatever leaked from upstream.
+        service_module = importlib.import_module("application.api.service")
+        app: "FastAPI" = service_module.create_app()
+        yield TestClient(app)
+    finally:
+        for key, value in saved.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
 
 
 def _measure_p95_ms(client: TestClient, path: str) -> tuple[float, float, float]:


### PR DESCRIPTION
Closes 3 contradictions surfaced by the codebase audit run after PRs #551 + #552:

1. **README invariant-count drift** — badges + headline table claimed 87, registry returns 90, body prose already said 90.
2. **commit-acceptor-gate.yml self-contradiction** — gate that enforces SHA-pinning used floating @v6 tags itself.
3. **Latency-budget test isolation** — module-level os.environ mutations from PR #550 leaked across session, breaking downstream metrics-expectations test (3/6 → 6/6 after fix).

See commit message for details. mypy --strict + ruff clean. validator exit 0.