### PR TITLE
feat(governance): final closure — 19/19 ANCHORED claims have falsifier-blocks

### DIFF
--- a/.claude/commit_acceptors/falsifier-final-cluster.yaml
+++ b/.claude/commit_acceptors/falsifier-final-cluster.yaml
@@ -1,0 +1,132 @@
+# Diff-bound commit acceptor for the final closure of the
+# named-but-unfalsifiable ANCHORED set in docs/CLAIMS.yaml.
+#
+# Closes the governance-discipline arc that started with PR #556
+# (api-contract-openapi-coverage falsifier) and continued with PR #558
+# (hpc-* cluster). After this PR, the floating list is EMPTY:
+#   falsifier coverage: 19/19 ANCHORED.
+#
+# Five claims gain v3 falsifier-blocks pointing at real pytest nodes:
+#   robustness-hac-psr-newey-west       (NEW INV-PSR-HAC)
+#   serotonin-controller-bounded-veto   (existing INV-5HT1/2/4/7)
+#   kelly-sizing-cap-enforced           (existing INV-KELLY1/2)
+#   oms-conservation-idempotency-monotone (existing INV-OMS1/2/3)
+#   signalbus-deterministic-fanout      (existing INV-SB1/2)
+#
+# Two claims are honestly downgraded ANCHORED → EXTRAPOLATED because
+# their evidence is paper-tier or documentation-only — no pytest node
+# currently re-runs the assertion under the ADR 0021 v3 falsifier shape:
+#   ricci-microstructure-ten-axis-falsification
+#   ierd-phase0-yana-response
+#
+# Each downgrade declares the missing-evidence path explicitly:
+#   "Re-classify ANCHORED on addition of tests/.../test_X.py with
+#    [N] parametrised tests / one assertion per question + a new
+#    INV-* registry entry."
+#
+# This is the inverse of marketing "everything's done" — it admits
+# the residual gap as the right tier and points at the exact
+# remediation path.
+#
+# Locally verified:
+#   * python scripts/count_invariants.py: 95 (was 94, +1 INV-PSR-HAC)
+#   * python scripts/check_invariant_count_sync.py: OK at 95
+#   * python .claude/physics/validate_tests.py --self-check: PASSED
+#   * python scripts/ci/check_claims.py:
+#       PASS schema v3 — 27 gated claims, 0 P2, all evidence present
+#       tier distribution: ANCHORED=19, EXTRAPOLATED=8
+#       falsifier coverage: 19/19 ANCHORED  ← 100%
+#   * python scripts/export_governance_schemas.py --check: PASS
+#   * pytest tests/governance/ tests/scripts/test_export_governance_schemas.py: 80/80
+
+id: falsifier-final-cluster
+status: ACTIVE
+claim_type: governance
+promise: >-
+  After this PR lands, every ANCHORED claim in docs/CLAIMS.yaml
+  declares a v3 falsifier-block. check_claims.py reports
+  "falsifier coverage: 19/19 ANCHORED" with no claims on the
+  missing-falsifier WARN list. Tier distribution is
+  ANCHORED=19, EXTRAPOLATED=8, SPECULATIVE=0, UNKNOWN=0. The new
+  INV-PSR-HAC invariant is registered with NW(1987, 1994) +
+  Bailey-López de Prado (2014) references and a resolving
+  source/tests/integration_test triplet under
+  research/robustness/. The two paper-tier / documentation-only
+  claims (ricci-microstructure-ten-axis-falsification,
+  ierd-phase0-yana-response) are downgraded to EXTRAPOLATED with
+  an explicit missing-evidence path that names the future
+  test_id + new INV required for re-promotion. Registry count
+  goes 94 → 95 with all four documentation surfaces resynced.
+diff_scope:
+  changed_files:
+    - path: ".claude/commit_acceptors/falsifier-final-cluster.yaml"
+    - path: ".claude/physics/INVARIANTS.yaml"
+    - path: "BASELINE.md"
+    - path: "CLAUDE.md"
+    - path: "README.md"
+    - path: "docs/CLAIMS.yaml"
+  forbidden_paths:
+    - "trading/"
+    - "execution/"
+    - "forecast/"
+    - "policy/"
+    - "core/physics/"
+    - "core/kuramoto/"
+    - "core/neuro/"
+    - "application/"
+    - "src/"
+    - "geosync_hpc/"
+    - "research/"
+    - "tools/commit_acceptor/"
+    - "scripts/ci/"
+    - "scripts/check_invariant_count_sync.py"
+    - "scripts/count_invariants.py"
+required_python_symbols: []
+expected_signal: >-
+  `python scripts/count_invariants.py` returns 95;
+  `python scripts/check_invariant_count_sync.py` reports
+  "OK: 95 invariants, all documentation surfaces in sync.";
+  `python .claude/physics/validate_tests.py --self-check` reports
+  "Self-check PASSED";
+  `python scripts/ci/check_claims.py` includes
+  "falsifier coverage: 19/19 ANCHORED" and the line
+  "tier distribution: ANCHORED=19, EXTRAPOLATED=8, SPECULATIVE=0,
+  UNKNOWN=0" with NO "WARN(v3): X/Y ANCHORED claim(s) lack
+  falsifier block" message;
+  `python scripts/export_governance_schemas.py --check` exits 0;
+  the on-disk JSON Schema artefacts under docs/schemas/governance/
+  are unchanged (the typed model is unchanged; only data is added).
+measurement_command: >-
+  bash -c 'python scripts/count_invariants.py | grep -q "^95$"
+  && PYTHONPATH=scripts python scripts/check_invariant_count_sync.py
+  && python .claude/physics/validate_tests.py --self-check
+  && python scripts/ci/check_claims.py 2>&1 | grep -q "19/19 ANCHORED"
+  && ! python scripts/ci/check_claims.py 2>&1 | grep -q "WARN(v3):"
+  && python scripts/export_governance_schemas.py --check'
+signal_artifact: "tmp/falsifier_final_cluster.log"
+falsifier:
+  command: >-
+    bash -c 'python scripts/ci/check_claims.py 2>&1
+    | grep -q "WARN(v3):.*ANCHORED claim.*lack falsifier"'
+  description: >-
+    Probes the missing-falsifier WARN line. After this PR, that
+    line MUST NOT appear (every ANCHORED claim has a falsifier).
+    If a future change adds a new ANCHORED claim without a
+    falsifier-block, OR strips a falsifier-block from an existing
+    ANCHORED, check_claims.py re-emits the WARN, the falsifier
+    exits 0, and the regression is flagged. Inverse-probe:
+    successful exit means the discipline has broken.
+rollback_command: >-
+  git checkout HEAD~1 --
+  .claude/physics/INVARIANTS.yaml
+  README.md
+  BASELINE.md
+  CLAUDE.md
+  docs/CLAIMS.yaml
+  .claude/commit_acceptors/falsifier-final-cluster.yaml
+rollback_verification_command: >-
+  bash -c 'python scripts/count_invariants.py | grep -q "^94$"'
+memory_update_type: append
+ledger_path: ".claude/commit_acceptors/falsifier-final-cluster.yaml"
+report_path: "tmp/falsifier_final_cluster.log"
+evidence: []

--- a/.claude/physics/INVARIANTS.yaml
+++ b/.claude/physics/INVARIANTS.yaml
@@ -574,6 +574,24 @@ hpc:
       - "NIST (2015). FIPS 180-4: Secure Hash Standard (SHA-256). National Institute of Standards and Technology."
     related: [INV-HPC1]
 
+  psr_hac_newey_west:
+    id: INV-PSR-HAC
+    type: monotonic
+    statement: "The HAC-adjusted Probabilistic Sharpe Ratio uses a Newey–West Bartlett-kernel HAC variance estimator with the NW(1994) automatic-bandwidth rule. The effective sample size n_eff shrinks under positive autocorrelation, equals n under zero autocorrelation, and grows under negative autocorrelation: n_eff(ρ > 0) < n; n_eff(ρ = 0) = n; n_eff(ρ < 0) > n. The auto-bandwidth output is a non-negative integer."
+    test_type: property_test
+    falsification: "Any AR(1) fixture with ρ > 0 yielding n_eff ≥ n; OR ρ = 0 yielding n_eff ≠ n; OR ρ < 0 yielding n_eff ≤ n; OR an auto-bandwidth output that is negative or non-integer."
+    priority: P1
+    provenance: ANCHORED
+    source: research/robustness/cpcv.py
+    tests: tests/research/robustness/test_hac_psr.py
+    integration_test: tests/research/robustness/test_hac_psr.py
+    runtime_evaluable: yes
+    references:
+      - "Newey, W. K. & West, K. D. (1987). A simple, positive semi-definite, heteroskedasticity and autocorrelation consistent covariance matrix. Econometrica 55(3), 703–708."
+      - "Newey, W. K. & West, K. D. (1994). Automatic lag selection in covariance matrix estimation. Rev. Economic Studies 61(4), 631–653."
+      - "Bailey, D. H. & López de Prado, M. (2014). The deflated Sharpe ratio: correcting for selection bias, backtest overfitting, and non-normality. J. Portfolio Management 40(5), 94–107."
+    related: []
+
   session_fsm_totality:
     id: INV-HPC5
     type: universal

--- a/BASELINE.md
+++ b/BASELINE.md
@@ -10,7 +10,7 @@ preserved as historical context, not as the current count.
 ## 0. TL;DR (current state, 2026-04-30)
 
 - **Physics kernel is real.** `.claude/physics/` currently contains
-  **94 invariants** (per `python scripts/count_invariants.py`, single source of
+  **95 invariants** (per `python scripts/count_invariants.py`, single source of
   truth: `.claude/physics/INVARIANTS.yaml`), 5 theory files, a 780-line
   validator with 7 levels (L1–L5 + C1–C2), and a self-check that passes.
   CI gate `invariant-count-sync` fail-closes on any drift between this file,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ GeoSync is a quantitative trading platform with neuroscience-inspired risk manag
 
 ---
 
-## INVARIANT REGISTRY — 94 invariants loaded by kernel self-check
+## INVARIANT REGISTRY — 95 invariants loaded by kernel self-check
 
 > **Single source of truth:** `.claude/physics/INVARIANTS.yaml` (`python scripts/count_invariants.py`). The 2026-04-30 external audit corrected a four-way drift (`57 / 66 / 67 / 87`); CI gate `invariant-count-sync` now fail-closes on any future divergence between this header, README badges, BASELINE.md, and the registry.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <br><br>
 
 [![modules-15](https://img.shields.io/badge/modules-15-blueviolet?style=for-the-badge)](docs/ARCHITECTURE.md)
-[![invariants-94](https://img.shields.io/badge/invariants-94-critical?style=for-the-badge)](CLAUDE.md)
+[![invariants-95](https://img.shields.io/badge/invariants-95-critical?style=for-the-badge)](CLAUDE.md)
 [![tests-11446](https://img.shields.io/badge/tests-11%2C446-brightgreen?style=for-the-badge)](tests/)
 [![indicators-17](https://img.shields.io/badge/indicators-17-gold?style=for-the-badge)](core/indicators/)
 [![ADRs-16](https://img.shields.io/badge/ADRs-16-blue?style=for-the-badge)](docs/adr/)
@@ -21,7 +21,7 @@
 Kuramoto synchronization  ·  Ricci curvature flow  ·  Free-energy thermodynamics  ·  Cryptobiosis
 ```
 
-*Physics-inspired quantitative research platform with 94 machine-checkable invariants.*
+*Physics-inspired quantitative research platform with 95 machine-checkable invariants.*
 *Every signal traces back to peer-reviewed science. Every clamp traces back to a law.*
 
 <br>
@@ -32,7 +32,7 @@ Kuramoto synchronization  ·  Ricci curvature flow  ·  Free-energy thermodynami
 [![Formal Verification](https://github.com/neuron7xLab/GeoSync/actions/workflows/formal-verification.yml/badge.svg?branch=main)](https://github.com/neuron7xLab/GeoSync/actions/workflows/formal-verification.yml)
 [![Python](https://img.shields.io/badge/Python-3.11%20%7C%203.12-3776AB?style=flat&logo=python&logoColor=white)](https://www.python.org/)
 [![Security](https://img.shields.io/badge/NIST%20SP%20800--53-aligned-red?style=flat)](docs/security/)
-[![Physics Gate](https://img.shields.io/badge/physics_gate-94_invariants-critical?style=flat)](CLAUDE.md)
+[![Physics Gate](https://img.shields.io/badge/physics_gate-95_invariants-critical?style=flat)](CLAUDE.md)
 [![Coverage](https://img.shields.io/badge/line_coverage-71%25-yellowgreen?style=flat)](BASELINE.md)
 
 </div>
@@ -145,13 +145,13 @@ dθᵢ/dt = ωᵢ + K · Σⱼ Aᵢⱼ sin(θⱼ − θᵢ)
 
 ## Physics Kernel
 
-GeoSync is a **physics-inspired quantitative research platform with a partially machine-checkable invariant layer**, not a "verified physical system" — that stronger claim was retracted on 2026-04-30 after an external audit ([CLAIMS.md](CLAIMS.md), [ALTERNATIVE_HYPOTHESES.md](.claude/physics/ALTERNATIVE_HYPOTHESES.md)). The physics kernel (`.claude/physics/`) declares **94 machine-checkable invariants** across the modules listed in [`INVARIANTS.yaml`](.claude/physics/INVARIANTS.yaml). Tests grounded in `INV-*` ids are *mathematical witnesses* of a specific invariant; the `BASELINE.md` ledger tracks how many of them currently exist (it is intentionally smaller than the registry — coverage growth is gated, not assumed).
+GeoSync is a **physics-inspired quantitative research platform with a partially machine-checkable invariant layer**, not a "verified physical system" — that stronger claim was retracted on 2026-04-30 after an external audit ([CLAIMS.md](CLAIMS.md), [ALTERNATIVE_HYPOTHESES.md](.claude/physics/ALTERNATIVE_HYPOTHESES.md)). The physics kernel (`.claude/physics/`) declares **95 machine-checkable invariants** across the modules listed in [`INVARIANTS.yaml`](.claude/physics/INVARIANTS.yaml). Tests grounded in `INV-*` ids are *mathematical witnesses* of a specific invariant; the `BASELINE.md` ledger tracks how many of them currently exist (it is intentionally smaller than the registry — coverage growth is gated, not assumed).
 
 Control-plane safety properties are additionally **model-checked in TLA⁺** — see [`formal/tla/AdmissionGate.tla`](formal/tla/AdmissionGate.tla) for the four-barrier admission gate with three TLC-checkable invariants (`TypeOK`, `SafeFirstRejectionWins`, `RejectCodeMatchesBarrier`). CI runs TLC on every PR via [`formal-verification.yml`](.github/workflows/formal-verification.yml).
 
 ```
                      ┌──────────────────────────────────────┐
-                     │   94 INVARIANTS  ·  registry-tracked  │
+                     │   95 INVARIANTS  ·  registry-tracked  │
                      │   Every assert derives its tolerance  │
                      │   from the law's formula, not from    │
                      │   a magic literal.                    │
@@ -172,7 +172,7 @@ Control-plane safety properties are additionally **model-checked in TLA⁺** —
 
 | Metric | Value | Source |
 |--------|-------|--------|
-| Physics invariants declared | **94 in `.claude/physics/INVARIANTS.yaml`** (single source of truth) | `python scripts/count_invariants.py` |
+| Physics invariants declared | **95 in `.claude/physics/INVARIANTS.yaml`** (single source of truth) | `python scripts/count_invariants.py` |
 | Physics invariants grounded by tests | tracked in [`BASELINE.md`](BASELINE.md) — **deliberately smaller than declared count**; coverage growth is gated, not assumed | `BASELINE.md` ledger |
 | C1/C2 code audit | **0** undocumented physics clamps in `core/` | `physics-kernel-gate.yml` |
 | CI gates | physics-kernel-gate · invariant-count-sync · formal-verification (TLA⁺) · claims-evidence-gate | `.github/workflows/` |
@@ -778,6 +778,6 @@ Trading financial instruments involves substantial risk of loss. GeoSync provide
 
 [![MIT](https://img.shields.io/badge/license-MIT-yellow?style=flat)](LICENSE)
 
-<sub>Built on peer-reviewed science. Physics-first, 94 invariants loaded from `.claude/physics/INVARIANTS.yaml`, every clamp documented.</sub>
+<sub>Built on peer-reviewed science. Physics-first, 95 invariants loaded from `.claude/physics/INVARIANTS.yaml`, every clamp documented.</sub>
 
 </div>

--- a/docs/CLAIMS.yaml
+++ b/docs/CLAIMS.yaml
@@ -202,7 +202,19 @@ claims:
       - research/robustness/cpcv.py
       - tests/research/robustness/test_hac_psr.py
       - results/cross_asset_kuramoto/robustness_v1/ROBUSTNESS_LIMITATIONS.md
+    falsifier:
+      test_id: tests/research/robustness/test_hac_psr.py::test_auto_bandwidth_matches_newey_west_1994_rule
+      invariants_cited:
+        - INV-PSR-HAC
+      failure_signature: >
+        AR(1) fixture with ρ > 0 yielding n_eff ≥ n; OR ρ = 0 yielding
+        n_eff ≠ n; OR ρ < 0 yielding n_eff ≤ n; OR auto-bandwidth
+        output that is negative or non-integer; OR a deviation from
+        the NW(1994) automatic-bandwidth rule beyond the documented
+        small-sample tolerance. Each surfaces as an AssertionError
+        citing INV-PSR-HAC.
     added_utc: "2026-04-25"
+    last_updated_utc: "2026-05-08"
 
   - id: cross-asset-walkforward-artifact-integrity
     priority: P1
@@ -224,18 +236,28 @@ claims:
 
   - id: ricci-microstructure-ten-axis-falsification
     priority: P1
-    tier: ANCHORED
+    tier: EXTRAPOLATED
     description: >
       The Ricci cross-sectional edge on L2 microstructure passes ten
       orthogonal validation axes (kill test, block-bootstrap CI,
       deflated Sharpe, purged CV, mutual info, lag attribution,
       power spectrum, DFA Hurst, pairwise/conditional TE, rolling
-      walk-forward) on the frozen Session 1 substrate.
+      walk-forward) on the frozen Session 1 substrate. Status
+      (Phase-1 falsifier audit, 2026-05-08): re-classified ANCHORED
+      → EXTRAPOLATED. The paper-tier evidence (FINDINGS.md, paper.tex)
+      is intact and the 10-axis result is reproducible from the frozen
+      substrate, but no programmatic falsifier-block currently exists
+      that re-runs the full 10-axis battery from a single pytest node
+      under the ADR 0021 v3 falsifier shape. Re-classify ANCHORED on
+      addition of `tests/research/microstructure/test_ten_axis.py`
+      with one parametrised test per axis, citing a new INV-RICCI-MS
+      invariant in the registry. Tracked as research-debt follow-up.
     evidence_paths:
       - research/microstructure/FINDINGS.md
       - paper/ricci_microstructure/paper.tex
       - paper/ricci_microstructure/references.bib
     added_utc: "2026-04-25"
+    last_updated_utc: "2026-05-08"
 
   # ---------------------------------------------------------------
   # IERD Phase-0 (2026-05-03) — invariant-anchored physics claims.
@@ -310,7 +332,21 @@ claims:
       - tests/core/neuro/serotonin/test_serotonin_controller.py
       - tests/core/neuro/serotonin/test_serotonin_properties.py
       - tests/unit/physics/test_T12_serotonin_stability.py
+    falsifier:
+      test_id: tests/unit/physics/test_T12_serotonin_stability.py::test_serotonin_lyapunov_is_non_increasing_under_zero_stress
+      invariants_cited:
+        - INV-5HT1
+        - INV-5HT2
+        - INV-5HT4
+        - INV-5HT7
+      failure_signature: >
+        Lyapunov V(s) increasing across any step under zero stress
+        (INV-5HT1); OR s(t) ∉ [0, 1] in any window (INV-5HT2); OR
+        sensitivity output ∉ [0.1, 1.0] (INV-5HT4); OR veto failing to
+        fire when stress ≥ 1.0 OR |dd| ≥ 0.5 (INV-5HT7 SAFETY).
+        Each surfaces as an AssertionError citing the offending INV.
     added_utc: "2026-05-03"
+    last_updated_utc: "2026-05-08"
 
   - id: dopamine-td-error-algebraic-exact
     priority: P0
@@ -399,7 +435,18 @@ claims:
       - tests/neuro/test_sizing.py
       - tests/analytics/test_kelly_criterion.py
       - tests/unit/physics/test_T14_portfolio_energy_conservation.py
+    falsifier:
+      test_id: tests/analytics/test_kelly_criterion.py::test_single_asset_kelly_closed_form
+      invariants_cited:
+        - INV-KELLY1
+        - INV-KELLY2
+      failure_signature: >
+        f* output diverges from μ/σ² to float precision on the closed-form
+        single-asset fixture (INV-KELLY1); OR applied fraction exceeds the
+        configured cap on any synthetic edge (INV-KELLY2). Each surfaces
+        as an AssertionError citing the offending INV.
     added_utc: "2026-05-03"
+    last_updated_utc: "2026-05-08"
 
   - id: oms-conservation-idempotency-monotone
     priority: P0
@@ -410,7 +457,20 @@ claims:
       timestamps monotone (INV-OMS3).
     evidence_paths:
       - tests/unit/physics/test_T15_oms_idempotency_causality.py
+    falsifier:
+      test_id: tests/unit/physics/test_T15_oms_idempotency_causality.py::test_oms_submit_is_idempotent_under_duplicate_correlation_id
+      invariants_cited:
+        - INV-OMS1
+        - INV-OMS2
+        - INV-OMS3
+      failure_signature: >
+        Two submits with identical correlation_id producing two distinct
+        orders OR distinct downstream state (INV-OMS2); OR per-order
+        lifecycle timestamps non-monotone in any window (INV-OMS3); OR
+        E_kinetic = ½Σ|pos|·ret² < 0 on any held position (INV-OMS1).
+        Each surfaces as an AssertionError citing the offending INV.
     added_utc: "2026-05-03"
+    last_updated_utc: "2026-05-08"
 
   - id: signalbus-deterministic-fanout
     priority: P0
@@ -423,7 +483,20 @@ claims:
     evidence_paths:
       - core/neuro/signal_bus.py
       - tests/unit/physics/test_T16_signalbus_dag.py
+    falsifier:
+      test_id: tests/unit/physics/test_T16_signalbus_dag.py::test_signalbus_dag_fanout_fires_each_subscriber_exactly_once
+      invariants_cited:
+        - INV-SB1
+        - INV-SB2
+      failure_signature: >
+        A subscriber not invoked exactly once per publish on a non-cyclic
+        DAG (INV-SB1); OR a deterministic-construction violation where
+        two publishes with identical input produce different observed
+        fan-out order (INV-SB2). Each surfaces as an AssertionError
+        citing the offending INV. Cyclic subscriptions raising
+        RecursionError remain a documented limit, not a falsification.
     added_utc: "2026-05-03"
+    last_updated_utc: "2026-05-08"
 
   - id: cryptobiosis-phase-transition-survival
     priority: P0
@@ -575,13 +648,22 @@ claims:
 
   - id: ierd-phase0-yana-response
     priority: P1
-    tier: ANCHORED
+    tier: EXTRAPOLATED
     description: >
       IERD-PAI-FPS-UX-001 Phase-0 response to the 2026-05-02
       external falsification audit is published with tier-labeled
       answers to all 7 questions, the directive is adopted as a
       binding standard, and the forbidden-terminology lint runs in
-      warn mode in CI.
+      warn mode in CI. Status (Phase-1 falsifier audit, 2026-05-08):
+      re-classified ANCHORED → EXTRAPOLATED. The documentation
+      artefacts are intact (yana-response.md addresses Q1–Q7; ADR
+      0020 ratifies adoption; lint_forbidden_terms.py runs in CI),
+      but no programmatic falsifier-block currently exists that
+      asserts the response covers each of Q1–Q7 from a single pytest
+      node under the ADR 0021 v3 falsifier shape. Re-classify ANCHORED
+      on addition of `tests/governance/test_yana_response_coverage.py`
+      with an assertion per question + a new INV-IERD-PHASE0
+      registry entry. Tracked as governance-debt follow-up.
     evidence_paths:
       - docs/governance/IERD-PAI-FPS-UX-001.md
       - docs/adr/0020-ierd-adoption.md
@@ -590,6 +672,7 @@ claims:
       - docs/validation/pai_report_2026_05_03.md
       - scripts/ci/lint_forbidden_terms.py
     added_utc: "2026-05-03"
+    last_updated_utc: "2026-05-08"
 
   # ---------------------------------------------------------------
   # IERD Phase-0 (2026-05-03) — frontend-integration gaps tracked


### PR DESCRIPTION
Closes the floating-falsifier set introduced by PRs #556 and #558.

5 falsifier-blocks added (INV-PSR-HAC new; rest map to existing INV-5HT/KELLY/OMS/SB).
2 tier downgrades ANCHORED → EXTRAPOLATED (paper-tier + doc-only claims, with explicit re-promotion path).
Registry 94 → 95.

Final state: 19/19 ANCHORED have falsifier-blocks. ADR 0021 §1 loophole closed.

See commit message for full details. All gates green locally.