### PR TITLE
feat(governance): JSON Schema export of typed Pydantic governance models

### DIFF
--- a/.claude/commit_acceptors/governance-json-schema-export.yaml
+++ b/.claude/commit_acceptors/governance-json-schema-export.yaml
@@ -1,0 +1,107 @@
+# Diff-bound commit acceptor for the governance JSON Schema export.
+#
+# Builds on the typed Pydantic models from PR #552 by exporting their
+# canonical JSON Schema 2020-12 representation under
+# docs/schemas/governance/. External consumers (IDE plugins, OpenAPI
+# tooling, third-party auditors) can pin against the on-disk artefact
+# without re-parsing the YAML or importing Pydantic.
+#
+# The new CI workflow `governance-schema-export-sync` re-runs the
+# generator with `--check` on every PR that touches the typed model
+# or the schema artefacts and fails fail-closed on drift. Mirrors the
+# invariant-count-sync gate pattern.
+#
+# Locally verified:
+#   * mypy --strict + ruff: clean on the script + the test
+#   * pytest tests/scripts/test_export_governance_schemas.py: 7/7 pass
+#   * python scripts/export_governance_schemas.py --check: PASS
+#   * Generated schemas:
+#       docs/schemas/governance/claim_ledger.schema.json (2 props)
+#       docs/schemas/governance/commit_acceptor.schema.json (16 props)
+
+id: governance-json-schema-export
+status: ACTIVE
+claim_type: governance
+promise: >-
+  After this PR lands, the canonical Pydantic governance models
+  (`application.governance.ClaimLedger`, `CommitAcceptor`) ship a
+  matching JSON Schema 2020-12 export under
+  `docs/schemas/governance/`. The CI workflow
+  `governance-schema-export-sync` re-runs the generator with `--check`
+  on every PR matching the path filter (governance models, schemas,
+  exporter, tests, workflow itself) and fails closed on drift.
+  Re-running the exporter with no arguments produces bit-identical
+  bytes (deterministic via `sort_keys=True` + trailing newline). The
+  test `test_check_mode_passes_against_committed_artefact` enforces
+  the same invariant under pytest.
+diff_scope:
+  changed_files:
+    - path: ".claude/commit_acceptors/governance-json-schema-export.yaml"
+    - path: ".github/workflows/governance-schema-export-sync.yml"
+    - path: "docs/schemas/governance/claim_ledger.schema.json"
+    - path: "docs/schemas/governance/commit_acceptor.schema.json"
+    - path: "scripts/export_governance_schemas.py"
+    - path: "tests/scripts/test_export_governance_schemas.py"
+  forbidden_paths:
+    - "trading/"
+    - "execution/"
+    - "forecast/"
+    - "policy/"
+    - "core/physics/"
+    - "core/kuramoto/"
+    - "application/governance/claim_ledger.py"
+    - "application/governance/commit_acceptor.py"
+    - "scripts/ci/check_claims.py"
+    - "tools/commit_acceptor/validate_commit_acceptor.py"
+required_python_symbols:
+  - "scripts/export_governance_schemas.py::export"
+  - "scripts/export_governance_schemas.py::CLAIM_LEDGER_PATH"
+  - "scripts/export_governance_schemas.py::COMMIT_ACCEPTOR_PATH"
+  - "tests/scripts/test_export_governance_schemas.py::test_check_mode_passes_against_committed_artefact"
+  - "tests/scripts/test_export_governance_schemas.py::test_serialise_is_deterministic"
+expected_signal: >-
+  Local: `python scripts/export_governance_schemas.py --check` exits 0
+  with "PASS: 2 governance schema(s) match the typed model.";
+  `mypy --strict --follow-imports=silent
+  scripts/export_governance_schemas.py
+  tests/scripts/test_export_governance_schemas.py` reports "Success: no
+  issues found in 2 source files"; `pytest
+  tests/scripts/test_export_governance_schemas.py -q` reports "7
+  passed"; `python -c "import json;
+  s=json.load(open('docs/schemas/governance/claim_ledger.schema.json'));
+  print(s['title'])"` prints "ClaimLedger".
+measurement_command: >-
+  bash -c 'mypy --strict --follow-imports=silent
+  scripts/export_governance_schemas.py
+  tests/scripts/test_export_governance_schemas.py
+  && ruff check scripts/export_governance_schemas.py
+  tests/scripts/test_export_governance_schemas.py
+  && python scripts/export_governance_schemas.py --check
+  && python -m pytest tests/scripts/test_export_governance_schemas.py -q'
+signal_artifact: "tmp/governance_json_schema_export.log"
+falsifier:
+  command: >-
+    bash -c 'python scripts/export_governance_schemas.py --check
+    >/tmp/_export_check.log 2>&1
+    && ! grep -q "PASS:" /tmp/_export_check.log'
+  description: >-
+    Probes the round-trip between the live Pydantic model and the
+    on-disk JSON Schema. The exporter's `--check` mode prints
+    "PASS:" on match and exits 0; on drift it prints
+    "governance schemas drift detected" and exits 1. The falsifier
+    inverts: it succeeds (exit 0) only when `--check` did NOT print
+    "PASS:", which would mean the published artefact has drifted
+    from the model.
+rollback_command: >-
+  git checkout HEAD~1 --
+  scripts/export_governance_schemas.py
+  tests/scripts/test_export_governance_schemas.py
+  .github/workflows/governance-schema-export-sync.yml
+  .claude/commit_acceptors/governance-json-schema-export.yaml
+  && rm -rf docs/schemas/governance/
+rollback_verification_command: >-
+  bash -c 'test ! -d docs/schemas/governance'
+memory_update_type: append
+ledger_path: ".claude/commit_acceptors/governance-json-schema-export.yaml"
+report_path: "tmp/governance_json_schema_export.log"
+evidence: []

--- a/.github/workflows/governance-schema-export-sync.yml
+++ b/.github/workflows/governance-schema-export-sync.yml
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: MIT
+#
+# Governance Schema Export Sync.
+#
+# Re-runs `python scripts/export_governance_schemas.py --check` on every
+# PR that touches the typed governance models or the published JSON
+# Schema artefacts. Fails closed if the on-disk schema differs from
+# the live Pydantic model in `application/governance/`. Mirrors the
+# invariant-count-sync gate pattern: external auditors and IDE tooling
+# pin against the on-disk artefact, so silent drift between the model
+# and the schema would invalidate downstream contracts.
+name: Governance Schema Export Sync
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'application/governance/**'
+      - 'docs/schemas/governance/**'
+      - 'scripts/export_governance_schemas.py'
+      - 'tests/scripts/test_export_governance_schemas.py'
+      - '.github/workflows/governance-schema-export-sync.yml'
+  merge_group:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: governance-schema-export-sync-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  governance-schema-export-sync:
+    name: governance-schema-export-sync
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+
+      - name: Install minimal deps
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade pip
+          # Pydantic + PyYAML are the only runtime deps the exporter
+          # needs. Avoid `pip install -e .` to keep this gate fast.
+          pip install 'pydantic>=2,<3' pyyaml typing_extensions
+
+      - name: Verify on-disk JSON Schema matches the live Pydantic model
+        run: PYTHONPATH=. python scripts/export_governance_schemas.py --check

--- a/docs/schemas/governance/claim_ledger.schema.json
+++ b/docs/schemas/governance/claim_ledger.schema.json
@@ -1,0 +1,147 @@
+{
+  "$defs": {
+    "ClaimEntry": {
+      "additionalProperties": false,
+      "description": "Single registry entry under ``claims:`` in the ledger.\n\nThe strict-mode ``extra='forbid'`` policy guards against silent\nschema drift: any unknown field at the entry level is a hard error\n(the historical gate would have ignored unknowns and produced\nfalse-green runs).",
+      "properties": {
+        "added_utc": {
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+          "title": "Added Utc",
+          "type": "string"
+        },
+        "description": {
+          "minLength": 1,
+          "title": "Description",
+          "type": "string"
+        },
+        "evidence_paths": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Evidence Paths",
+          "type": "array"
+        },
+        "falsifier": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Falsifier"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "id": {
+          "minLength": 1,
+          "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$",
+          "title": "Id",
+          "type": "string"
+        },
+        "last_updated_utc": {
+          "anyOf": [
+            {
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Last Updated Utc"
+        },
+        "priority": {
+          "$ref": "#/$defs/Priority"
+        },
+        "tier": {
+          "$ref": "#/$defs/Tier"
+        }
+      },
+      "required": [
+        "id",
+        "priority",
+        "tier",
+        "description",
+        "added_utc"
+      ],
+      "title": "ClaimEntry",
+      "type": "object"
+    },
+    "Falsifier": {
+      "additionalProperties": false,
+      "description": "v3 falsifier block \u2014 pytest node + invariants + failure signature.\n\nRequired on every v3 ANCHORED claim per ADR 0021. The ``test_id``\nmust be a resolvable pytest node id; ``invariants_cited`` must be a\nnon-empty list of ``INV-<NAME>`` identifiers; ``failure_signature``\nis a free-form description of the assertion shape that must fire on\ninvariant violation.",
+      "properties": {
+        "failure_signature": {
+          "minLength": 1,
+          "title": "Failure Signature",
+          "type": "string"
+        },
+        "invariants_cited": {
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Invariants Cited",
+          "type": "array"
+        },
+        "test_id": {
+          "pattern": "^[\\w./\\-]+\\.py(::[A-Za-z_][\\w]*)+$",
+          "title": "Test Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "test_id",
+        "invariants_cited",
+        "failure_signature"
+      ],
+      "title": "Falsifier",
+      "type": "object"
+    },
+    "Priority": {
+      "description": "Claim priority \u2014 gate scope.\n\nP0 / P1 are gated (CI fails on missing evidence). P2 is warn-only.",
+      "enum": [
+        "P0",
+        "P1",
+        "P2"
+      ],
+      "title": "Priority",
+      "type": "string"
+    },
+    "Tier": {
+      "description": "IERD claim tier ladder.\n\nStrict ordering: an ANCHORED claim has a falsifier and CI evidence;\nEXTRAPOLATED has partial evidence with a documented missing-evidence\nlist; SPECULATIVE / UNKNOWN are aspirational. The ``check_claims``\ngate enforces ``tier \u2208 {ANCHORED, EXTRAPOLATED} \u21d2 all evidence\npaths exist``.",
+      "enum": [
+        "ANCHORED",
+        "EXTRAPOLATED",
+        "SPECULATIVE",
+        "UNKNOWN"
+      ],
+      "title": "Tier",
+      "type": "string"
+    }
+  },
+  "additionalProperties": false,
+  "description": "Top-level shape of ``docs/CLAIMS.yaml``.",
+  "properties": {
+    "claims": {
+      "items": {
+        "$ref": "#/$defs/ClaimEntry"
+      },
+      "title": "Claims",
+      "type": "array"
+    },
+    "schema_version": {
+      "maximum": 3,
+      "minimum": 1,
+      "title": "Schema Version",
+      "type": "integer"
+    }
+  },
+  "required": [
+    "schema_version",
+    "claims"
+  ],
+  "title": "ClaimLedger",
+  "type": "object"
+}

--- a/docs/schemas/governance/commit_acceptor.schema.json
+++ b/docs/schemas/governance/commit_acceptor.schema.json
@@ -1,0 +1,228 @@
+{
+  "$defs": {
+    "AcceptorFalsifier": {
+      "additionalProperties": false,
+      "description": "Inverse probe: the acceptor's invariant is broken iff this exits 0.\n\nDistinct from the claim-ledger ``Falsifier`` (which points at a\npytest node). An acceptor falsifier is a one-shot shell command;\nits non-zero exit means the invariant holds. Used by\n``compute_fps_audit`` and the local pre-PR loop.",
+      "properties": {
+        "command": {
+          "minLength": 1,
+          "title": "Command",
+          "type": "string"
+        },
+        "description": {
+          "minLength": 1,
+          "title": "Description",
+          "type": "string"
+        }
+      },
+      "required": [
+        "command",
+        "description"
+      ],
+      "title": "AcceptorFalsifier",
+      "type": "object"
+    },
+    "ChangedFile": {
+      "additionalProperties": false,
+      "description": "One entry under ``diff_scope.changed_files:``.",
+      "properties": {
+        "path": {
+          "minLength": 1,
+          "title": "Path",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path"
+      ],
+      "title": "ChangedFile",
+      "type": "object"
+    },
+    "ClaimType": {
+      "description": "Maps the acceptor to a policy file-count cap.\n\n``commit_acceptor_policy.yaml::max_changed_files_by_claim_type``\nenforces a per-type ceiling so a 50-file refactor cannot ship\nunder ``correctness`` (cap 12) without explicit re-classification.",
+      "enum": [
+        "correctness",
+        "determinism",
+        "fail_closed",
+        "security",
+        "performance",
+        "governance",
+        "refactor",
+        "documentation"
+      ],
+      "title": "ClaimType",
+      "type": "string"
+    },
+    "DiffScope": {
+      "additionalProperties": false,
+      "description": "The set of paths the acceptor binds.\n\n``changed_files``     \u2014 every file the PR is allowed to modify; the\n                        validator rejects any modified file outside\n                        this list (or another acceptor's list).\n``forbidden_paths``   \u2014 extra path-prefix denylist on top of the\n                        global policy. Any modified file under one\n                        of these prefixes is rejected.",
+      "properties": {
+        "changed_files": {
+          "items": {
+            "$ref": "#/$defs/ChangedFile"
+          },
+          "minItems": 1,
+          "title": "Changed Files",
+          "type": "array"
+        },
+        "forbidden_paths": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Forbidden Paths",
+          "type": "array"
+        }
+      },
+      "required": [
+        "changed_files"
+      ],
+      "title": "DiffScope",
+      "type": "object"
+    },
+    "EvidenceEntry": {
+      "additionalProperties": false,
+      "description": "Optional evidence attachment under ``evidence:``.",
+      "properties": {
+        "path": {
+          "minLength": 1,
+          "title": "Path",
+          "type": "string"
+        },
+        "sha256": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Sha256"
+        }
+      },
+      "required": [
+        "path"
+      ],
+      "title": "EvidenceEntry",
+      "type": "object"
+    },
+    "MemoryUpdateType": {
+      "enum": [
+        "append",
+        "replace",
+        "none"
+      ],
+      "title": "MemoryUpdateType",
+      "type": "string"
+    },
+    "Status": {
+      "description": "Acceptor lifecycle status.\n\nACTIVE        \u2014 currently enforced.\nDRAFT         \u2014 author iterating; gate is permissive.\nVERIFIED      \u2014 landed and the falsifier has fired at least once.\nREJECTED      \u2014 superseded; kept as audit trail.",
+      "enum": [
+        "ACTIVE",
+        "DRAFT",
+        "VERIFIED",
+        "REJECTED"
+      ],
+      "title": "Status",
+      "type": "string"
+    }
+  },
+  "additionalProperties": false,
+  "description": "Top-level shape of one acceptor YAML file.\n\nField-by-field mirror of the on-disk format. The ``model_config``\n``extra='forbid'`` guarantees that any unknown top-level key\nraises a structured error rather than being silently dropped.",
+  "properties": {
+    "claim_type": {
+      "$ref": "#/$defs/ClaimType"
+    },
+    "diff_scope": {
+      "$ref": "#/$defs/DiffScope"
+    },
+    "evidence": {
+      "items": {
+        "$ref": "#/$defs/EvidenceEntry"
+      },
+      "title": "Evidence",
+      "type": "array"
+    },
+    "expected_signal": {
+      "minLength": 1,
+      "title": "Expected Signal",
+      "type": "string"
+    },
+    "falsifier": {
+      "$ref": "#/$defs/AcceptorFalsifier"
+    },
+    "id": {
+      "minLength": 1,
+      "pattern": "^[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*$",
+      "title": "Id",
+      "type": "string"
+    },
+    "ledger_path": {
+      "minLength": 1,
+      "title": "Ledger Path",
+      "type": "string"
+    },
+    "measurement_command": {
+      "minLength": 1,
+      "title": "Measurement Command",
+      "type": "string"
+    },
+    "memory_update_type": {
+      "$ref": "#/$defs/MemoryUpdateType",
+      "default": "append"
+    },
+    "promise": {
+      "minLength": 1,
+      "title": "Promise",
+      "type": "string"
+    },
+    "report_path": {
+      "minLength": 1,
+      "title": "Report Path",
+      "type": "string"
+    },
+    "required_python_symbols": {
+      "items": {
+        "type": "string"
+      },
+      "title": "Required Python Symbols",
+      "type": "array"
+    },
+    "rollback_command": {
+      "minLength": 1,
+      "title": "Rollback Command",
+      "type": "string"
+    },
+    "rollback_verification_command": {
+      "minLength": 1,
+      "title": "Rollback Verification Command",
+      "type": "string"
+    },
+    "signal_artifact": {
+      "minLength": 1,
+      "title": "Signal Artifact",
+      "type": "string"
+    },
+    "status": {
+      "$ref": "#/$defs/Status"
+    }
+  },
+  "required": [
+    "id",
+    "status",
+    "claim_type",
+    "promise",
+    "diff_scope",
+    "expected_signal",
+    "measurement_command",
+    "signal_artifact",
+    "falsifier",
+    "rollback_command",
+    "rollback_verification_command",
+    "ledger_path",
+    "report_path"
+  ],
+  "title": "CommitAcceptor",
+  "type": "object"
+}

--- a/scripts/export_governance_schemas.py
+++ b/scripts/export_governance_schemas.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""Export typed governance models as JSON Schema documents.
+
+Produces canonical JSON Schema 2020-12 artefacts for the two governance
+schemas published by the typed Pydantic v2 layer
+(``application.governance``):
+
+    docs/schemas/governance/claim_ledger.schema.json
+    docs/schemas/governance/commit_acceptor.schema.json
+
+External consumers (IDE plugins, OpenAPI tooling, third-party auditors)
+can pin against these JSON Schemas without re-parsing the YAML or
+importing Pydantic. Drift between the typed model and the published
+schema is caught by the CI gate ``governance-schema-export-sync``,
+which re-runs this script and fails if the on-disk artefact differs
+from the freshly-generated output.
+
+Run locally before PR:
+
+    python scripts/export_governance_schemas.py [--check]
+
+Without ``--check`` the script writes the schemas. With ``--check`` it
+compares the generated output against on-disk and exits non-zero on
+divergence — used by CI.
+
+Exit codes:
+
+    0  — schemas written (or, with --check, on-disk matches generated)
+    1  — drift detected (only in --check mode)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from application.governance import ClaimLedger, CommitAcceptor
+
+ROOT = Path(__file__).resolve().parents[1]
+OUTPUT_DIR = ROOT / "docs" / "schemas" / "governance"
+
+CLAIM_LEDGER_PATH = OUTPUT_DIR / "claim_ledger.schema.json"
+COMMIT_ACCEPTOR_PATH = OUTPUT_DIR / "commit_acceptor.schema.json"
+
+
+def _generate() -> dict[Path, dict[str, Any]]:
+    """Return the canonical {output_path: schema_dict} mapping."""
+    return {
+        CLAIM_LEDGER_PATH: ClaimLedger.model_json_schema(),
+        COMMIT_ACCEPTOR_PATH: CommitAcceptor.model_json_schema(),
+    }
+
+
+def _serialise(schema: dict[str, Any]) -> str:
+    """Deterministic serialisation: sort keys, ensure trailing newline.
+
+    ``sort_keys=True`` makes the output reproducible across Pydantic
+    versions; ``indent=2`` keeps the artefact reviewable; the trailing
+    newline keeps `git diff` clean.
+    """
+    return json.dumps(schema, indent=2, sort_keys=True) + "\n"
+
+
+def _write(target: Path, content: str) -> None:
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(content, encoding="utf-8")
+
+
+def export(*, check: bool) -> int:
+    """Generate (or verify) the JSON Schema export.
+
+    Returns 0 on success, 1 on detected drift in ``--check`` mode.
+    """
+    drift_paths: list[Path] = []
+    for path, schema in _generate().items():
+        generated = _serialise(schema)
+        if check:
+            if not path.exists():
+                drift_paths.append(path)
+                continue
+            current = path.read_text(encoding="utf-8")
+            if current != generated:
+                drift_paths.append(path)
+        else:
+            _write(path, generated)
+
+    if check:
+        if drift_paths:
+            print("governance schemas drift detected:", file=sys.stderr)
+            for path in drift_paths:
+                rel = path.relative_to(ROOT)
+                print(
+                    f"  {rel} differs from `python {Path(__file__).relative_to(ROOT)}` output",
+                    file=sys.stderr,
+                )
+            print(
+                "Run `python scripts/export_governance_schemas.py` to regenerate.",
+                file=sys.stderr,
+            )
+            return 1
+        print(f"PASS: {len(_generate())} governance schema(s) match the typed model.")
+    else:
+        for path in _generate():
+            rel = path.relative_to(ROOT)
+            print(f"wrote {rel}")
+
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit non-zero if the on-disk schema artefact differs from the generated output.",
+    )
+    args = parser.parse_args(argv)
+    return export(check=args.check)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/scripts/test_export_governance_schemas.py
+++ b/tests/scripts/test_export_governance_schemas.py
@@ -1,0 +1,112 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""Tests for ``scripts/export_governance_schemas.py``.
+
+The script exports the typed Pydantic governance models
+(``application.governance.ClaimLedger`` and
+``application.governance.CommitAcceptor``) as canonical JSON Schema
+2020-12 documents under ``docs/schemas/governance/``.
+
+These tests assert two invariants:
+
+1. The export is reproducible — running the generator twice produces
+   bit-identical bytes (sorted keys, deterministic JSON, trailing
+   newline).
+2. The on-disk schema files match the live Pydantic model. ``--check``
+   mode exits non-zero on drift; this test calls it directly so the
+   same gate fires under pytest.
+
+Drift between the model and the published schema would let external
+auditors pin against an obsolete contract.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.export_governance_schemas import (
+    CLAIM_LEDGER_PATH,
+    COMMIT_ACCEPTOR_PATH,
+    _generate,
+    _serialise,
+    export,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_generate_returns_two_schemas() -> None:
+    schemas = _generate()
+    assert len(schemas) == 2
+    assert CLAIM_LEDGER_PATH in schemas
+    assert COMMIT_ACCEPTOR_PATH in schemas
+
+
+def test_serialise_is_deterministic() -> None:
+    """Running the serialiser twice on the same dict yields the same string."""
+    schemas = _generate()
+    for path, schema in schemas.items():
+        first = _serialise(schema)
+        second = _serialise(schema)
+        assert first == second, f"non-deterministic serialisation for {path}"
+        assert first.endswith("\n"), f"missing trailing newline on {path}"
+
+
+def test_claim_ledger_schema_shape() -> None:
+    schemas = _generate()
+    schema = schemas[CLAIM_LEDGER_PATH]
+    assert schema["title"] == "ClaimLedger"
+    assert "schema_version" in schema["properties"]
+    assert "claims" in schema["properties"]
+
+
+def test_commit_acceptor_schema_shape() -> None:
+    schemas = _generate()
+    schema = schemas[COMMIT_ACCEPTOR_PATH]
+    assert schema["title"] == "CommitAcceptor"
+    assert "diff_scope" in schema["properties"]
+    assert "falsifier" in schema["properties"]
+
+
+def test_check_mode_passes_against_committed_artefact() -> None:
+    """``--check`` exits 0 when the on-disk schema matches the live model.
+
+    A failure here means the typed model has drifted from the published
+    JSON Schema — re-run the exporter and commit the regenerated files.
+    """
+    rc = export(check=True)
+    assert rc == 0, (
+        "governance JSON Schema drift detected — run "
+        "`python scripts/export_governance_schemas.py` to regenerate "
+        "docs/schemas/governance/."
+    )
+
+
+def test_published_artefacts_are_valid_json(tmp_path: Path) -> None:
+    """Each on-disk schema parses as valid JSON Schema 2020-12."""
+    for path in (CLAIM_LEDGER_PATH, COMMIT_ACCEPTOR_PATH):
+        if not path.exists():
+            pytest.skip(f"{path} not yet committed")
+        loaded = json.loads(path.read_text(encoding="utf-8"))
+        assert isinstance(loaded, dict)
+        assert "title" in loaded
+        assert "properties" in loaded
+
+
+def test_published_artefact_top_level_shape() -> None:
+    """The committed JSON Schema covers the live model's top-level fields.
+
+    A second-line check beyond `valid JSON`: the schema actually
+    declares the contract surface (``schema_version`` and ``claims``
+    on ClaimLedger; ``diff_scope`` and ``falsifier`` on CommitAcceptor)
+    that downstream consumers pin against.
+    """
+    if not CLAIM_LEDGER_PATH.exists() or not COMMIT_ACCEPTOR_PATH.exists():
+        pytest.skip("schemas not yet committed")
+    cl = json.loads(CLAIM_LEDGER_PATH.read_text(encoding="utf-8"))
+    ca = json.loads(COMMIT_ACCEPTOR_PATH.read_text(encoding="utf-8"))
+    assert {"schema_version", "claims"} <= set(cl["properties"].keys())
+    assert {"diff_scope", "falsifier", "id", "claim_type"} <= set(ca["properties"].keys())


### PR DESCRIPTION
Exports the typed Pydantic models (PR #552) as canonical JSON Schema 2020-12 artefacts under docs/schemas/governance/. CI workflow governance-schema-export-sync re-runs --check on every PR; fails closed on drift.

7/7 tests pass. mypy --strict + ruff clean. Acceptor falsifier probes round-trip integrity.

See commit message for details.