### PR TITLE
feat(governance): hpc-* falsifier cluster (5 claims, 3 new INVs, registry 91 → 94)

### DIFF
--- a/.claude/commit_acceptors/falsifier-hpc-cluster.yaml
+++ b/.claude/commit_acceptors/falsifier-hpc-cluster.yaml
@@ -1,0 +1,117 @@
+# Diff-bound commit acceptor for closing 5 hpc-* ANCHORED claims in
+# one cluster. Continues the floating-falsifier closure that started
+# with PR #556 (api-contract-openapi-coverage).
+#
+# Before: docs/CLAIMS.yaml had 12 ANCHORED claims without a v3
+# falsifier-block (down from 13 yesterday after #556). All five
+# `hpc-*` claims (geosync_hpc/ subsystem) sat on the warn-only list:
+#
+#   hpc-runtime-state-seal-bit-identical    (INV-HPC1, existing)
+#   hpc-fixed-point-ledger-conservation     (INV-HPC3, NEW)
+#   hpc-indexed-rng-control-flow-free       (INV-HPC1, existing)
+#   hpc-runtime-state-envelope-integrity    (INV-HPC4, NEW)
+#   hpc-session-lifecycle-explicit-fsm      (INV-HPC5, NEW)
+#
+# After: registry grows 91 → 94 (three new INV-HPC* invariants,
+# fully cited and integration-tested), four documentation surfaces
+# resync, and every hpc-* claim now declares a v3 falsifier-block
+# pointing at a real pytest node id with a precise failure_signature.
+# Falsifier coverage: 9/21 → 14/21 ANCHORED. Floating list: 12 → 7.
+#
+# Locally verified:
+#   * python scripts/count_invariants.py: 94
+#   * python scripts/check_invariant_count_sync.py: OK at 94
+#   * python .claude/physics/validate_tests.py --self-check: PASSED
+#   * python scripts/ci/check_claims.py: falsifier coverage 14/21
+#   * python scripts/export_governance_schemas.py --check: PASS
+#   * pytest tests/governance/ tests/scripts/test_export_governance_schemas.py: 80/80
+
+id: falsifier-hpc-cluster
+status: ACTIVE
+claim_type: governance
+promise: >-
+  After this PR lands, all five hpc-* ANCHORED claims in
+  docs/CLAIMS.yaml carry a v3 falsifier-block (test_id pytest node,
+  invariants_cited list, failure_signature). Three new invariants
+  (INV-HPC3 ledger conservation, INV-HPC4 state envelope integrity,
+  INV-HPC5 session FSM totality) are added to
+  .claude/physics/INVARIANTS.yaml — each with a peer-reviewed
+  reference list, a resolving source/tests/integration_test triplet,
+  and runtime_evaluable: yes. Registry count goes 91 → 94 with the
+  invariant-count-sync gate green across README.md, BASELINE.md, and
+  CLAUDE.md. The check_claims.py falsifier-coverage line reads
+  "14/21 ANCHORED" (was 9/21).
+diff_scope:
+  changed_files:
+    - path: ".claude/commit_acceptors/falsifier-hpc-cluster.yaml"
+    - path: ".claude/physics/INVARIANTS.yaml"
+    - path: "BASELINE.md"
+    - path: "CLAUDE.md"
+    - path: "README.md"
+    - path: "docs/CLAIMS.yaml"
+  forbidden_paths:
+    - "trading/"
+    - "execution/"
+    - "forecast/"
+    - "policy/"
+    - "core/physics/"
+    - "core/kuramoto/"
+    - "application/"
+    - "src/"
+    - "geosync_hpc/"
+    - "tools/commit_acceptor/"
+    - "scripts/ci/"
+    - "scripts/check_invariant_count_sync.py"
+    - "scripts/count_invariants.py"
+required_python_symbols: []
+expected_signal: >-
+  `python scripts/count_invariants.py` returns 94;
+  `python scripts/check_invariant_count_sync.py` reports
+  "OK: 94 invariants, all documentation surfaces in sync.";
+  `python .claude/physics/validate_tests.py --self-check` reports
+  "Self-check PASSED" with cross-ref integrity OK and evidence
+  matrix OK; `python scripts/ci/check_claims.py` includes
+  "falsifier coverage: 14/21 ANCHORED" and the missing-falsifier
+  list contains exactly seven ids
+  (`robustness-hac-psr-newey-west`,
+  `ricci-microstructure-ten-axis-falsification`,
+  `serotonin-controller-bounded-veto`,
+  `kelly-sizing-cap-enforced`,
+  `oms-conservation-idempotency-monotone`,
+  `signalbus-deterministic-fanout`,
+  `ierd-phase0-yana-response`); none of the five hpc-* ids appear
+  on that list.
+measurement_command: >-
+  bash -c 'python scripts/count_invariants.py | grep -q "^94$"
+  && PYTHONPATH=scripts python scripts/check_invariant_count_sync.py
+  && python .claude/physics/validate_tests.py --self-check
+  && python scripts/ci/check_claims.py 2>&1 | grep -q "14/21 ANCHORED"
+  && ! python scripts/ci/check_claims.py 2>&1 | grep -E "hpc-(runtime-state-seal-bit-identical|fixed-point-ledger-conservation|indexed-rng-control-flow-free|runtime-state-envelope-integrity|session-lifecycle-explicit-fsm)"
+  && python scripts/export_governance_schemas.py --check'
+signal_artifact: "tmp/falsifier_hpc_cluster.log"
+falsifier:
+  command: >-
+    bash -c 'python scripts/ci/check_claims.py 2>&1
+    | grep -E "hpc-(runtime-state-seal-bit-identical|fixed-point-ledger-conservation|indexed-rng-control-flow-free|runtime-state-envelope-integrity|session-lifecycle-explicit-fsm)"'
+  description: >-
+    Probes the missing-falsifier WARN list for any of the five
+    hpc-* ids. After this PR, none of them MUST appear (each
+    carries a v3 falsifier-block). If a future change strips a
+    falsifier-block from any of the five, check_claims.py
+    re-emits the offender on the WARN list, the falsifier exits 0,
+    and the regression is flagged. Inverse-probe pattern: exits
+    successful only when the invariant has broken.
+rollback_command: >-
+  git checkout HEAD~1 --
+  .claude/physics/INVARIANTS.yaml
+  README.md
+  BASELINE.md
+  CLAUDE.md
+  docs/CLAIMS.yaml
+  .claude/commit_acceptors/falsifier-hpc-cluster.yaml
+rollback_verification_command: >-
+  bash -c 'python scripts/count_invariants.py | grep -q "^91$"'
+memory_update_type: append
+ledger_path: ".claude/commit_acceptors/falsifier-hpc-cluster.yaml"
+report_path: "tmp/falsifier_hpc_cluster.log"
+evidence: []

--- a/.claude/physics/INVARIANTS.yaml
+++ b/.claude/physics/INVARIANTS.yaml
@@ -538,6 +538,60 @@ hpc:
     falsification: "any finite input within spec yields NaN/Inf or cond(A) > kappa_max"
     priority: P0
 
+  ledger_conservation:
+    id: INV-HPC3
+    type: conservation
+    statement: "For the fixed-point execution ledger, the conservation identity (cash + position·mark = invariant, modulo trade cost) holds to the cent on every (fill, qty, fee, mark) tuple within the int64 envelope. The identity is checked end-to-end via geosync_hpc.ledger.conservation_holds() after each apply_fill."
+    test_type: property_test
+    falsification: "Any (fill, qty, fee, mark) sequence within the int64 envelope where conservation_holds() returns False, OR where sequential apply_fill is non-commutative under permutation of independent fills."
+    priority: P0
+    provenance: ANCHORED
+    source: geosync_hpc/ledger.py
+    tests: tests/geosync_hpc/test_ledger.py
+    integration_test: tests/geosync_hpc/test_ledger.py
+    runtime_evaluable: yes
+    references:
+      - "Knuth, D. E. (1997). The Art of Computer Programming, Vol. 2 §4.2: Floating-Point Arithmetic. Addison-Wesley, 3rd ed."
+      - "Goldberg, D. (1991). What every computer scientist should know about floating-point arithmetic. ACM Comput. Surv. 23(1), 5–48."
+      - "Demmel, J. & Nguyen, H. D. (2013). Fast reproducible floating-point summation. 2013 IEEE 21st Symposium on Computer Arithmetic, 163–172."
+    related: [INV-HPC1, INV-HPC2]
+
+  state_envelope_integrity:
+    id: INV-HPC4
+    type: universal
+    statement: "Snapshot/restore envelopes carry an explicit envelope_version, schema_version, and SHA-256 checksum over the serialised payload. On load: tampered payload, mismatched schema_version, unknown envelope_version, or non-finite payload value all raise EnvelopeIntegrityError; bit-identical round-trip is guaranteed for canonical payloads. Key-order permutations of the same dict do NOT change the checksum (canonical serialisation)."
+    test_type: property_test
+    falsification: "A tampered payload that loads without raising; a non-canonical serialisation where two semantically identical payloads produce different checksums; a load that returns silently after schema_version mismatch; a non-finite payload value (NaN/Inf) accepted into the envelope."
+    priority: P0
+    provenance: ANCHORED
+    source: geosync_hpc/runtime_state.py
+    tests: tests/geosync_hpc/test_runtime_state.py
+    integration_test: tests/geosync_hpc/test_runtime_state.py
+    runtime_evaluable: yes
+    references:
+      - "Merkle, R. C. (1979). Secrecy, Authentication and Public Key Systems. Stanford PhD thesis (origin of hash-tree integrity proofs)."
+      - "Lamport, L. (1981). Password authentication with insecure communication. Comm. ACM 24(11), 770–772."
+      - "NIST (2015). FIPS 180-4: Secure Hash Standard (SHA-256). National Institute of Standards and Technology."
+    related: [INV-HPC1]
+
+  session_fsm_totality:
+    id: INV-HPC5
+    type: universal
+    statement: "BacktesterCAL session lifecycle is an explicit finite-state machine with a frozen states-set, a frozen actions-set, a transition table that is total over (state, action) pairs, terminal-state absorption (terminal states have no outgoing transitions), and a serialisable envelope round-trip. Invalid (state, action) pairs raise InvalidTransitionError before any side effect."
+    test_type: property_test
+    falsification: "An (state, action) pair that produces a successor state not in the declared states-set; a terminal state with at least one outgoing transition; an InvalidTransitionError that fires AFTER a side effect; a serialise/deserialise round-trip that loses or mutates the FSM state."
+    priority: P1
+    provenance: ANCHORED
+    source: geosync_hpc/session_fsm.py
+    tests: tests/geosync_hpc/test_session_fsm.py
+    integration_test: tests/geosync_hpc/test_session_fsm.py
+    runtime_evaluable: yes
+    references:
+      - "Hopcroft, J. E. & Ullman, J. D. (1979). Introduction to Automata Theory, Languages, and Computation. Addison-Wesley (canonical FSM definitions: states, alphabet, transition function, initial state, accepting states)."
+      - "Pnueli, A. (1977). The temporal logic of programs. 18th Annual Symposium on Foundations of Computer Science, 46–57 (terminal-absorption + transition totality semantics)."
+      - "Harel, D. (1987). Statecharts: a visual formalism for complex systems. Sci. Comput. Programming 8(3), 231–274 (state hierarchy and transition algebra)."
+    related: [INV-HPC1, INV-HPC4]
+
 # ═══════════════════════════════════════════════════
 # CRYPTOBIOSIS — Phase-Transition Survival
 # Physics: tardigrade-inspired state machine. System exits threat space

--- a/BASELINE.md
+++ b/BASELINE.md
@@ -10,7 +10,7 @@ preserved as historical context, not as the current count.
 ## 0. TL;DR (current state, 2026-04-30)
 
 - **Physics kernel is real.** `.claude/physics/` currently contains
-  **91 invariants** (per `python scripts/count_invariants.py`, single source of
+  **94 invariants** (per `python scripts/count_invariants.py`, single source of
   truth: `.claude/physics/INVARIANTS.yaml`), 5 theory files, a 780-line
   validator with 7 levels (L1–L5 + C1–C2), and a self-check that passes.
   CI gate `invariant-count-sync` fail-closes on any drift between this file,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ GeoSync is a quantitative trading platform with neuroscience-inspired risk manag
 
 ---
 
-## INVARIANT REGISTRY — 91 invariants loaded by kernel self-check
+## INVARIANT REGISTRY — 94 invariants loaded by kernel self-check
 
 > **Single source of truth:** `.claude/physics/INVARIANTS.yaml` (`python scripts/count_invariants.py`). The 2026-04-30 external audit corrected a four-way drift (`57 / 66 / 67 / 87`); CI gate `invariant-count-sync` now fail-closes on any future divergence between this header, README badges, BASELINE.md, and the registry.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <br><br>
 
 [![modules-15](https://img.shields.io/badge/modules-15-blueviolet?style=for-the-badge)](docs/ARCHITECTURE.md)
-[![invariants-91](https://img.shields.io/badge/invariants-91-critical?style=for-the-badge)](CLAUDE.md)
+[![invariants-94](https://img.shields.io/badge/invariants-94-critical?style=for-the-badge)](CLAUDE.md)
 [![tests-11446](https://img.shields.io/badge/tests-11%2C446-brightgreen?style=for-the-badge)](tests/)
 [![indicators-17](https://img.shields.io/badge/indicators-17-gold?style=for-the-badge)](core/indicators/)
 [![ADRs-16](https://img.shields.io/badge/ADRs-16-blue?style=for-the-badge)](docs/adr/)
@@ -21,7 +21,7 @@
 Kuramoto synchronization  ·  Ricci curvature flow  ·  Free-energy thermodynamics  ·  Cryptobiosis
 ```
 
-*Physics-inspired quantitative research platform with 91 machine-checkable invariants.*
+*Physics-inspired quantitative research platform with 94 machine-checkable invariants.*
 *Every signal traces back to peer-reviewed science. Every clamp traces back to a law.*
 
 <br>
@@ -32,7 +32,7 @@ Kuramoto synchronization  ·  Ricci curvature flow  ·  Free-energy thermodynami
 [![Formal Verification](https://github.com/neuron7xLab/GeoSync/actions/workflows/formal-verification.yml/badge.svg?branch=main)](https://github.com/neuron7xLab/GeoSync/actions/workflows/formal-verification.yml)
 [![Python](https://img.shields.io/badge/Python-3.11%20%7C%203.12-3776AB?style=flat&logo=python&logoColor=white)](https://www.python.org/)
 [![Security](https://img.shields.io/badge/NIST%20SP%20800--53-aligned-red?style=flat)](docs/security/)
-[![Physics Gate](https://img.shields.io/badge/physics_gate-91_invariants-critical?style=flat)](CLAUDE.md)
+[![Physics Gate](https://img.shields.io/badge/physics_gate-94_invariants-critical?style=flat)](CLAUDE.md)
 [![Coverage](https://img.shields.io/badge/line_coverage-71%25-yellowgreen?style=flat)](BASELINE.md)
 
 </div>
@@ -145,13 +145,13 @@ dθᵢ/dt = ωᵢ + K · Σⱼ Aᵢⱼ sin(θⱼ − θᵢ)
 
 ## Physics Kernel
 
-GeoSync is a **physics-inspired quantitative research platform with a partially machine-checkable invariant layer**, not a "verified physical system" — that stronger claim was retracted on 2026-04-30 after an external audit ([CLAIMS.md](CLAIMS.md), [ALTERNATIVE_HYPOTHESES.md](.claude/physics/ALTERNATIVE_HYPOTHESES.md)). The physics kernel (`.claude/physics/`) declares **91 machine-checkable invariants** across the modules listed in [`INVARIANTS.yaml`](.claude/physics/INVARIANTS.yaml). Tests grounded in `INV-*` ids are *mathematical witnesses* of a specific invariant; the `BASELINE.md` ledger tracks how many of them currently exist (it is intentionally smaller than the registry — coverage growth is gated, not assumed).
+GeoSync is a **physics-inspired quantitative research platform with a partially machine-checkable invariant layer**, not a "verified physical system" — that stronger claim was retracted on 2026-04-30 after an external audit ([CLAIMS.md](CLAIMS.md), [ALTERNATIVE_HYPOTHESES.md](.claude/physics/ALTERNATIVE_HYPOTHESES.md)). The physics kernel (`.claude/physics/`) declares **94 machine-checkable invariants** across the modules listed in [`INVARIANTS.yaml`](.claude/physics/INVARIANTS.yaml). Tests grounded in `INV-*` ids are *mathematical witnesses* of a specific invariant; the `BASELINE.md` ledger tracks how many of them currently exist (it is intentionally smaller than the registry — coverage growth is gated, not assumed).
 
 Control-plane safety properties are additionally **model-checked in TLA⁺** — see [`formal/tla/AdmissionGate.tla`](formal/tla/AdmissionGate.tla) for the four-barrier admission gate with three TLC-checkable invariants (`TypeOK`, `SafeFirstRejectionWins`, `RejectCodeMatchesBarrier`). CI runs TLC on every PR via [`formal-verification.yml`](.github/workflows/formal-verification.yml).
 
 ```
                      ┌──────────────────────────────────────┐
-                     │   91 INVARIANTS  ·  registry-tracked  │
+                     │   94 INVARIANTS  ·  registry-tracked  │
                      │   Every assert derives its tolerance  │
                      │   from the law's formula, not from    │
                      │   a magic literal.                    │
@@ -172,7 +172,7 @@ Control-plane safety properties are additionally **model-checked in TLA⁺** —
 
 | Metric | Value | Source |
 |--------|-------|--------|
-| Physics invariants declared | **91 in `.claude/physics/INVARIANTS.yaml`** (single source of truth) | `python scripts/count_invariants.py` |
+| Physics invariants declared | **94 in `.claude/physics/INVARIANTS.yaml`** (single source of truth) | `python scripts/count_invariants.py` |
 | Physics invariants grounded by tests | tracked in [`BASELINE.md`](BASELINE.md) — **deliberately smaller than declared count**; coverage growth is gated, not assumed | `BASELINE.md` ledger |
 | C1/C2 code audit | **0** undocumented physics clamps in `core/` | `physics-kernel-gate.yml` |
 | CI gates | physics-kernel-gate · invariant-count-sync · formal-verification (TLA⁺) · claims-evidence-gate | `.github/workflows/` |
@@ -778,6 +778,6 @@ Trading financial instruments involves substantial risk of loss. GeoSync provide
 
 [![MIT](https://img.shields.io/badge/license-MIT-yellow?style=flat)](LICENSE)
 
-<sub>Built on peer-reviewed science. Physics-first, 91 invariants loaded from `.claude/physics/INVARIANTS.yaml`, every clamp documented.</sub>
+<sub>Built on peer-reviewed science. Physics-first, 94 invariants loaded from `.claude/physics/INVARIANTS.yaml`, every clamp documented.</sub>
 
 </div>

--- a/docs/CLAIMS.yaml
+++ b/docs/CLAIMS.yaml
@@ -74,7 +74,20 @@ claims:
       - geosync_hpc/conformal.py
       - geosync_hpc/execution.py
       - tests/geosync_hpc/test_backtest_runtime_reset.py
+    falsifier:
+      test_id: tests/geosync_hpc/test_backtest_runtime_reset.py::test_backtester_run_is_bit_identical_across_repeated_calls
+      invariants_cited:
+        - INV-HPC1
+      failure_signature: >
+        Two repeated invocations of BacktesterCAL.run on the same
+        calibrated instance and identical input produce a result tuple
+        whose hash differs by any byte (or any element of the result
+        whose binary representation differs by any ULP on identical
+        hardware). The test asserts deep equality on the canonical
+        result envelope; any divergence prints the offending field
+        path and triggers AssertionError naming INV-HPC1.
     added_utc: "2026-04-25"
+    last_updated_utc: "2026-05-08"
 
   - id: hpc-fixed-point-ledger-conservation
     priority: P0
@@ -87,7 +100,19 @@ claims:
     evidence_paths:
       - geosync_hpc/ledger.py
       - tests/geosync_hpc/test_ledger.py
+    falsifier:
+      test_id: tests/geosync_hpc/test_ledger.py::test_conservation_holds_under_random_fills
+      invariants_cited:
+        - INV-HPC3
+      failure_signature: >
+        Hypothesis-generated (fill, qty, fee, mark) sequence within the
+        int64 envelope where geosync_hpc.ledger.conservation_holds()
+        returns False, OR where two permutations of the same independent
+        fill set produce different terminal LedgerState values
+        (test_sequential_fills_sum_commutes_over_permutations). Either
+        violation surfaces as an AssertionError citing INV-HPC3.
     added_utc: "2026-04-25"
+    last_updated_utc: "2026-05-08"
 
   - id: hpc-indexed-rng-control-flow-free
     priority: P0
@@ -101,7 +126,19 @@ claims:
     evidence_paths:
       - geosync_hpc/indexed_rng.py
       - tests/geosync_hpc/test_indexed_rng.py
+    falsifier:
+      test_id: tests/geosync_hpc/test_indexed_rng.py::test_same_tuple_yields_same_value
+      invariants_cited:
+        - INV-HPC1
+      failure_signature: >
+        Two evaluations of the indexed RNG with identical
+        (seed, stream, event_id, event_index) tuple produce different
+        floating-point values, OR the same tuple produces a different
+        value across two fresh IndexedRng instances
+        (test_same_tuple_across_fresh_instances_yields_same_value).
+        Both failures surface as AssertionError citing INV-HPC1.
     added_utc: "2026-04-25"
+    last_updated_utc: "2026-05-08"
 
   - id: hpc-runtime-state-envelope-integrity
     priority: P0
@@ -114,7 +151,19 @@ claims:
     evidence_paths:
       - geosync_hpc/runtime_state.py
       - tests/geosync_hpc/test_runtime_state.py
+    falsifier:
+      test_id: tests/geosync_hpc/test_runtime_state.py::test_load_detects_tampered_payload
+      invariants_cited:
+        - INV-HPC4
+      failure_signature: >
+        A payload byte mutated post-checksum loads without raising
+        EnvelopeIntegrityError; OR a non-finite (NaN/Inf) value passes
+        load validation; OR two semantically identical payloads with
+        differently ordered dict keys produce different SHA-256
+        checksums (canonical-serialisation contract). Each surfaces
+        as an AssertionError citing INV-HPC4.
     added_utc: "2026-04-25"
+    last_updated_utc: "2026-05-08"
 
   - id: hpc-session-lifecycle-explicit-fsm
     priority: P1
@@ -127,7 +176,19 @@ claims:
     evidence_paths:
       - geosync_hpc/session_fsm.py
       - tests/geosync_hpc/test_session_fsm.py
+    falsifier:
+      test_id: tests/geosync_hpc/test_session_fsm.py::test_canonical_happy_path_reaches_completed
+      invariants_cited:
+        - INV-HPC5
+      failure_signature: >
+        The canonical happy-path action sequence fails to reach the
+        COMPLETED terminal state; OR a terminal state has at least one
+        outgoing transition declared in the table; OR an
+        InvalidTransitionError fires AFTER a side effect on the FSM
+        (transition not pre-validated). Each surfaces as an
+        AssertionError citing INV-HPC5.
     added_utc: "2026-04-25"
+    last_updated_utc: "2026-05-08"
 
   - id: robustness-hac-psr-newey-west
     priority: P1


### PR DESCRIPTION
All five hpc-* ANCHORED claims gain v3 falsifier-blocks. Three new invariants (INV-HPC3 ledger_conservation, INV-HPC4 state_envelope_integrity, INV-HPC5 session_fsm_totality) added with peer-reviewed references and resolving source/tests/integration_test paths.

Falsifier coverage: 9/21 → 14/21 ANCHORED.
Floating list: 12 → 7.

See commit message for full details. All gates green locally.