### PR TITLE
ci(deps): pydantic 2.13.2→2.13.4 in /constraints (rebased, supersedes #598)

### DIFF
--- a/constraints/security.txt
+++ b/constraints/security.txt
@@ -50,7 +50,7 @@ SQLAlchemy==2.0.44
 
 # pydantic: Data validation, critical for API input validation
 # Security fixes for ReDoS and validation bypass
-pydantic==2.13.2
+pydantic==2.13.4
 pydantic-settings==2.12.0
 
 # pandera: DataFrame validation, data quality and security


### PR DESCRIPTION
Rebased #598 onto fresh main. Same 1-line constraint bump. Closes #598.