### PR TITLE
feat(governance): falsifier-block for api-contract-openapi-coverage + INV-API-CONTRACT

### DIFF
--- a/.claude/commit_acceptors/falsifier-api-contract-openapi-coverage.yaml
+++ b/.claude/commit_acceptors/falsifier-api-contract-openapi-coverage.yaml
@@ -1,0 +1,105 @@
+# Diff-bound commit acceptor for closing my own contribution to the
+# named-but-unfalsifiable ANCHORED set in docs/CLAIMS.yaml.
+#
+# Context: PR #551 (Q4 Phase-3 EXIT, 2026-05-07) re-classified the
+# claim `api-contract-openapi-coverage` from EXTRAPOLATED to ANCHORED
+# without writing the falsifier-block ADR 0021 mandates on every v3
+# ANCHORED claim. Today's audit (run after #551 + #552 + #553 + #554 +
+# #555) named that omission: my own claim was on the floating list.
+#
+# This PR closes it. INV-API-CONTRACT is added to
+# .claude/physics/INVARIANTS.yaml (registry: 90 → 91), the four
+# documentation surfaces that the invariant-count-sync gate audits
+# are bumped in lock-step (README.md, BASELINE.md, CLAUDE.md
+# headline), and the CLAIMS.yaml entry for api-contract-openapi-coverage
+# now carries a falsifier-block citing INV-API-CONTRACT and the
+# canonical pytest test_id.
+#
+# Locally verified:
+#   * python scripts/count_invariants.py: 91
+#   * python scripts/check_invariant_count_sync.py: OK 91
+#   * python scripts/ci/check_claims.py:
+#       falsifier coverage 9/21 ANCHORED (was 8/21)
+#       12/21 ANCHORED still lack falsifier (was 13/21)
+#   * python scripts/export_governance_schemas.py --check: PASS
+#   * pytest tests/governance/test_typed_models.py
+#         tests/scripts/test_export_governance_schemas.py: 19/19 pass
+
+id: falsifier-api-contract-openapi-coverage
+status: ACTIVE
+claim_type: governance
+promise: >-
+  After this PR lands, the docs/CLAIMS.yaml entry
+  `api-contract-openapi-coverage` carries a v3 falsifier-block whose
+  test_id resolves to a real pytest node
+  (`tests/api/test_schemathesis_contract.py::test_api_operation_conforms_to_schema`)
+  and whose `invariants_cited` references the new INV-API-CONTRACT
+  declared in .claude/physics/INVARIANTS.yaml. The
+  invariant-count-sync gate reports OK at 91 across the four
+  documentation surfaces. The check_claims falsifier-coverage line
+  reads "9/21 ANCHORED" (was 8/21). My own contribution to the
+  named-but-unfalsifiable list (closed yesterday in #551) is removed
+  from the list today by writing the falsifier-block I owed.
+diff_scope:
+  changed_files:
+    - path: ".claude/commit_acceptors/falsifier-api-contract-openapi-coverage.yaml"
+    - path: ".claude/physics/INVARIANTS.yaml"
+    - path: "BASELINE.md"
+    - path: "CLAUDE.md"
+    - path: "README.md"
+    - path: "docs/CLAIMS.yaml"
+  forbidden_paths:
+    - "trading/"
+    - "execution/"
+    - "forecast/"
+    - "policy/"
+    - "core/physics/"
+    - "core/kuramoto/"
+    - "application/"
+    - "src/"
+    - "tools/commit_acceptor/"
+    - "scripts/ci/"
+    - "scripts/check_invariant_count_sync.py"
+    - "scripts/count_invariants.py"
+required_python_symbols: []
+expected_signal: >-
+  `python scripts/count_invariants.py` returns 91; `python
+  scripts/check_invariant_count_sync.py` reports
+  "OK: 91 invariants, all documentation surfaces in sync.";
+  `python scripts/ci/check_claims.py` includes the line
+  "falsifier coverage: 9/21 ANCHORED" and the missing-falsifier list
+  no longer contains `api-contract-openapi-coverage`. `python
+  scripts/export_governance_schemas.py --check` exits 0.
+measurement_command: >-
+  bash -c 'python scripts/count_invariants.py | grep -q "^91$"
+  && PYTHONPATH=scripts python scripts/check_invariant_count_sync.py
+  && python scripts/ci/check_claims.py 2>&1 | grep -q "9/21 ANCHORED"
+  && ! python scripts/ci/check_claims.py 2>&1 | grep -q "api-contract-openapi-coverage"
+  && python scripts/export_governance_schemas.py --check'
+signal_artifact: "tmp/falsifier_api_contract_openapi_coverage.log"
+falsifier:
+  command: >-
+    bash -c 'python scripts/ci/check_claims.py 2>&1
+    | grep -q "api-contract-openapi-coverage"'
+  description: >-
+    Probes the claim-ledger gate for the api-contract-openapi-coverage
+    id appearing in the missing-falsifier WARN list. After this PR,
+    that id MUST NOT appear (it carries a v3 falsifier-block now).
+    If a future change strips the falsifier block, check_claims.py
+    re-emits the id on the WARN list, the falsifier exits 0, and
+    the regression is flagged. This is the inverse-probe pattern: the
+    falsifier exits 0 ONLY when the invariant has broken.
+rollback_command: >-
+  git checkout HEAD~1 --
+  .claude/physics/INVARIANTS.yaml
+  README.md
+  BASELINE.md
+  CLAUDE.md
+  docs/CLAIMS.yaml
+  .claude/commit_acceptors/falsifier-api-contract-openapi-coverage.yaml
+rollback_verification_command: >-
+  bash -c 'python scripts/count_invariants.py | grep -q "^90$"'
+memory_update_type: append
+ledger_path: ".claude/commit_acceptors/falsifier-api-contract-openapi-coverage.yaml"
+report_path: "tmp/falsifier_api_contract_openapi_coverage.log"
+evidence: []

--- a/.claude/physics/INVARIANTS.yaml
+++ b/.claude/physics/INVARIANTS.yaml
@@ -1053,6 +1053,7 @@ api_contract:
     provenance: ANCHORED
     source: application/api/service.py
     tests: tests/api/test_schemathesis_contract.py
+    integration_test: tests/api/test_schemathesis_contract.py
     runtime_evaluable: yes
     references:
       - "OpenAPI Initiative (2024). OpenAPI Specification 3.1.0. https://spec.openapis.org/oas/v3.1.0"

--- a/.claude/physics/INVARIANTS.yaml
+++ b/.claude/physics/INVARIANTS.yaml
@@ -1032,3 +1032,30 @@ pncc:
       - "Landauer, R. (1961). Irreversibility and Heat Generation in the Computing Process. IBM J. Res. Dev. 5, 183."
       - "Bennett, C. H. (1982). The thermodynamics of computation — a review. Int. J. Theor. Phys. 21, 905."
     related: [INV-BEKENSTEIN-COGNITIVE, INV-ARROW-OF-TIME]
+
+# ═══════════════════════════════════════════════════
+# API CONTRACT — schemathesis-enforced OpenAPI 3.1 surface (Phase-3 EXIT)
+# ═══════════════════════════════════════════════════
+# IERD-PAI-FPS-UX-001 §5 + ADR 0020 (Phase-3 EXIT, 2026-05-07): every
+# response emitted by `application.api.service.create_app()` must conform
+# to the OpenAPI 3.1 contract published in `schemas/openapi/`. Schemathesis
+# property-based fuzz fires on every PR touching application/api/** with
+# fail-closed semantics (no continue-on-error; the gate blocks merge).
+
+api_contract:
+  openapi_conformance:
+    id: INV-API-CONTRACT
+    type: universal
+    statement: "For every (path, method) declared in schemas/openapi/geosync-online-inference-v1.json, runtime responses from `application.api.service.create_app()` satisfy: (a) HTTP status code ∈ declared response codes for that operation; (b) response body validates against the declared JSON Schema for that status; (c) Content-Type matches the declared media type; (d) declared headers are present; (e) schema-violating requests are rejected with one of the declared 4xx codes (no silent acceptance)."
+    test_type: property_test
+    falsification: "Any response from `create_app()` whose status code, body, Content-Type, or headers diverge from the declared OpenAPI 3.1 contract; OR any schema-violating request silently accepted. Schemathesis emits a structured FailureGroup naming one of: UndefinedStatusCode, JsonSchemaError, MalformedMediaType, MissingHeaders, AcceptedNegativeData, ServerError."
+    priority: P1
+    provenance: ANCHORED
+    source: application/api/service.py
+    tests: tests/api/test_schemathesis_contract.py
+    runtime_evaluable: yes
+    references:
+      - "OpenAPI Initiative (2024). OpenAPI Specification 3.1.0. https://spec.openapis.org/oas/v3.1.0"
+      - "Hatfield-Dodds, Z. et al. Schemathesis: property-based API testing. https://schemathesis.readthedocs.io"
+      - "IERD-PAI-FPS-UX-001 §5 (this repository): Phase-3 EXIT contract for the HTTP API."
+    related: []

--- a/BASELINE.md
+++ b/BASELINE.md
@@ -10,7 +10,7 @@ preserved as historical context, not as the current count.
 ## 0. TL;DR (current state, 2026-04-30)
 
 - **Physics kernel is real.** `.claude/physics/` currently contains
-  **90 invariants** (per `python scripts/count_invariants.py`, single source of
+  **91 invariants** (per `python scripts/count_invariants.py`, single source of
   truth: `.claude/physics/INVARIANTS.yaml`), 5 theory files, a 780-line
   validator with 7 levels (L1–L5 + C1–C2), and a self-check that passes.
   CI gate `invariant-count-sync` fail-closes on any drift between this file,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ GeoSync is a quantitative trading platform with neuroscience-inspired risk manag
 
 ---
 
-## INVARIANT REGISTRY — 90 invariants loaded by kernel self-check
+## INVARIANT REGISTRY — 91 invariants loaded by kernel self-check
 
 > **Single source of truth:** `.claude/physics/INVARIANTS.yaml` (`python scripts/count_invariants.py`). The 2026-04-30 external audit corrected a four-way drift (`57 / 66 / 67 / 87`); CI gate `invariant-count-sync` now fail-closes on any future divergence between this header, README badges, BASELINE.md, and the registry.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <br><br>
 
 [![modules-15](https://img.shields.io/badge/modules-15-blueviolet?style=for-the-badge)](docs/ARCHITECTURE.md)
-[![invariants-90](https://img.shields.io/badge/invariants-90-critical?style=for-the-badge)](CLAUDE.md)
+[![invariants-91](https://img.shields.io/badge/invariants-91-critical?style=for-the-badge)](CLAUDE.md)
 [![tests-11446](https://img.shields.io/badge/tests-11%2C446-brightgreen?style=for-the-badge)](tests/)
 [![indicators-17](https://img.shields.io/badge/indicators-17-gold?style=for-the-badge)](core/indicators/)
 [![ADRs-16](https://img.shields.io/badge/ADRs-16-blue?style=for-the-badge)](docs/adr/)
@@ -21,7 +21,7 @@
 Kuramoto synchronization  ·  Ricci curvature flow  ·  Free-energy thermodynamics  ·  Cryptobiosis
 ```
 
-*Physics-inspired quantitative research platform with 90 machine-checkable invariants.*
+*Physics-inspired quantitative research platform with 91 machine-checkable invariants.*
 *Every signal traces back to peer-reviewed science. Every clamp traces back to a law.*
 
 <br>
@@ -32,7 +32,7 @@ Kuramoto synchronization  ·  Ricci curvature flow  ·  Free-energy thermodynami
 [![Formal Verification](https://github.com/neuron7xLab/GeoSync/actions/workflows/formal-verification.yml/badge.svg?branch=main)](https://github.com/neuron7xLab/GeoSync/actions/workflows/formal-verification.yml)
 [![Python](https://img.shields.io/badge/Python-3.11%20%7C%203.12-3776AB?style=flat&logo=python&logoColor=white)](https://www.python.org/)
 [![Security](https://img.shields.io/badge/NIST%20SP%20800--53-aligned-red?style=flat)](docs/security/)
-[![Physics Gate](https://img.shields.io/badge/physics_gate-90_invariants-critical?style=flat)](CLAUDE.md)
+[![Physics Gate](https://img.shields.io/badge/physics_gate-91_invariants-critical?style=flat)](CLAUDE.md)
 [![Coverage](https://img.shields.io/badge/line_coverage-71%25-yellowgreen?style=flat)](BASELINE.md)
 
 </div>
@@ -145,13 +145,13 @@ dθᵢ/dt = ωᵢ + K · Σⱼ Aᵢⱼ sin(θⱼ − θᵢ)
 
 ## Physics Kernel
 
-GeoSync is a **physics-inspired quantitative research platform with a partially machine-checkable invariant layer**, not a "verified physical system" — that stronger claim was retracted on 2026-04-30 after an external audit ([CLAIMS.md](CLAIMS.md), [ALTERNATIVE_HYPOTHESES.md](.claude/physics/ALTERNATIVE_HYPOTHESES.md)). The physics kernel (`.claude/physics/`) declares **90 machine-checkable invariants** across the modules listed in [`INVARIANTS.yaml`](.claude/physics/INVARIANTS.yaml). Tests grounded in `INV-*` ids are *mathematical witnesses* of a specific invariant; the `BASELINE.md` ledger tracks how many of them currently exist (it is intentionally smaller than the registry — coverage growth is gated, not assumed).
+GeoSync is a **physics-inspired quantitative research platform with a partially machine-checkable invariant layer**, not a "verified physical system" — that stronger claim was retracted on 2026-04-30 after an external audit ([CLAIMS.md](CLAIMS.md), [ALTERNATIVE_HYPOTHESES.md](.claude/physics/ALTERNATIVE_HYPOTHESES.md)). The physics kernel (`.claude/physics/`) declares **91 machine-checkable invariants** across the modules listed in [`INVARIANTS.yaml`](.claude/physics/INVARIANTS.yaml). Tests grounded in `INV-*` ids are *mathematical witnesses* of a specific invariant; the `BASELINE.md` ledger tracks how many of them currently exist (it is intentionally smaller than the registry — coverage growth is gated, not assumed).
 
 Control-plane safety properties are additionally **model-checked in TLA⁺** — see [`formal/tla/AdmissionGate.tla`](formal/tla/AdmissionGate.tla) for the four-barrier admission gate with three TLC-checkable invariants (`TypeOK`, `SafeFirstRejectionWins`, `RejectCodeMatchesBarrier`). CI runs TLC on every PR via [`formal-verification.yml`](.github/workflows/formal-verification.yml).
 
 ```
                      ┌──────────────────────────────────────┐
-                     │   90 INVARIANTS  ·  registry-tracked  │
+                     │   91 INVARIANTS  ·  registry-tracked  │
                      │   Every assert derives its tolerance  │
                      │   from the law's formula, not from    │
                      │   a magic literal.                    │
@@ -172,7 +172,7 @@ Control-plane safety properties are additionally **model-checked in TLA⁺** —
 
 | Metric | Value | Source |
 |--------|-------|--------|
-| Physics invariants declared | **90 in `.claude/physics/INVARIANTS.yaml`** (single source of truth) | `python scripts/count_invariants.py` |
+| Physics invariants declared | **91 in `.claude/physics/INVARIANTS.yaml`** (single source of truth) | `python scripts/count_invariants.py` |
 | Physics invariants grounded by tests | tracked in [`BASELINE.md`](BASELINE.md) — **deliberately smaller than declared count**; coverage growth is gated, not assumed | `BASELINE.md` ledger |
 | C1/C2 code audit | **0** undocumented physics clamps in `core/` | `physics-kernel-gate.yml` |
 | CI gates | physics-kernel-gate · invariant-count-sync · formal-verification (TLA⁺) · claims-evidence-gate | `.github/workflows/` |
@@ -778,6 +778,6 @@ Trading financial instruments involves substantial risk of loss. GeoSync provide
 
 [![MIT](https://img.shields.io/badge/license-MIT-yellow?style=flat)](LICENSE)
 
-<sub>Built on peer-reviewed science. Physics-first, 90 invariants loaded from `.claude/physics/INVARIANTS.yaml`, every clamp documented.</sub>
+<sub>Built on peer-reviewed science. Physics-first, 91 invariants loaded from `.claude/physics/INVARIANTS.yaml`, every clamp documented.</sub>
 
 </div>

--- a/docs/CLAIMS.yaml
+++ b/docs/CLAIMS.yaml
@@ -567,8 +567,27 @@ claims:
       - .github/workflows/schemathesis-contract.yml
       - schemas/openapi/geosync-online-inference-v1.json
       - application/api/errors.py
+    falsifier:
+      test_id: tests/api/test_schemathesis_contract.py::test_api_operation_conforms_to_schema
+      invariants_cited:
+        - INV-API-CONTRACT
+      failure_signature: >
+        Any (path, method) declared in
+        schemas/openapi/geosync-online-inference-v1.json that diverges
+        from the OpenAPI 3.1 contract under property-based fuzz produces
+        a Schemathesis FailureGroup naming one of: UndefinedStatusCode
+        (HTTP code emitted at runtime not in declared response set),
+        JsonSchemaError (response body shape divergent from declared
+        $ref), MalformedMediaType / MissingHeaders (response Content-Type
+        or declared headers missing), AcceptedNegativeData (schema-
+        violating input silently accepted), ServerError (5xx emitted
+        when the spec declares only success codes). The /graphql
+        operations are excluded by design (Strawberry has its own
+        typed schema; tracked under a separate GraphQL contract suite).
+        On Phase-3 EXIT the workflow run-step continue-on-error is
+        false; any of the above failures blocks merge.
     added_utc: "2026-05-03"
-    last_updated_utc: "2026-05-07"
+    last_updated_utc: "2026-05-08"
 
   - id: ux-readiness-state-coverage
     priority: P1


### PR DESCRIPTION
Closes the named-but-unfalsifiable loop my own PR #551 opened. Adds INV-API-CONTRACT to the registry (90 → 91), syncs all 4 doc surfaces, writes the v3 falsifier-block on the claim citing the canonical pytest test_id.

Falsifier coverage: 8/21 → 9/21 ANCHORED.
Floating list: 13 → 12.

See commit message for details. All gates green locally.