### PR TITLE
feat(research/systemic_risk): canonical-seven end-to-end orchestrator

### DIFF
--- a/.claude/commit_acceptors/canonical-seven-orchestrator.yaml
+++ b/.claude/commit_acceptors/canonical-seven-orchestrator.yaml
@@ -1,0 +1,104 @@
+# Diff-bound commit acceptor for the Canonical-Seven orchestrator.
+#
+# Capstone of the Canonical Seven foundation work. Adds a single
+# pure-function entry point that takes a bundle of pillar outputs
+# (firewall, leakage, ladder, fragility, replication) plus the
+# current GovernanceFSM, and returns the post-application FSM along
+# with the dominant TierTransition.
+#
+# This closes the gap between "every pillar exists" and "every pillar
+# is callable in one canonical round". After this PR, callers no
+# longer need to know about DeathState/DeathConditionsRegistry/
+# default_registry plumbing — they just call run_canonical_seven.
+#
+# Pure-function, no I/O, mypy --strict / ruff / black clean.
+#
+# Locally verified:
+#   * pytest tests/research/systemic_risk/test_canonical_seven.py: 10/10 pass
+#   * pytest tests/research/systemic_risk/: 388/388 pass
+#   * mypy --strict on orchestrator + test file: 0 errors
+#   * ruff + black on changed files: clean
+
+id: canonical-seven-orchestrator
+status: ACTIVE
+claim_type: governance
+promise: >-
+  After this PR lands, ``research.systemic_risk`` exposes
+  ``run_canonical_seven`` plus its frozen input/outcome dataclasses.
+  One call drives a claim through the canonical round (firewall →
+  leakage → ladder → fragility → replication → death engine → FSM)
+  and returns the new FSM state.
+
+diff_scope:
+  changed_files:
+    - path: ".claude/commit_acceptors/canonical-seven-orchestrator.yaml"
+    - path: "research/systemic_risk/__init__.py"
+    - path: "research/systemic_risk/canonical_seven.py"
+    - path: "tests/research/systemic_risk/test_canonical_seven.py"
+  forbidden_paths:
+    - "trading/"
+    - "execution/"
+    - "forecast/"
+    - "policy/"
+    - "core/"
+    - "runtime/"
+    - "application/"
+
+required_python_symbols:
+  - "research/systemic_risk/canonical_seven.py::run_canonical_seven"
+  - "research/systemic_risk/canonical_seven.py::CanonicalSevenInputs"
+  - "research/systemic_risk/canonical_seven.py::CanonicalSevenOutcome"
+  - "tests/research/systemic_risk/test_canonical_seven.py::TestCanonicalSevenOrchestrator"
+
+expected_signal: >-
+  ``pytest tests/research/systemic_risk/test_canonical_seven.py -q``
+  reports 10 passed; before this PR the same command fails with
+  ModuleNotFoundError on ``research.systemic_risk.canonical_seven``.
+
+measurement_command: >-
+  bash -c '
+    mypy --strict
+      research/systemic_risk/canonical_seven.py
+      tests/research/systemic_risk/test_canonical_seven.py
+    && python -m pytest tests/research/systemic_risk/test_canonical_seven.py -q
+  '
+
+signal_artifact: "tmp/canonical_seven_orchestrator.log"
+
+falsifier:
+  command: >-
+    bash -c '
+      python -c "from research.systemic_risk import run_canonical_seven, CanonicalSevenInputs, GovernanceFSM; assert run_canonical_seven(inputs=CanonicalSevenInputs(), fsm_before=GovernanceFSM.initial()).fsm_after.state == \"IDEA\"" 2>/dev/null
+      && exit 1
+      || exit 0
+    '
+  description: >-
+    Probes that the orchestrator runs end-to-end on empty inputs and
+    leaves the FSM at IDEA. Falsifier inverts: it succeeds (exit 0)
+    only when the import or the empty-pipeline assertion fails.
+
+rollback_command: >-
+  bash -c '
+    git rm -f
+      research/systemic_risk/canonical_seven.py
+      tests/research/systemic_risk/test_canonical_seven.py
+      .claude/commit_acceptors/canonical-seven-orchestrator.yaml
+    && git checkout HEAD~1 -- research/systemic_risk/__init__.py
+  '
+
+rollback_verification_command: >-
+  bash -c '
+    python -c "
+    try:
+        from research.systemic_risk import run_canonical_seven
+    except ImportError:
+        pass
+    else:
+        raise SystemExit(1)
+    "
+  '
+
+memory_update_type: append
+ledger_path: ".claude/commit_acceptors/canonical-seven-orchestrator.yaml"
+report_path: "tmp/canonical_seven_orchestrator.log"
+evidence: []

--- a/research/systemic_risk/__init__.py
+++ b/research/systemic_risk/__init__.py
@@ -30,6 +30,11 @@ from .baselines import (
     edge_density_score,
     rolling_volatility_score,
 )
+from .canonical_seven import (
+    CanonicalSevenInputs,
+    CanonicalSevenOutcome,
+    run_canonical_seven,
+)
 from .coupling import (
     coupling_from_exposures,
     omega_from_volatility,
@@ -208,6 +213,8 @@ __all__ = [
     "BankingCrisisLedger",
     "CSDConfig",
     "CSDIndicators",
+    "CanonicalSevenInputs",
+    "CanonicalSevenOutcome",
     "ClassificationMetrics",
     "CrisisOutcome",
     "DEFAULT_BIT_IDENTICAL_TOLERANCE",
@@ -331,6 +338,7 @@ __all__ = [
     "replication_match_bayes_factor",
     "rolling_volatility_score",
     "run_adversarial_ladder",
+    "run_canonical_seven",
     "run_data_firewall",
     "run_end_to_end_falsification",
     "run_falsification",

--- a/research/systemic_risk/canonical_seven.py
+++ b/research/systemic_risk/canonical_seven.py
@@ -1,0 +1,138 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""Canonical-Seven orchestrator — composes all seven pillars.
+
+End-to-end glue that takes the supplied evidence inputs (firewall,
+leakage, ladder, fragility, replication) and produces:
+
+    1. The aggregate :class:`TierTransition` from the death engine.
+    2. The post-application :class:`GovernanceFSM` state.
+
+This is the capstone function: callers can drive a claim through one
+canonical round by collecting outcomes from each pillar and passing
+them here. The orchestrator is **stateless** — it never reads from
+disk, never mutates inputs, and is fully deterministic on its
+arguments.
+
+Pure-function API. No I/O.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .death_conditions import (
+    DataFirewallResultLike,
+    DeathConditionsRegistry,
+    DeathState,
+    FragilityResultLike,
+    LadderResultLike,
+    LeakageResultLike,
+    ReplicationResultLike,
+    TierTransition,
+    default_registry,
+)
+from .governance_fsm import GovernanceFSM
+
+__all__ = [
+    "CanonicalSevenInputs",
+    "CanonicalSevenOutcome",
+    "run_canonical_seven",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class CanonicalSevenInputs:
+    """Bundle of pillar outputs consumed by the orchestrator.
+
+    Each field is optional; missing inputs simply produce
+    ``fired=False`` outcomes for the corresponding trigger (per the
+    contract of :class:`DeathConditionsRegistry`).
+
+    Attributes
+    ----------
+    firewall
+        Output of :func:`research.systemic_risk.data_firewall
+        .run_data_firewall`. ``passed_all=False`` drives ``STOP``
+        via T5.
+    leakage
+        Output of :func:`research.systemic_risk.leakage_sentinel
+        .run_leakage_audit`. ``detected=True`` drives
+        ``INVALIDATE`` via T2.
+    ladder
+        Output of :func:`research.systemic_risk.adversarial_ladder
+        .run_adversarial_ladder`. Non-empty ``losing_paths`` drives
+        ``DEMOTE`` via T1.
+    fragility
+        Output of the parameter-fragility audit. ``fragile=True``
+        drives ``QUARANTINE`` via T3.
+    replication
+        Output of :func:`research.systemic_risk.replication_capsule
+        .compare_run_outputs`. ``matched=False`` drives ``KILL`` via
+        T4.
+    """
+
+    firewall: DataFirewallResultLike | None = None
+    leakage: LeakageResultLike | None = None
+    ladder: LadderResultLike | None = None
+    fragility: FragilityResultLike | None = None
+    replication: ReplicationResultLike | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class CanonicalSevenOutcome:
+    """Capstone outcome of a single canonical round.
+
+    Attributes
+    ----------
+    transition
+        Aggregate :class:`TierTransition` from the death engine — the
+        single dominant action under
+        ``KILL > INVALIDATE > QUARANTINE > DEMOTE > STOP > NONE``.
+    fsm_after
+        :class:`GovernanceFSM` after applying the transition.
+    """
+
+    transition: TierTransition
+    fsm_after: GovernanceFSM
+
+
+def run_canonical_seven(
+    *,
+    inputs: CanonicalSevenInputs,
+    fsm_before: GovernanceFSM,
+    registry: DeathConditionsRegistry | None = None,
+) -> CanonicalSevenOutcome:
+    """Drive one claim through one canonical round.
+
+    Parameters
+    ----------
+    inputs
+        Bundle of pillar outputs (firewall, leakage, ladder,
+        fragility, replication). Any subset may be ``None``.
+    fsm_before
+        Current :class:`GovernanceFSM` state of the claim. Must not
+        be in :data:`research.systemic_risk.governance_fsm.TERMINAL_STATES`
+        unless the caller is intentionally re-validating an absorbed
+        claim (in which case the FSM's absorbing logic returns the
+        same state with an audit row).
+    registry
+        Optional custom death-conditions registry. Defaults to
+        :func:`default_registry` (the canonical 5 triggers).
+
+    Returns
+    -------
+    CanonicalSevenOutcome
+        Aggregate transition + post-application FSM state.
+    """
+    death_state = DeathState(
+        ladder=inputs.ladder,
+        leakage=inputs.leakage,
+        fragility=inputs.fragility,
+        replication=inputs.replication,
+        firewall=inputs.firewall,
+    )
+    reg = registry if registry is not None else default_registry()
+    transition = reg.evaluate(death_state)
+    fsm_after = fsm_before.apply(transition)
+    return CanonicalSevenOutcome(transition=transition, fsm_after=fsm_after)

--- a/tests/research/systemic_risk/test_canonical_seven.py
+++ b/tests/research/systemic_risk/test_canonical_seven.py
@@ -1,0 +1,151 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""Canonical-Seven orchestrator tests — end-to-end pipeline composition."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from research.systemic_risk.canonical_seven import (
+    CanonicalSevenInputs,
+    CanonicalSevenOutcome,
+    run_canonical_seven,
+)
+from research.systemic_risk.governance_fsm import GovernanceFSM
+
+
+@dataclass
+class _Ladder:
+    losing_paths: tuple[str, ...]
+
+
+@dataclass
+class _Leakage:
+    detected: bool
+
+
+@dataclass
+class _Fragility:
+    fragile: bool
+
+
+@dataclass
+class _Replication:
+    matched: bool
+
+
+@dataclass
+class _Firewall:
+    passed_all: bool
+
+
+class TestCanonicalSevenOrchestrator:
+    def test_all_clean_yields_none_action_and_unchanged_state(self) -> None:
+        inputs = CanonicalSevenInputs(
+            firewall=_Firewall(passed_all=True),
+            leakage=_Leakage(detected=False),
+            ladder=_Ladder(losing_paths=()),
+            fragility=_Fragility(fragile=False),
+            replication=_Replication(matched=True),
+        )
+        fsm = GovernanceFSM.initial()
+        out = run_canonical_seven(inputs=inputs, fsm_before=fsm)
+        assert isinstance(out, CanonicalSevenOutcome)
+        assert out.transition.action == "NONE"
+        assert out.fsm_after.state == "IDEA"
+
+    def test_kill_path_drives_to_rejected(self) -> None:
+        inputs = CanonicalSevenInputs(
+            replication=_Replication(matched=False),
+        )
+        fsm = GovernanceFSM.initial()
+        out = run_canonical_seven(inputs=inputs, fsm_before=fsm)
+        assert out.transition.action == "KILL"
+        assert out.fsm_after.state == "REJECTED"
+        assert out.fsm_after.is_terminal
+
+    def test_kill_dominates_demote(self) -> None:
+        # T1 (DEMOTE) AND T4 (KILL) both fire — KILL must win.
+        inputs = CanonicalSevenInputs(
+            ladder=_Ladder(losing_paths=("naive",)),
+            replication=_Replication(matched=False),
+        )
+        fsm = GovernanceFSM.initial()
+        out = run_canonical_seven(inputs=inputs, fsm_before=fsm)
+        assert out.transition.action == "KILL"
+        assert "T1_baseline_dominance" in out.transition.fired_triggers
+        assert "T4_replication_mismatch" in out.transition.fired_triggers
+        assert out.fsm_after.state == "REJECTED"
+
+    def test_invalidate_resets_to_idea(self) -> None:
+        inputs = CanonicalSevenInputs(leakage=_Leakage(detected=True))
+        fsm = GovernanceFSM.initial().promote(
+            target="HYPOTHESIS", evidence_supports=True, reason="seed"
+        )
+        out = run_canonical_seven(inputs=inputs, fsm_before=fsm)
+        assert out.transition.action == "INVALIDATE"
+        assert out.fsm_after.state == "IDEA"
+
+    def test_quarantine_freezes(self) -> None:
+        inputs = CanonicalSevenInputs(fragility=_Fragility(fragile=True))
+        fsm = GovernanceFSM.initial()
+        out = run_canonical_seven(inputs=inputs, fsm_before=fsm)
+        assert out.transition.action == "QUARANTINE"
+        assert out.fsm_after.state == "QUARANTINED"
+
+    def test_demote_steps_back_one_tier(self) -> None:
+        inputs = CanonicalSevenInputs(ladder=_Ladder(losing_paths=("naive",)))
+        fsm = GovernanceFSM.initial().promote(target="MEASURED", evidence_supports=True, reason="m")
+        out = run_canonical_seven(inputs=inputs, fsm_before=fsm)
+        assert out.transition.action == "DEMOTE"
+        assert out.fsm_after.state == "TESTED_ON_REAL_DATA"
+
+    def test_stop_does_not_change_fsm_state(self) -> None:
+        inputs = CanonicalSevenInputs(firewall=_Firewall(passed_all=False))
+        fsm = GovernanceFSM.initial().promote(
+            target="HYPOTHESIS", evidence_supports=True, reason="h"
+        )
+        out = run_canonical_seven(inputs=inputs, fsm_before=fsm)
+        assert out.transition.action == "STOP"
+        assert out.fsm_after.state == "HYPOTHESIS"
+
+    def test_partial_inputs_supported(self) -> None:
+        # Only firewall supplied — every other trigger sees None.
+        inputs = CanonicalSevenInputs(firewall=_Firewall(passed_all=True))
+        fsm = GovernanceFSM.initial()
+        out = run_canonical_seven(inputs=inputs, fsm_before=fsm)
+        assert out.transition.action == "NONE"
+        assert out.fsm_after.state == "IDEA"
+
+    def test_history_extended_by_one_per_call(self) -> None:
+        fsm = GovernanceFSM.initial()
+        for _ in range(3):
+            out = run_canonical_seven(
+                inputs=CanonicalSevenInputs(),  # all None → NONE action
+                fsm_before=fsm,
+            )
+            fsm = out.fsm_after
+        assert len(fsm.history) == 3
+        assert all(r.action == "NONE" for r in fsm.history)
+
+    def test_rejected_is_absorbing_through_orchestrator(self) -> None:
+        # Drive into REJECTED, then any subsequent call cannot resurrect.
+        fsm = GovernanceFSM.initial()
+        out1 = run_canonical_seven(
+            inputs=CanonicalSevenInputs(replication=_Replication(matched=False)),
+            fsm_before=fsm,
+        )
+        assert out1.fsm_after.state == "REJECTED"
+
+        # Even with all-clean inputs, REJECTED stays REJECTED.
+        out2 = run_canonical_seven(
+            inputs=CanonicalSevenInputs(
+                firewall=_Firewall(passed_all=True),
+                leakage=_Leakage(detected=False),
+                ladder=_Ladder(losing_paths=()),
+                fragility=_Fragility(fragile=False),
+                replication=_Replication(matched=True),
+            ),
+            fsm_before=out1.fsm_after,
+        )
+        assert out2.fsm_after.state == "REJECTED"


### PR DESCRIPTION
## Summary

**Capstone** of the Canonical Seven foundation work. Adds a single pure-function entry point — `run_canonical_seven(inputs, fsm_before)` — that takes a bundle of pillar outputs (firewall, leakage, ladder, fragility, replication) plus the current `GovernanceFSM` and returns the post-application FSM along with the dominant `TierTransition`.

Closes the gap between "every pillar exists" (PRs #567, #569, #570, #571) and "every pillar is callable in one canonical round". Callers no longer need to know about `DeathState` / `DeathConditionsRegistry` / `default_registry` plumbing — they just call `run_canonical_seven`.

## Usage

```python
from research.systemic_risk import (
    CanonicalSevenInputs,
    GovernanceFSM,
    run_canonical_seven,
    run_data_firewall,
    run_leakage_audit,
    run_adversarial_ladder,
    compare_run_outputs,
)

inputs = CanonicalSevenInputs(
    firewall=run_data_firewall(panel, node_labels, provs),
    leakage=run_leakage_audit(sentinel_outcomes),
    ladder=run_adversarial_ladder(...),
    replication=compare_run_outputs(...),
)
outcome = run_canonical_seven(
    inputs=inputs,
    fsm_before=GovernanceFSM.initial(),
)
print(outcome.transition.action)        # KILL / INVALIDATE / etc.
print(outcome.fsm_after.state)          # new state
```

## Public surface delta

+3 symbols: `CanonicalSevenInputs`, `CanonicalSevenOutcome`, `run_canonical_seven`. No breaking change.

## Test plan

- [x] `pytest tests/research/systemic_risk/test_canonical_seven.py -q` — 10/10 pass
- [x] `pytest tests/research/systemic_risk/ -q` — **388/388 pass** (incl. all prior pillars)
- [x] `mypy --strict` on orchestrator + test file — 0 errors
- [x] `ruff check` + `black --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)