### PR TITLE
fix(api): catch UnicodeDecodeError in JSON body parser — 400 not 500

### DIFF
--- a/.claude/commit_acceptors/api-utf8-decode-guard.yaml
+++ b/.claude/commit_acceptors/api-utf8-decode-guard.yaml
@@ -1,0 +1,88 @@
+# Diff-bound commit acceptor for the API UnicodeDecodeError → 400 fix.
+#
+# After PR #566 (adversarial ladder) merged into main, the
+# Schemathesis Contract workflow began failing on `POST /api/v1/predictions`
+# because the body-parser middleware caught only `JSONDecodeError`, while
+# `json.loads(body)` raises `UnicodeDecodeError` for non-utf-8 bytes. The
+# uncaught exception bubbled up to the cache-headers middleware and surfaced
+# as a 500 — schemathesis correctly flagged this as a contract violation.
+#
+# Fix: extend the except clause to `(JSONDecodeError, UnicodeDecodeError)`.
+# Both are 400-class client errors and must produce the structured
+# Malformed-JSON envelope.
+#
+# Locally verified:
+#   * pytest tests/api/test_service.py::test_invalid_utf8_body_returns_400_not_500: 4/4 pass
+#   * mypy --strict application/api/service.py: 0 errors
+#   * ruff + black on changed files: clean
+
+id: api-utf8-decode-guard
+status: ACTIVE
+claim_type: correctness
+promise: >-
+  After this PR lands, posting non-utf-8 bytes to any JSON endpoint of
+  the FastAPI service yields a structured 400 BAD_REQUEST envelope with
+  ``ERR_BAD_REQUEST`` code, never an uncaught 500. The schemathesis
+  contract test for ``POST /api/v1/predictions`` returns to green.
+
+diff_scope:
+  changed_files:
+    - path: ".claude/commit_acceptors/api-utf8-decode-guard.yaml"
+    - path: "application/api/service.py"
+    - path: "tests/api/test_service.py"
+  forbidden_paths:
+    - "trading/"
+    - "execution/"
+    - "forecast/"
+    - "policy/"
+    - "core/"
+    - "research/"
+
+required_python_symbols:
+  - "application/api/service.py::create_app"
+  - "tests/api/test_service.py::test_invalid_utf8_body_returns_400_not_500"
+
+expected_signal: >-
+  ``pytest tests/api/test_service.py::test_invalid_utf8_body_returns_400_not_500
+  -q`` reports 4 passed (4 parametrized cases). Before this PR the
+  middleware crashed with UnicodeDecodeError and the cases would have
+  surfaced as 500.
+
+measurement_command: >-
+  bash -c '
+    mypy --strict application/api/service.py
+    && python -m pytest
+      tests/api/test_service.py::test_invalid_utf8_body_returns_400_not_500 -q
+  '
+
+signal_artifact: "tmp/api_utf8_decode_guard.log"
+
+falsifier:
+  command: >-
+    bash -c '
+      grep -q "(JSONDecodeError, UnicodeDecodeError)" application/api/service.py 2>/dev/null
+      && exit 1
+      || exit 0
+    '
+  description: >-
+    Probes that the except clause in the body-parser middleware catches
+    UnicodeDecodeError. The falsifier inverts: it succeeds (exit 0) only
+    when the joint clause is missing, which would mean the fix rolled back.
+
+rollback_command: >-
+  bash -c '
+    git checkout HEAD~1 -- application/api/service.py tests/api/test_service.py
+    && git rm -f .claude/commit_acceptors/api-utf8-decode-guard.yaml
+  '
+
+rollback_verification_command: >-
+  bash -c '
+    grep -q "(JSONDecodeError, UnicodeDecodeError)" application/api/service.py
+    && exit 1
+    || exit 0
+  '
+
+memory_update_type: append
+ledger_path: ".claude/commit_acceptors/api-utf8-decode-guard.yaml"
+report_path: "tmp/api_utf8_decode_guard.log"
+evidence: []

--- a/application/api/service.py
+++ b/application/api/service.py
@@ -1166,7 +1166,11 @@ class PayloadGuardMiddleware(BaseHTTPMiddleware):
                 if body:
                     try:
                         parsed = json.loads(body)
-                    except JSONDecodeError:
+                    except (JSONDecodeError, UnicodeDecodeError):
+                        # JSONDecodeError: malformed JSON syntax.
+                        # UnicodeDecodeError: bytes that are not decodable as the
+                        # advertised encoding (default utf-8). Both are 400-class
+                        # client errors — never let them surface as a 500.
                         return build_error_envelope(
                             status_code=status.HTTP_400_BAD_REQUEST,
                             code=ApiErrorCode.BAD_REQUEST,

--- a/tests/api/test_service.py
+++ b/tests/api/test_service.py
@@ -512,6 +512,44 @@ def test_websocket_stream_broadcasts_updates(
         assert "signal" in signal_event
 
 
+@pytest.mark.parametrize(
+    "raw_body",
+    [
+        pytest.param(b"\x00\x00\x00\x00\x00", id="utf32-be-truncated"),
+        pytest.param(b"\x80start", id="invalid-utf8-start-byte"),
+        pytest.param(b"\xff\xfe\x00", id="bare-bom-no-payload"),
+        pytest.param(b"\x90\x90\x90\x90", id="invalid-utf8-continuation"),
+    ],
+)
+def test_invalid_utf8_body_returns_400_not_500(
+    configured_app: FastAPI,
+    security_context: Callable[..., str],
+    raw_body: bytes,
+) -> None:
+    """Schemathesis fuzzing produced UnicodeDecodeError paths that surfaced as 500s.
+
+    Root cause: ``json.loads(body)`` raises ``UnicodeDecodeError`` (not
+    ``JSONDecodeError``) when *body* contains bytes that do not decode under
+    the advertised encoding. The body-parser middleware now catches both,
+    so every non-UTF-8 body returns a structured 400 instead of crashing.
+    """
+    client = TestClient(configured_app, raise_server_exceptions=False)
+    token = security_context(subject="fuzz-user")
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+    }
+    response = client.post(_api_v1("/predictions"), content=raw_body, headers=headers)
+    assert response.status_code == status.HTTP_400_BAD_REQUEST, (
+        f"expected 400 BAD_REQUEST on non-UTF-8 body, got "
+        f"{response.status_code} (body would have crashed json.loads with "
+        f"UnicodeDecodeError before the fix)"
+    )
+    body = response.json()
+    assert body["error"]["code"] == "ERR_BAD_REQUEST"
+    assert "Malformed JSON" in body["error"]["message"]
+
+
 def test_internal_errors_return_structured_payload(configured_app: FastAPI) -> None:
     app = configured_app
 


### PR DESCRIPTION
## Summary

Schemathesis Contract workflow began failing on `main` immediately after PR #566 merged (run [25560094349](https://github.com/neuron7xLab/GeoSync/actions/runs/25560094349)). Root cause: the body-parser middleware in `application/api/service.py:1167-1175` caught only `JSONDecodeError` on `json.loads(body)`, but `json.loads` on bytes containing invalid utf-8 raises `UnicodeDecodeError`, which is **not** a subclass of `JSONDecodeError`. The uncaught exception bubbled up to `add_cache_headers` middleware and surfaced as a 500 — schemathesis correctly flagged this as a contract violation.

## Fix

Extend the `except` clause to `(JSONDecodeError, UnicodeDecodeError)`. Both are 400-class client errors and must yield the structured Malformed-JSON envelope.

```python
try:
    parsed = json.loads(body)
except (JSONDecodeError, UnicodeDecodeError):
    return build_error_envelope(
        status_code=status.HTTP_400_BAD_REQUEST,
        code=ApiErrorCode.BAD_REQUEST,
        message="Malformed JSON payload.",
        path=request.url.path,
    )
```

## Regression test

Adds `test_invalid_utf8_body_returns_400_not_500` parametrized over four distinct invalid-utf-8 byte patterns:

- `\x00\x00\x00\x00\x00` (utf-32-be truncated)
- `\x80start` (invalid utf-8 start byte)
- `\xff\xfe\x00` (bare BOM, no payload)
- `\x90\x90\x90\x90` (invalid utf-8 continuation)

Each asserts structured 400 with `ERR_BAD_REQUEST` code. Pre-fix, all four would have crashed with UnicodeDecodeError and surfaced as 500.

## Test plan

- [x] `pytest tests/api/test_service.py::test_invalid_utf8_body_returns_400_not_500 -q` — 4/4 pass
- [x] `mypy --strict application/api/service.py` — 0 errors
- [x] `ruff check` + `black --check` on changed files — clean
- [x] Schemathesis Contract on this PR (CI) — expect green

🤖 Generated with [Claude Code](https://claude.com/claude-code)