### PR TITLE
ci(deps): pydantic 2.13.3→2.13.4 in coherence_bridge + sbom (supersedes #609)

### DIFF
--- a/coherence_bridge/requirements.txt
+++ b/coherence_bridge/requirements.txt
@@ -4,7 +4,7 @@ grpcio-health-checking==1.80.0
 kafka-python==2.2.15
 numpy==2.4.4
 prometheus-client==0.25.0
-pydantic==2.13.3
+pydantic==2.13.4
 python-dotenv==1.2.2
 questdb==4.1.0
 uvicorn==0.46.0

--- a/sbom/combined-requirements.txt
+++ b/sbom/combined-requirements.txt
@@ -101,7 +101,7 @@ psycopg-binary==3.2.11
 pyarrow==21.0.0
 pycares==4.11.0
 pycparser==3.0
-pydantic==2.13.3
+pydantic==2.13.4
 pydantic-core==2.41.5
 pydantic-settings==2.12.0
 pydeck==0.9.1


### PR DESCRIPTION
Pure 2-file pydantic bump in coherence_bridge/requirements.txt + sbom/combined-requirements.txt. The constraints/security.txt portion of #609 is already in #632. Closes #609.