### PR TITLE
feat(x10r-1-#3): BankLevelGate5Audit (epic #638 PR #3)

### DIFF
--- a/.claude/commit_acceptors/x10r-1-bank-level-gate5-audit.yaml
+++ b/.claude/commit_acceptors/x10r-1-bank-level-gate5-audit.yaml
@@ -1,0 +1,109 @@
+# Diff-bound commit acceptor for X-10R-1 PR #3 — allocator-side
+# Gate-5-style multi-metric recovery audit on bank-level marginals.
+#
+# What lands:
+#   * research/reconstruction/allocator/bank_level_audit.py
+#       BankLevelRecoveryReport + audit_bank_level_recovery
+#   * tests/reconstruction/allocator/test_bank_level_audit.py
+#       13 new tests pinning every metric, threshold defaults,
+#       per-country argmax reporting, threshold customisation,
+#       and the falsification anchor (UniformPrior on lognormal
+#       substrate fails total_l1).
+#
+# Locally verified:
+#   * pytest tests/reconstruction/allocator/: 85/85 passed
+#   * mypy --strict + ruff + black:           clean
+
+id: x10r-1-bank-level-gate5-audit
+status: ACTIVE
+claim_type: chore
+promise: >-
+  After this PR lands, research/reconstruction/allocator/ exposes
+  a Gate-5-style multi-metric recovery audit on bank-level
+  marginals: BankLevelRecoveryReport carries
+  total_relative_l1, top_k_bank_jaccard (k = N//5), per-country
+  relative L1 with argmax country, and conservation_total_relative
+  _error. audit_bank_level_recovery enforces four thresholds
+  (0.20 / 0.60 / 0.05 / 1e-9) by default; each metric is
+  independently testable. 13 tests pin: defaults, perfect-recovery
+  passes all, end-to-end aligned-SizeWeightedPrior passes,
+  UniformPrior on lognormal fails total_l1, per_country_l1
+  catches local distortions the aggregate misses, top_k_jaccard
+  fails on inversion, conservation surfaces separately, input
+  contract (shape mismatch / map length / non-finite),
+  threshold + k_top customisation, argmax country reporting.
+diff_scope:
+  changed_files:
+    - path: ".claude/commit_acceptors/x10r-1-bank-level-gate5-audit.yaml"
+    - path: "research/reconstruction/allocator/__init__.py"
+    - path: "research/reconstruction/allocator/bank_level_audit.py"
+    - path: "tests/reconstruction/allocator/test_bank_level_audit.py"
+  forbidden_paths:
+    - "trading/"
+    - "execution/"
+    - "forecast/"
+    - "policy/"
+    - "core/physics/"
+    - "core/kuramoto/"
+    - "application/governance/claim_ledger.py"
+    - "application/governance/commit_acceptor.py"
+required_python_symbols:
+  - "research/reconstruction/allocator/bank_level_audit.py::BankLevelRecoveryReport"
+  - "research/reconstruction/allocator/bank_level_audit.py::audit_bank_level_recovery"
+expected_signal: >-
+  Local: `pytest tests/reconstruction/allocator/ -q` reports
+  "85 passed"; `mypy --strict` is clean on every file under
+  research/reconstruction/allocator/ and
+  tests/reconstruction/allocator/; `ruff check` and
+  `black --check` both pass on those paths.
+measurement_command: >-
+  bash -c 'mypy --strict --follow-imports=silent
+  research/reconstruction/allocator/ tests/reconstruction/allocator/
+  && ruff check research/reconstruction/allocator/ tests/reconstruction/allocator/
+  && black --check research/reconstruction/allocator/ tests/reconstruction/allocator/
+  && pytest tests/reconstruction/allocator/ -q'
+signal_artifact: "tmp/x10r_1_bank_level_audit.log"
+falsifier:
+  command: >-
+    bash -c 'python -c "
+    import numpy as np
+    from research.reconstruction.allocator import (
+        CountryToBankAllocator, UniformPrior,
+        audit_bank_level_recovery, synthetic_country_aggregates,
+    )
+    agg_in, agg_out, gt_in, gt_out, bcm = synthetic_country_aggregates(
+        n_countries=4, n_banks_per_country=8,
+        share_distribution=\"lognormal\", seed=42,
+    )
+    cert = CountryToBankAllocator(
+        prior=UniformPrior(bank_country_map=bcm)
+    ).allocate(agg_in, agg_out, bank_country_map=bcm)
+    rep = audit_bank_level_recovery(
+        ground_truth_s_in=gt_in, ground_truth_s_out=gt_out,
+        allocated_s_in=cert.s_in, allocated_s_out=cert.s_out,
+        bank_country_map=bcm,
+    )
+    assert rep.passed is False, \"audit must fail UniformPrior on lognormal\"
+    assert any(\"total_relative_l1\" in r for r in rep.failure_reasons), (
+        f\"audit must surface total_relative_l1 failure; got {rep.failure_reasons}\"
+    )
+    "'
+  description: >-
+    Probes the falsification anchor: UniformPrior on lognormal-
+    share substrate at N=32 banks must produce an audit that fails
+    on total_relative_l1. If the audit passes, either the metric
+    is computed wrong or the substrate is somehow not lognormal —
+    either way, downstream concrete priors have nothing to beat.
+rollback_command: >-
+  bash -c 'git checkout HEAD~1 --
+  && rm -f research/reconstruction/allocator/bank_level_audit.py
+  tests/reconstruction/allocator/test_bank_level_audit.py
+  .claude/commit_acceptors/x10r-1-bank-level-gate5-audit.yaml'
+rollback_verification_command: >-
+  bash -c 'test ! -f research/reconstruction/allocator/bank_level_audit.py
+  && test ! -f tests/reconstruction/allocator/test_bank_level_audit.py
+  && test ! -f .claude/commit_acceptors/x10r-1-bank-level-gate5-audit.yaml'
+memory_update_type: append
+ledger_path: ".claude/commit_acceptors/x10r-1-bank-level-gate5-audit.yaml"
+report_path: "tmp/x10r_1_bank_level_audit.log"
+evidence: []

--- a/research/reconstruction/allocator/__init__.py
+++ b/research/reconstruction/allocator/__init__.py
@@ -10,6 +10,10 @@ transparency, BankFocus) land in subsequent epic PRs.
 """
 
 from research.reconstruction.allocator.allocator import CountryToBankAllocator
+from research.reconstruction.allocator.bank_level_audit import (
+    BankLevelRecoveryReport,
+    audit_bank_level_recovery,
+)
 from research.reconstruction.allocator.certificate import (
     BankLevelMarginalsCertificate,
     compute_cert_id,
@@ -28,10 +32,12 @@ from research.reconstruction.allocator.synthetic import (
 __all__ = [
     "AllocatorPrior",
     "BankLevelMarginalsCertificate",
+    "BankLevelRecoveryReport",
     "CountryToBankAllocator",
     "ShareDistribution",
     "SizeWeightedPrior",
     "UniformPrior",
+    "audit_bank_level_recovery",
     "bank_level_recovery_l1",
     "compute_cert_id",
     "registry_to_bank_country_map",

--- a/research/reconstruction/allocator/bank_level_audit.py
+++ b/research/reconstruction/allocator/bank_level_audit.py
@@ -1,0 +1,196 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""BankLevelGate5Audit — allocator-side Gate-5-style recovery audit.
+
+Per X-10R-1 PR #3 (epic #638), the allocator's positive controls
+need a multi-metric recovery report — not just a single relative-L1
+scalar. The X-10R reconstruction pipeline (PR #635) uses a
+Gate-5 audit with four thresholds (spectral radius, top-k hub
+jaccard, row/col L1) so a *partial* failure (one metric clipping
+its threshold) is observable without losing the others.
+
+This module brings the same discipline to the allocator side, but
+adapted to the marginals domain (no spectral radius — the allocator
+emits 1-D marginals, not a square coupling matrix):
+
+    BankLevelRecoveryReport
+        * total_relative_l1                    — Σ |gt - alloc| / Σ |gt|
+        * top_k_bank_jaccard                   — top-k by strength
+        * per_country_relative_l1_max          — worst-country L1
+        * conservation_total_relative_error    — |Σgt - Σalloc| / Σgt
+        * passed: bool — every threshold ≤ its bound
+
+Default thresholds:
+        total_relative_l1                    ≤ 0.20
+        top_k_bank_jaccard (k = N//5)        ≥ 0.60
+        per_country_relative_l1_max          ≤ 0.05
+        conservation_total_relative_error    ≤ 1e-9
+
+Rationale for k = N//5:
+    The X-10R reconstruction uses k = N//10 because the network has
+    N nodes and the systemic-hub set is sparse. The allocator emits
+    N total bank-level marginals (where N = #banks ≪ #network edges)
+    and the systemic-importance ranking is much sharper at the
+    bank-level. k = N//5 keeps the test discriminating without
+    over-fitting to the substrate.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+# Default thresholds — can be overridden in the audit call.
+TOTAL_RELATIVE_L1_MAX_DEFAULT: float = 0.20
+TOP_K_BANK_JACCARD_MIN_DEFAULT: float = 0.60
+PER_COUNTRY_RELATIVE_L1_MAX_DEFAULT: float = 0.05
+CONSERVATION_TOTAL_RELATIVE_ERROR_MAX_DEFAULT: float = 1e-9
+
+
+@dataclass(frozen=True)
+class BankLevelRecoveryReport:
+    """Frozen Gate-5-style recovery report on bank-level marginals.
+
+    Each metric is reported AND each threshold is checked; ``passed``
+    is the conjunction. ``failure_reasons`` is a tuple of human-
+    readable strings for the metrics that crossed their bound (if
+    any) — the same shape the X-10R reconstruction's RecoveryReport
+    uses.
+    """
+
+    total_relative_l1: float
+    top_k_bank_jaccard: float
+    per_country_relative_l1_max: float
+    per_country_relative_l1_argmax: str  # which country was worst
+    conservation_total_relative_error: float
+    n_banks: int
+    n_countries: int
+    k_top: int
+    passed: bool
+    failure_reasons: tuple[str, ...]
+
+
+def _top_k_jaccard(deg_true: np.ndarray, deg_recon: np.ndarray, *, k: int) -> float:
+    """Strength-based top-k jaccard. Same shape as the X-10R version."""
+    if k <= 0:
+        return 0.0
+    top_t = set(np.argsort(-deg_true)[:k].tolist())
+    top_r = set(np.argsort(-deg_recon)[:k].tolist())
+    union = top_t | top_r
+    if not union:
+        return 0.0
+    return float(len(top_t & top_r) / len(union))
+
+
+def audit_bank_level_recovery(
+    *,
+    ground_truth_s_in: np.ndarray,
+    ground_truth_s_out: np.ndarray,
+    allocated_s_in: np.ndarray,
+    allocated_s_out: np.ndarray,
+    bank_country_map: tuple[tuple[str, str], ...],
+    k_top: int | None = None,
+    total_relative_l1_max: float = TOTAL_RELATIVE_L1_MAX_DEFAULT,
+    top_k_bank_jaccard_min: float = TOP_K_BANK_JACCARD_MIN_DEFAULT,
+    per_country_relative_l1_max: float = PER_COUNTRY_RELATIVE_L1_MAX_DEFAULT,
+    conservation_total_relative_error_max: float = (CONSERVATION_TOTAL_RELATIVE_ERROR_MAX_DEFAULT),
+) -> BankLevelRecoveryReport:
+    """Audit the allocator's bank-level marginal recovery.
+
+    The four metrics together pin a substantive recovery contract:
+      * total_relative_l1        — coarse aggregate match
+      * top_k_bank_jaccard       — systemic-hub identification (the
+                                    metric the downstream X-10R Gate 6
+                                    inherits via spectral leading EV)
+      * per_country_relative_l1_max — local distortion: a prior that
+                                    matches in aggregate but is wildly
+                                    wrong inside one country fails here
+      * conservation_total_relative_error — bookkeeping: total mass
+                                    must match to numerical tolerance
+                                    (otherwise the allocator broke
+                                    GATE_A1 conservation upstream)
+    """
+    gt_in = np.asarray(ground_truth_s_in, dtype=np.float64).ravel()
+    gt_out = np.asarray(ground_truth_s_out, dtype=np.float64).ravel()
+    al_in = np.asarray(allocated_s_in, dtype=np.float64).ravel()
+    al_out = np.asarray(allocated_s_out, dtype=np.float64).ravel()
+    n = gt_in.shape[0]
+    if gt_out.shape != (n,) or al_in.shape != (n,) or al_out.shape != (n,):
+        raise ValueError(
+            "all four marginal vectors must share the same shape "
+            f"(n,) where n = ground_truth_s_in.shape[0]={n}; got "
+            f"gt_out={gt_out.shape}, al_in={al_in.shape}, al_out={al_out.shape}"
+        )
+    if len(bank_country_map) != n:
+        raise ValueError(f"bank_country_map length {len(bank_country_map)} ≠ marginal length {n}")
+    if not np.all(np.isfinite(gt_in)) or not np.all(np.isfinite(gt_out)):
+        raise ValueError("ground-truth marginals must be finite")
+    if not np.all(np.isfinite(al_in)) or not np.all(np.isfinite(al_out)):
+        raise ValueError("allocated marginals must be finite")
+
+    countries = sorted({c for _, c in bank_country_map})
+    n_countries = len(countries)
+    k = k_top if k_top is not None else max(1, n // 5)
+
+    # Aggregate metrics over s_in (s_out audit follows the same shape).
+    denom = float(np.abs(gt_in).sum())
+    total_l1 = float(np.abs(gt_in - al_in).sum() / denom) if denom > 0 else 0.0
+
+    # Bank importance by combined strength (same convention as the
+    # X-10R reconstruction RecoveryReport).
+    strength_true = (gt_in + gt_out).astype(np.float64)
+    strength_recon = (al_in + al_out).astype(np.float64)
+    jacc = _top_k_jaccard(strength_true, strength_recon, k=k)
+
+    # Per-country relative L1.
+    bank_to_idx = {b: i for i, (b, _) in enumerate(bank_country_map)}
+    per_country: dict[str, float] = {}
+    for country in countries:
+        idxs = [bank_to_idx[b] for b, c in bank_country_map if c == country]
+        if not idxs:
+            continue
+        gt_c = gt_in[idxs]
+        al_c = al_in[idxs]
+        d = float(np.abs(gt_c).sum())
+        per_country[country] = float(np.abs(gt_c - al_c).sum() / d) if d > 0 else 0.0
+    if per_country:
+        worst_country = max(per_country, key=lambda c: per_country[c])
+        per_country_l1_max = per_country[worst_country]
+    else:
+        worst_country = ""
+        per_country_l1_max = 0.0
+
+    # Conservation total (mass discrepancy in aggregate).
+    total_gt = float(gt_in.sum())
+    total_al = float(al_in.sum())
+    cons_err = float(abs(total_gt - total_al) / total_gt) if total_gt > 0 else 0.0
+
+    failures: list[str] = []
+    if total_l1 > total_relative_l1_max:
+        failures.append(f"total_relative_l1={total_l1:.4f} > {total_relative_l1_max}")
+    if jacc < top_k_bank_jaccard_min:
+        failures.append(f"top_k_bank_jaccard={jacc:.4f} < {top_k_bank_jaccard_min}")
+    if per_country_l1_max > per_country_relative_l1_max:
+        failures.append(
+            f"per_country_relative_l1_max={per_country_l1_max:.4f} "
+            f"({worst_country!r}) > {per_country_relative_l1_max}"
+        )
+    if cons_err > conservation_total_relative_error_max:
+        failures.append(
+            f"conservation_total_relative_error={cons_err:.6e} "
+            f"> {conservation_total_relative_error_max}"
+        )
+
+    return BankLevelRecoveryReport(
+        total_relative_l1=total_l1,
+        top_k_bank_jaccard=jacc,
+        per_country_relative_l1_max=per_country_l1_max,
+        per_country_relative_l1_argmax=worst_country,
+        conservation_total_relative_error=cons_err,
+        n_banks=n,
+        n_countries=n_countries,
+        k_top=k,
+        passed=not failures,
+        failure_reasons=tuple(failures),
+    )

--- a/tests/reconstruction/allocator/test_bank_level_audit.py
+++ b/tests/reconstruction/allocator/test_bank_level_audit.py
@@ -1,0 +1,344 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""Tests for the BankLevelGate5Audit (X-10R-1 PR #3).
+
+Pins five contracts:
+  1. Reports four metrics simultaneously, ``passed`` is the AND.
+  2. Default thresholds match the X-10R-1 spec (0.20 / 0.60 / 0.05 / 1e-9).
+  3. Perfect recovery ⇒ all metrics at their best, passed=True.
+  4. Each threshold is independently testable (a failure on metric M
+     surfaces in failure_reasons regardless of other metrics).
+  5. Per-country relative L1 catches local distortions that the
+     aggregate L1 averages out.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from research.reconstruction.allocator import (
+    BankLevelRecoveryReport,
+    CountryToBankAllocator,
+    SizeWeightedPrior,
+    UniformPrior,
+    audit_bank_level_recovery,
+    synthetic_country_aggregates,
+)
+from research.reconstruction.allocator.bank_level_audit import (
+    CONSERVATION_TOTAL_RELATIVE_ERROR_MAX_DEFAULT,
+    PER_COUNTRY_RELATIVE_L1_MAX_DEFAULT,
+    TOP_K_BANK_JACCARD_MIN_DEFAULT,
+    TOTAL_RELATIVE_L1_MAX_DEFAULT,
+)
+
+
+def _make_substrate(n_countries: int = 3, n_banks: int = 6, seed: int = 42) -> tuple[
+    dict[str, float],
+    dict[str, float],
+    np.ndarray,
+    np.ndarray,
+    tuple[tuple[str, str], ...],
+]:
+    return synthetic_country_aggregates(
+        n_countries=n_countries,
+        n_banks_per_country=n_banks,
+        share_distribution="lognormal",
+        seed=seed,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Defaults match the spec
+# ---------------------------------------------------------------------------
+
+
+def test_default_thresholds_match_x10r1_spec() -> None:
+    assert TOTAL_RELATIVE_L1_MAX_DEFAULT == 0.20
+    assert TOP_K_BANK_JACCARD_MIN_DEFAULT == 0.60
+    assert PER_COUNTRY_RELATIVE_L1_MAX_DEFAULT == 0.05
+    assert CONSERVATION_TOTAL_RELATIVE_ERROR_MAX_DEFAULT == 1e-9
+
+
+# ---------------------------------------------------------------------------
+# Perfect-recovery direction
+# ---------------------------------------------------------------------------
+
+
+def test_perfect_recovery_passes_all_thresholds() -> None:
+    """Allocated == ground truth ⇒ passed=True with every metric at
+    its best value."""
+    _agg_in, _agg_out, gt_in, gt_out, bcm = _make_substrate(seed=1)
+    report = audit_bank_level_recovery(
+        ground_truth_s_in=gt_in,
+        ground_truth_s_out=gt_out,
+        allocated_s_in=gt_in.copy(),
+        allocated_s_out=gt_out.copy(),
+        bank_country_map=bcm,
+    )
+    assert isinstance(report, BankLevelRecoveryReport)
+    assert report.passed is True
+    assert report.failure_reasons == ()
+    assert report.total_relative_l1 == 0.0
+    assert report.top_k_bank_jaccard == 1.0
+    assert report.per_country_relative_l1_max == 0.0
+    assert report.conservation_total_relative_error == 0.0
+
+
+def test_aligned_size_weighted_prior_passes_audit_end_to_end() -> None:
+    """Realistic check: a SizeWeightedPrior with weights aligned to
+    the ground truth should pass the audit end-to-end via the
+    allocator."""
+    agg_in, agg_out, gt_in, gt_out, bcm = _make_substrate(n_banks=6, seed=2)
+    weights = {bank: float(gt_in[i]) for i, (bank, _) in enumerate(bcm)}
+    cert = CountryToBankAllocator(
+        prior=SizeWeightedPrior(bank_country_map=bcm, bank_weights=weights)
+    ).allocate(agg_in, agg_out, bank_country_map=bcm)
+    report = audit_bank_level_recovery(
+        ground_truth_s_in=gt_in,
+        ground_truth_s_out=gt_out,
+        allocated_s_in=cert.s_in,
+        allocated_s_out=cert.s_out,
+        bank_country_map=bcm,
+    )
+    assert report.passed is True
+
+
+# ---------------------------------------------------------------------------
+# Each metric is independently triggerable
+# ---------------------------------------------------------------------------
+
+
+def test_uniform_prior_fails_total_l1_on_lognormal() -> None:
+    """UniformPrior on lognormal substrate fails the aggregate L1
+    bound (0.20). This is the falsification anchor surface — if the
+    audit fails to detect it, downstream priors have nothing to beat."""
+    agg_in, agg_out, gt_in, gt_out, bcm = _make_substrate(n_banks=8, seed=3)
+    cert = CountryToBankAllocator(prior=UniformPrior(bank_country_map=bcm)).allocate(
+        agg_in, agg_out, bank_country_map=bcm
+    )
+    report = audit_bank_level_recovery(
+        ground_truth_s_in=gt_in,
+        ground_truth_s_out=gt_out,
+        allocated_s_in=cert.s_in,
+        allocated_s_out=cert.s_out,
+        bank_country_map=bcm,
+    )
+    assert report.passed is False
+    assert any("total_relative_l1" in r for r in report.failure_reasons)
+
+
+def test_per_country_l1_catches_local_distortion_aggregate_misses() -> None:
+    """A pathological allocator that gets the country aggregates RIGHT
+    but the within-country distribution wrong would pass total_l1 and
+    fail per_country_l1. The audit's per-country term must surface this
+    distinct failure mode."""
+    # 2 countries × 5 banks. Ground truth: bank 0 is the giant in C0;
+    # all others equal.
+    bcm = (
+        ("B0", "C0"),
+        ("B1", "C0"),
+        ("B2", "C0"),
+        ("B3", "C0"),
+        ("B4", "C0"),
+        ("B5", "C1"),
+        ("B6", "C1"),
+        ("B7", "C1"),
+    )
+    gt_in = np.array([100.0, 1.0, 1.0, 1.0, 1.0, 10.0, 10.0, 10.0])
+    gt_out = gt_in.copy()
+    # Allocator output: same country totals (104, 30) but completely
+    # rearranged within-country.
+    al_in = np.array([1.0, 1.0, 1.0, 1.0, 100.0, 10.0, 10.0, 10.0])
+    al_out = al_in.copy()
+    report = audit_bank_level_recovery(
+        ground_truth_s_in=gt_in,
+        ground_truth_s_out=gt_out,
+        allocated_s_in=al_in,
+        allocated_s_out=al_out,
+        bank_country_map=bcm,
+    )
+    # Total L1 is non-zero but country totals match exactly.
+    assert report.conservation_total_relative_error < 1e-9
+    # Per-country must catch the within-country shuffle.
+    assert report.per_country_relative_l1_max > 0.05
+    assert any("per_country_relative_l1_max" in r for r in report.failure_reasons)
+    assert report.per_country_relative_l1_argmax == "C0"
+
+
+def test_top_k_jaccard_fails_when_top_banks_misidentified() -> None:
+    """If the allocator inverts the bank ranking, the top-k jaccard
+    drops below 0.6. Catches the situation where the per-country
+    distribution is wrong AND the worst-bank is now ranked top —
+    a correctness signal that aggregate L1 alone cannot spot."""
+    bcm = (
+        ("B0", "C0"),
+        ("B1", "C0"),
+        ("B2", "C0"),
+        ("B3", "C0"),
+        ("B4", "C0"),
+        ("B5", "C0"),
+        ("B6", "C0"),
+        ("B7", "C0"),
+    )
+    n = 8
+    gt = np.arange(1, n + 1, dtype=np.float64)  # 1..8
+    al = gt[::-1].copy()  # 8..1 — full inversion
+    report = audit_bank_level_recovery(
+        ground_truth_s_in=gt,
+        ground_truth_s_out=gt,
+        allocated_s_in=al,
+        allocated_s_out=al,
+        bank_country_map=bcm,
+    )
+    # Top-k = N//5 = 1; the top bank is fully inverted ⇒ jaccard = 0.
+    assert report.top_k_bank_jaccard == 0.0
+    assert any("top_k_bank_jaccard" in r for r in report.failure_reasons)
+
+
+def test_conservation_failure_surfaces_separately() -> None:
+    """Total mass mismatch (allocator broke GATE_A1 upstream) must be
+    a distinct failure reason — we don't conflate it with L1."""
+    bcm = (("B0", "C0"), ("B1", "C0"))
+    gt = np.array([100.0, 100.0])
+    al = np.array([100.0, 50.0])  # 25% missing mass in country
+    report = audit_bank_level_recovery(
+        ground_truth_s_in=gt,
+        ground_truth_s_out=gt,
+        allocated_s_in=al,
+        allocated_s_out=al,
+        bank_country_map=bcm,
+    )
+    assert any("conservation_total_relative_error" in r for r in report.failure_reasons)
+
+
+# ---------------------------------------------------------------------------
+# Input contract
+# ---------------------------------------------------------------------------
+
+
+def test_audit_rejects_shape_mismatch() -> None:
+    bcm = (("B0", "C0"), ("B1", "C0"))
+    gt = np.zeros(2)
+    al_wrong = np.zeros(3)
+    with pytest.raises(ValueError, match="same shape"):
+        audit_bank_level_recovery(
+            ground_truth_s_in=gt,
+            ground_truth_s_out=gt,
+            allocated_s_in=al_wrong,
+            allocated_s_out=gt,
+            bank_country_map=bcm,
+        )
+
+
+def test_audit_rejects_bank_country_map_length_mismatch() -> None:
+    bcm = (("B0", "C0"),)  # length 1
+    gt = np.zeros(2)  # length 2
+    with pytest.raises(ValueError, match="bank_country_map length"):
+        audit_bank_level_recovery(
+            ground_truth_s_in=gt,
+            ground_truth_s_out=gt,
+            allocated_s_in=gt,
+            allocated_s_out=gt,
+            bank_country_map=bcm,
+        )
+
+
+def test_audit_rejects_non_finite_inputs() -> None:
+    bcm = (("B0", "C0"), ("B1", "C0"))
+    gt = np.array([1.0, 2.0])
+    bad = np.array([1.0, np.nan])
+    with pytest.raises(ValueError, match="finite"):
+        audit_bank_level_recovery(
+            ground_truth_s_in=bad,
+            ground_truth_s_out=gt,
+            allocated_s_in=gt,
+            allocated_s_out=gt,
+            bank_country_map=bcm,
+        )
+    with pytest.raises(ValueError, match="finite"):
+        audit_bank_level_recovery(
+            ground_truth_s_in=gt,
+            ground_truth_s_out=gt,
+            allocated_s_in=np.array([1.0, np.inf]),
+            allocated_s_out=gt,
+            bank_country_map=bcm,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Threshold customisation
+# ---------------------------------------------------------------------------
+
+
+def test_custom_thresholds_change_pass_outcome() -> None:
+    """Loosening the bound on a failing case lets it pass; tightening
+    on a passing case lets it fail."""
+    _agg_in, _agg_out, gt_in, gt_out, bcm = _make_substrate(seed=11)
+    report_strict = audit_bank_level_recovery(
+        ground_truth_s_in=gt_in,
+        ground_truth_s_out=gt_out,
+        allocated_s_in=gt_in.copy(),
+        allocated_s_out=gt_out.copy(),
+        bank_country_map=bcm,
+        top_k_bank_jaccard_min=2.0,  # impossible threshold
+    )
+    assert report_strict.passed is False
+    assert any("top_k_bank_jaccard" in r for r in report_strict.failure_reasons)
+
+
+def test_k_top_override_changes_jaccard_resolution() -> None:
+    """With k_top=1 only the top bank matters; with k_top=N every
+    bank does. Different k → different jaccard for partial overlap."""
+    bcm = tuple((f"B{i}", "C0") for i in range(10))
+    gt = np.arange(1, 11, dtype=np.float64)
+    # Partial inversion: swap top-1 with bottom-1 only.
+    al = gt.copy()
+    al[0], al[9] = gt[9], gt[0]
+    r_k1 = audit_bank_level_recovery(
+        ground_truth_s_in=gt,
+        ground_truth_s_out=gt,
+        allocated_s_in=al,
+        allocated_s_out=al,
+        bank_country_map=bcm,
+        k_top=1,
+    )
+    r_k10 = audit_bank_level_recovery(
+        ground_truth_s_in=gt,
+        ground_truth_s_out=gt,
+        allocated_s_in=al,
+        allocated_s_out=al,
+        bank_country_map=bcm,
+        k_top=10,
+    )
+    # k=1 → top is now the one that was bottom → jaccard = 0
+    # k=10 → all banks are in both top-10 sets → jaccard = 1
+    assert r_k1.top_k_bank_jaccard == 0.0
+    assert r_k10.top_k_bank_jaccard == 1.0
+
+
+# ---------------------------------------------------------------------------
+# Argmax country reporting
+# ---------------------------------------------------------------------------
+
+
+def test_per_country_argmax_identifies_worst_country() -> None:
+    """When multiple countries fail at different L1 levels, the report
+    must name the WORST one — useful for triage."""
+    bcm = (
+        ("B0", "C0"),
+        ("B1", "C0"),
+        ("B2", "C1"),
+        ("B3", "C1"),
+    )
+    gt = np.array([10.0, 10.0, 10.0, 10.0])
+    # C0 perfectly recovered; C1 wildly off.
+    al = np.array([10.0, 10.0, 1.0, 19.0])
+    report = audit_bank_level_recovery(
+        ground_truth_s_in=gt,
+        ground_truth_s_out=gt,
+        allocated_s_in=al,
+        allocated_s_out=al,
+        bank_country_map=bcm,
+    )
+    assert report.per_country_relative_l1_argmax == "C1"


### PR DESCRIPTION
## Summary

Third PR of the X-10R-1 epic. Brings the X-10R reconstruction's multi-metric Gate-5 discipline to the allocator side: a single relative-L1 scalar (`bank_level_recovery_l1`, from PR #642) is too coarse to catch within-country distortions or systemic-hub mis-identification. This PR adds a four-metric report so a *partial* failure surfaces without losing the others.

Refs #638.

## What lands

`BankLevelRecoveryReport` carries:

| Metric | What it measures |
|---|---|
| `total_relative_l1` | `Σ\|gt − alloc\| / Σ\|gt\|` — coarse aggregate match |
| `top_k_bank_jaccard` | systemic-hub identification (k = N//5) — same metric class the downstream X-10R Gate 6 inherits via spectral leading EV |
| `per_country_relative_l1_max` | worst-country local distortion |
| `per_country_relative_l1_argmax` | name of worst country |
| `conservation_total_relative_error` | total mass match (catches upstream GATE_A1 break) |

Default thresholds: `0.20 / 0.60 / 0.05 / 1e-9`. Each independently customisable.

## Why four metrics, not one

| Failure mode | Single L1 catches? | Four-metric catches? |
|---|---|---|
| Aggregate L1 above 20% | yes | yes |
| Country totals match but within-country shuffle | NO (averages out) | yes (per-country argmax) |
| Top systemic bank mis-ranked | NO (small fraction of mass) | yes (jaccard) |
| Total mass conservation broken | partially | yes (conservation field is distinct) |

`test_per_country_l1_catches_local_distortion_aggregate_misses` constructs the precise failure mode that single-L1 misses and verifies the multi-metric report flags it.

## Tests (13 new — 85 in `tests/reconstruction/allocator/` total)

- Defaults match the X-10R-1 spec exactly.
- Perfect recovery ⇒ all metrics at best, passed=True.
- Aligned `SizeWeightedPrior` end-to-end pass via the allocator.
- **Falsification anchor**: `UniformPrior` on lognormal fails `total_l1`.
- Per-country L1 catches local distortions the aggregate misses (constructed adversarial: within-country shuffle preserving country totals).
- Top-k jaccard fails on rank inversion (a failure mode that `total_l1` alone cannot localise).
- Conservation failure surfaces separately (no conflation with L1).
- Input contract: shape mismatch, map-length mismatch, non-finite inputs all raise.
- Threshold + `k_top` customisation actually changes verdicts.
- `per_country_relative_l1_argmax` identifies worst-country.

## Local results

- `pytest tests/reconstruction/allocator/`: **85 passed** in 2.1 s
- `mypy --strict --follow-imports=silent`: **15 source files clean**
- `ruff check` + `black --check`: clean

## What this PR does NOT land

- Real ECB MFI data ingestion (PR #4 of the epic)
- Real EBA transparency size weights (PR #5)
- BankFocus license-gated path (PR #6)
- X-10R reconstruction composition (DoV gate composition over allocator + reconstruction envelopes — PR #7)
- E2E allocator → Gate 6 forward signal (PR #8)

The bank-level inference claim REMAINS forbidden by INV-IDENTIFICATION-1 until those land.

## Acceptance gates (per `.claude/commit_acceptors/x10r-1-bank-level-gate5-audit.yaml`)

- [x] `BankLevelRecoveryReport` exposed
- [x] `audit_bank_level_recovery` exposed
- [x] Falsifier: UniformPrior on lognormal substrate must fail with `total_relative_l1` in `failure_reasons`

## Test plan

- [ ] CI green on `pytest tests/reconstruction/allocator/`
- [ ] CI green on `ruff check` + `mypy --strict` + `black --check`
- [ ] Acceptor passes
- [ ] PR description matches code

🤖 Generated with [Claude Code](https://claude.com/claude-code)