### PR TITLE
feat(x10r-2): reciprocity-aware positive controls (closes #636)

### DIFF
--- a/.claude/commit_acceptors/x10r-2-reciprocity-aware-controls.yaml
+++ b/.claude/commit_acceptors/x10r-2-reciprocity-aware-controls.yaml
@@ -1,0 +1,119 @@
+# Diff-bound commit acceptor for X-10R-2 — reciprocity-aware positive
+# controls (GH issue #636). Closes the FIX B6 debt from PR #635.
+#
+# Adds to research/reconstruction/positive_control.py:
+#   * compute_reciprocity_ratio(W)  — empirical r-ratio observable
+#   * reciprocity_keep_p_for_target(r)  — closed-form inverse mapping
+#   * _apply_reciprocity_filter — drop one direction of bidirectional
+#     pairs with prob 1 − keep_p (preserves one edge per previously-
+#     edged pair → no disconnection at small N)
+#   * `reciprocity_keep_p` param on ground_truth_ba/_core_periphery/
+#     _hierarchical (default 1.0 ⇒ original behaviour)
+#   * `tested_at_reciprocity` populated from achieved ratio when
+#     Gate-5 sweep passes
+#   * ReciprocityAwareRecoveryCertificate + run_reciprocity_aware_recovery
+#     for a (reciprocity × density) grid aggregate
+#
+# In research/reconstruction/recovery_audit.py:
+#   * Reciprocity dimension RE-classified as provenance-only on the
+#     domain-of-validity gate. The previous FIX B2 wiring conflated
+#     network-level reciprocity (substrate topology) with marginal-
+#     level Pearson(s_in, s_out); these are different observables and
+#     gating one against the other is a category error. The
+#     `tested_at_reciprocity` envelope is still surfaced in
+#     `certified_envelope` for inspection but does NOT drive verdicts.
+#
+# Locally verified:
+#   * pytest tests/reconstruction/ -m "not slow": 160 passed
+#   * pytest tests/reconstruction/ -m "slow":      17 passed
+#   * mypy --strict + ruff + black:                clean
+
+id: x10r-2-reciprocity-aware-controls
+status: ACTIVE
+claim_type: chore
+promise: >-
+  After this PR lands, research/reconstruction/positive_control.py
+  exposes a `reciprocity_keep_p` parameter on every ground-truth
+  generator + a closed-form mapping
+  reciprocity_keep_p_for_target(r) = r/(2-r) and an empirical
+  observable compute_reciprocity_ratio(W). run_recovery_on_substrate
+  populates tested_at_reciprocity with the substrate's achieved
+  ratio when Gate-5 passes. ReciprocityAwareRecoveryCertificate +
+  run_reciprocity_aware_recovery walk a (reciprocity × density)
+  grid; tested_at_reciprocity on the aggregate is non-empty iff
+  every cell passes. recovery_audit.check_domain_of_validity is
+  amended: reciprocity becomes provenance-only because Pearson
+  (the only marginal observable) measures node balance, not
+  network reciprocity. 18 new tests pin the contract: closed-form
+  inversion, achieved-ratio convergence under the 1/3 keep_p
+  setting (target 0.5), one-edge-per-pair invariant, sweep
+  rejection of empty grids and out-of-range targets, failed-cell
+  envelope discipline (tested_at_reciprocity = () on partial
+  sweeps).
+diff_scope:
+  changed_files:
+    - path: ".claude/commit_acceptors/x10r-2-reciprocity-aware-controls.yaml"
+    - path: "research/reconstruction/__init__.py"
+    - path: "research/reconstruction/positive_control.py"
+    - path: "research/reconstruction/recovery_audit.py"
+    - path: "tests/reconstruction/test_domain_of_validity.py"
+    - path: "tests/reconstruction/test_reciprocity_aware_recovery.py"
+  forbidden_paths:
+    - "trading/"
+    - "execution/"
+    - "forecast/"
+    - "policy/"
+    - "core/physics/"
+    - "core/kuramoto/"
+    - "application/governance/claim_ledger.py"
+    - "application/governance/commit_acceptor.py"
+required_python_symbols:
+  - "research/reconstruction/positive_control.py::compute_reciprocity_ratio"
+  - "research/reconstruction/positive_control.py::reciprocity_keep_p_for_target"
+  - "research/reconstruction/positive_control.py::ReciprocityAwareRecoveryCertificate"
+  - "research/reconstruction/positive_control.py::run_reciprocity_aware_recovery"
+expected_signal: >-
+  Local: `pytest tests/reconstruction/ -m "not slow"` reports
+  "160 passed"; `pytest tests/reconstruction/ -m "slow"` reports
+  "17 passed"; `mypy --strict` is clean on every file under
+  research/reconstruction/ and tests/reconstruction/;
+  `ruff check` and `black --check` both pass on those paths.
+measurement_command: >-
+  bash -c 'mypy --strict --follow-imports=silent
+  research/reconstruction/ tests/reconstruction/
+  && ruff check research/reconstruction/ tests/reconstruction/
+  && black --check research/reconstruction/ tests/reconstruction/
+  && pytest tests/reconstruction/ -m "not slow" -q'
+signal_artifact: "tmp/x10r_2_reciprocity.log"
+falsifier:
+  command: >-
+    bash -c 'python -c "
+    from research.reconstruction.positive_control import (
+        compute_reciprocity_ratio, ground_truth_core_periphery,
+        reciprocity_keep_p_for_target,
+    )
+    keep_p = reciprocity_keep_p_for_target(0.5)
+    rs = [compute_reciprocity_ratio(
+        ground_truth_core_periphery(n=120, core_frac=0.30, seed=s,
+                                    reciprocity_keep_p=keep_p))
+        for s in range(5)]
+    mean = sum(rs) / 5
+    assert 0.40 <= mean <= 0.60, f\"r-mean {mean:.3f} out of [0.40, 0.60]\"
+    "'
+  description: >-
+    Probes the closed-form mapping
+    reciprocity_keep_p = r_target / (2 - r_target). With r_target = 0.5
+    the keep_p is 1/3 and the empirical achieved ratio across 5
+    seeds at N=120 must land in [0.40, 0.60]. Falls outside that
+    band ⇒ either the filter or the closed-form is broken.
+rollback_command: >-
+  bash -c 'git checkout HEAD~1 --
+  && rm -f tests/reconstruction/test_reciprocity_aware_recovery.py
+  .claude/commit_acceptors/x10r-2-reciprocity-aware-controls.yaml'
+rollback_verification_command: >-
+  bash -c 'test ! -f tests/reconstruction/test_reciprocity_aware_recovery.py
+  && test ! -f .claude/commit_acceptors/x10r-2-reciprocity-aware-controls.yaml'
+memory_update_type: append
+ledger_path: ".claude/commit_acceptors/x10r-2-reciprocity-aware-controls.yaml"
+report_path: "tmp/x10r_2_reciprocity.log"
+evidence: []

--- a/research/reconstruction/__init__.py
+++ b/research/reconstruction/__init__.py
@@ -44,9 +44,13 @@ from research.reconstruction.negative_control import (
 )
 from research.reconstruction.positive_control import (
     GroundTruthRecoveryCertificate,
+    ReciprocityAwareRecoveryCertificate,
+    compute_reciprocity_ratio,
     ground_truth_ba,
     ground_truth_core_periphery,
     ground_truth_hierarchical,
+    reciprocity_keep_p_for_target,
+    run_reciprocity_aware_recovery,
     run_recovery_on_substrate,
 )
 from research.reconstruction.reconstruction_capsule import (
@@ -87,6 +91,7 @@ __all__ = [
     "PrecursorDirection",
     "PrecursorReport",
     "RECOVERY_THRESHOLDS",
+    "ReciprocityAwareRecoveryCertificate",
     "ReconstructionCapsule",
     "ReconstructionStatus",
     "RecoveryReport",
@@ -97,6 +102,7 @@ __all__ = [
     "build_reconstruction_capsule",
     "calibrate_density_z",
     "check_domain_of_validity",
+    "compute_reciprocity_ratio",
     "conservation_of_mass_passes",
     "density_bound_passes",
     "fit_cimini_squartini",
@@ -111,9 +117,11 @@ __all__ = [
     "neg_path_lattice",
     "neg_ring_lattice",
     "p_link",
+    "reciprocity_keep_p_for_target",
     "rerun_reconstruction_strict",
     "run_all_negative_controls",
     "run_negative_control",
+    "run_reciprocity_aware_recovery",
     "run_recovery_on_substrate",
     "sample_adjacency_bernoulli",
     "serialise_reconstruction_capsule",

--- a/research/reconstruction/positive_control.py
+++ b/research/reconstruction/positive_control.py
@@ -70,6 +70,7 @@ References for the reciprocity-aware extension:
 from __future__ import annotations
 
 import hashlib
+from collections.abc import Callable
 from dataclasses import dataclass
 
 import networkx as nx
@@ -91,11 +92,107 @@ from research.reconstruction.weighted_allocation import (
 )
 
 # ---------------------------------------------------------------------------
+# Reciprocity machinery (X-10R-2, GH issue #636)
+# ---------------------------------------------------------------------------
+#
+# Reciprocity in a directed weighted network = fraction of directed edges
+# whose reverse is also present:
+#
+#     r(W) = #{(i,j) : a_ij=1 ∧ a_ji=1, i≠j} / #{(i,j) : a_ij=1, i≠j}
+#
+# Empirical interbank networks (e-MID, BIS LBS proxies) sit in the
+# r ≈ 0.3–0.6 range. The current substrates (CP, hierarchical, BA) build
+# both directions whenever an edge exists, so their intrinsic reciprocity
+# is ≈ 1.0. To probe the spectral-recovery sensitivity to reciprocity
+# (Vandermarliere/Heiberger 2024 e-MID line of work), we expose a
+# reciprocity-keep parameter that drops one direction of bidirectional
+# edge pairs with probability `1 - keep_p`.
+#
+# Mapping from the keep parameter to achieved reciprocity ratio:
+#   r_achieved = 2·keep_p / (1 + keep_p)
+#   keep_p  = r_target / (2 − r_target)   (inverse)
+#
+# Examples:
+#   keep_p = 1.0 → r_achieved = 1.0 (pure bidirectional)
+#   keep_p = 1/3 → r_achieved = 0.5
+#   keep_p = 0.0 → r_achieved = 0.0 (purely unidirectional)
+
+
+def reciprocity_keep_p_for_target(r_target: float) -> float:
+    """Inverse of `r_achieved = 2·keep_p / (1 + keep_p)`.
+
+    Maps a desired achieved-reciprocity ratio in [0, 1] to the
+    keep-probability the substrate generators consume.
+    """
+    if not (0.0 <= r_target <= 1.0):
+        raise ValueError(f"r_target must be in [0, 1]; got {r_target}")
+    return r_target / (2.0 - r_target)
+
+
+def compute_reciprocity_ratio(w: np.ndarray) -> float:
+    """Achieved reciprocity ratio of a directed weighted matrix.
+
+    r(W) = (#edges (i,j) with both w_ij > 0 and w_ji > 0)
+           / (#edges (i,j) with w_ij > 0)
+
+    Returns 0.0 on empty matrices to keep the denominator safe.
+    """
+    if w.ndim != 2 or w.shape[0] != w.shape[1]:
+        raise ValueError(f"w must be square 2-D; got {w.shape}")
+    a = (w > 0).astype(np.uint8)
+    np.fill_diagonal(a, 0)
+    n_edges = int(a.sum())
+    if n_edges == 0:
+        return 0.0
+    bidirectional = a * a.T  # 1 only where both directions exist
+    return float(int(bidirectional.sum()) / n_edges)
+
+
+def _apply_reciprocity_filter(
+    w: np.ndarray, *, keep_p: float, rng: np.random.Generator
+) -> np.ndarray:
+    """Drop one direction of each bidirectional edge pair with prob 1 - keep_p.
+
+    For each unordered pair (i, j) with i < j and both w_ij > 0 and w_ji > 0:
+      * with probability keep_p, leave both directions intact;
+      * with probability 1 - keep_p, zero out one direction (uniform random).
+
+    This preserves the underlying topology's marginal degree (one edge
+    survives in every previously-bidirectional pair) while attenuating
+    reciprocity to the target ratio. Pure unidirectional pairs are
+    unchanged.
+    """
+    if not (0.0 <= keep_p <= 1.0):
+        raise ValueError(f"keep_p must be in [0, 1]; got {keep_p}")
+    out = w.copy()
+    if keep_p >= 1.0:
+        return out  # full reciprocity preserved — fast path
+    n = out.shape[0]
+    for i in range(n):
+        for j in range(i + 1, n):
+            if out[i, j] > 0 and out[j, i] > 0:
+                if rng.uniform() < keep_p:
+                    continue  # keep both directions
+                # Drop one direction; pick uniformly at random which.
+                if rng.uniform() < 0.5:
+                    out[i, j] = 0.0
+                else:
+                    out[j, i] = 0.0
+    return out
+
+
+# ---------------------------------------------------------------------------
 # Ground-truth generators
 # ---------------------------------------------------------------------------
 
 
-def ground_truth_ba(n: int = 200, m: int = 5, *, seed: int = 42) -> np.ndarray:
+def ground_truth_ba(
+    n: int = 200,
+    m: int = 5,
+    *,
+    seed: int = 42,
+    reciprocity_keep_p: float = 1.0,
+) -> np.ndarray:
     """BA(N, m) skeleton with log-normal weights.
 
     Default m=5 (not m=3 from spec). Rationale: fitness-only Cimini cannot
@@ -105,6 +202,11 @@ def ground_truth_ba(n: int = 200, m: int = 5, *, seed: int = 42) -> np.ndarray:
     BA(m=5) is still scale-free (γ=3) but the degree heterogeneity is
     within the model's regime of validity. m=3 remains available for
     stress testing — it WILL trigger INVALID_RECONSTRUCTION.
+
+    `reciprocity_keep_p ∈ [0, 1]` (X-10R-2): the per-edge probability
+    that a bidirectional pair survives intact. Default 1.0 ⇒ original
+    behaviour. Achieved reciprocity = 2·p / (1 + p); use
+    `reciprocity_keep_p_for_target` to invert.
     """
     rng = np.random.default_rng(seed)
     g = nx.barabasi_albert_graph(n, m, seed=int(rng.integers(0, 2**31 - 1)))
@@ -115,13 +217,24 @@ def ground_truth_ba(n: int = 200, m: int = 5, *, seed: int = 42) -> np.ndarray:
         # Asymmetric: assign reverse weight independently for directed
         w[v, u] = float(rng.lognormal(mean=12.0, sigma=2.0))
     np.fill_diagonal(w, 0.0)
+    if reciprocity_keep_p < 1.0:
+        w = _apply_reciprocity_filter(w, keep_p=reciprocity_keep_p, rng=rng)
     return w
 
 
 def ground_truth_core_periphery(
-    n: int = 200, *, core_frac: float = 0.30, seed: int = 42
+    n: int = 200,
+    *,
+    core_frac: float = 0.30,
+    seed: int = 42,
+    reciprocity_keep_p: float = 1.0,
 ) -> np.ndarray:
-    """Core (fully connected) + periphery (sparse to core only)."""
+    """Core (fully connected) + periphery (sparse to core only).
+
+    `reciprocity_keep_p ∈ [0, 1]` (X-10R-2): per-bidirectional-pair
+    keep probability; see module docstring for the mapping to achieved
+    reciprocity ratio.
+    """
     rng = np.random.default_rng(seed)
     n_core = max(2, int(n * core_frac))
     w = np.zeros((n, n), dtype=np.float64)
@@ -138,11 +251,23 @@ def ground_truth_core_periphery(
             w[i, int(j)] = float(rng.lognormal(mean=11.0, sigma=2.0))
             w[int(j), i] = float(rng.lognormal(mean=11.0, sigma=2.0))
     np.fill_diagonal(w, 0.0)
+    if reciprocity_keep_p < 1.0:
+        w = _apply_reciprocity_filter(w, keep_p=reciprocity_keep_p, rng=rng)
     return w
 
 
-def ground_truth_hierarchical(n: int = 200, *, n_tiers: int = 4, seed: int = 42) -> np.ndarray:
-    """Block-structured tiers with descending strength (Bardoscia stylized)."""
+def ground_truth_hierarchical(
+    n: int = 200,
+    *,
+    n_tiers: int = 4,
+    seed: int = 42,
+    reciprocity_keep_p: float = 1.0,
+) -> np.ndarray:
+    """Block-structured tiers with descending strength (Bardoscia stylized).
+
+    `reciprocity_keep_p ∈ [0, 1]` (X-10R-2): per-bidirectional-pair
+    keep probability; see module docstring for the mapping.
+    """
     rng = np.random.default_rng(seed)
     tier_size = n // n_tiers
     w = np.zeros((n, n), dtype=np.float64)
@@ -164,6 +289,8 @@ def ground_truth_hierarchical(n: int = 200, *, n_tiers: int = 4, seed: int = 42)
                     if rng.uniform() < 0.2:
                         w[i, j] = float(rng.lognormal(mean=weight_mean - 1.0, sigma=1.0))
     np.fill_diagonal(w, 0.0)
+    if reciprocity_keep_p < 1.0:
+        w = _apply_reciprocity_filter(w, keep_p=reciprocity_keep_p, rng=rng)
     return w
 
 
@@ -256,10 +383,15 @@ def run_recovery_on_substrate(
     """Run Gate 5 recovery audit across the density sweep on a substrate.
 
     All sweep densities must pass for the certificate to be valid.
+    The achieved reciprocity ratio of ``w_true`` is measured once and
+    stored in ``tested_at_reciprocity = (r_observed,)`` so a downstream
+    domain-of-validity gate can use the certificate's reciprocity
+    envelope when it is non-trivial.
     """
     s_out_true = w_true.sum(axis=1)
     s_in_true = w_true.sum(axis=0)
     n = w_true.shape[0]
+    r_observed = compute_reciprocity_ratio(w_true)
     per_density: dict[float, RecoveryReport] = {}
     failures: list[str] = []
     for d in sweep:
@@ -281,10 +413,12 @@ def run_recovery_on_substrate(
     # certify it as `passed`.
     tested_densities = tuple(sorted(per_density.keys()))
     tested_n_nodes = (int(n),)
+    tested_reciprocity = (round(r_observed, 6),) if passed else ()
     cert_payload = (
         f"{substrate_name}|n={n}|seed={seed}|sweep={sweep}|"
         f"thresholds={sorted(RECOVERY_THRESHOLDS.items())}|"
         f"tested_n_nodes={tested_n_nodes}|tested_densities={tested_densities}|"
+        f"tested_reciprocity={tested_reciprocity}|"
         f"passed={passed}"
     )
     cert_id = hashlib.sha256(cert_payload.encode("utf-8")).hexdigest()
@@ -299,5 +433,158 @@ def run_recovery_on_substrate(
         cert_id=cert_id,
         tested_at_n_nodes=tested_n_nodes,
         tested_at_densities=tested_densities,
-        tested_at_reciprocity=(),
+        tested_at_reciprocity=tested_reciprocity,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Reciprocity × density sweep — the X-10R-2 evidence builder
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ReciprocityAwareRecoveryCertificate:
+    """Aggregate of (reciprocity × density) Gate-5 recovery results.
+
+    Built by `run_reciprocity_aware_recovery` (X-10R-2). Each grid cell
+    is a `GroundTruthRecoveryCertificate` from a freshly-generated
+    substrate at a target reciprocity; a cell counts as `passed` only if
+    Gate 5 holds at every density for that reciprocity. The aggregate
+    `tested_at_reciprocity` is the union of achieved reciprocity ratios
+    across cells that passed.
+    """
+
+    substrate_name: str
+    n_nodes: int
+    target_reciprocity_grid: tuple[float, ...]
+    achieved_reciprocity_grid: tuple[float, ...]
+    sweep_densities: tuple[float, ...]
+    per_reciprocity_certs: dict[float, GroundTruthRecoveryCertificate]
+    passed: bool
+    failure_reasons: tuple[str, ...]
+    cert_id: str
+    tested_at_n_nodes: tuple[int, ...]
+    tested_at_densities: tuple[float, ...]
+    tested_at_reciprocity: tuple[float, ...]
+
+    def is_valid(self) -> bool:
+        return self.passed and bool(self.cert_id)
+
+    def evidence_envelope(self) -> dict[str, tuple[float, float] | tuple[int, int]]:
+        envelope: dict[str, tuple[float, float] | tuple[int, int]] = {}
+        if self.tested_at_n_nodes:
+            envelope["n_nodes"] = (
+                int(min(self.tested_at_n_nodes)),
+                int(max(self.tested_at_n_nodes)),
+            )
+        if self.tested_at_densities:
+            envelope["density"] = (
+                float(min(self.tested_at_densities)),
+                float(max(self.tested_at_densities)),
+            )
+        if self.tested_at_reciprocity:
+            envelope["reciprocity"] = (
+                float(min(self.tested_at_reciprocity)),
+                float(max(self.tested_at_reciprocity)),
+            )
+        return envelope
+
+
+# Default reciprocity grid — covers the empirical interbank range
+# (e-MID 2008 ≈ 0.27; pre-crisis core-periphery substrates 0.6–0.9; the
+# r=1 anchor preserves the original X-10R behaviour for backward compat).
+_RECIPROCITY_GRID: tuple[float, ...] = (0.30, 0.60, 1.00)
+
+
+def run_reciprocity_aware_recovery(
+    substrate_name: str,
+    *,
+    substrate_factory: Callable[[float, int], np.ndarray],
+    seed: int = 42,
+    reciprocity_grid: tuple[float, ...] = _RECIPROCITY_GRID,
+    density_sweep: tuple[float, ...] = _DENSITY_SWEEP,
+) -> ReciprocityAwareRecoveryCertificate:
+    """Sweep Gate 5 recovery across a (reciprocity × density) grid.
+
+    `substrate_factory(r_target, seed)` must return the directed
+    weighted matrix at the target reciprocity ratio. Use
+    `reciprocity_keep_p_for_target` to invert the target into the
+    keep-probability the existing generators consume.
+
+    Each (r_target) cell:
+      1. builds the substrate at that target reciprocity,
+      2. measures achieved reciprocity (which is what the certificate
+         records — empirical, not intended),
+      3. runs the full density sweep via `run_recovery_on_substrate`,
+      4. counts the cell as PASS iff that nested certificate passes.
+
+    Aggregate PASS iff every cell passes. `tested_at_reciprocity` on
+    the aggregate is the union of achieved reciprocity ratios across
+    PASSING cells — the evidence the domain-of-validity gate consumes.
+    """
+    if not reciprocity_grid:
+        raise ValueError("reciprocity_grid must be non-empty")
+    if not density_sweep:
+        raise ValueError("density_sweep must be non-empty")
+
+    per_reciprocity: dict[float, GroundTruthRecoveryCertificate] = {}
+    achieved: list[float] = []
+    failures: list[str] = []
+
+    for r_target in reciprocity_grid:
+        if not (0.0 <= r_target <= 1.0):
+            raise ValueError(f"reciprocity grid value out of [0, 1]: {r_target}")
+        cell_seed = seed + int(round(r_target * 10_000))
+        try:
+            w_true = substrate_factory(r_target, cell_seed)
+        except (ValueError, FloatingPointError) as exc:
+            failures.append(f"r_target={r_target}: substrate build failed ({exc})")
+            continue
+        r_actual = compute_reciprocity_ratio(w_true)
+        achieved.append(round(r_actual, 6))
+        cell_cert = run_recovery_on_substrate(
+            f"{substrate_name}_r{r_target:.2f}",
+            w_true,
+            seed=cell_seed,
+            sweep=density_sweep,
+        )
+        per_reciprocity[r_target] = cell_cert
+        if not cell_cert.passed:
+            failures.append(
+                f"r_target={r_target} (achieved={r_actual:.3f}): "
+                + "; ".join(cell_cert.failure_reasons)
+            )
+
+    passed = not failures and len(per_reciprocity) == len(reciprocity_grid)
+
+    # Evidence surface: only achieved reciprocities of PASSING cells
+    # count toward tested_at_reciprocity. This mirrors the density-sweep
+    # contract — a crashed or failed cell cannot certify the regime.
+    tested_reciprocity: tuple[float, ...] = ()
+    if passed:
+        tested_reciprocity = tuple(sorted(achieved))
+    n_nodes = (
+        per_reciprocity[reciprocity_grid[0]].n_nodes
+        if reciprocity_grid[0] in per_reciprocity
+        else 0
+    )
+    cert_payload = (
+        f"{substrate_name}|n={n_nodes}|seed={seed}|"
+        f"r_grid={reciprocity_grid}|d_sweep={density_sweep}|"
+        f"achieved={tuple(sorted(achieved))}|passed={passed}"
+    )
+    cert_id = hashlib.sha256(cert_payload.encode("utf-8")).hexdigest()
+    return ReciprocityAwareRecoveryCertificate(
+        substrate_name=substrate_name,
+        n_nodes=n_nodes,
+        target_reciprocity_grid=reciprocity_grid,
+        achieved_reciprocity_grid=tuple(sorted(achieved)),
+        sweep_densities=density_sweep,
+        per_reciprocity_certs=per_reciprocity,
+        passed=passed,
+        failure_reasons=tuple(failures),
+        cert_id=cert_id,
+        tested_at_n_nodes=(int(n_nodes),) if n_nodes else (),
+        tested_at_densities=tuple(density_sweep),
+        tested_at_reciprocity=tested_reciprocity,
     )

--- a/research/reconstruction/recovery_audit.py
+++ b/research/reconstruction/recovery_audit.py
@@ -162,16 +162,22 @@ def check_domain_of_validity(
       * ``n_nodes``       — input size against tested_at_n_nodes envelope
       * ``density``       — caller-supplied inferred density against
                             tested_at_densities envelope
-      * ``reciprocity``   — Pearson(s_out, s_in) against
-                            tested_at_reciprocity envelope (FIX B6
-                            placeholder; default empty until reciprocity-
-                            aware controls land)
       * ``aggregation_ratio`` — caller-supplied if available
 
-    Heterogeneity (Gini of strengths) is reported in `measured` for
-    transparency but is not gated unless the caller adds it to
-    `require_dims` (kept off the default path because the certificate
-    in PR #635 does not yet carry a heterogeneity envelope).
+    Heterogeneity (Gini of strengths), Pearson(s_in, s_out), and
+    network reciprocity (when carried by the certificate) are reported
+    in `measured` / `certified_envelope` for transparency but are NOT
+    gate dimensions:
+
+      * `pearson_in_out` is a node-marginal balance measure; the
+        certificate's `tested_at_reciprocity` (X-10R-2) is the
+        substrate's *topological* reciprocity ratio. These are
+        different observables; gating one against the other is a
+        category error. Network reciprocity therefore appears in
+        `certified_envelope` for provenance but does not drive the
+        verdict.
+      * `gini_s_*` is reported because heavy-tailed marginals are
+        what the BIS path will see; it is not gated.
 
     Verdict semantics:
       * INSUFFICIENT_CERTIFICATE — the certificate is silent on every
@@ -226,11 +232,17 @@ def check_domain_of_validity(
 
     _gate("n_nodes", measured["n_nodes"])
     _gate("density", measured.get("density"))
+    # Reciprocity is provenance-only (see docstring): the certificate's
+    # `tested_at_reciprocity` is topological while the only observable on
+    # real marginals is Pearson(s_in, s_out). We surface the certified
+    # envelope but do NOT gate on it. A caller that demands reciprocity
+    # via `require_dims` still triggers INSUFFICIENT — the contract
+    # honours their explicit ask, but the *default* path no longer
+    # falsely gates a node-balance number against a topology number.
     if "reciprocity" in envelope:
-        _gate("reciprocity", measured["pearson_in_out"])
-    elif "reciprocity" in require_dims:
-        # The caller demanded a reciprocity gate but the certificate
-        # has none — count as missing (drives INSUFFICIENT below).
+        lo_raw, hi_raw = envelope["reciprocity"]
+        certified_envelope["reciprocity"] = (float(lo_raw), float(hi_raw))
+    if "reciprocity" in require_dims and "reciprocity" not in checks:
         missing.append("reciprocity")
 
     required_missing = [d for d in require_dims if d in missing]

--- a/tests/reconstruction/test_domain_of_validity.py
+++ b/tests/reconstruction/test_domain_of_validity.py
@@ -267,7 +267,13 @@ def test_domain_check_rejects_non_finite_marginals() -> None:
 
 
 def test_evidence_envelope_reports_min_max() -> None:
-    """The envelope helper returns (min, max) per dimension that has evidence."""
+    """The envelope helper returns (min, max) per dimension that has evidence.
+
+    Post X-10R-2 (#636): reciprocity is now populated from the substrate's
+    achieved ratio whenever the certificate passes. Default substrates
+    (CP, hierarchical, BA) build both directions per edge, so the
+    achieved ratio is 1.0 unless reciprocity_keep_p < 1.0.
+    """
     cert = _cached_cert_n80_seed42()
     env = cert.evidence_envelope()
     assert "n_nodes" in env
@@ -275,8 +281,10 @@ def test_evidence_envelope_reports_min_max() -> None:
     assert "density" in env
     lo, hi = env["density"]
     assert lo <= hi
-    # Reciprocity not yet swept (FIX B6 placeholder).
-    assert "reciprocity" not in env
+    # Default CP substrate has full bidirectional symmetry → r=1.
+    assert "reciprocity" in env
+    r_lo, r_hi = env["reciprocity"]
+    assert 0.99 <= r_lo <= r_hi <= 1.0
 
 
 def test_within_domain_when_real_n_at_envelope_boundary() -> None:

--- a/tests/reconstruction/test_reciprocity_aware_recovery.py
+++ b/tests/reconstruction/test_reciprocity_aware_recovery.py
@@ -116,9 +116,9 @@ def test_cp_keep_p_half_lands_near_predicted_ratio() -> None:
         achieved.append(compute_reciprocity_ratio(w))
     mean_achieved = float(np.mean(achieved))
     # ±0.10 envelope absorbs finite-N variance at N=120 with 5 seeds.
-    assert math.isclose(
-        mean_achieved, 0.5, abs_tol=0.10
-    ), f"expected r ≈ 0.5, got mean(achieved)={mean_achieved:.3f} across seeds {(1, 2, 3, 4, 5)}"
+    assert math.isclose(mean_achieved, 0.5, abs_tol=0.10), (
+        f"expected r ≈ 0.5, got mean(achieved)={mean_achieved:.3f} across seeds {(1, 2, 3, 4, 5)}"
+    )
 
 
 def test_hierarchical_keep_p_zero_drives_reciprocity_to_zero() -> None:
@@ -150,6 +150,7 @@ def test_keep_p_filter_preserves_one_edge_per_pair() -> None:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.slow
 def test_run_recovery_populates_tested_reciprocity_when_passed() -> None:
     """`run_recovery_on_substrate` records the substrate's achieved
     reciprocity ratio in `tested_at_reciprocity` when Gate 5 passes."""
@@ -162,6 +163,7 @@ def test_run_recovery_populates_tested_reciprocity_when_passed() -> None:
         assert 0.0 <= r <= 1.0
 
 
+@pytest.mark.slow
 def test_run_recovery_evidence_envelope_carries_reciprocity() -> None:
     """The certificate's evidence_envelope must surface the recorded
     reciprocity dimension when the sweep passed."""
@@ -242,6 +244,7 @@ def test_reciprocity_aware_sweep_failed_cell_keeps_envelope_empty() -> None:
     assert cert.tested_at_reciprocity == ()
 
 
+@pytest.mark.slow
 def test_reciprocity_aware_cert_id_is_64_hex_and_seed_sensitive() -> None:
     def factory_a(r_target: float, seed: int) -> np.ndarray:
         keep_p = reciprocity_keep_p_for_target(r_target)

--- a/tests/reconstruction/test_reciprocity_aware_recovery.py
+++ b/tests/reconstruction/test_reciprocity_aware_recovery.py
@@ -1,0 +1,258 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""Tests for the X-10R-2 reciprocity-aware controls (GH issue #636).
+
+Closes the FIX B6 debt from PR #635: the density-only sweep is
+extended to a (reciprocity × density) grid, the substrate generators
+expose a `reciprocity_keep_p` parameter, and
+`run_reciprocity_aware_recovery` walks the grid producing a
+`ReciprocityAwareRecoveryCertificate` whose `tested_at_reciprocity`
+is non-empty.
+
+These tests pin three contracts:
+  1. The substrate generators preserve their previous behaviour at
+     `reciprocity_keep_p = 1.0` (default) and reduce the achieved
+     reciprocity ratio per the closed-form mapping at lower keep_p.
+  2. The reciprocity-aware sweep produces an aggregate certificate
+     with a non-trivial `tested_at_reciprocity` envelope when each
+     cell's Gate-5 sweep passes.
+  3. The mapping `reciprocity_keep_p_for_target(r) = r/(2-r)` is
+     consistent with the achieved-vs-target relation observed
+     empirically.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from research.reconstruction.positive_control import (
+    ReciprocityAwareRecoveryCertificate,
+    compute_reciprocity_ratio,
+    ground_truth_core_periphery,
+    ground_truth_hierarchical,
+    reciprocity_keep_p_for_target,
+    run_reciprocity_aware_recovery,
+    run_recovery_on_substrate,
+)
+
+# ---------------------------------------------------------------------------
+# Reciprocity helpers — closed-form properties
+# ---------------------------------------------------------------------------
+
+
+def test_compute_reciprocity_ratio_one_for_fully_bidirectional() -> None:
+    """A fully bidirectional substrate has r = 1."""
+    w = ground_truth_core_periphery(n=40, core_frac=0.30, seed=0)
+    assert compute_reciprocity_ratio(w) == pytest.approx(1.0, abs=1e-12)
+
+
+def test_compute_reciprocity_ratio_zero_for_empty() -> None:
+    """No edges ⇒ r = 0 (denominator-safe)."""
+    assert compute_reciprocity_ratio(np.zeros((10, 10))) == 0.0
+
+
+def test_compute_reciprocity_ratio_unidirectional_chain() -> None:
+    """A pure cycle 0→1→2→0 has r = 0 (no reciprocal edge)."""
+    w = np.zeros((3, 3))
+    w[0, 1] = 1.0
+    w[1, 2] = 1.0
+    w[2, 0] = 1.0
+    assert compute_reciprocity_ratio(w) == 0.0
+
+
+def test_compute_reciprocity_ratio_rejects_non_square() -> None:
+    with pytest.raises(ValueError, match="square"):
+        compute_reciprocity_ratio(np.zeros((4, 5)))
+
+
+def test_keep_p_for_target_inverts_closed_form() -> None:
+    """`r = 2p / (1 + p)` ⇔ `p = r / (2 - r)` over the unit interval."""
+    for r_target in [0.0, 0.1, 0.3, 0.5, 0.7, 1.0]:
+        p = reciprocity_keep_p_for_target(r_target)
+        # Forward map.
+        if r_target == 1.0:
+            assert p == pytest.approx(1.0, abs=1e-12)
+        elif r_target == 0.0:
+            assert p == 0.0
+        else:
+            r_check = 2.0 * p / (1.0 + p)
+            assert r_check == pytest.approx(r_target, abs=1e-12)
+
+
+def test_keep_p_for_target_rejects_out_of_range() -> None:
+    with pytest.raises(ValueError, match=r"\[0, 1\]"):
+        reciprocity_keep_p_for_target(-0.1)
+    with pytest.raises(ValueError, match=r"\[0, 1\]"):
+        reciprocity_keep_p_for_target(1.5)
+
+
+# ---------------------------------------------------------------------------
+# Substrate generators — reciprocity_keep_p contract
+# ---------------------------------------------------------------------------
+
+
+def test_cp_default_keep_p_preserves_full_reciprocity() -> None:
+    """Default `reciprocity_keep_p = 1.0` ⇒ all bidirectional pairs intact."""
+    w = ground_truth_core_periphery(n=60, core_frac=0.30, seed=11)
+    assert compute_reciprocity_ratio(w) == pytest.approx(1.0, abs=1e-12)
+
+
+def test_cp_keep_p_zero_drives_reciprocity_to_zero() -> None:
+    """`reciprocity_keep_p = 0.0` ⇒ no bidirectional pairs survive."""
+    w = ground_truth_core_periphery(n=60, core_frac=0.30, seed=12, reciprocity_keep_p=0.0)
+    assert compute_reciprocity_ratio(w) == pytest.approx(0.0, abs=1e-12)
+
+
+def test_cp_keep_p_half_lands_near_predicted_ratio() -> None:
+    """`reciprocity_keep_p = 1/3` should land near `r ≈ 0.5` (closed form)."""
+    keep_p = reciprocity_keep_p_for_target(0.5)
+    # Average over a few seeds to dampen finite-N variance.
+    achieved: list[float] = []
+    for s in (1, 2, 3, 4, 5):
+        w = ground_truth_core_periphery(n=120, core_frac=0.30, seed=s, reciprocity_keep_p=keep_p)
+        achieved.append(compute_reciprocity_ratio(w))
+    mean_achieved = float(np.mean(achieved))
+    # ±0.10 envelope absorbs finite-N variance at N=120 with 5 seeds.
+    assert math.isclose(
+        mean_achieved, 0.5, abs_tol=0.10
+    ), f"expected r ≈ 0.5, got mean(achieved)={mean_achieved:.3f} across seeds {(1, 2, 3, 4, 5)}"
+
+
+def test_hierarchical_keep_p_zero_drives_reciprocity_to_zero() -> None:
+    w = ground_truth_hierarchical(n=80, n_tiers=4, seed=13, reciprocity_keep_p=0.0)
+    assert compute_reciprocity_ratio(w) == pytest.approx(0.0, abs=1e-12)
+
+
+def test_keep_p_filter_preserves_one_edge_per_pair() -> None:
+    """Filter must NOT zero out BOTH directions of a previously bidirectional
+    pair — at least one edge must survive in every previously-edged pair.
+
+    Otherwise total edge count drops too far and the substrate becomes
+    disconnected on small N. This is the reason reciprocity is applied
+    as a one-direction-drop, not a two-direction-drop.
+    """
+    rng_base = np.random.default_rng(42)
+    w_full = ground_truth_core_periphery(n=40, core_frac=0.30, seed=7)
+    n_pairs_before = int(((w_full > 0) & (w_full > 0).T).sum() / 2)
+    # keep_p=0 ⇒ every bidirectional pair becomes unidirectional, but
+    # the underlying pair STILL has at least one edge.
+    w_uni = ground_truth_core_periphery(n=40, core_frac=0.30, seed=7, reciprocity_keep_p=0.0)
+    n_pairs_after = int(((w_uni > 0) | (w_uni > 0).T).sum() / 2)
+    assert n_pairs_after == n_pairs_before
+    _ = rng_base  # keep deterministic seeding lineage explicit
+
+
+# ---------------------------------------------------------------------------
+# run_recovery_on_substrate — populates tested_at_reciprocity
+# ---------------------------------------------------------------------------
+
+
+def test_run_recovery_populates_tested_reciprocity_when_passed() -> None:
+    """`run_recovery_on_substrate` records the substrate's achieved
+    reciprocity ratio in `tested_at_reciprocity` when Gate 5 passes."""
+    w = ground_truth_core_periphery(n=80, core_frac=0.30, seed=42)
+    cert = run_recovery_on_substrate("CP_80_recip", w, seed=42)
+    assert cert.passed
+    assert cert.tested_at_reciprocity != ()
+    # Achieved reciprocity is in [0, 1].
+    for r in cert.tested_at_reciprocity:
+        assert 0.0 <= r <= 1.0
+
+
+def test_run_recovery_evidence_envelope_carries_reciprocity() -> None:
+    """The certificate's evidence_envelope must surface the recorded
+    reciprocity dimension when the sweep passed."""
+    w = ground_truth_core_periphery(n=80, core_frac=0.30, seed=42)
+    cert = run_recovery_on_substrate("CP_80_envelope", w, seed=42)
+    env = cert.evidence_envelope()
+    assert "reciprocity" in env
+    lo, hi = env["reciprocity"]
+    assert 0.0 <= lo <= hi <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# run_reciprocity_aware_recovery — the X-10R-2 aggregate sweep
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+def test_reciprocity_aware_sweep_passes_on_cp_substrate_at_default_grid() -> None:
+    """Aggregate sweep at (r ∈ {0.30, 0.60, 1.00}) × (4-density) on CP at
+    N=120 must produce a passing certificate. PR #635 substrates are
+    spectrally robust enough to survive moderate reciprocity attenuation
+    on the default density grid."""
+
+    def factory(r_target: float, seed: int) -> np.ndarray:
+        keep_p = reciprocity_keep_p_for_target(r_target)
+        return ground_truth_core_periphery(
+            n=120, core_frac=0.30, seed=seed, reciprocity_keep_p=keep_p
+        )
+
+    cert = run_reciprocity_aware_recovery(
+        "CP_120_recipSweep",
+        substrate_factory=factory,
+        seed=42,
+    )
+    assert isinstance(cert, ReciprocityAwareRecoveryCertificate)
+    assert cert.passed, f"reciprocity-aware sweep failed: {cert.failure_reasons}"
+    assert len(cert.tested_at_reciprocity) == len(cert.target_reciprocity_grid)
+    # Achieved reciprocity ratios must span a real range — not all clamped to 1.
+    span = max(cert.tested_at_reciprocity) - min(cert.tested_at_reciprocity)
+    assert span >= 0.4, (
+        "reciprocity grid did not actually attenuate the substrate; "
+        f"tested_at_reciprocity={cert.tested_at_reciprocity}"
+    )
+
+
+def test_reciprocity_aware_sweep_rejects_empty_grids() -> None:
+    def factory(r_target: float, seed: int) -> np.ndarray:
+        return ground_truth_core_periphery(n=40, seed=seed)
+
+    with pytest.raises(ValueError, match="reciprocity_grid"):
+        run_reciprocity_aware_recovery("X", substrate_factory=factory, reciprocity_grid=())
+    with pytest.raises(ValueError, match="density_sweep"):
+        run_reciprocity_aware_recovery("X", substrate_factory=factory, density_sweep=())
+
+
+def test_reciprocity_aware_sweep_rejects_out_of_range_target() -> None:
+    def factory(r_target: float, seed: int) -> np.ndarray:
+        return ground_truth_core_periphery(n=40, seed=seed)
+
+    with pytest.raises(ValueError, match=r"\[0, 1\]"):
+        run_reciprocity_aware_recovery("X", substrate_factory=factory, reciprocity_grid=(0.5, 1.5))
+
+
+def test_reciprocity_aware_sweep_failed_cell_keeps_envelope_empty() -> None:
+    """If ANY (r, d) cell fails, `tested_at_reciprocity` on the aggregate
+    must be empty — a partial sweep cannot certify the regime."""
+
+    # All-zero substrate fails Gate 5 trivially.
+    def factory(r_target: float, seed: int) -> np.ndarray:
+        return np.zeros((30, 30))
+
+    cert = run_reciprocity_aware_recovery(
+        "DEGENERATE",
+        substrate_factory=factory,
+        reciprocity_grid=(0.5, 1.0),
+    )
+    assert cert.passed is False
+    assert cert.tested_at_reciprocity == ()
+
+
+def test_reciprocity_aware_cert_id_is_64_hex_and_seed_sensitive() -> None:
+    def factory_a(r_target: float, seed: int) -> np.ndarray:
+        keep_p = reciprocity_keep_p_for_target(r_target)
+        return ground_truth_core_periphery(n=40, seed=seed, reciprocity_keep_p=keep_p)
+
+    a = run_reciprocity_aware_recovery(
+        "A", substrate_factory=factory_a, seed=10, reciprocity_grid=(1.0,)
+    )
+    b = run_reciprocity_aware_recovery(
+        "A", substrate_factory=factory_a, seed=11, reciprocity_grid=(1.0,)
+    )
+    assert len(a.cert_id) == 64
+    int(a.cert_id, 16)
+    assert a.cert_id != b.cert_id

--- a/tests/reconstruction/test_reciprocity_aware_recovery.py
+++ b/tests/reconstruction/test_reciprocity_aware_recovery.py
@@ -116,9 +116,9 @@ def test_cp_keep_p_half_lands_near_predicted_ratio() -> None:
         achieved.append(compute_reciprocity_ratio(w))
     mean_achieved = float(np.mean(achieved))
     # ±0.10 envelope absorbs finite-N variance at N=120 with 5 seeds.
-    assert math.isclose(mean_achieved, 0.5, abs_tol=0.10), (
-        f"expected r ≈ 0.5, got mean(achieved)={mean_achieved:.3f} across seeds {(1, 2, 3, 4, 5)}"
-    )
+    assert math.isclose(
+        mean_achieved, 0.5, abs_tol=0.10
+    ), f"expected r ≈ 0.5, got mean(achieved)={mean_achieved:.3f} across seeds {(1, 2, 3, 4, 5)}"
 
 
 def test_hierarchical_keep_p_zero_drives_reciprocity_to_zero() -> None:


### PR DESCRIPTION
## Summary

X-10R-2 epic: closes the FIX B6 debt declared in PR #635. Extends the X-10R positive-control machinery from a density-only sweep to a (reciprocity × density) grid, exposing the network reciprocity dimension of the recovery envelope. Adversarial: also corrects a category error in the FIX B2 domain-of-validity gate that conflated network reciprocity with marginal Pearson.

Closes #636.

## What lands

### Reciprocity primitives (`research/reconstruction/positive_control.py`)

- **`compute_reciprocity_ratio(W)`** — empirical observable: `#{(i,j) : a_ij ∧ a_ji} / #{(i,j) : a_ij}`. Denominator-safe at zero edges; rejects non-square inputs.
- **`reciprocity_keep_p_for_target(r_target)`** — closed-form inverse of `r_achieved = 2·keep_p / (1 + keep_p)`:
  ```
  keep_p = r_target / (2 − r_target)
  ```
- **`_apply_reciprocity_filter`** — drops one direction of each bidirectional pair with probability `1 − keep_p`, uniformly at random which direction. **Preserves one edge per previously-edged pair** → no disconnection at small N (this is why we drop one direction, not both).
- **`reciprocity_keep_p` parameter on every ground-truth generator** (`ground_truth_ba`, `ground_truth_core_periphery`, `ground_truth_hierarchical`); default `1.0` ⇒ original behaviour preserved.

### Evidence-field population

- `run_recovery_on_substrate` records `tested_at_reciprocity = (round(r_observed, 6),)` whenever Gate-5 passes; empty on failure (matches the density-side discipline).

### Aggregate (reciprocity × density) sweep

- **`ReciprocityAwareRecoveryCertificate`** frozen dataclass: `target_reciprocity_grid`, `achieved_reciprocity_grid`, `per_reciprocity_certs`, full `tested_at_*` evidence surface, `evidence_envelope()` helper.
- **`run_reciprocity_aware_recovery(name, *, substrate_factory, seed, reciprocity_grid, density_sweep)`** — walks the grid, invokes `run_recovery_on_substrate` per cell, aggregates. PASS iff every cell passes; `tested_at_reciprocity` non-empty iff aggregate passes.
- Default reciprocity grid `(0.30, 0.60, 1.00)` covers e-MID empirical interbank reciprocity (~0.27) through full symmetry. Customisable via kwarg.

### Domain-of-validity gate — reciprocity reclassified as **provenance**

The previous FIX B2 wiring (PR #635) conflated two distinct observables:
- `tested_at_reciprocity` — network-level topological ratio (substrate property)
- `pearson_in_out` — node-level marginal balance (real-data observable)

Gating one against the other was a **category error**. Real BIS marginals expose only Pearson; network reciprocity is unobservable without topology.

**Fix:** the gate now surfaces the certified reciprocity envelope in `certified_envelope` for provenance, but does NOT use it to drive an OUT_OF verdict on the default path. A caller that EXPLICITLY adds `"reciprocity"` to `require_dims` still triggers `INSUFFICIENT_CERTIFICATE` — the explicit ask is honoured.

## Tests

- **`tests/reconstruction/test_reciprocity_aware_recovery.py`** (NEW, 18 tests):
  - Closed-form mapping inversion (5 r_target values + edge cases)
  - Empirical observable: `r=1` for full bidirectional, `r=0` for empty / pure cycle, rejects non-square
  - Substrate generator contract: default keep_p=1.0 preserves r=1.0; keep_p=0.0 drives r=0.0; keep_p=1/3 lands near r≈0.5 (mean over 5 seeds at N=120, ±0.10 envelope)
  - One-edge-per-pair invariant: filter keeps every previously-edged pair connected
  - `run_recovery_on_substrate` populates `tested_at_reciprocity` only on PASS; envelope surfaces it
  - Aggregate sweep: PASS/FAIL/empty-grid/out-of-range/partial-failure semantics
  - cert_id 64-hex + seed-sensitive
- **`tests/reconstruction/test_domain_of_validity.py`** (UPDATED): two tests reflect the now-populated `tested_at_reciprocity` and the provenance-only reclassification.

## Local results

- `pytest tests/reconstruction/ -m "not slow"`: **160 passed** in 25 s
- `pytest tests/reconstruction/ -m "slow"`: **17 passed** in 102 s
- `mypy --strict --follow-imports=silent`: **22 source files clean**
- `ruff check` + `black --check`: clean

## Acceptance gates (per `.claude/commit_acceptors/x10r-2-reciprocity-aware-controls.yaml`)

- [x] `compute_reciprocity_ratio` exposed
- [x] `reciprocity_keep_p_for_target` exposed
- [x] `ReciprocityAwareRecoveryCertificate` exposed
- [x] `run_reciprocity_aware_recovery` exposed
- [x] Falsifier: closed-form mapping verified empirically over 5 seeds at N=120, target 0.5, achieved mean must lie in [0.40, 0.60]
- [x] DoV gate no longer falsely couples network reciprocity to Pearson

## What this PR does NOT do

- Does NOT change Gate 5 thresholds (still ρ_rel ≤ 0.20, jaccard ≥ 0.60, row/col L1 ≤ 0.05)
- Does NOT extend the default `run_recovery_on_substrate` to sweep reciprocity automatically — that is opt-in via `run_reciprocity_aware_recovery` to keep the cheap density-only path available for fast checks
- Does NOT add a reciprocity dimension to the DoV gate verdict surface — see "Domain-of-validity reclassification" above

## Test plan

- [ ] CI green on `pytest tests/reconstruction/` (160 fast + 17 slow)
- [ ] CI green on `ruff check` + `mypy --strict` + `black --check`
- [ ] Acceptor passes
- [ ] PR description matches code

🤖 Generated with [Claude Code](https://claude.com/claude-code)