### PR TITLE
feat(x10r-1-#2): SizeWeightedPrior + registry loader (epic #638 PR #2)

### DIFF
--- a/.claude/commit_acceptors/x10r-1-size-weighted-prior.yaml
+++ b/.claude/commit_acceptors/x10r-1-size-weighted-prior.yaml
@@ -1,0 +1,132 @@
+# Diff-bound commit acceptor for X-10R-1 PR #2 — first concrete
+# prior beyond UniformPrior, plus the registry-loader surface.
+#
+# What lands:
+#   * research/reconstruction/allocator/size_weighted_prior.py
+#       SizeWeightedPrior: per-bank size-weighted shares with
+#       per-country mean imputation for missing weights.
+#   * research/reconstruction/allocator/registry.py
+#       registry_to_bank_country_map: parses {country: [banks]}
+#       into the canonical deterministic bank_country_map tuple.
+#   * tests/reconstruction/allocator/test_size_weighted_prior.py
+#       19 tests pinning protocol satisfaction, closed-form share,
+#       has_evidence semantics, falsification anchor (aligned
+#       SizeWeightedPrior crushes UniformPrior; anti-aligned does
+#       NOT beat UniformPrior; empty weights degenerate to
+#       UniformPrior recovery error), cert_id distinguishes priors.
+#   * tests/reconstruction/allocator/test_registry.py
+#       10 tests: deterministic ordering, duplicate-detection,
+#       blank-input rejection, round-trip with SizeWeightedPrior.
+#
+# Locally verified:
+#   * pytest tests/reconstruction/allocator/: 72/72 passed
+#   * mypy --strict + ruff + black:           clean
+
+id: x10r-1-size-weighted-prior
+status: ACTIVE
+claim_type: chore
+promise: >-
+  After this PR lands, research/reconstruction/allocator/ ships its
+  first concrete prior beyond the UniformPrior falsification anchor.
+  SizeWeightedPrior consumes a per-bank weight dict and assigns
+  shares ∝ weight within country, with maximum-entropy mean
+  imputation for banks resident in the country but missing from
+  the weight dict. The closed-form share contract is share(c, b) =
+  weight[b] / Σ resident weights, validated by the test
+  test_share_equals_weight_over_country_total.
+  registry_to_bank_country_map converts a {country: [banks]}
+  dictionary into the deterministic bank_country_map tuple the
+  allocator and priors consume — alphabetical country order +
+  preserved within-country bank order. 29 new tests pin: protocol
+  satisfaction, closed-form correctness, has_evidence semantics,
+  cert_id distinguishes priors with different prior_id, the
+  allocator's GATE_A1 conservation under SizeWeightedPrior, and
+  the FALSIFICATION ANCHOR — SizeWeightedPrior with weights
+  ALIGNED to ground-truth shares MUST beat UniformPrior on a
+  lognormal substrate by ≥ 6 orders of magnitude in relative L1
+  error; ANTI-aligned weights MUST NOT beat UniformPrior; empty-
+  weight SizeWeightedPrior must degenerate to UniformPrior.
+diff_scope:
+  changed_files:
+    - path: ".claude/commit_acceptors/x10r-1-size-weighted-prior.yaml"
+    - path: "research/reconstruction/allocator/__init__.py"
+    - path: "research/reconstruction/allocator/registry.py"
+    - path: "research/reconstruction/allocator/size_weighted_prior.py"
+    - path: "tests/reconstruction/allocator/test_registry.py"
+    - path: "tests/reconstruction/allocator/test_size_weighted_prior.py"
+  forbidden_paths:
+    - "trading/"
+    - "execution/"
+    - "forecast/"
+    - "policy/"
+    - "core/physics/"
+    - "core/kuramoto/"
+    - "application/governance/claim_ledger.py"
+    - "application/governance/commit_acceptor.py"
+required_python_symbols:
+  - "research/reconstruction/allocator/size_weighted_prior.py::SizeWeightedPrior"
+  - "research/reconstruction/allocator/registry.py::registry_to_bank_country_map"
+expected_signal: >-
+  Local: `pytest tests/reconstruction/allocator/ -q` reports
+  "72 passed"; `mypy --strict` is clean on every file under
+  research/reconstruction/allocator/ and
+  tests/reconstruction/allocator/; `ruff check` and
+  `black --check` both pass on those paths.
+measurement_command: >-
+  bash -c 'mypy --strict --follow-imports=silent
+  research/reconstruction/allocator/ tests/reconstruction/allocator/
+  && ruff check research/reconstruction/allocator/ tests/reconstruction/allocator/
+  && black --check research/reconstruction/allocator/ tests/reconstruction/allocator/
+  && pytest tests/reconstruction/allocator/ -q'
+signal_artifact: "tmp/x10r_1_size_weighted_prior.log"
+falsifier:
+  command: >-
+    bash -c 'python -c "
+    from research.reconstruction.allocator import (
+        CountryToBankAllocator, SizeWeightedPrior, UniformPrior,
+        bank_level_recovery_l1, synthetic_country_aggregates,
+    )
+    agg_in, agg_out, gt_in, _, bcm = synthetic_country_aggregates(
+        n_countries=4, n_banks_per_country=8,
+        share_distribution=\"lognormal\", seed=42,
+    )
+    weights = {b: float(gt_in[i]) for i, (b, _) in enumerate(bcm)}
+    err_sw = bank_level_recovery_l1(
+        ground_truth=gt_in,
+        allocated=CountryToBankAllocator(
+            prior=SizeWeightedPrior(bank_country_map=bcm, bank_weights=weights)
+        ).allocate(agg_in, agg_out, bank_country_map=bcm).s_in,
+    )
+    err_un = bank_level_recovery_l1(
+        ground_truth=gt_in,
+        allocated=CountryToBankAllocator(
+            prior=UniformPrior(bank_country_map=bcm)
+        ).allocate(agg_in, agg_out, bank_country_map=bcm).s_in,
+    )
+    assert err_un / max(err_sw, 1e-30) > 1e6, (
+        f\"falsification anchor broken: SizeWeightedPrior aligned err={err_sw:.6e} \"
+        f\"vs UniformPrior err={err_un:.6e}\"
+    )
+    "'
+  description: >-
+    Probes the falsification anchor: aligned SizeWeightedPrior on a
+    lognormal-share substrate must beat UniformPrior by at least
+    6 orders of magnitude in relative L1 (the aligned prior should
+    be exact). If it does not, either the closed-form share is
+    broken or the substrate is somehow not lognormal — either way,
+    the prior is doing no work.
+rollback_command: >-
+  bash -c 'git checkout HEAD~1 --
+  && rm -f research/reconstruction/allocator/registry.py
+  research/reconstruction/allocator/size_weighted_prior.py
+  tests/reconstruction/allocator/test_registry.py
+  tests/reconstruction/allocator/test_size_weighted_prior.py
+  .claude/commit_acceptors/x10r-1-size-weighted-prior.yaml'
+rollback_verification_command: >-
+  bash -c 'test ! -f research/reconstruction/allocator/registry.py
+  && test ! -f research/reconstruction/allocator/size_weighted_prior.py
+  && test ! -f .claude/commit_acceptors/x10r-1-size-weighted-prior.yaml'
+memory_update_type: append
+ledger_path: ".claude/commit_acceptors/x10r-1-size-weighted-prior.yaml"
+report_path: "tmp/x10r_1_size_weighted_prior.log"
+evidence: []

--- a/research/reconstruction/allocator/__init__.py
+++ b/research/reconstruction/allocator/__init__.py
@@ -15,6 +15,10 @@ from research.reconstruction.allocator.certificate import (
     compute_cert_id,
 )
 from research.reconstruction.allocator.prior import AllocatorPrior, UniformPrior
+from research.reconstruction.allocator.registry import registry_to_bank_country_map
+from research.reconstruction.allocator.size_weighted_prior import (
+    SizeWeightedPrior,
+)
 from research.reconstruction.allocator.synthetic import (
     ShareDistribution,
     bank_level_recovery_l1,
@@ -26,8 +30,10 @@ __all__ = [
     "BankLevelMarginalsCertificate",
     "CountryToBankAllocator",
     "ShareDistribution",
+    "SizeWeightedPrior",
     "UniformPrior",
     "bank_level_recovery_l1",
     "compute_cert_id",
+    "registry_to_bank_country_map",
     "synthetic_country_aggregates",
 ]

--- a/research/reconstruction/allocator/registry.py
+++ b/research/reconstruction/allocator/registry.py
@@ -1,0 +1,71 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""Registry loader — parses a per-country bank list into the
+deterministic ordered ``bank_country_map`` shape the allocator and
+priors consume.
+
+Real-world registry sources land in subsequent epic PRs:
+
+  * ECB MFI list (TSV/CSV at ``ecb.europa.eu/stats/financial_corporations
+    /list_of_financial_institutions/html/``) — the canonical
+    "monetary financial institution" registry for the euro area.
+  * FDIC institutions list (CSV at ``fdic.gov``) — US-side equivalent.
+
+This module ships the *parser surface* that those PRs will plug into.
+It accepts already-parsed Python data (``dict[country, list[bank_id]]``)
+and returns the canonical ``bank_country_map`` tuple. Disk-loading
+PRs will call this helper after parsing their format-of-record.
+"""
+
+from __future__ import annotations
+
+
+def registry_to_bank_country_map(
+    registry: dict[str, list[str]],
+) -> tuple[tuple[str, str], ...]:
+    """Convert a ``{country: [bank_ids]}`` mapping to the canonical
+    ``bank_country_map`` tuple consumed by ``AllocatorPrior``
+    implementations and ``CountryToBankAllocator``.
+
+    Parameters
+    ----------
+    registry:
+        ``{country -> ordered list of resident bank identifiers}``.
+        Bank identifiers must be unique GLOBALLY (not just within a
+        country); otherwise the allocator's per-bank index would be
+        ambiguous.
+
+    Returns
+    -------
+    A deterministic tuple of ``(bank_id, country)`` pairs sorted
+    primarily by country (alphabetical) and secondarily by the order
+    each bank appears in its country list. Determinism is mandatory
+    for the allocator's bit-exact replay contract (GATE_A4).
+    """
+    if not registry:
+        raise ValueError("registry must be non-empty")
+
+    seen_banks: set[str] = set()
+    out: list[tuple[str, str]] = []
+    for country in sorted(registry.keys()):
+        if not country or not isinstance(country, str):
+            raise ValueError(f"every country key must be a non-empty string; got {country!r}")
+        banks = registry[country]
+        if not banks:
+            raise ValueError(
+                f"country {country!r} has empty bank list; "
+                "drop the country from the registry before passing it in"
+            )
+        for bank_id in banks:
+            if not bank_id or not isinstance(bank_id, str):
+                raise ValueError(
+                    f"every bank_id must be a non-empty string; got {bank_id!r} in {country!r}"
+                )
+            if bank_id in seen_banks:
+                raise ValueError(
+                    f"bank_id {bank_id!r} appears in multiple countries; "
+                    "bank identifiers must be globally unique"
+                )
+            seen_banks.add(bank_id)
+            out.append((bank_id, country))
+    return tuple(out)

--- a/research/reconstruction/allocator/size_weighted_prior.py
+++ b/research/reconstruction/allocator/size_weighted_prior.py
@@ -1,0 +1,127 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""SizeWeightedPrior — first concrete prior beyond the UniformPrior anchor.
+
+Per X-10R-1 PR #2 (epic #638 follow-up to PR #1):
+
+Real-world allocator priors land in two layers:
+
+  1. A **registry** layer (which banks are resident in which country)
+     — ECB MFI list, FDIC call reports, ICIJ Offshore Leaks reverse
+     — every concrete prior must know this. UniformPrior already
+     uses a registry internally.
+
+  2. A **size signal** layer (relative size of each registered bank)
+     — EBA transparency disclosures, Moody's BankFocus / Orbis,
+     central bank supervisory disclosures. Without size signal a
+     prior degenerates to 1/k and is identical to UniformPrior.
+
+This module ships the size-signal layer in the simplest possible
+form: a per-bank scalar weight, with shares proportional to weight
+within country. The closed-form contract is
+
+    expected_share(c, b) = weight[b] / Σ_{b' resident in c} weight[b']
+
+Sources for real per-bank size signals (subsequent epic PRs):
+  * `EBATransparencyPrior` — total assets from the latest EBA
+    transparency exercise (annual; 119 banks / 25 EU+EEA; public).
+  * `BankFocusPrior`       — Moody's BankFocus / Orbis Bank Focus
+    extract (license-gated; richer coverage than EBA but commercial).
+
+This PR ships the *constructor* with synthetic weights for tests.
+A subsequent PR will load real EBA total-assets into the same
+constructor.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class SizeWeightedPrior:
+    """Per-bank size-weighted prior over country-resident banks.
+
+    Parameters
+    ----------
+    bank_country_map:
+        Ordered tuple of ``(bank_id, country)`` — the registry
+        layer. Same shape the allocator already consumes.
+    bank_weights:
+        Mapping ``{bank_id -> non-negative float}``. The *size
+        signal*. Banks present in ``bank_country_map`` but missing
+        from this mapping fall back to the per-country mean of
+        the banks that DO have a weight; if no bank in the country
+        has a weight, ``has_evidence(country)`` returns False so
+        the allocator can apply its declared fallback policy.
+    prior_id_tag:
+        Stable identifier to attach to the certificate; default
+        ``"size_weighted"``. A subsequent PR loading real EBA data
+        will pass ``"eba_transparency_2024Q4"`` etc.
+    """
+
+    bank_country_map: tuple[tuple[str, str], ...]
+    bank_weights: dict[str, float] = field(default_factory=dict)
+    prior_id_tag: str = "size_weighted"
+
+    def __post_init__(self) -> None:
+        for bank_id, w in self.bank_weights.items():
+            if not (w >= 0):  # also catches NaN
+                raise ValueError(
+                    f"bank_weights[{bank_id!r}] must be a non-negative finite number; got {w}"
+                )
+        # Detect a degenerate prior right at construction so a misuse
+        # surfaces here, not at allocation time.
+        countries = {c for _, c in self.bank_country_map}
+        if not countries:
+            raise ValueError("bank_country_map must be non-empty")
+
+    @property
+    def prior_id(self) -> str:
+        return self.prior_id_tag
+
+    def banks_in(self, country: str) -> tuple[str, ...]:
+        return tuple(b for b, c in self.bank_country_map if c == country)
+
+    def _country_weight_total(self, country: str) -> float:
+        """Σ weights over banks resident in `country` AND with a weight.
+
+        Used both by has_evidence (positive ⇒ True) and by the
+        fallback computation in expected_share.
+        """
+        return float(
+            sum(self.bank_weights[b] for b in self.banks_in(country) if b in self.bank_weights)
+        )
+
+    def has_evidence(self, country: str) -> bool:
+        if not any(c == country for _, c in self.bank_country_map):
+            return False
+        # Evidence exists iff at least one resident bank has a weight
+        # AND the country's total resident weight is positive.
+        return self._country_weight_total(country) > 0.0
+
+    def expected_share(self, *, country: str, bank_id: str) -> float:
+        banks = self.banks_in(country)
+        if not banks:
+            raise ValueError(f"SizeWeightedPrior has no banks recorded for country {country!r}")
+        if bank_id not in banks:
+            raise ValueError(f"bank_id {bank_id!r} is not resident in country {country!r}")
+        total_weight = self._country_weight_total(country)
+        if total_weight <= 0:
+            # No size signal at all — degenerate to 1/k. The allocator
+            # may instead apply its fallback policy depending on
+            # has_evidence — that path is exercised in the prior tests.
+            return 1.0 / len(banks)
+        # Per-bank weight, defaulting to per-country mean for banks
+        # missing from `bank_weights`. Mean is the maximum-entropy
+        # imputation for missing entries: it minimises the prior's
+        # impact on the unobserved share without spuriously zeroing it.
+        n_with_weight = sum(1 for b in banks if b in self.bank_weights)
+        country_mean = total_weight / n_with_weight if n_with_weight else 0.0
+        weight = self.bank_weights.get(bank_id, country_mean)
+        # Effective denominator: sum of (weights ∪ imputed-mean-for-missing).
+        n_missing = len(banks) - n_with_weight
+        effective_total = total_weight + country_mean * n_missing
+        if effective_total <= 0:
+            return 1.0 / len(banks)
+        return float(weight / effective_total)

--- a/tests/reconstruction/allocator/test_registry.py
+++ b/tests/reconstruction/allocator/test_registry.py
@@ -1,0 +1,82 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""Tests for registry → bank_country_map conversion."""
+
+from __future__ import annotations
+
+import pytest
+
+from research.reconstruction.allocator.registry import registry_to_bank_country_map
+
+
+def test_registry_to_map_returns_canonical_tuple_shape() -> None:
+    bcm = registry_to_bank_country_map({"DE": ["DE-001", "DE-002"], "FR": ["FR-001"]})
+    assert isinstance(bcm, tuple)
+    for entry in bcm:
+        assert isinstance(entry, tuple)
+        assert len(entry) == 2
+
+
+def test_registry_sorts_countries_alphabetically() -> None:
+    """Country order in the canonical map must be deterministic
+    (alphabetical) so the allocator's bit-exact replay contract is
+    not seed-of-dict-order-dependent."""
+    bcm = registry_to_bank_country_map({"FR": ["FR-001"], "DE": ["DE-001"], "AT": ["AT-001"]})
+    countries = [c for _, c in bcm]
+    assert countries == ["AT", "DE", "FR"]
+
+
+def test_registry_preserves_within_country_bank_order() -> None:
+    """Inside a country the order is the order the caller supplied —
+    the registry parser should not re-sort within country."""
+    bcm = registry_to_bank_country_map({"DE": ["DE-Z", "DE-A", "DE-M"]})
+    banks = [b for b, _ in bcm]
+    assert banks == ["DE-Z", "DE-A", "DE-M"]
+
+
+def test_registry_rejects_empty() -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        registry_to_bank_country_map({})
+
+
+def test_registry_rejects_country_with_empty_bank_list() -> None:
+    with pytest.raises(ValueError, match="empty bank list"):
+        registry_to_bank_country_map({"DE": []})
+
+
+def test_registry_rejects_blank_country_key() -> None:
+    with pytest.raises(ValueError, match="non-empty string"):
+        registry_to_bank_country_map({"": ["BANK"]})
+
+
+def test_registry_rejects_blank_bank_id() -> None:
+    with pytest.raises(ValueError, match="non-empty string"):
+        registry_to_bank_country_map({"DE": [""]})
+
+
+def test_registry_rejects_duplicate_bank_across_countries() -> None:
+    """Bank IDs must be globally unique. Two countries claiming the
+    same bank ⇒ the allocator's per-bank index would be ambiguous."""
+    with pytest.raises(ValueError, match="multiple countries"):
+        registry_to_bank_country_map({"DE": ["DUP"], "FR": ["DUP"]})
+
+
+def test_registry_round_trip_through_size_weighted_prior() -> None:
+    """The map produced here must be a drop-in for the allocator."""
+    from research.reconstruction.allocator import SizeWeightedPrior
+
+    bcm = registry_to_bank_country_map({"DE": ["DE-001", "DE-002"], "FR": ["FR-001"]})
+    p = SizeWeightedPrior(
+        bank_country_map=bcm,
+        bank_weights={"DE-001": 60.0, "DE-002": 40.0, "FR-001": 100.0},
+    )
+    assert p.banks_in("DE") == ("DE-001", "DE-002")
+    assert p.expected_share(country="DE", bank_id="DE-001") == pytest.approx(0.6)
+
+
+def test_registry_is_deterministic_for_same_input() -> None:
+    """Two calls with the same registry dict must return the same map."""
+    reg = {"DE": ["DE-001"], "FR": ["FR-001", "FR-002"]}
+    a = registry_to_bank_country_map(reg)
+    b = registry_to_bank_country_map(reg)
+    assert a == b

--- a/tests/reconstruction/allocator/test_size_weighted_prior.py
+++ b/tests/reconstruction/allocator/test_size_weighted_prior.py
@@ -1,0 +1,310 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""Tests for SizeWeightedPrior — first concrete prior beating UniformPrior.
+
+The contract under test:
+  1. Protocol satisfaction (drop-in replacement for UniformPrior).
+  2. Closed-form share = weight / Σ_country_weights, with mean
+     imputation for banks missing from the weight dict.
+  3. has_evidence semantics — True iff the country has positive
+     total weight; False otherwise.
+  4. **Falsification**: SizeWeightedPrior with weights ALIGNED to
+     the ground-truth shares MUST recover the bank-level marginals
+     materially better than UniformPrior on the same substrate.
+     Otherwise the size-signal layer is doing no work.
+  5. Symmetry: SizeWeightedPrior with EMPTY weight dict
+     degenerates to UniformPrior behavior — same recovery error.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from research.reconstruction.allocator import (
+    AllocatorPrior,
+    CountryToBankAllocator,
+    SizeWeightedPrior,
+    UniformPrior,
+    bank_level_recovery_l1,
+    synthetic_country_aggregates,
+)
+
+
+def _bcm() -> tuple[tuple[str, str], ...]:
+    return (
+        ("BankA1", "C1"),
+        ("BankA2", "C1"),
+        ("BankA3", "C1"),
+        ("BankB1", "C2"),
+        ("BankB2", "C2"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Protocol satisfaction
+# ---------------------------------------------------------------------------
+
+
+def test_size_weighted_prior_satisfies_protocol() -> None:
+    p = SizeWeightedPrior(bank_country_map=_bcm(), bank_weights={})
+    assert isinstance(p, AllocatorPrior)
+
+
+def test_size_weighted_prior_id_is_configurable() -> None:
+    assert SizeWeightedPrior(bank_country_map=_bcm()).prior_id == "size_weighted"
+    custom = SizeWeightedPrior(bank_country_map=_bcm(), prior_id_tag="eba_2024Q4")
+    assert custom.prior_id == "eba_2024Q4"
+
+
+def test_size_weighted_prior_banks_in_matches_registry() -> None:
+    p = SizeWeightedPrior(bank_country_map=_bcm())
+    assert p.banks_in("C1") == ("BankA1", "BankA2", "BankA3")
+    assert p.banks_in("C2") == ("BankB1", "BankB2")
+    assert p.banks_in("UNKNOWN") == ()
+
+
+# ---------------------------------------------------------------------------
+# Closed-form share contract
+# ---------------------------------------------------------------------------
+
+
+def test_share_equals_weight_over_country_total() -> None:
+    weights = {"BankA1": 30.0, "BankA2": 20.0, "BankA3": 50.0}
+    p = SizeWeightedPrior(bank_country_map=_bcm(), bank_weights=weights)
+    assert p.expected_share(country="C1", bank_id="BankA1") == pytest.approx(0.30)
+    assert p.expected_share(country="C1", bank_id="BankA2") == pytest.approx(0.20)
+    assert p.expected_share(country="C1", bank_id="BankA3") == pytest.approx(0.50)
+    total = sum(p.expected_share(country="C1", bank_id=b) for b in p.banks_in("C1"))
+    assert total == pytest.approx(1.0, abs=1e-12)
+
+
+def test_missing_bank_imputed_at_country_mean() -> None:
+    """Banks resident in a country but missing from the weight dict
+    get the per-country mean weight as imputation. Effective shares
+    still sum to 1."""
+    weights = {"BankA1": 30.0, "BankA2": 20.0}  # BankA3 missing
+    p = SizeWeightedPrior(bank_country_map=_bcm(), bank_weights=weights)
+    # mean over (30, 20) = 25 → BankA3 gets share 25 / (30+20+25) = 1/3
+    assert p.expected_share(country="C1", bank_id="BankA3") == pytest.approx(25.0 / 75.0, rel=1e-12)
+    total = sum(p.expected_share(country="C1", bank_id=b) for b in p.banks_in("C1"))
+    assert total == pytest.approx(1.0, abs=1e-12)
+
+
+def test_zero_weight_bank_gets_zero_share() -> None:
+    """Explicit zero weight is treated as zero share — distinct from
+    "missing" which gets imputed."""
+    weights = {"BankA1": 0.0, "BankA2": 50.0, "BankA3": 50.0}
+    p = SizeWeightedPrior(bank_country_map=_bcm(), bank_weights=weights)
+    assert p.expected_share(country="C1", bank_id="BankA1") == 0.0
+    assert p.expected_share(country="C1", bank_id="BankA2") == pytest.approx(0.5)
+    assert p.expected_share(country="C1", bank_id="BankA3") == pytest.approx(0.5)
+
+
+# ---------------------------------------------------------------------------
+# has_evidence semantics
+# ---------------------------------------------------------------------------
+
+
+def test_has_evidence_true_when_any_bank_in_country_has_weight() -> None:
+    weights = {"BankA1": 10.0}  # only one of three C1 banks
+    p = SizeWeightedPrior(bank_country_map=_bcm(), bank_weights=weights)
+    assert p.has_evidence("C1") is True
+
+
+def test_has_evidence_false_when_country_has_zero_total_weight() -> None:
+    """Country without any positive-weight bank ⇒ no evidence (allocator
+    will fall back per its policy)."""
+    p = SizeWeightedPrior(bank_country_map=_bcm(), bank_weights={})
+    assert p.has_evidence("C1") is False
+    assert p.has_evidence("C2") is False
+
+
+def test_has_evidence_false_for_unknown_country() -> None:
+    p = SizeWeightedPrior(bank_country_map=_bcm(), bank_weights={"BankA1": 1.0})
+    assert p.has_evidence("UNKNOWN") is False
+
+
+# ---------------------------------------------------------------------------
+# Input contract
+# ---------------------------------------------------------------------------
+
+
+def test_rejects_negative_weight() -> None:
+    with pytest.raises(ValueError, match="non-negative"):
+        SizeWeightedPrior(bank_country_map=_bcm(), bank_weights={"BankA1": -1.0})
+
+
+def test_rejects_nan_weight() -> None:
+    with pytest.raises(ValueError, match="non-negative"):
+        SizeWeightedPrior(bank_country_map=_bcm(), bank_weights={"BankA1": float("nan")})
+
+
+def test_rejects_empty_bank_country_map() -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        SizeWeightedPrior(bank_country_map=())
+
+
+def test_share_rejects_unknown_country() -> None:
+    p = SizeWeightedPrior(bank_country_map=_bcm())
+    with pytest.raises(ValueError, match="no banks"):
+        p.expected_share(country="UNKNOWN", bank_id="X")
+
+
+def test_share_rejects_non_resident_bank() -> None:
+    p = SizeWeightedPrior(bank_country_map=_bcm())
+    with pytest.raises(ValueError, match="not resident"):
+        p.expected_share(country="C1", bank_id="BankB1")
+
+
+# ---------------------------------------------------------------------------
+# Falsification anchor — does the size signal beat UniformPrior?
+# ---------------------------------------------------------------------------
+
+
+def test_aligned_size_weighted_prior_beats_uniform_on_lognormal() -> None:
+    """When the size weights ARE the ground-truth bank sizes, the
+    size-weighted prior MUST recover the bank-level marginals
+    materially better than UniformPrior. Otherwise the size signal
+    is doing no work and the prior is method theatre."""
+    agg_in, agg_out, gt_in, _gt_out, bcm = synthetic_country_aggregates(
+        n_countries=4,
+        n_banks_per_country=8,
+        share_distribution="lognormal",
+        seed=42,
+    )
+    # Size weights = ground-truth s_in (the prior is "informed" about
+    # the size signal). On lognormal substrates this should crush
+    # UniformPrior by a wide margin.
+    weights = {bank: float(gt_in[i]) for i, (bank, _) in enumerate(bcm)}
+
+    cert_uniform = CountryToBankAllocator(prior=UniformPrior(bank_country_map=bcm)).allocate(
+        agg_in, agg_out, bank_country_map=bcm
+    )
+    cert_sw = CountryToBankAllocator(
+        prior=SizeWeightedPrior(bank_country_map=bcm, bank_weights=weights)
+    ).allocate(agg_in, agg_out, bank_country_map=bcm)
+
+    err_uniform = bank_level_recovery_l1(ground_truth=gt_in, allocated=cert_uniform.s_in)
+    err_sw = bank_level_recovery_l1(ground_truth=gt_in, allocated=cert_sw.s_in)
+
+    # Aligned size-weighted on s_in must recover s_in nearly perfectly.
+    assert err_sw < 1e-9, f"aligned SizeWeightedPrior should be exact; got {err_sw}"
+    # And uniform must be far worse.
+    assert err_uniform > err_sw * 1e6, (
+        f"falsification anchor broken: SizeWeightedPrior aligned "
+        f"err={err_sw:.6e} vs UniformPrior err={err_uniform:.6e}"
+    )
+
+
+def test_misaligned_size_weighted_prior_does_not_beat_uniform() -> None:
+    """Negative direction: SizeWeightedPrior with weights ANTI-aligned
+    to ground truth must NOT recover the marginals better than
+    UniformPrior. Otherwise the prior is somehow extracting signal
+    from a contradiction — which would be a numerical accident, not
+    real information."""
+    agg_in, agg_out, gt_in, _gt_out, bcm = synthetic_country_aggregates(
+        n_countries=4,
+        n_banks_per_country=8,
+        share_distribution="lognormal",
+        seed=43,
+    )
+    # Anti-aligned: largest bank gets smallest weight, etc.
+    sorted_truth = sorted(gt_in)
+    inverted = sorted_truth[::-1]
+    # Map: i-th bank in bcm ↔ i-th rank in gt_in ↔ swapped weight.
+    rank_by_bank: dict[str, int] = {}
+    sorted_idx = sorted(range(len(gt_in)), key=lambda i: gt_in[i])
+    for rank, idx in enumerate(sorted_idx):
+        bank_id = bcm[idx][0]
+        rank_by_bank[bank_id] = rank
+    weights = {bank: float(inverted[rank]) for bank, rank in rank_by_bank.items()}
+
+    cert_uniform = CountryToBankAllocator(prior=UniformPrior(bank_country_map=bcm)).allocate(
+        agg_in, agg_out, bank_country_map=bcm
+    )
+    cert_sw = CountryToBankAllocator(
+        prior=SizeWeightedPrior(bank_country_map=bcm, bank_weights=weights)
+    ).allocate(agg_in, agg_out, bank_country_map=bcm)
+
+    err_uniform = bank_level_recovery_l1(ground_truth=gt_in, allocated=cert_uniform.s_in)
+    err_sw = bank_level_recovery_l1(ground_truth=gt_in, allocated=cert_sw.s_in)
+
+    # Anti-aligned must be at least as bad as uniform.
+    assert err_sw >= err_uniform * 0.95, (
+        f"anti-aligned size weights should NOT beat UniformPrior; "
+        f"got err_sw={err_sw:.4f} vs err_uniform={err_uniform:.4f}"
+    )
+
+
+def test_empty_weight_dict_degenerates_to_uniform_recovery() -> None:
+    """SizeWeightedPrior with no weights at all has no evidence;
+    via fallback_policy='uniform_within_country' it places 1/k —
+    indistinguishable from UniformPrior in recovery error."""
+    agg_in, agg_out, gt_in, _gt_out, bcm = synthetic_country_aggregates(
+        n_countries=3,
+        n_banks_per_country=6,
+        share_distribution="lognormal",
+        seed=44,
+    )
+    cert_uniform = CountryToBankAllocator(prior=UniformPrior(bank_country_map=bcm)).allocate(
+        agg_in, agg_out, bank_country_map=bcm
+    )
+    cert_empty_sw = CountryToBankAllocator(
+        prior=SizeWeightedPrior(bank_country_map=bcm, bank_weights={})
+    ).allocate(agg_in, agg_out, bank_country_map=bcm)
+
+    err_uniform = bank_level_recovery_l1(ground_truth=gt_in, allocated=cert_uniform.s_in)
+    err_empty_sw = bank_level_recovery_l1(ground_truth=gt_in, allocated=cert_empty_sw.s_in)
+
+    # Two priors with the same effective shares should produce the
+    # same recovery error to numerical tolerance.
+    assert err_uniform == pytest.approx(err_empty_sw, rel=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# Integration: cert_id distinguishes priors with different signals
+# ---------------------------------------------------------------------------
+
+
+def test_cert_id_distinguishes_size_weighted_from_uniform() -> None:
+    """Same aggregates + different priors ⇒ different cert_id.
+
+    This is the GATE_A4 surface for the prior-id field — the
+    allocator's certificate must hash the prior_id, otherwise
+    two different priors collapse to the same provenance hash."""
+    agg_in, agg_out, _gt_in, _gt_out, bcm = synthetic_country_aggregates(
+        n_countries=2, n_banks_per_country=3, seed=45
+    )
+    cert_uniform = CountryToBankAllocator(prior=UniformPrior(bank_country_map=bcm)).allocate(
+        agg_in, agg_out, bank_country_map=bcm
+    )
+    weights = {b: float(i + 1) for i, (b, _) in enumerate(bcm)}
+    cert_sw = CountryToBankAllocator(
+        prior=SizeWeightedPrior(bank_country_map=bcm, bank_weights=weights)
+    ).allocate(agg_in, agg_out, bank_country_map=bcm)
+    assert cert_uniform.cert_id != cert_sw.cert_id
+    assert cert_uniform.prior_id == "uniform"
+    assert cert_sw.prior_id == "size_weighted"
+
+
+# ---------------------------------------------------------------------------
+# Verify the allocator's GATE_A1 (conservation) holds under SW prior
+# ---------------------------------------------------------------------------
+
+
+def test_size_weighted_allocator_conserves_per_country() -> None:
+    agg_in, agg_out, gt_in, _gt_out, bcm = synthetic_country_aggregates(
+        n_countries=3, n_banks_per_country=5, seed=46
+    )
+    weights = {bank: float(gt_in[i]) for i, (bank, _) in enumerate(bcm)}
+    cert = CountryToBankAllocator(
+        prior=SizeWeightedPrior(bank_country_map=bcm, bank_weights=weights)
+    ).allocate(agg_in, agg_out, bank_country_map=bcm)
+
+    bank_to_idx = {b: i for i, (b, _) in enumerate(bcm)}
+    for country in agg_in:
+        in_sum = sum(cert.s_in[bank_to_idx[b]] for b, c in bcm if c == country)
+        assert in_sum == pytest.approx(agg_in[country], rel=1e-9)
+    np.testing.assert_array_compare(np.greater_equal, cert.s_in, 0.0)
+    np.testing.assert_array_compare(np.greater_equal, cert.s_out, 0.0)


### PR DESCRIPTION
## Summary

Second PR of the X-10R-1 epic — first concrete allocator prior beyond the UniformPrior falsification anchor (PR #642). Adds `SizeWeightedPrior` (per-bank size-weighted shares with maximum-entropy mean imputation for missing weights) and the `registry_to_bank_country_map` loader surface that subsequent PRs (real ECB MFI, real EBA transparency) will plug into.

Refs #638.

## What lands

### `SizeWeightedPrior` (`research/reconstruction/allocator/size_weighted_prior.py`)

Closed-form share contract:
```
share(c, b) = weight[b] / Σ_{b' resident in c} weight[b']
```
Banks resident in `c` but missing from `bank_weights` get **per-country mean imputation** — maximum-entropy for missing entries (does not zero them spuriously, does not bias them). `has_evidence(country)` returns `True` iff Σ resident weights > 0.

`prior_id_tag` is configurable so subsequent PRs loading EBA / BankFocus / FDIC weights can stamp meaningful identifiers onto the certificate without a new class per data source.

### `registry_to_bank_country_map` (`research/reconstruction/allocator/registry.py`)

Converts a `{country: [banks]}` Python dict into the canonical deterministic `bank_country_map` tuple. Alphabetical country order; preserved within-country bank order; rejects empty inputs, blank IDs, and globally non-unique bank IDs (the allocator's per-bank index would be ambiguous otherwise).

### Falsification anchor (the headline test)

`SizeWeightedPrior` only earns its place if it materially beats `UniformPrior` when given an informative size signal. Three tests pin this:

| Test | Contract |
|---|---|
| `test_aligned_size_weighted_prior_beats_uniform_on_lognormal` | Aligned weights (= ground-truth sizes) recover exactly; UniformPrior loses by ≥ 6 orders of magnitude |
| `test_misaligned_size_weighted_prior_does_not_beat_uniform` | Anti-aligned weights MUST NOT beat UniformPrior (catches numerical-accident "wins") |
| `test_empty_weight_dict_degenerates_to_uniform_recovery` | Empty-weight SizeWeightedPrior matches UniformPrior recovery error within 1e-9 (consistency check) |

## Tests (29 new — 72 in `tests/reconstruction/allocator/` total)

**`test_size_weighted_prior.py`** (19): Protocol satisfaction, configurable `prior_id_tag`, closed-form share, mean-imputation for missing weights, zero-weight (explicit) ≠ missing (imputed), `has_evidence` semantics, input contract (rejects negative/NaN/empty/unknown country/non-resident bank), falsification anchor (3 directions above), `cert_id` distinguishes priors via GATE_A4 surface, allocator GATE_A1 conservation under SW prior.

**`test_registry.py`** (10): Canonical tuple shape, alphabetical country ordering, preserved within-country bank order, rejects empty/blank/duplicate, deterministic per-input, round-trip into `SizeWeightedPrior`.

## Local results

- `pytest tests/reconstruction/allocator/`: **72 passed** in 2.4 s
- `mypy --strict --follow-imports=silent`: **13 source files clean**
- `ruff check` + `black --check`: clean

## What this PR does NOT land

- Real ECB MFI data ingestion (PR #3 of the epic)
- Real EBA transparency exercise size weights (PR #4)
- BankFocus license-gated path (PR #5)
- X-10R reconstruction composition (PR #6)
- E2E allocator → Gate 6 forward signal (PR #7)

The bank-level inference claim REMAINS forbidden by INV-IDENTIFICATION-1 until the composition lands.

## Acceptance gates (per `.claude/commit_acceptors/x10r-1-size-weighted-prior.yaml`)

- [x] `SizeWeightedPrior` exposed
- [x] `registry_to_bank_country_map` exposed
- [x] Falsifier: aligned SW prior must beat UniformPrior by > 6 OoM on lognormal substrate

## Test plan

- [ ] CI green on `pytest tests/reconstruction/allocator/`
- [ ] CI green on `ruff check` + `mypy --strict` + `black --check`
- [ ] Acceptor passes
- [ ] PR description matches code

🤖 Generated with [Claude Code](https://claude.com/claude-code)