### PR TITLE
ci(deps): bump actions/dependency-review-action 4.9.0→5.0.0 (supersedes #607)

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -377,7 +377,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: GitHub dependency review
-        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           fail-on-severity: critical
           deny-licenses: GPL-2.0, GPL-3.0, AGPL-3.0

--- a/INVENTORY.json
+++ b/INVENTORY.json
@@ -11,7 +11,7 @@
   "files": [
     {
       "path": ".github/workflows/pr-gate.yml",
-      "sha256": "2b8de402bbfd2a6d452481f7d9efaf3fe15f6b09362f2b06d3c593ef3bd79547"
+      "sha256": "260d2fa2a8a1e65da2713f20bd9e3c6afdf2be2d3309185144855342351bb6cf"
     },
     {
       "path": "scripts/ci/check_central_files_touched.py",


### PR DESCRIPTION
Supersedes #607 (dependabot PR could not pass repo-policy because the workflow file SHA changed and INVENTORY.json was stale).

This PR:
- bumps actions/dependency-review-action from 4.9.0 to 5.0.0 (same as #607)
- refreshes INVENTORY.json sha256 for `.github/workflows/pr-gate.yml`

Closes #607.

🤖 Generated with [Claude Code](https://claude.com/claude-code)