### PR TITLE
feat(research/systemic_risk): quick_round — primitive-input ergonomic API

### DIFF
--- a/.claude/commit_acceptors/quick-round-ergonomics.yaml
+++ b/.claude/commit_acceptors/quick-round-ergonomics.yaml
@@ -1,0 +1,105 @@
+# Diff-bound commit acceptor for the quick-round ergonomic API.
+#
+# Closes the speed-of-thought gap of the audit. The full canonical
+# pipeline normally requires constructing five protocol-shaped
+# dataclasses; that ceremony is appropriate for production audit
+# but slow during interactive research. This module ships a single
+# function `quick_round(*, fsm_before, ...)` that accepts plain
+# Python booleans / tuples for the five evidence channels.
+#
+# The slow path `run_canonical_seven` remains the production entry
+# point.
+#
+# Locally verified:
+#   * pytest tests/research/systemic_risk/test_quick_round.py: 10/10 pass
+#   * pytest tests/research/systemic_risk/: 451/451 pass
+#   * mypy --strict on quick_round + tests: 0 errors
+#   * ruff + black: clean
+
+id: quick-round-ergonomics
+status: ACTIVE
+claim_type: governance
+promise: >-
+  After this PR lands, ``research.systemic_risk`` exposes a single
+  ``quick_round(*, fsm_before, ...)`` function that wraps the full
+  canonical-seven pipeline. Researchers can drive a claim through
+  one round with primitive inputs (booleans, tuples) without
+  constructing five protocol-shaped dataclasses.
+
+diff_scope:
+  changed_files:
+    - path: ".claude/commit_acceptors/quick-round-ergonomics.yaml"
+    - path: "research/systemic_risk/__init__.py"
+    - path: "research/systemic_risk/quick_round.py"
+    - path: "tests/research/systemic_risk/test_quick_round.py"
+  forbidden_paths:
+    - "trading/"
+    - "execution/"
+    - "forecast/"
+    - "policy/"
+    - "core/"
+    - "runtime/"
+    - "application/"
+
+required_python_symbols:
+  - "research/systemic_risk/quick_round.py::quick_round"
+  - "tests/research/systemic_risk/test_quick_round.py::TestQuickRound"
+
+expected_signal: >-
+  ``pytest tests/research/systemic_risk/test_quick_round.py -q`` reports
+  10 passed; before this PR the same command fails with
+  ModuleNotFoundError on ``research.systemic_risk.quick_round``.
+
+measurement_command: >-
+  bash -c '
+    mypy --strict
+      research/systemic_risk/quick_round.py
+      tests/research/systemic_risk/test_quick_round.py
+    && python -m pytest tests/research/systemic_risk/test_quick_round.py -q
+  '
+
+signal_artifact: "tmp/quick_round_ergonomics.log"
+
+falsifier:
+  command: >-
+    bash -c '
+      python -c "
+      from research.systemic_risk import quick_round, GovernanceFSM
+      out = quick_round(fsm_before=GovernanceFSM.initial(), replication_matched=False)
+      assert out.fsm_after.state == 'REJECTED'
+      " 2>/dev/null
+      && exit 1
+      || exit 0
+    '
+  description: >-
+    Probes that quick_round wires the KILL path correctly: a
+    replication mismatch via the primitive flag drives the FSM to
+    REJECTED. Falsifier inverts: it succeeds (exit 0) only when
+    the import or the assertion fails, which would mean the
+    ergonomic wrapper rolled back.
+
+rollback_command: >-
+  bash -c '
+    git rm -f
+      research/systemic_risk/quick_round.py
+      tests/research/systemic_risk/test_quick_round.py
+      .claude/commit_acceptors/quick-round-ergonomics.yaml
+    && git checkout HEAD~1 -- research/systemic_risk/__init__.py
+  '
+
+rollback_verification_command: >-
+  bash -c '
+    python -c "
+    try:
+        from research.systemic_risk import quick_round
+    except ImportError:
+        pass
+    else:
+        raise SystemExit(1)
+    "
+  '
+
+memory_update_type: append
+ledger_path: ".claude/commit_acceptors/quick-round-ergonomics.yaml"
+report_path: "tmp/quick_round_ergonomics.log"
+evidence: []

--- a/research/systemic_risk/__init__.py
+++ b/research/systemic_risk/__init__.py
@@ -196,6 +196,7 @@ from .phase_extraction import (
     INTERBANK_DEFAULT_BAND,
     interbank_phase_extract,
 )
+from .quick_round import quick_round
 from .replication import (
     RunManifest,
     build_run_manifest,
@@ -357,6 +358,7 @@ __all__ = [
     "omega_from_volatility",
     "parameter_fragility_audit",
     "permuted_crisis_dates",
+    "quick_round",
     "random_exposure_weights",
     "replication_match_bayes_factor",
     "rolling_volatility_score",

--- a/research/systemic_risk/quick_round.py
+++ b/research/systemic_risk/quick_round.py
@@ -1,0 +1,146 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""Research-speed ergonomics — one-call round through the Canonical Seven.
+
+Closes the speed-of-thought gap of the audit. The full canonical
+pipeline normally requires constructing five protocol-shaped
+dataclasses (firewall, leakage, ladder, fragility, replication)
+plus a :class:`GovernanceFSM`; that ceremony is appropriate for
+production audit but slow during interactive research.
+
+This module ships a single function
+
+    quick_round(*, fsm_before, ...)  → CanonicalSevenOutcome
+
+that accepts plain Python booleans / tuples / floats for the five
+canonical evidence channels. It builds the protocol-shaped wrappers
+internally and forwards to :func:`canonical_seven.run_canonical_seven`.
+
+Pure-function API; no I/O. The slow path
+:func:`run_canonical_seven` remains the production entry point.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .canonical_seven import (
+    CanonicalSevenInputs,
+    CanonicalSevenOutcome,
+    run_canonical_seven,
+)
+from .governance_fsm import GovernanceFSM
+
+__all__ = [
+    "quick_round",
+]
+
+
+# Shims must use ordinary (non-frozen) dataclasses so mypy treats
+# their attributes as *settable* — this is what the `*ResultLike`
+# Protocols in death_conditions.py expect at the type-check level.
+# At runtime nothing mutates them; the shims are constructed once and
+# discarded inside :func:`quick_round`.
+@dataclass
+class _LadderShim:
+    losing_paths: tuple[str, ...]
+
+
+@dataclass
+class _LeakageShim:
+    detected: bool
+
+
+@dataclass
+class _FragilityShim:
+    fragile: bool
+
+
+@dataclass
+class _ReplicationShim:
+    matched: bool
+
+
+@dataclass
+class _FirewallShim:
+    passed_all: bool
+
+
+def quick_round(
+    *,
+    fsm_before: GovernanceFSM,
+    losing_paths: tuple[str, ...] | None = None,
+    leakage_detected: bool | None = None,
+    fragile: bool | None = None,
+    replication_matched: bool | None = None,
+    firewall_passed_all: bool | None = None,
+) -> CanonicalSevenOutcome:
+    """Run one canonical round from primitive inputs.
+
+    Each evidence channel is independently optional; missing channels
+    are treated as "no signal" by the death engine (the corresponding
+    trigger does not fire).
+
+    Parameters
+    ----------
+    fsm_before
+        Current :class:`GovernanceFSM` of the claim.
+    losing_paths
+        Tuple of prosecutor names not beaten by the candidate. Empty
+        tuple = "no losing paths". ``None`` = "ladder not run yet".
+    leakage_detected
+        ``True`` if any leakage sentinel fired. ``None`` = sentinel
+        not run.
+    fragile
+        ``True`` if the parameter-fragility audit flipped the
+        verdict. ``None`` = not run.
+    replication_matched
+        ``True`` if the rerun matched primary; ``False`` triggers
+        KILL. ``None`` = capsule not run.
+    firewall_passed_all
+        ``True`` if the 8-gate firewall accepted the panel.
+        ``None`` = firewall not run.
+
+    Returns
+    -------
+    CanonicalSevenOutcome
+        Same outcome shape as :func:`run_canonical_seven`.
+
+    Examples
+    --------
+    A rerun-mismatch alone drives the FSM to ``REJECTED``::
+
+        out = quick_round(
+            fsm_before=GovernanceFSM.initial(),
+            replication_matched=False,
+        )
+        assert out.fsm_after.state == "REJECTED"
+
+    A clean round leaves state unchanged::
+
+        out = quick_round(
+            fsm_before=GovernanceFSM.initial(),
+            losing_paths=(),
+            leakage_detected=False,
+            fragile=False,
+            replication_matched=True,
+            firewall_passed_all=True,
+        )
+        assert out.transition.action == "NONE"
+    """
+    inputs = CanonicalSevenInputs(
+        firewall=(
+            _FirewallShim(passed_all=firewall_passed_all)
+            if firewall_passed_all is not None
+            else None
+        ),
+        leakage=(_LeakageShim(detected=leakage_detected) if leakage_detected is not None else None),
+        ladder=(_LadderShim(losing_paths=losing_paths) if losing_paths is not None else None),
+        fragility=(_FragilityShim(fragile=fragile) if fragile is not None else None),
+        replication=(
+            _ReplicationShim(matched=replication_matched)
+            if replication_matched is not None
+            else None
+        ),
+    )
+    return run_canonical_seven(inputs=inputs, fsm_before=fsm_before)

--- a/tests/research/systemic_risk/test_quick_round.py
+++ b/tests/research/systemic_risk/test_quick_round.py
@@ -1,0 +1,101 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""Quick-round ergonomic-API tests."""
+
+from __future__ import annotations
+
+from research.systemic_risk.governance_fsm import GovernanceFSM
+from research.systemic_risk.quick_round import quick_round
+
+
+class TestQuickRound:
+    def test_all_none_yields_none_action(self) -> None:
+        out = quick_round(fsm_before=GovernanceFSM.initial())
+        assert out.transition.action == "NONE"
+        assert out.fsm_after.state == "IDEA"
+
+    def test_replication_mismatch_drives_kill(self) -> None:
+        out = quick_round(
+            fsm_before=GovernanceFSM.initial(),
+            replication_matched=False,
+        )
+        assert out.transition.action == "KILL"
+        assert out.fsm_after.state == "REJECTED"
+
+    def test_leakage_detected_drives_invalidate(self) -> None:
+        fsm = GovernanceFSM.initial().promote(
+            target="HYPOTHESIS", evidence_supports=True, reason="seed"
+        )
+        out = quick_round(fsm_before=fsm, leakage_detected=True)
+        assert out.transition.action == "INVALIDATE"
+        assert out.fsm_after.state == "IDEA"
+
+    def test_fragile_drives_quarantine(self) -> None:
+        out = quick_round(fsm_before=GovernanceFSM.initial(), fragile=True)
+        assert out.transition.action == "QUARANTINE"
+        assert out.fsm_after.state == "QUARANTINED"
+
+    def test_losing_paths_drives_demote(self) -> None:
+        fsm = GovernanceFSM.initial().promote(target="MEASURED", evidence_supports=True, reason="m")
+        out = quick_round(fsm_before=fsm, losing_paths=("naive_baseline",))
+        assert out.transition.action == "DEMOTE"
+        assert out.fsm_after.state == "TESTED_ON_REAL_DATA"
+
+    def test_firewall_failure_drives_stop(self) -> None:
+        out = quick_round(
+            fsm_before=GovernanceFSM.initial(),
+            firewall_passed_all=False,
+        )
+        assert out.transition.action == "STOP"
+        # STOP does not change state.
+        assert out.fsm_after.state == "IDEA"
+
+    def test_clean_round_keeps_state(self) -> None:
+        fsm = GovernanceFSM.initial()
+        out = quick_round(
+            fsm_before=fsm,
+            firewall_passed_all=True,
+            leakage_detected=False,
+            losing_paths=(),
+            fragile=False,
+            replication_matched=True,
+        )
+        assert out.transition.action == "NONE"
+        assert out.fsm_after.state == "IDEA"
+
+    def test_kill_dominates_demote_via_quick(self) -> None:
+        # T1 (DEMOTE from losing_paths) AND T4 (KILL from
+        # replication_matched=False) both fire — KILL wins.
+        out = quick_round(
+            fsm_before=GovernanceFSM.initial(),
+            losing_paths=("p1",),
+            replication_matched=False,
+        )
+        assert out.transition.action == "KILL"
+        assert out.fsm_after.state == "REJECTED"
+
+    def test_partial_inputs_are_safe(self) -> None:
+        # Only the evidence channels you actually evaluated should
+        # fire triggers. Setting only firewall_passed_all=True must
+        # not cause spurious DEMOTE/INVALIDATE.
+        out = quick_round(
+            fsm_before=GovernanceFSM.initial(),
+            firewall_passed_all=True,
+        )
+        assert out.transition.action == "NONE"
+        assert out.fsm_after.state == "IDEA"
+
+    def test_iterative_research_loop_pattern(self) -> None:
+        # The canonical research-loop pattern: thread the FSM through
+        # successive rounds without rebuilding inputs each time.
+        fsm = GovernanceFSM.initial()
+        for _ in range(3):
+            out = quick_round(
+                fsm_before=fsm,
+                firewall_passed_all=True,
+                leakage_detected=False,
+                losing_paths=(),
+            )
+            fsm = out.fsm_after
+        assert len(fsm.history) == 3
+        assert fsm.state == "IDEA"


### PR DESCRIPTION
## Summary

Closes the **speed-of-thought gap (axis 5, was 72/100)** of the audit. The full canonical pipeline normally requires constructing five protocol-shaped dataclasses; that ceremony is appropriate for production audit but slow during interactive research.

Adds `quick_round(*, fsm_before, ...)` that accepts primitive Python inputs (booleans, tuples) for each evidence channel and forwards to `run_canonical_seven`.

## Usage — research-loop pattern

```python
from research.systemic_risk import quick_round, GovernanceFSM

# One-line round through the canonical seven
out = quick_round(
    fsm_before=GovernanceFSM.initial(),
    replication_matched=False,    # → KILL
)
assert out.fsm_after.state == "REJECTED"
```

vs. the production form which still works for audit-grade pipelines:

```python
inputs = CanonicalSevenInputs(
    firewall=run_data_firewall(panel, labels, provs),
    leakage=run_leakage_audit(sentinel_outcomes),
    ladder=run_adversarial_ladder(...),
    replication=compare_run_outputs(...),
)
out = run_canonical_seven(inputs=inputs, fsm_before=fsm)
```

## Test plan

- [x] `pytest tests/research/systemic_risk/test_quick_round.py -q` — 10/10 pass
- [x] `pytest tests/research/systemic_risk/ -q` — **451/451 pass**
- [x] `mypy --strict` on quick_round + tests — 0 errors
- [x] Every action path (KILL/INVALIDATE/QUARANTINE/DEMOTE/STOP/NONE) covered
- [x] KILL-dominates-DEMOTE precedence preserved through wrapper

🤖 Generated with [Claude Code](https://claude.com/claude-code)