### PR TITLE
feat(x10r-1): MFI demo fixture + composed DoV gate (epic #638 PRs #5 + #6)

### DIFF
--- a/.claude/commit_acceptors/x10r-1-dov-composition.yaml
+++ b/.claude/commit_acceptors/x10r-1-dov-composition.yaml
@@ -1,0 +1,135 @@
+# Diff-bound commit acceptor for X-10R-1 PR #6 — composed
+# Domain-of-Validity gate that requires BOTH the allocator
+# certificate envelope AND the reconstruction certificate envelope
+# to certify a real BIS bank-level run.
+#
+# What lands:
+#   * research/reconstruction/allocator/dov_composition.py
+#       ComposedDomainStatus enum + ComposedDomainCheck dataclass +
+#       check_composed_domain_of_validity helper.
+#   * tests/reconstruction/allocator/test_dov_composition.py
+#       9 new tests pinning the 4-cell verdict matrix
+#       (BOTH_WITHIN / RECONSTRUCTION_OUT / ALLOCATOR_OUT /
+#       BOTH_OUT), coverage threshold customisation, provenance
+#       fields surfaced as measured-only, and a full E2E run
+#       through the frozen MFI demo fixture into BOTH_WITHIN.
+#
+# Locally verified:
+#   * pytest tests/reconstruction/allocator/: 126/126 passed
+#   * mypy --strict + ruff + black:           clean
+
+id: x10r-1-dov-composition
+status: ACTIVE
+claim_type: chore
+promise: >-
+  After this PR lands, research/reconstruction/allocator/ exposes
+  a composed Domain-of-Validity gate that combines the existing
+  X-10R reconstruction DoV verdict with the allocator-side
+  coverage_ratio envelope. ComposedDomainStatus is a 4-element
+  enum: BOTH_WITHIN (the only verdict admitting a bank-level
+  claim), RECONSTRUCTION_OUT, ALLOCATOR_OUT, BOTH_OUT.
+  ComposedDomainCheck.is_admissible_for_bank_level_claim is the
+  single boolean for downstream consumers. The default coverage
+  threshold is 0.80 (≥80% of countries with real prior evidence);
+  customisable via allocator_coverage_ratio_min. The composed
+  gate is FAIL-CLOSED — anything other than BOTH_WITHIN keeps
+  INV-IDENTIFICATION-1 in force and forbids bank-level claims.
+  9 new tests pin the contract: every cell of the verdict matrix,
+  coverage threshold customisation, default 0.80, provenance
+  surface (n_banks / n_countries surface as measured-only and
+  do NOT drive the verdict), envelope record carries the applied
+  threshold for audit, and a full E2E run from MFI demo fixture
+  through SizeWeightedPrior + CountryToBankAllocator into
+  BOTH_WITHIN.
+diff_scope:
+  changed_files:
+    - path: ".claude/commit_acceptors/x10r-1-dov-composition.yaml"
+    - path: "research/reconstruction/allocator/__init__.py"
+    - path: "research/reconstruction/allocator/dov_composition.py"
+    - path: "tests/reconstruction/allocator/test_dov_composition.py"
+  forbidden_paths:
+    - "trading/"
+    - "execution/"
+    - "forecast/"
+    - "policy/"
+    - "core/physics/"
+    - "core/kuramoto/"
+    - "application/governance/claim_ledger.py"
+    - "application/governance/commit_acceptor.py"
+required_python_symbols:
+  - "research/reconstruction/allocator/dov_composition.py::ComposedDomainStatus"
+  - "research/reconstruction/allocator/dov_composition.py::ComposedDomainCheck"
+  - "research/reconstruction/allocator/dov_composition.py::check_composed_domain_of_validity"
+expected_signal: >-
+  Local: `pytest tests/reconstruction/allocator/ -q` reports
+  "126 passed"; `mypy --strict` is clean on every file under
+  research/reconstruction/allocator/ and
+  tests/reconstruction/allocator/; `ruff check` and
+  `black --check` both pass on those paths.
+measurement_command: >-
+  bash -c 'mypy --strict --follow-imports=silent
+  research/reconstruction/allocator/ tests/reconstruction/allocator/
+  && ruff check research/reconstruction/allocator/ tests/reconstruction/allocator/
+  && black --check research/reconstruction/allocator/ tests/reconstruction/allocator/
+  && pytest tests/reconstruction/allocator/ -q'
+signal_artifact: "tmp/x10r_1_dov_composition.log"
+falsifier:
+  command: >-
+    bash -c 'python -c "
+    from research.reconstruction.allocator import (
+        ComposedDomainStatus,
+        check_composed_domain_of_validity,
+    )
+    from research.reconstruction.allocator.certificate import BankLevelMarginalsCertificate
+    from research.reconstruction.positive_control import (
+        ground_truth_core_periphery, run_recovery_on_substrate,
+    )
+    import numpy as np
+    rec_cert = run_recovery_on_substrate(
+        \"CP_80_falsifier\",
+        ground_truth_core_periphery(n=80, core_frac=0.30, seed=42),
+        seed=42,
+    )
+    alloc_cert = BankLevelMarginalsCertificate(
+        prior_id=\"stub\", n_countries=1, n_banks=1, coverage_ratio=0.40,
+        fallback_policy=\"uniform_within_country\",
+        bank_country_map=((\"B0\", \"C0\"),),
+        s_in=np.array([1.0]), s_out=np.array([1.0]),
+        country_aggregates_in=((\"C0\", 1.0),),
+        country_aggregates_out=((\"C0\", 1.0),),
+        cert_id=\"0\" * 64,
+    )
+    rng = np.random.default_rng(0)
+    s = rng.lognormal(mean=10.0, sigma=1.0, size=80)
+    s_in = s * (s.sum() / s.sum())
+    inside = float(
+        (min(rec_cert.tested_at_densities) + max(rec_cert.tested_at_densities)) / 2.0
+    )
+    composed = check_composed_domain_of_validity(
+        s, s_in, recovery_certificate=rec_cert,
+        allocator_certificate=alloc_cert,
+        reconstruction_inferred_density=inside,
+    )
+    assert composed.status is ComposedDomainStatus.ALLOCATOR_OUT
+    assert not composed.is_admissible_for_bank_level_claim
+    "'
+  description: >-
+    Probes the failure-direction of the composed gate: a real
+    coverage_ratio of 0.40 (well below 0.80 default) MUST surface
+    as ALLOCATOR_OUT and forbid the bank-level claim. If the gate
+    erroneously emits BOTH_WITHIN at this coverage, the
+    fail-closed contract is broken — bank-level claims could
+    leak through with insufficient prior evidence.
+rollback_command: >-
+  bash -c 'git checkout HEAD~1 --
+  && rm -f research/reconstruction/allocator/dov_composition.py
+  tests/reconstruction/allocator/test_dov_composition.py
+  .claude/commit_acceptors/x10r-1-dov-composition.yaml'
+rollback_verification_command: >-
+  bash -c 'test ! -f research/reconstruction/allocator/dov_composition.py
+  && test ! -f tests/reconstruction/allocator/test_dov_composition.py
+  && test ! -f .claude/commit_acceptors/x10r-1-dov-composition.yaml'
+memory_update_type: append
+ledger_path: ".claude/commit_acceptors/x10r-1-dov-composition.yaml"
+report_path: "tmp/x10r_1_dov_composition.log"
+evidence: []

--- a/.claude/commit_acceptors/x10r-1-mfi-fixture-e2e.yaml
+++ b/.claude/commit_acceptors/x10r-1-mfi-fixture-e2e.yaml
@@ -48,6 +48,11 @@ diff_scope:
     - path: "research/reconstruction/allocator/data/__init__.py"
     - path: "research/reconstruction/allocator/data/mfi_demo.tsv"
     - path: "tests/reconstruction/allocator/test_mfi_fixture_e2e.py"
+    # ILS-2026 review-driven additions (committed in 7d82ce4 / next):
+    - path: "research/reconstruction/allocator/dov_composition.py"
+    - path: "tests/reconstruction/allocator/test_dov_composition.py"
+    - path: ".claude/commit_acceptors/x10r-1-dov-composition.yaml"
+    - path: "X10R_INSTRUMENTED_STATE.md"
   forbidden_paths:
     - "trading/"
     - "execution/"

--- a/.claude/commit_acceptors/x10r-1-mfi-fixture-e2e.yaml
+++ b/.claude/commit_acceptors/x10r-1-mfi-fixture-e2e.yaml
@@ -1,0 +1,108 @@
+# Diff-bound commit acceptor for X-10R-1 PR #5 — frozen MFI demo
+# fixture + end-to-end pipeline test (closes the X-10R-1 epic
+# foundation: load → prior → allocator → audit on a stable, hermetic
+# dataset).
+#
+# What lands:
+#   * research/reconstruction/allocator/data/__init__.py
+#       Exposes DATA_DIR + MFI_DEMO_TSV path constants.
+#   * research/reconstruction/allocator/data/mfi_demo.tsv
+#       Frozen 25-bank × 5-country synthetic registry.
+#   * tests/reconstruction/allocator/test_mfi_fixture_e2e.py
+#       9 new tests pinning fixture integrity (existence, shape,
+#       country alphabetical order, sha256 hash) + end-to-end
+#       pipeline: load → SizeWeightedPrior → CountryToBankAllocator
+#       → audit. Aligned-SW beats Uniform by ≥ 6 OoM; Uniform fails
+#       audit; cert_id replay-stable.
+#
+# Locally verified:
+#   * pytest tests/reconstruction/allocator/: 117/117 passed
+#   * mypy --strict + ruff + black:           clean
+
+id: x10r-1-mfi-fixture-e2e
+status: ACTIVE
+claim_type: chore
+promise: >-
+  After this PR lands, research/reconstruction/allocator/data/
+  ships a frozen ECB-MFI-shaped fixture (mfi_demo.tsv, 25 banks
+  across 5 EU+EEA countries, illustrative total_assets) plus the
+  DATA_DIR / MFI_DEMO_TSV path constants. The fixture is hermetic,
+  license-clean, and exercise-only — real datasets (ECB MFI, EBA
+  transparency, BankFocus) ship in later epic PRs. tests/
+  reconstruction/allocator/test_mfi_fixture_e2e.py wraps the
+  PR-#642…#645 stack into a single end-to-end regression: load
+  → SizeWeightedPrior → CountryToBankAllocator → audit_bank_level_
+  recovery, on aligned (SW exact, audit passes) and on misaligned
+  (Uniform fails audit) directions. 9 new tests pin: fixture
+  existence, n_rows == 25, country alphabetical order, sha256
+  byte-content snapshot, conservation per country, prior_id flows
+  through, falsification anchor over the frozen fixture (aligned
+  SW beats Uniform by ≥ 6 OoM relative L1), audit pass + audit
+  fail directions, GATE_A4 cert_id replay stability through TSV
+  ingestion + prior + allocator.
+diff_scope:
+  changed_files:
+    - path: ".claude/commit_acceptors/x10r-1-mfi-fixture-e2e.yaml"
+    - path: ".gitignore"
+    - path: "research/reconstruction/allocator/__init__.py"
+    - path: "research/reconstruction/allocator/data/__init__.py"
+    - path: "research/reconstruction/allocator/data/mfi_demo.tsv"
+    - path: "tests/reconstruction/allocator/test_mfi_fixture_e2e.py"
+  forbidden_paths:
+    - "trading/"
+    - "execution/"
+    - "forecast/"
+    - "policy/"
+    - "core/physics/"
+    - "core/kuramoto/"
+    - "application/governance/claim_ledger.py"
+    - "application/governance/commit_acceptor.py"
+required_python_symbols:
+  - "research/reconstruction/allocator/data/__init__.py::DATA_DIR"
+  - "research/reconstruction/allocator/data/__init__.py::MFI_DEMO_TSV"
+expected_signal: >-
+  Local: `pytest tests/reconstruction/allocator/ -q` reports
+  "117 passed"; `mypy --strict` is clean on every file under
+  research/reconstruction/allocator/ and
+  tests/reconstruction/allocator/; `ruff check` and
+  `black --check` both pass on those paths.
+measurement_command: >-
+  bash -c 'mypy --strict --follow-imports=silent
+  research/reconstruction/allocator/ tests/reconstruction/allocator/
+  && ruff check research/reconstruction/allocator/ tests/reconstruction/allocator/
+  && black --check research/reconstruction/allocator/ tests/reconstruction/allocator/
+  && pytest tests/reconstruction/allocator/ -q'
+signal_artifact: "tmp/x10r_1_mfi_fixture_e2e.log"
+falsifier:
+  command: >-
+    bash -c 'python -c "
+    from research.reconstruction.allocator import (
+        MFI_DEMO_TSV, CountryToBankAllocator, SizeWeightedPrior,
+        UniformPrior, audit_bank_level_recovery, load_mfi_registry,
+    )
+    import numpy as np
+    out = load_mfi_registry(MFI_DEMO_TSV)
+    assert out.n_rows == 25, f\"demo fixture should have 25 rows, got {out.n_rows}\"
+    countries = {c for _, c in out.bank_country_map}
+    assert countries == {\"DE\", \"FR\", \"IT\", \"ES\", \"NL\"}, (
+        f\"demo fixture should have 5 EU countries, got {countries}\"
+    )
+    "'
+  description: >-
+    Probes the frozen fixture is loadable and shaped correctly:
+    25 banks × 5 EU countries (DE / ES / FR / IT / NL). If a future
+    PR rewrites the fixture, this falsifier surfaces shape drift
+    immediately.
+rollback_command: >-
+  bash -c 'git checkout HEAD~1 --
+  && rm -rf research/reconstruction/allocator/data/
+  tests/reconstruction/allocator/test_mfi_fixture_e2e.py
+  .claude/commit_acceptors/x10r-1-mfi-fixture-e2e.yaml'
+rollback_verification_command: >-
+  bash -c 'test ! -d research/reconstruction/allocator/data
+  && test ! -f tests/reconstruction/allocator/test_mfi_fixture_e2e.py
+  && test ! -f .claude/commit_acceptors/x10r-1-mfi-fixture-e2e.yaml'
+memory_update_type: append
+ledger_path: ".claude/commit_acceptors/x10r-1-mfi-fixture-e2e.yaml"
+report_path: "tmp/x10r_1_mfi_fixture_e2e.log"
+evidence: []

--- a/.gitignore
+++ b/.gitignore
@@ -168,5 +168,10 @@ tests/unit/execution/test_order_lifecycle_deep.py
 
 # L2 killtest substrate (NARROW — prevent-regen only; result JSONs tracked explicitly)
 data/
+# X-10R-1 allocator demo fixture (license-clean, hermetic; tracked explicitly).
+!research/reconstruction/allocator/data/
+!research/reconstruction/allocator/data/__init__.py
+!research/reconstruction/allocator/data/*.tsv
+!research/reconstruction/allocator/data/*.csv
 logs/
 tmp/

--- a/X10R_INSTRUMENTED_STATE.md
+++ b/X10R_INSTRUMENTED_STATE.md
@@ -1,0 +1,207 @@
+# X-10R — INSTRUMENTED STATE
+
+**X-10R is currently in INSTRUMENTED state. No bank-level claims
+are allowed on real data until both (a) the country-to-bank
+allocator's synthetic certificate is issued AND (b) the X-10R
+reconstruction's synthetic certificate is issued AND (c) a Gate 6
+forward signal lands on the composed certificate.**
+
+This file is the canonical audit surface for every binding
+discipline rule the X-10R stack imposes. Each item below points
+to the merged PR + commit + tested invariant that pins the rule
+in regression.
+
+---
+
+## Discipline rules pinned in code
+
+### 1. Synthetic-vs-real boundary is hard-coded
+
+Real BIS LBS marginals get ZERO recovery test. The strongest
+available gate on real data is **domain-of-validity** — do real
+inputs fall inside the regime where synthetic recovery has been
+demonstrated?
+
+- **PR #635** (sha `f580c33`) FIX B2 — `recovery_audit.check_domain_of_validity`
+- **INV-RECONSTRUCTION-2** is the named invariant
+- `assert_real_data_status_legal` raises `ValueError` if real-data
+  path emits `GROUND_TRUTH_RECOVERED`
+- Test pin: `test_real_data_path_emits_within_or_out_never_recovered`
+
+### 2. Mathematical contract on weight allocation is correct
+
+Naive gravity rule
+`w_ij = a_ij·s_i^out·s_j^in / W_total` does NOT preserve
+`E[Σ_j w_ij] = s_i^out` once the support of `A` is sparsified.
+
+The production allocator uses Almog-Squartini 2017 IPF
+(Sinkhorn-Knopp) projection on the realised support of A, which
+enforces the marginals exactly post-hoc.
+
+- **PR #635** FIX B1 — `weighted_allocation.allocate_weights` docstring
+  corrected; implementation already used IPF
+- **Empirical certification**: `test_naive_gravity_does_not_preserve_marginals_on_sparse_support`
+  proves the claim falsifiably (naive gravity loses ≥ 10 % row mass
+  on sparse supports; IPF is ≥ 10× tighter)
+
+### 3. Reciprocity-aware controls
+
+Density-only sweep is insufficient for spectral recovery (the
+quantity Gate 6 inherits via `_normalise_to_unit_spectral_radius`
+and `_kc_lorentzian_proxy`).
+
+- **PR #641** (epic X-10R-2, sha `15068b0`) `compute_reciprocity_ratio` +
+  `reciprocity_keep_p_for_target` + `_apply_reciprocity_filter`
+  + `reciprocity_keep_p` parameter on every ground-truth generator
+- **PR #641** `run_reciprocity_aware_recovery` walks a
+  `(reciprocity × density)` grid; `tested_at_reciprocity` is
+  populated only on PASS
+- Closed issue #636
+
+### 4. Allocator is a separate testable unit
+
+`research/reconstruction/allocator/` (8 source modules + 7 test
+modules + 128 tests):
+
+| PR | sha | Module |
+|---|---|---|
+| #642 (X-10R-1 PR #1) | `fe204b7` | foundation: `AllocatorPrior`, `UniformPrior`, `CountryToBankAllocator`, `BankLevelMarginalsCertificate`, synthetic |
+| #643 (X-10R-1 PR #2) | `d129b1e` | `SizeWeightedPrior` + `registry_to_bank_country_map` |
+| #644 (X-10R-1 PR #3) | `d63026b` | `BankLevelGate5Audit` (4-metric report) |
+| #645 (X-10R-1 PR #4) | `a36adf9` | `load_mfi_registry` (TSV/CSV ingestion) |
+| #646 (X-10R-1 PR #5+#6) | this PR | demo fixture + composed DoV gate |
+
+Four allocator-side gates pinned:
+
+- **GATE_A1** — conservation per country (Σ shares ≡ 1 to 1e-9 rel)
+- **GATE_A2** — `coverage_ratio` surfaced as evidence (NOT fail-closed
+  on the allocator side; consumed by the *composed* gate at PR #6)
+- **GATE_A3** — non-negative shares + non-negative emitted marginals
+- **GATE_A4** — bit-exact replay via sha256 `cert_id`
+
+### 5. Composed Domain-of-Validity gate (PR #6 in this PR)
+
+Bank-level admissibility requires BOTH the X-10R reconstruction
+DoV verdict AND the allocator-side coverage envelope. The gate
+emits a 4-cell verdict (`BOTH_WITHIN` / `RECONSTRUCTION_OUT` /
+`ALLOCATOR_OUT` / `BOTH_OUT`). Only `BOTH_WITHIN` is admissible.
+
+**Admissibility ≠ validation.** Two distinct properties on the
+verdict:
+
+- `is_admissible_for_downstream_bank_level_test` — True iff
+  `BOTH_WITHIN`. Gates the *next-step test* (Gate 6 forward
+  signal in epic PR #7), NOT a bank-level claim.
+- `is_scientifically_validated_bank_level_result` — hard-coded
+  `False` at this layer; flipped True only by Gate 6 PASS in
+  epic PR #7.
+
+`coverage_ratio ≥ 0.80` is **necessary, not sufficient.**
+
+### 6. Synthetic positive control with injected precursor
+
+`research/reconstruction/positive_control.py` ships:
+
+- 3 ground-truth substrates (BA, CP, hierarchical) at N=200
+- 4-density sweep `(0.03, 0.05, 0.08, 0.12)`
+- Reciprocity-aware sweep `(0.30, 0.60, 1.00)` (PR #641)
+
+Gate 6 (`kuramoto_on_reconstruction.gate_6_precursor_discriminative`)
+explicitly injects a Kuramoto R(∞) precursor and bootstraps the
+ΔR distribution against a topology-randomised null. The PASS
+predicate is "95 % CI of ΔR excludes the `[-min_gap, +min_gap]`
+zone". `min_gap` defaults to 0.05.
+
+### 7. Empirical certification of recovery
+
+Multi-seed multi-substrate empirical recovery summary lands in
+`X10R_EMPIRICAL_RECOVERY_SUMMARY.md` (committed in PR #635):
+
+- 20 cells (substrate × N × seed)
+- **18/20 PASS = 90 %** Gate 5 recovery rate
+- ρ relative error: median 0.075, p95 0.183
+- top-k hub jaccard: median 1.000
+
+### 8. Provenance vs admissibility separation
+
+Every certificate dataclass distinguishes *provenance fields*
+(populated for auditability, NOT gate-driving) from *gate fields*
+(consumed by an explicit threshold check):
+
+- `RecoveryReport.failure_reasons` (gate) vs `mean_strength` (provenance)
+- `BankLevelMarginalsCertificate.coverage_ratio` (gate) vs
+  `n_banks` / `n_countries` / `prior_id` / `fallback_policy` (provenance)
+- `ComposedDomainCheck.allocator_checks` (gate) vs `allocator_measured` (provenance)
+- `tested_at_*` evidence surface tuples (provenance) vs
+  `valid_for_*` intent surface (declarative)
+
+### 9. INV-IDENTIFICATION-1 stays in force
+
+The bank-level inference claim is FORBIDDEN until ALL of:
+
+1. Allocator GATE_A1–A4 pass (PR #642–#645 — done)
+2. Reconstruction Gate 5 + Gate 6 pass on synthetic ground truth
+   (PR #635 — done)
+3. Composed DoV gate emits `BOTH_WITHIN` (PR #6 in this PR — done)
+4. **Gate 6 forward signal on the *bank-level reconstructed network*
+   PASSES** (epic PR #7 — STILL DEFERRED)
+
+Item 4 is the missing piece. Until it lands, the X-10R-1
+country-to-bank allocator stack is **INSTRUMENTED, NOT
+VALIDATED**.
+
+### 10. INSTRUMENTED state declaration
+
+(This document is the declaration. Top-of-file paragraph quotes
+it verbatim.)
+
+---
+
+## What is NOT pinned in this PR
+
+The following items are explicitly out of scope for this PR.
+They are tracked in `ISSUE_DRAFTS_X10R.md` and as GitHub issues
+#636–#640:
+
+- Real ECB MFI dataset ingestion (license-clean download path)
+- Real EBA transparency size weights
+- Moody's BankFocus / Orbis Bank Focus (license-gated)
+- BIS CBS reconstruction comparison (X-10R-3 epic)
+- RO-Crate / OSF / AsPredicted governance layer (X-10R-4 epic)
+- E2E allocator → reconstruction → Gate 6 forward signal (epic
+  PR #7 — final epic PR; lifts the INSTRUMENTED state)
+
+---
+
+## 10-point ILS-2026 audit (per PR #646 review)
+
+| # | Item | Status | Evidence |
+|---|---|---|---|
+| 1 | Replace demo-fixture illusion | **Documented**: hermetic + license-clean, NOT validation | this file §1 |
+| 2 | Real prior for fitness model | **Interface ready, real data deferred** | PR #643 SizeWeightedPrior; PR #645 mfi_loader |
+| 3 | Mathematical correctness of weight allocation | **Done** | this file §2; PR #635 FIX B1 |
+| 4 | DoV gate replaces "recovery on real data" | **Done** | this file §1; PR #635 FIX B2 |
+| 5 | Reciprocity constraint | **Done** | this file §3; PR #641 |
+| 6 | Allocator as separate testable unit | **Done** | this file §4; PRs #642–#646 |
+| 7 | Reduce LoC and boilerplate | **Out of scope here** — the foundation cannot be < 350 LoC and still satisfy items 1–9; reduction lands as a separate refactor PR after item 10 lands |
+| 8 | Synthetic positive control with injected precursor | **Done** | this file §6 |
+| 9 | Forbid real-data verdicts before synthetic certificate | **Done** | this file §9; INV-IDENTIFICATION-1 |
+| 10 | INSTRUMENTED state declaration | **Done** | this file (the declaration paragraph at the top) |
+
+---
+
+## How to flip from INSTRUMENTED to VALIDATED
+
+The flip is a single named event: the Gate 6 forward signal
+on the bank-level reconstructed network passes against a
+topology-randomised null at the published `min_gap = 0.05`,
+bootstrapped over ≥ 8 ω-seeds, on a real BIS LBS run that
+already cleared the composed DoV gate.
+
+That signal is owned by epic PR #7. When it lands, this file's
+top paragraph will be amended to read **VALIDATED**, the
+`is_scientifically_validated_bank_level_result` property will
+be wired to that Gate 6 verdict, and `INV-IDENTIFICATION-1` will
+be lifted in the same commit.
+
+Until then: **no bank-level claims.**

--- a/research/reconstruction/allocator/__init__.py
+++ b/research/reconstruction/allocator/__init__.py
@@ -18,6 +18,7 @@ from research.reconstruction.allocator.certificate import (
     BankLevelMarginalsCertificate,
     compute_cert_id,
 )
+from research.reconstruction.allocator.data import DATA_DIR, MFI_DEMO_TSV
 from research.reconstruction.allocator.mfi_loader import (
     DialectName,
     MFIRegistryLoad,
@@ -39,8 +40,10 @@ __all__ = [
     "BankLevelMarginalsCertificate",
     "BankLevelRecoveryReport",
     "CountryToBankAllocator",
+    "DATA_DIR",
     "DialectName",
     "MFIRegistryLoad",
+    "MFI_DEMO_TSV",
     "ShareDistribution",
     "SizeWeightedPrior",
     "UniformPrior",

--- a/research/reconstruction/allocator/__init__.py
+++ b/research/reconstruction/allocator/__init__.py
@@ -19,6 +19,12 @@ from research.reconstruction.allocator.certificate import (
     compute_cert_id,
 )
 from research.reconstruction.allocator.data import DATA_DIR, MFI_DEMO_TSV
+from research.reconstruction.allocator.dov_composition import (
+    ALLOCATOR_COVERAGE_RATIO_MIN_DEFAULT,
+    ComposedDomainCheck,
+    ComposedDomainStatus,
+    check_composed_domain_of_validity,
+)
 from research.reconstruction.allocator.mfi_loader import (
     DialectName,
     MFIRegistryLoad,
@@ -36,9 +42,12 @@ from research.reconstruction.allocator.synthetic import (
 )
 
 __all__ = [
+    "ALLOCATOR_COVERAGE_RATIO_MIN_DEFAULT",
     "AllocatorPrior",
     "BankLevelMarginalsCertificate",
     "BankLevelRecoveryReport",
+    "ComposedDomainCheck",
+    "ComposedDomainStatus",
     "CountryToBankAllocator",
     "DATA_DIR",
     "DialectName",
@@ -49,6 +58,7 @@ __all__ = [
     "UniformPrior",
     "audit_bank_level_recovery",
     "bank_level_recovery_l1",
+    "check_composed_domain_of_validity",
     "compute_cert_id",
     "load_mfi_registry",
     "registry_to_bank_country_map",

--- a/research/reconstruction/allocator/data/__init__.py
+++ b/research/reconstruction/allocator/data/__init__.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""Frozen demo fixture for the allocator pipeline (X-10R-1 PR #5).
+
+This package ships a single TSV — ``mfi_demo.tsv`` — with a small
+synthetic ECB-MFI-shaped registry (25 banks across 5 EU+EEA
+countries) plus illustrative ``total_assets`` values. It is
+*deliberately not real* — the purpose is to exercise the full
+allocator pipeline (load → SizeWeightedPrior → CountryToBankAllocator
+→ BankLevelGate5Audit) on a stable, license-clean fixture.
+
+Real datasets (ECB MFI + EBA transparency + BankFocus) ship in
+later epic PRs with their own license footprint.
+"""
+
+from pathlib import Path
+
+DATA_DIR: Path = Path(__file__).resolve().parent
+
+MFI_DEMO_TSV: Path = DATA_DIR / "mfi_demo.tsv"
+"""Frozen demo TSV — 25 banks × 5 countries, illustrative
+total_assets. Use ``load_mfi_registry(MFI_DEMO_TSV)`` to ingest."""
+
+
+__all__ = ["DATA_DIR", "MFI_DEMO_TSV"]

--- a/research/reconstruction/allocator/data/mfi_demo.tsv
+++ b/research/reconstruction/allocator/data/mfi_demo.tsv
@@ -1,0 +1,26 @@
+bank_id	country	name	total_assets
+DE-DEMO-001	DE	Deutsche Demo Holding AG	1850000
+DE-DEMO-002	DE	Frankfurt Demo Bank	920000
+DE-DEMO-003	DE	Munich Demo Privat	410000
+DE-DEMO-004	DE	Hamburg Demo Sparkasse	185000
+DE-DEMO-005	DE	Berlin Demo eG	95000
+FR-DEMO-001	FR	Paris Demo Banque SA	1620000
+FR-DEMO-002	FR	Lyon Demo Crédit	780000
+FR-DEMO-003	FR	Marseille Demo Mutuel	340000
+FR-DEMO-004	FR	Toulouse Demo Régional	160000
+FR-DEMO-005	FR	Bordeaux Demo Coopératif	72000
+IT-DEMO-001	IT	Roma Demo SpA	1180000
+IT-DEMO-002	IT	Milano Demo Group	610000
+IT-DEMO-003	IT	Napoli Demo Banca	280000
+IT-DEMO-004	IT	Torino Demo Popolare	125000
+IT-DEMO-005	IT	Bologna Demo Cooperativa	58000
+ES-DEMO-001	ES	Madrid Demo SA	980000
+ES-DEMO-002	ES	Barcelona Demo Caixa	490000
+ES-DEMO-003	ES	Sevilla Demo Banco	220000
+ES-DEMO-004	ES	Valencia Demo Cooperativa	98000
+ES-DEMO-005	ES	Bilbao Demo Caja	44000
+NL-DEMO-001	NL	Amsterdam Demo NV	820000
+NL-DEMO-002	NL	Rotterdam Demo Bank	380000
+NL-DEMO-003	NL	Den Haag Demo Coöperatief	150000
+NL-DEMO-004	NL	Utrecht Demo Spaar	68000
+NL-DEMO-005	NL	Eindhoven Demo Krediet	28000

--- a/research/reconstruction/allocator/dov_composition.py
+++ b/research/reconstruction/allocator/dov_composition.py
@@ -1,0 +1,176 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""Composed Domain-of-Validity gate (X-10R-1 PR #6).
+
+Per epic #638: a real-data bank-level run is admissible only if BOTH
+the country-to-bank ALLOCATOR layer AND the X-10R RECONSTRUCTION
+layer certify the inputs. Each layer's domain-of-validity is
+independent — the allocator's certificate envelope (registry size,
+coverage_ratio, reciprocity / size-signal evidence) is orthogonal
+to the reconstruction's envelope (n_nodes, density, network
+reciprocity). Lifting one layer's WITHIN to a bank-level claim
+without the other's WITHIN would smuggle an unverified assumption
+into the verdict.
+
+This module ships the *composition surface*:
+
+    check_composed_domain_of_validity(
+        s_out_real, s_in_real,
+        recovery_certificate=...,         # X-10R reconstruction cert
+        allocator_certificate=...,        # bank-level allocator cert
+        reconstruction_inferred_density=...,
+    ) -> ComposedDomainCheck
+
+The composed verdict semantics:
+
+    BOTH_WITHIN          recovery + allocator both WITHIN
+    RECONSTRUCTION_OUT   recovery layer says OUT or INSUFFICIENT
+    ALLOCATOR_OUT        allocator layer says OUT or INSUFFICIENT
+    BOTH_OUT             both layers fail
+
+Composition is FAIL-CLOSED: anything other than BOTH_WITHIN means
+the bank-level claim is forbidden. INV-IDENTIFICATION-1 stays in
+force until at least BOTH_WITHIN clears, AND a downstream Gate 6
+forward signal lands (subsequent epic PR).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+
+import numpy as np
+
+from research.reconstruction.allocator.certificate import (
+    BankLevelMarginalsCertificate,
+)
+from research.reconstruction.recovery_audit import (
+    DomainCheck,
+    DomainOfValidityStatus,
+    check_domain_of_validity,
+)
+
+
+class ComposedDomainStatus(Enum):
+    """Verdict surface of the composed gate.
+
+    Disjoint from the per-layer DomainOfValidityStatus to keep
+    bank-level admissibility strictly ABOVE the per-layer surface
+    in the type hierarchy (a caller cannot accidentally pass a
+    DomainOfValidityStatus where ComposedDomainStatus is required).
+    """
+
+    BOTH_WITHIN = "both_within_validated_domain"
+    RECONSTRUCTION_OUT = "reconstruction_out_of_validated_domain"
+    ALLOCATOR_OUT = "allocator_out_of_validated_domain"
+    BOTH_OUT = "both_out_of_validated_domain"
+
+
+@dataclass(frozen=True)
+class ComposedDomainCheck:
+    """Frozen composite verdict.
+
+    Carries the per-layer DomainCheck (from recovery_audit) AND the
+    allocator-side per-dimension envelope checks. Both layers are
+    surfaced separately so a downstream consumer can show the user
+    *which* layer caused a NOT-BOTH-WITHIN verdict.
+    """
+
+    status: ComposedDomainStatus
+    reconstruction_check: DomainCheck
+    allocator_checks: dict[str, bool] = field(default_factory=dict)
+    allocator_measured: dict[str, float] = field(default_factory=dict)
+    allocator_envelope: dict[str, tuple[float, float]] = field(default_factory=dict)
+    notes: str = ""
+
+    @property
+    def is_admissible_for_bank_level_claim(self) -> bool:
+        """Single boolean for downstream consumers. True iff the
+        composed verdict is BOTH_WITHIN. Anything else forbids a
+        bank-level claim per INV-IDENTIFICATION-1."""
+        return self.status is ComposedDomainStatus.BOTH_WITHIN
+
+
+# Default thresholds for the allocator-side composition layer.
+# coverage_ratio_min: by default we require the allocator to have
+# real evidence for ≥ 80 % of the countries it allocated to (the
+# fallback policy explains the rest, but full evidence is the
+# admissibility bar).
+ALLOCATOR_COVERAGE_RATIO_MIN_DEFAULT: float = 0.80
+"""Default coverage_ratio threshold for the composed gate."""
+
+
+def check_composed_domain_of_validity(
+    s_out_real: np.ndarray,
+    s_in_real: np.ndarray,
+    *,
+    recovery_certificate: object,  # GroundTruthRecoveryCertificate
+    allocator_certificate: BankLevelMarginalsCertificate,
+    reconstruction_inferred_density: float,
+    allocator_coverage_ratio_min: float = ALLOCATOR_COVERAGE_RATIO_MIN_DEFAULT,
+) -> ComposedDomainCheck:
+    """Compose the X-10R reconstruction DoV gate with the allocator's
+    own coverage / fallback envelope.
+
+    Returns
+    -------
+    ComposedDomainCheck — see verdict matrix in module docstring.
+    """
+    # Layer 1: reconstruction-side DoV (existing X-10R surface).
+    recovery_check = check_domain_of_validity(
+        s_out_real,
+        s_in_real,
+        recovery_certificate,  # type: ignore[arg-type]
+        inferred_density=reconstruction_inferred_density,
+    )
+
+    # Layer 2: allocator-side admissibility envelope.
+    allocator_checks: dict[str, bool] = {}
+    allocator_measured: dict[str, float] = {}
+    allocator_envelope: dict[str, tuple[float, float]] = {}
+
+    # coverage_ratio is the gate-able allocator metric; defaults
+    # require ≥ 0.80 of countries to have real prior evidence.
+    coverage_ok = allocator_certificate.coverage_ratio >= allocator_coverage_ratio_min
+    allocator_checks["coverage_ratio"] = coverage_ok
+    allocator_measured["coverage_ratio"] = float(allocator_certificate.coverage_ratio)
+    allocator_envelope["coverage_ratio"] = (
+        float(allocator_coverage_ratio_min),
+        1.0,
+    )
+
+    # Provenance fields surfaced (informational, not gated):
+    allocator_measured["n_banks"] = float(allocator_certificate.n_banks)
+    allocator_measured["n_countries"] = float(allocator_certificate.n_countries)
+
+    allocator_within = all(allocator_checks.values())
+    reconstruction_within = recovery_check.status is DomainOfValidityStatus.WITHIN_VALIDATED_DOMAIN
+
+    if reconstruction_within and allocator_within:
+        status = ComposedDomainStatus.BOTH_WITHIN
+        notes = "both layers certify; bank-level claim admissible"
+    elif not reconstruction_within and not allocator_within:
+        status = ComposedDomainStatus.BOTH_OUT
+        notes = (
+            f"reconstruction: {recovery_check.notes}; "
+            f"allocator: coverage_ratio={allocator_certificate.coverage_ratio:.3f} "
+            f"< {allocator_coverage_ratio_min}"
+        )
+    elif not reconstruction_within:
+        status = ComposedDomainStatus.RECONSTRUCTION_OUT
+        notes = f"reconstruction layer out: {recovery_check.notes}"
+    else:
+        status = ComposedDomainStatus.ALLOCATOR_OUT
+        notes = (
+            f"allocator coverage_ratio={allocator_certificate.coverage_ratio:.3f} "
+            f"< {allocator_coverage_ratio_min}"
+        )
+
+    return ComposedDomainCheck(
+        status=status,
+        reconstruction_check=recovery_check,
+        allocator_checks=allocator_checks,
+        allocator_measured=allocator_measured,
+        allocator_envelope=allocator_envelope,
+        notes=notes,
+    )

--- a/research/reconstruction/allocator/dov_composition.py
+++ b/research/reconstruction/allocator/dov_composition.py
@@ -1,16 +1,36 @@
 # Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
 # SPDX-License-Identifier: MIT
-"""Composed Domain-of-Validity gate (X-10R-1 PR #6).
+"""Composed Domain-of-Validity ADMISSIBILITY gate (X-10R-1 PR #6).
 
-Per epic #638: a real-data bank-level run is admissible only if BOTH
-the country-to-bank ALLOCATOR layer AND the X-10R RECONSTRUCTION
-layer certify the inputs. Each layer's domain-of-validity is
-independent — the allocator's certificate envelope (registry size,
-coverage_ratio, reciprocity / size-signal evidence) is orthogonal
-to the reconstruction's envelope (n_nodes, density, network
-reciprocity). Lifting one layer's WITHIN to a bank-level claim
-without the other's WITHIN would smuggle an unverified assumption
-into the verdict.
+NAMING DISCIPLINE (per ILS-2026 critique on PR #646)
+====================================================
+This gate certifies *admissibility*, NOT *validity*. A `BOTH_WITHIN`
+verdict means the inputs fall inside the regime where downstream
+testing IS DEFINED — it does NOT mean the bank-level marginals are
+scientifically validated. Validity requires a downstream Gate 6
+forward signal on the reconstructed bank-level network. This is
+deliberately a *necessary* condition, not a sufficient one.
+
+Concretely:
+
+    is_admissible_for_downstream_bank_level_test == True
+        ⇏ is_scientifically_validated_bank_level_result == True
+
+The latter is set by a separate Gate 6 layer (epic PR #7). Both
+flags appear on `ComposedDomainCheck` so a downstream consumer
+cannot accidentally treat admissibility as validation.
+
+WHY ARCHITECTURE
+================
+Per epic #638: a real-data bank-level run becomes admissible only
+if BOTH the country-to-bank ALLOCATOR layer AND the X-10R
+RECONSTRUCTION layer certify the inputs. Each layer's
+domain-of-validity is independent — the allocator's certificate
+envelope (registry size, coverage_ratio, reciprocity / size-signal
+evidence) is orthogonal to the reconstruction's envelope (n_nodes,
+density, network reciprocity). Lifting one layer's WITHIN to a
+bank-level claim without the other's WITHIN would smuggle an
+unverified assumption into the verdict.
 
 This module ships the *composition surface*:
 
@@ -28,10 +48,20 @@ The composed verdict semantics:
     ALLOCATOR_OUT        allocator layer says OUT or INSUFFICIENT
     BOTH_OUT             both layers fail
 
-Composition is FAIL-CLOSED: anything other than BOTH_WITHIN means
-the bank-level claim is forbidden. INV-IDENTIFICATION-1 stays in
-force until at least BOTH_WITHIN clears, AND a downstream Gate 6
-forward signal lands (subsequent epic PR).
+Composition is FAIL-CLOSED: anything other than `BOTH_WITHIN`
+forbids the next-step downstream test. INV-IDENTIFICATION-1
+stays in force until BOTH `BOTH_WITHIN` clears AND a downstream
+Gate 6 forward signal lands.
+
+COVERAGE RATIO IS NECESSARY, NOT SUFFICIENT
+============================================
+The default coverage threshold (`ALLOCATOR_COVERAGE_RATIO_MIN_DEFAULT
+= 0.80`) answers: "did the prior have evidence for ≥ 80 % of
+countries?". It does NOT answer: "is that evidence informative
+enough to allocate country aggregates correctly?". Coverage is a
+necessary condition — without it the prior is degenerate — but it
+is NOT sufficient. Sufficiency requires real-data validation
+landing in epic PR #7.
 """
 
 from __future__ import annotations
@@ -84,11 +114,28 @@ class ComposedDomainCheck:
     notes: str = ""
 
     @property
-    def is_admissible_for_bank_level_claim(self) -> bool:
+    def is_admissible_for_downstream_bank_level_test(self) -> bool:
         """Single boolean for downstream consumers. True iff the
-        composed verdict is BOTH_WITHIN. Anything else forbids a
-        bank-level claim per INV-IDENTIFICATION-1."""
+        composed verdict is BOTH_WITHIN — meaning the *next-step*
+        test (Gate 6 forward signal in epic PR #7) is well-defined
+        on these inputs.
+
+        This is admissibility, NOT validation. A True here is
+        *necessary* but NOT *sufficient* for a bank-level claim.
+        The full validation contract requires
+        `is_scientifically_validated_bank_level_result` to also
+        be True (set only by a Gate 6 PASS in epic PR #7)."""
         return self.status is ComposedDomainStatus.BOTH_WITHIN
+
+    @property
+    def is_scientifically_validated_bank_level_result(self) -> bool:
+        """Always False at this layer. Validation requires a Gate 6
+        forward signal on the reconstructed bank-level network,
+        which is owned by epic PR #7. This property exists so a
+        downstream consumer that tries to use `is_admissible_…` as
+        a validation flag will fail loudly: validation lives on a
+        DIFFERENT property and is set by a DIFFERENT layer."""
+        return False
 
 
 # Default thresholds for the allocator-side composition layer.

--- a/tests/reconstruction/allocator/test_dov_composition.py
+++ b/tests/reconstruction/allocator/test_dov_composition.py
@@ -94,7 +94,7 @@ def test_both_within_when_both_layers_certify() -> None:
     )
     assert isinstance(composed, ComposedDomainCheck)
     assert composed.status is ComposedDomainStatus.BOTH_WITHIN
-    assert composed.is_admissible_for_bank_level_claim is True
+    assert composed.is_admissible_for_downstream_bank_level_test is True
 
 
 def test_reconstruction_out_when_only_allocator_certifies() -> None:
@@ -113,7 +113,7 @@ def test_reconstruction_out_when_only_allocator_certifies() -> None:
         reconstruction_inferred_density=inside,
     )
     assert composed.status is ComposedDomainStatus.RECONSTRUCTION_OUT
-    assert composed.is_admissible_for_bank_level_claim is False
+    assert composed.is_admissible_for_downstream_bank_level_test is False
 
 
 def test_allocator_out_when_coverage_below_threshold() -> None:
@@ -132,7 +132,7 @@ def test_allocator_out_when_coverage_below_threshold() -> None:
         reconstruction_inferred_density=inside,
     )
     assert composed.status is ComposedDomainStatus.ALLOCATOR_OUT
-    assert composed.is_admissible_for_bank_level_claim is False
+    assert composed.is_admissible_for_downstream_bank_level_test is False
     assert composed.allocator_checks["coverage_ratio"] is False
 
 
@@ -152,7 +152,7 @@ def test_both_out_when_neither_layer_certifies() -> None:
         reconstruction_inferred_density=inside,
     )
     assert composed.status is ComposedDomainStatus.BOTH_OUT
-    assert composed.is_admissible_for_bank_level_claim is False
+    assert composed.is_admissible_for_downstream_bank_level_test is False
     assert "reconstruction" in composed.notes
     assert "coverage_ratio" in composed.notes
 
@@ -263,9 +263,67 @@ def test_e2e_demo_fixture_produces_both_within_at_matched_envelopes() -> None:
         reconstruction_inferred_density=inside,
     )
     assert composed.status is ComposedDomainStatus.BOTH_WITHIN
-    assert composed.is_admissible_for_bank_level_claim is True
+    assert composed.is_admissible_for_downstream_bank_level_test is True
     # Allocator coverage on the demo fixture is 1.0 (every country
     # has positive total weight).
     assert composed.allocator_measured["coverage_ratio"] == pytest.approx(1.0)
     assert composed.allocator_measured["n_banks"] == 25.0
     assert composed.allocator_measured["n_countries"] == 5.0
+
+
+# ---------------------------------------------------------------------------
+# Admissibility ≠ validation discipline
+# ---------------------------------------------------------------------------
+
+
+def test_both_within_does_not_imply_gate6_ready_or_validated() -> None:
+    """A BOTH_WITHIN composed verdict means inputs are admissible
+    for the NEXT downstream test (Gate 6 forward signal in epic
+    PR #7). It does NOT mean the bank-level result is
+    scientifically validated. The two properties are deliberately
+    distinct so a downstream consumer cannot conflate them."""
+    rec_cert = _within_recovery_cert(n=80, seed=8)
+    alloc_cert = _stub_allocator_cert(coverage=1.0)
+    s_out, s_in = _balanced_marginals_at_n(n=80, seed=21)
+    inside = float((min(rec_cert.tested_at_densities) + max(rec_cert.tested_at_densities)) / 2.0)
+    composed = check_composed_domain_of_validity(
+        s_out,
+        s_in,
+        recovery_certificate=rec_cert,
+        allocator_certificate=alloc_cert,
+        reconstruction_inferred_density=inside,
+    )
+    # The two flags are independent properties. Admissibility True,
+    # validation False — that gap is the entire point of this layer.
+    assert composed.is_admissible_for_downstream_bank_level_test is True
+    assert composed.is_scientifically_validated_bank_level_result is False
+
+
+def test_validated_flag_is_false_on_every_verdict() -> None:
+    """`is_scientifically_validated_bank_level_result` is hard-coded
+    False on every ComposedDomainCheck — validation is owned by
+    Gate 6 (epic PR #7), NOT by the DoV gate. This test pins the
+    property's invariant: it cannot be flipped True by composition
+    alone, regardless of how many envelopes certify."""
+    rec_cert = _within_recovery_cert(n=80, seed=9)
+    s_out, s_in = _balanced_marginals_at_n(n=80, seed=22)
+    inside = float((min(rec_cert.tested_at_densities) + max(rec_cert.tested_at_densities)) / 2.0)
+    # Run every cell of the verdict matrix; the validated flag must
+    # stay False on each.
+    for coverage, expected_status in [
+        (1.0, ComposedDomainStatus.BOTH_WITHIN),
+        (0.40, ComposedDomainStatus.ALLOCATOR_OUT),
+    ]:
+        alloc_cert = _stub_allocator_cert(coverage=coverage)
+        composed = check_composed_domain_of_validity(
+            s_out,
+            s_in,
+            recovery_certificate=rec_cert,
+            allocator_certificate=alloc_cert,
+            reconstruction_inferred_density=inside,
+        )
+        assert composed.status is expected_status
+        assert composed.is_scientifically_validated_bank_level_result is False, (
+            f"validation flag must remain False at {expected_status.value}; "
+            "validation is owned by Gate 6 (epic PR #7), not the DoV gate"
+        )

--- a/tests/reconstruction/allocator/test_dov_composition.py
+++ b/tests/reconstruction/allocator/test_dov_composition.py
@@ -1,0 +1,271 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""Tests for the composed Domain-of-Validity gate (X-10R-1 PR #6).
+
+The composition is a 4-cell verdict matrix:
+
+    reconstruction WITHIN  &  allocator WITHIN  ⇒ BOTH_WITHIN
+    reconstruction OUT     &  allocator WITHIN  ⇒ RECONSTRUCTION_OUT
+    reconstruction WITHIN  &  allocator OUT     ⇒ ALLOCATOR_OUT
+    reconstruction OUT     &  allocator OUT     ⇒ BOTH_OUT
+
+Only BOTH_WITHIN admits a bank-level claim. Anything else keeps
+INV-IDENTIFICATION-1 in force.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from research.reconstruction.allocator import (
+    ALLOCATOR_COVERAGE_RATIO_MIN_DEFAULT,
+    BankLevelMarginalsCertificate,
+    ComposedDomainCheck,
+    ComposedDomainStatus,
+    CountryToBankAllocator,
+    SizeWeightedPrior,
+    check_composed_domain_of_validity,
+    load_mfi_registry,
+)
+from research.reconstruction.allocator.data import MFI_DEMO_TSV
+from research.reconstruction.positive_control import (
+    GroundTruthRecoveryCertificate,
+    ground_truth_core_periphery,
+    run_recovery_on_substrate,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _within_recovery_cert(n: int = 80, seed: int = 42) -> GroundTruthRecoveryCertificate:
+    w = ground_truth_core_periphery(n=n, core_frac=0.30, seed=seed)
+    return run_recovery_on_substrate(f"CP_{n}_dov_compose", w, seed=seed)
+
+
+def _stub_allocator_cert(coverage: float) -> BankLevelMarginalsCertificate:
+    """Construct a BankLevelMarginalsCertificate with the requested
+    coverage_ratio. Other fields filled with minimal valid values
+    so the dataclass post-init invariants pass."""
+    s = np.array([1.0], dtype=np.float64)
+    return BankLevelMarginalsCertificate(
+        prior_id="stub",
+        n_countries=1,
+        n_banks=1,
+        coverage_ratio=coverage,
+        fallback_policy="uniform_within_country",
+        bank_country_map=(("B0", "C0"),),
+        s_in=s,
+        s_out=s,
+        country_aggregates_in=(("C0", 1.0),),
+        country_aggregates_out=(("C0", 1.0),),
+        cert_id="0" * 64,
+    )
+
+
+def _balanced_marginals_at_n(n: int, seed: int = 0) -> tuple[np.ndarray, np.ndarray]:
+    rng = np.random.default_rng(seed)
+    s_out = rng.lognormal(mean=10.0, sigma=1.0, size=n)
+    s_in = rng.lognormal(mean=10.0, sigma=1.0, size=n)
+    s_in = s_in * (s_out.sum() / s_in.sum())
+    return s_out, s_in
+
+
+# ---------------------------------------------------------------------------
+# Verdict matrix — the four canonical paths
+# ---------------------------------------------------------------------------
+
+
+def test_both_within_when_both_layers_certify() -> None:
+    """Reconstruction WITHIN + allocator coverage ≥ 0.80 ⇒ BOTH_WITHIN.
+    This is the only verdict that admits a bank-level claim."""
+    rec_cert = _within_recovery_cert(n=80, seed=1)
+    alloc_cert = _stub_allocator_cert(coverage=1.0)
+    s_out, s_in = _balanced_marginals_at_n(n=80, seed=11)
+    inside = float((min(rec_cert.tested_at_densities) + max(rec_cert.tested_at_densities)) / 2.0)
+    composed = check_composed_domain_of_validity(
+        s_out,
+        s_in,
+        recovery_certificate=rec_cert,
+        allocator_certificate=alloc_cert,
+        reconstruction_inferred_density=inside,
+    )
+    assert isinstance(composed, ComposedDomainCheck)
+    assert composed.status is ComposedDomainStatus.BOTH_WITHIN
+    assert composed.is_admissible_for_bank_level_claim is True
+
+
+def test_reconstruction_out_when_only_allocator_certifies() -> None:
+    """Reconstruction OUT + allocator WITHIN ⇒ RECONSTRUCTION_OUT.
+    Bank-level claim still forbidden."""
+    rec_cert = _within_recovery_cert(n=80, seed=2)
+    alloc_cert = _stub_allocator_cert(coverage=1.0)
+    # Push reconstruction OUT: real N way above the certified envelope.
+    s_out, s_in = _balanced_marginals_at_n(n=400, seed=12)
+    inside = float((min(rec_cert.tested_at_densities) + max(rec_cert.tested_at_densities)) / 2.0)
+    composed = check_composed_domain_of_validity(
+        s_out,
+        s_in,
+        recovery_certificate=rec_cert,
+        allocator_certificate=alloc_cert,
+        reconstruction_inferred_density=inside,
+    )
+    assert composed.status is ComposedDomainStatus.RECONSTRUCTION_OUT
+    assert composed.is_admissible_for_bank_level_claim is False
+
+
+def test_allocator_out_when_coverage_below_threshold() -> None:
+    """Reconstruction WITHIN + allocator coverage < 0.80 ⇒
+    ALLOCATOR_OUT. Bank-level claim still forbidden."""
+    rec_cert = _within_recovery_cert(n=80, seed=3)
+    # Coverage 0.50 < 0.80 default threshold.
+    alloc_cert = _stub_allocator_cert(coverage=0.50)
+    s_out, s_in = _balanced_marginals_at_n(n=80, seed=13)
+    inside = float((min(rec_cert.tested_at_densities) + max(rec_cert.tested_at_densities)) / 2.0)
+    composed = check_composed_domain_of_validity(
+        s_out,
+        s_in,
+        recovery_certificate=rec_cert,
+        allocator_certificate=alloc_cert,
+        reconstruction_inferred_density=inside,
+    )
+    assert composed.status is ComposedDomainStatus.ALLOCATOR_OUT
+    assert composed.is_admissible_for_bank_level_claim is False
+    assert composed.allocator_checks["coverage_ratio"] is False
+
+
+def test_both_out_when_neither_layer_certifies() -> None:
+    """Reconstruction OUT + allocator OUT ⇒ BOTH_OUT.
+    Both reasons are surfaced in `notes`."""
+    rec_cert = _within_recovery_cert(n=80, seed=4)
+    alloc_cert = _stub_allocator_cert(coverage=0.40)
+    # Push reconstruction OUT.
+    s_out, s_in = _balanced_marginals_at_n(n=400, seed=14)
+    inside = float((min(rec_cert.tested_at_densities) + max(rec_cert.tested_at_densities)) / 2.0)
+    composed = check_composed_domain_of_validity(
+        s_out,
+        s_in,
+        recovery_certificate=rec_cert,
+        allocator_certificate=alloc_cert,
+        reconstruction_inferred_density=inside,
+    )
+    assert composed.status is ComposedDomainStatus.BOTH_OUT
+    assert composed.is_admissible_for_bank_level_claim is False
+    assert "reconstruction" in composed.notes
+    assert "coverage_ratio" in composed.notes
+
+
+# ---------------------------------------------------------------------------
+# Coverage threshold customisation
+# ---------------------------------------------------------------------------
+
+
+def test_default_coverage_threshold_is_0_80() -> None:
+    assert ALLOCATOR_COVERAGE_RATIO_MIN_DEFAULT == 0.80
+
+
+def test_custom_coverage_threshold_changes_verdict() -> None:
+    """A caller can tighten the coverage threshold to push an
+    otherwise-WITHIN allocator into OUT territory."""
+    rec_cert = _within_recovery_cert(n=80, seed=5)
+    alloc_cert = _stub_allocator_cert(coverage=0.95)
+    s_out, s_in = _balanced_marginals_at_n(n=80, seed=15)
+    inside = float((min(rec_cert.tested_at_densities) + max(rec_cert.tested_at_densities)) / 2.0)
+    composed = check_composed_domain_of_validity(
+        s_out,
+        s_in,
+        recovery_certificate=rec_cert,
+        allocator_certificate=alloc_cert,
+        reconstruction_inferred_density=inside,
+        allocator_coverage_ratio_min=0.99,  # tighter than default
+    )
+    assert composed.status is ComposedDomainStatus.ALLOCATOR_OUT
+
+
+# ---------------------------------------------------------------------------
+# Provenance fields surfaced in measured but not gated
+# ---------------------------------------------------------------------------
+
+
+def test_n_banks_and_n_countries_surface_as_measured_only() -> None:
+    """`n_banks` and `n_countries` are PROVENANCE — they appear in
+    `allocator_measured` for inspection but do NOT drive the verdict
+    (separate from `allocator_checks`)."""
+    rec_cert = _within_recovery_cert(n=80, seed=6)
+    alloc_cert = _stub_allocator_cert(coverage=1.0)
+    s_out, s_in = _balanced_marginals_at_n(n=80, seed=16)
+    inside = float((min(rec_cert.tested_at_densities) + max(rec_cert.tested_at_densities)) / 2.0)
+    composed = check_composed_domain_of_validity(
+        s_out,
+        s_in,
+        recovery_certificate=rec_cert,
+        allocator_certificate=alloc_cert,
+        reconstruction_inferred_density=inside,
+    )
+    assert "n_banks" in composed.allocator_measured
+    assert "n_countries" in composed.allocator_measured
+    assert "n_banks" not in composed.allocator_checks
+    assert "n_countries" not in composed.allocator_checks
+
+
+def test_allocator_envelope_carries_coverage_threshold() -> None:
+    """`allocator_envelope` records the threshold so reviewers can
+    audit which bound was applied."""
+    rec_cert = _within_recovery_cert(n=80, seed=7)
+    alloc_cert = _stub_allocator_cert(coverage=1.0)
+    s_out, s_in = _balanced_marginals_at_n(n=80, seed=17)
+    inside = float((min(rec_cert.tested_at_densities) + max(rec_cert.tested_at_densities)) / 2.0)
+    composed = check_composed_domain_of_validity(
+        s_out,
+        s_in,
+        recovery_certificate=rec_cert,
+        allocator_certificate=alloc_cert,
+        reconstruction_inferred_density=inside,
+        allocator_coverage_ratio_min=0.85,
+    )
+    assert composed.allocator_envelope["coverage_ratio"] == (0.85, 1.0)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: real fixture → real allocator cert → composed gate
+# ---------------------------------------------------------------------------
+
+
+def test_e2e_demo_fixture_produces_both_within_at_matched_envelopes() -> None:
+    """Final E2E: load the frozen MFI demo fixture, build a real
+    BankLevelMarginalsCertificate via SizeWeightedPrior + the
+    allocator, build a real reconstruction certificate at matched
+    N + density, and verify the composed gate emits BOTH_WITHIN
+    on within-envelope marginals."""
+    out = load_mfi_registry(MFI_DEMO_TSV)
+    n_banks = out.n_rows  # 25 banks
+    # Reconstruction certificate at the same N as the bank count.
+    rec_cert = _within_recovery_cert(n=n_banks, seed=42)
+
+    agg_in = {"DE": 100.0, "FR": 90.0, "IT": 70.0, "ES": 60.0, "NL": 50.0}
+    agg_out = {"DE": 95.0, "FR": 85.0, "IT": 65.0, "ES": 55.0, "NL": 45.0}
+    alloc_cert = CountryToBankAllocator(
+        prior=SizeWeightedPrior(
+            bank_country_map=out.bank_country_map,
+            bank_weights=out.bank_weights,
+        )
+    ).allocate(agg_in, agg_out, bank_country_map=out.bank_country_map)
+
+    s_out, s_in = _balanced_marginals_at_n(n=n_banks, seed=42)
+    inside = float((min(rec_cert.tested_at_densities) + max(rec_cert.tested_at_densities)) / 2.0)
+    composed = check_composed_domain_of_validity(
+        s_out,
+        s_in,
+        recovery_certificate=rec_cert,
+        allocator_certificate=alloc_cert,
+        reconstruction_inferred_density=inside,
+    )
+    assert composed.status is ComposedDomainStatus.BOTH_WITHIN
+    assert composed.is_admissible_for_bank_level_claim is True
+    # Allocator coverage on the demo fixture is 1.0 (every country
+    # has positive total weight).
+    assert composed.allocator_measured["coverage_ratio"] == pytest.approx(1.0)
+    assert composed.allocator_measured["n_banks"] == 25.0
+    assert composed.allocator_measured["n_countries"] == 5.0

--- a/tests/reconstruction/allocator/test_mfi_fixture_e2e.py
+++ b/tests/reconstruction/allocator/test_mfi_fixture_e2e.py
@@ -77,23 +77,22 @@ def test_demo_fixture_country_order_is_alphabetical() -> None:
 def test_demo_fixture_content_hash_is_pinned() -> None:
     """Locks the fixture's exact byte content. Any rewrite of the
     fixture must intentionally update this hash — it is the canonical
-    "the demo data has changed" signal in the regression surface."""
+    "the demo data has changed" signal in the regression surface.
+
+    Recompute on rewrite via::
+
+        python -c "import hashlib, pathlib; \\
+            print(hashlib.sha256(pathlib.Path( \\
+                'research/reconstruction/allocator/data/mfi_demo.tsv' \\
+            ).read_bytes()).hexdigest())"
+    """
     blob = MFI_DEMO_TSV.read_bytes()
     actual = hashlib.sha256(blob).hexdigest()
-    expected = (
-        # Recompute on rewrite via:
-        # python -c "import hashlib,pathlib; print(hashlib.sha256(pathlib.Path("
-        # "'research/reconstruction/allocator/data/mfi_demo.tsv'"
-        # ").read_bytes()).hexdigest())"
-        ""
+    expected = "304612f1c45aa433522f221b4fcf28fc15d4969dac155013783b1e2f384c2e2b"
+    assert actual == expected, (
+        f"demo fixture drift: actual sha256 = {actual}, pinned = {expected}; "
+        "intentionally update the pinned hash if the rewrite is expected."
     )
-    if not expected:
-        # First commit: just snapshot. On the second run the assertion
-        # below will catch a drift. The bare `assert actual` ensures
-        # we still don't ship an empty hash silently.
-        assert actual
-        return
-    assert actual == expected, f"demo fixture drift: actual sha256 = {actual}, pinned = {expected}"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/reconstruction/allocator/test_mfi_fixture_e2e.py
+++ b/tests/reconstruction/allocator/test_mfi_fixture_e2e.py
@@ -1,0 +1,264 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""End-to-end tests over the frozen MFI demo fixture (X-10R-1 PR #5).
+
+The fixture lives at
+``research/reconstruction/allocator/data/mfi_demo.tsv`` and ships
+25 banks across 5 EU countries with illustrative ``total_assets``
+values. These tests certify the *whole* PR-#642…#645 stack hangs
+together end-to-end on a stable, license-clean dataset:
+
+    load_mfi_registry        (PR #645 — TSV/CSV ingestion)
+        ⬇
+    SizeWeightedPrior        (PR #643 — concrete prior)
+        ⬇
+    CountryToBankAllocator   (PR #642 — split + GATE_A1..A4)
+        ⬇
+    audit_bank_level_recovery  (PR #644 — Gate-5-style audit)
+
+The fixture is frozen — its hash is one of the things this test
+pins. If a future PR rewrites the fixture, this test will fail
+loudly, and the rewrite must update the hash explicitly.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+import numpy as np
+import pytest
+
+from research.reconstruction.allocator import (
+    MFI_DEMO_TSV,
+    BankLevelRecoveryReport,
+    CountryToBankAllocator,
+    SizeWeightedPrior,
+    UniformPrior,
+    audit_bank_level_recovery,
+    bank_level_recovery_l1,
+    load_mfi_registry,
+)
+
+# ---------------------------------------------------------------------------
+# Fixture integrity
+# ---------------------------------------------------------------------------
+
+
+def test_demo_fixture_exists_and_is_readable() -> None:
+    assert MFI_DEMO_TSV.exists()
+    text = MFI_DEMO_TSV.read_text(encoding="utf-8")
+    assert text.startswith("bank_id\tcountry\tname\ttotal_assets\n")
+    assert "DE-DEMO-001" in text
+
+
+def test_demo_fixture_loads_to_25_banks_5_countries() -> None:
+    out = load_mfi_registry(MFI_DEMO_TSV)
+    assert out.n_rows == 25
+    assert out.n_with_assets == 25  # every demo row carries a weight
+    countries = {c for _, c in out.bank_country_map}
+    assert countries == {"DE", "FR", "IT", "ES", "NL"}
+    # 5 banks per country.
+    for country in countries:
+        n = sum(1 for _, c in out.bank_country_map if c == country)
+        assert n == 5
+
+
+def test_demo_fixture_country_order_is_alphabetical() -> None:
+    """The canonical bank_country_map is sorted by country
+    alphabetically — bit-exact replay contract for the allocator."""
+    out = load_mfi_registry(MFI_DEMO_TSV)
+    countries_seen: list[str] = []
+    for _, c in out.bank_country_map:
+        if not countries_seen or countries_seen[-1] != c:
+            countries_seen.append(c)
+    assert countries_seen == ["DE", "ES", "FR", "IT", "NL"]
+
+
+def test_demo_fixture_content_hash_is_pinned() -> None:
+    """Locks the fixture's exact byte content. Any rewrite of the
+    fixture must intentionally update this hash — it is the canonical
+    "the demo data has changed" signal in the regression surface."""
+    blob = MFI_DEMO_TSV.read_bytes()
+    actual = hashlib.sha256(blob).hexdigest()
+    expected = (
+        # Recompute on rewrite via:
+        # python -c "import hashlib,pathlib; print(hashlib.sha256(pathlib.Path("
+        # "'research/reconstruction/allocator/data/mfi_demo.tsv'"
+        # ").read_bytes()).hexdigest())"
+        ""
+    )
+    if not expected:
+        # First commit: just snapshot. On the second run the assertion
+        # below will catch a drift. The bare `assert actual` ensures
+        # we still don't ship an empty hash silently.
+        assert actual
+        return
+    assert actual == expected, f"demo fixture drift: actual sha256 = {actual}, pinned = {expected}"
+
+
+# ---------------------------------------------------------------------------
+# E2E pipeline
+# ---------------------------------------------------------------------------
+
+
+def _country_aggregates_for_demo() -> tuple[dict[str, float], dict[str, float]]:
+    """Return illustrative country aggregates aligned with the demo
+    fixture's countries. Values chosen so the resulting bank-level
+    marginals are realistic in scale (EUR billions)."""
+    agg_in = {"DE": 800.0, "FR": 700.0, "IT": 500.0, "ES": 450.0, "NL": 350.0}
+    agg_out = {"DE": 750.0, "FR": 660.0, "IT": 470.0, "ES": 420.0, "NL": 320.0}
+    return agg_in, agg_out
+
+
+def test_e2e_demo_to_allocator_conserves_per_country() -> None:
+    out = load_mfi_registry(MFI_DEMO_TSV)
+    agg_in, agg_out = _country_aggregates_for_demo()
+    cert = CountryToBankAllocator(
+        prior=SizeWeightedPrior(
+            bank_country_map=out.bank_country_map,
+            bank_weights=out.bank_weights,
+            prior_id_tag="mfi_demo_v1",
+        )
+    ).allocate(agg_in, agg_out, bank_country_map=out.bank_country_map)
+    bank_to_idx = {b: i for i, (b, _) in enumerate(out.bank_country_map)}
+    for country in agg_in:
+        in_sum = sum(cert.s_in[bank_to_idx[b]] for b, c in out.bank_country_map if c == country)
+        out_sum = sum(cert.s_out[bank_to_idx[b]] for b, c in out.bank_country_map if c == country)
+        assert in_sum == pytest.approx(agg_in[country], rel=1e-9)
+        assert out_sum == pytest.approx(agg_out[country], rel=1e-9)
+    assert cert.prior_id == "mfi_demo_v1"
+    assert cert.coverage_ratio == 1.0
+
+
+def test_e2e_demo_size_weighted_beats_uniform_when_sizes_align() -> None:
+    """If the ground-truth bank-level marginals match the fixture's
+    total_assets up to the country scale, the SizeWeightedPrior
+    prediction is exact and crushes UniformPrior on the bank-level
+    audit. Real falsification anchor on a real-shape registry."""
+    out = load_mfi_registry(MFI_DEMO_TSV)
+    agg_in, agg_out = _country_aggregates_for_demo()
+
+    # Construct ground truth: each bank's true marginal is its
+    # (total_assets / Σ_country_assets) × country_aggregate.
+    bank_to_idx = {b: i for i, (b, _) in enumerate(out.bank_country_map)}
+    n = len(out.bank_country_map)
+    gt_in = np.zeros(n, dtype=np.float64)
+    gt_out = np.zeros(n, dtype=np.float64)
+    for country in agg_in:
+        country_banks = [b for b, c in out.bank_country_map if c == country]
+        country_total = sum(out.bank_weights[b] for b in country_banks)
+        for b in country_banks:
+            share = out.bank_weights[b] / country_total
+            gt_in[bank_to_idx[b]] = share * agg_in[country]
+            gt_out[bank_to_idx[b]] = share * agg_out[country]
+
+    cert_sw = CountryToBankAllocator(
+        prior=SizeWeightedPrior(
+            bank_country_map=out.bank_country_map,
+            bank_weights=out.bank_weights,
+        )
+    ).allocate(agg_in, agg_out, bank_country_map=out.bank_country_map)
+    cert_un = CountryToBankAllocator(
+        prior=UniformPrior(bank_country_map=out.bank_country_map)
+    ).allocate(agg_in, agg_out, bank_country_map=out.bank_country_map)
+
+    err_sw = bank_level_recovery_l1(ground_truth=gt_in, allocated=cert_sw.s_in)
+    err_un = bank_level_recovery_l1(ground_truth=gt_in, allocated=cert_un.s_in)
+    # SW is exact; UniformPrior loses by ≥ 6 OoM.
+    assert err_sw < 1e-9
+    assert err_un / max(err_sw, 1e-30) > 1e6
+
+
+def test_e2e_demo_audit_passes_on_aligned_size_weighted() -> None:
+    """Run the full Gate-5-style audit on the aligned scenario.
+    The four-metric report must come back passed=True."""
+    out = load_mfi_registry(MFI_DEMO_TSV)
+    agg_in, agg_out = _country_aggregates_for_demo()
+    bank_to_idx = {b: i for i, (b, _) in enumerate(out.bank_country_map)}
+    n = len(out.bank_country_map)
+    gt_in = np.zeros(n, dtype=np.float64)
+    gt_out = np.zeros(n, dtype=np.float64)
+    for country in agg_in:
+        country_banks = [b for b, c in out.bank_country_map if c == country]
+        country_total = sum(out.bank_weights[b] for b in country_banks)
+        for b in country_banks:
+            share = out.bank_weights[b] / country_total
+            gt_in[bank_to_idx[b]] = share * agg_in[country]
+            gt_out[bank_to_idx[b]] = share * agg_out[country]
+
+    cert = CountryToBankAllocator(
+        prior=SizeWeightedPrior(
+            bank_country_map=out.bank_country_map,
+            bank_weights=out.bank_weights,
+        )
+    ).allocate(agg_in, agg_out, bank_country_map=out.bank_country_map)
+
+    report = audit_bank_level_recovery(
+        ground_truth_s_in=gt_in,
+        ground_truth_s_out=gt_out,
+        allocated_s_in=cert.s_in,
+        allocated_s_out=cert.s_out,
+        bank_country_map=out.bank_country_map,
+    )
+    assert isinstance(report, BankLevelRecoveryReport)
+    assert report.passed is True
+    assert report.failure_reasons == ()
+
+
+def test_e2e_demo_audit_fails_on_uniform_when_sizes_skewed() -> None:
+    """Mirror direction: with sizes skewed enough that UniformPrior
+    is off by > 20% on aggregate L1 (it is, on the demo fixture's
+    skewed sizes), the audit MUST surface a failure. End-to-end
+    falsification anchor over the frozen fixture."""
+    out = load_mfi_registry(MFI_DEMO_TSV)
+    agg_in, agg_out = _country_aggregates_for_demo()
+    bank_to_idx = {b: i for i, (b, _) in enumerate(out.bank_country_map)}
+    n = len(out.bank_country_map)
+    gt_in = np.zeros(n, dtype=np.float64)
+    gt_out = np.zeros(n, dtype=np.float64)
+    for country in agg_in:
+        country_banks = [b for b, c in out.bank_country_map if c == country]
+        country_total = sum(out.bank_weights[b] for b in country_banks)
+        for b in country_banks:
+            share = out.bank_weights[b] / country_total
+            gt_in[bank_to_idx[b]] = share * agg_in[country]
+            gt_out[bank_to_idx[b]] = share * agg_out[country]
+
+    cert_un = CountryToBankAllocator(
+        prior=UniformPrior(bank_country_map=out.bank_country_map)
+    ).allocate(agg_in, agg_out, bank_country_map=out.bank_country_map)
+    report = audit_bank_level_recovery(
+        ground_truth_s_in=gt_in,
+        ground_truth_s_out=gt_out,
+        allocated_s_in=cert_un.s_in,
+        allocated_s_out=cert_un.s_out,
+        bank_country_map=out.bank_country_map,
+    )
+    assert report.passed is False
+    assert any(
+        "total_relative_l1" in r or "per_country_relative_l1" in r for r in report.failure_reasons
+    )
+
+
+def test_e2e_demo_cert_id_is_replay_stable() -> None:
+    """Same fixture + same aggregates ⇒ same cert_id (GATE_A4 over
+    the full pipeline including TSV ingestion + size-weighted prior
+    + allocator)."""
+    out_a = load_mfi_registry(MFI_DEMO_TSV)
+    out_b = load_mfi_registry(MFI_DEMO_TSV)
+    agg_in, agg_out = _country_aggregates_for_demo()
+    cert_a = CountryToBankAllocator(
+        prior=SizeWeightedPrior(
+            bank_country_map=out_a.bank_country_map,
+            bank_weights=out_a.bank_weights,
+            prior_id_tag="mfi_demo_v1",
+        )
+    ).allocate(agg_in, agg_out, bank_country_map=out_a.bank_country_map)
+    cert_b = CountryToBankAllocator(
+        prior=SizeWeightedPrior(
+            bank_country_map=out_b.bank_country_map,
+            bank_weights=out_b.bank_weights,
+            prior_id_tag="mfi_demo_v1",
+        )
+    ).allocate(agg_in, agg_out, bank_country_map=out_b.bank_country_map)
+    assert cert_a.cert_id == cert_b.cert_id

--- a/tests/reconstruction/allocator/test_mfi_fixture_e2e.py
+++ b/tests/reconstruction/allocator/test_mfi_fixture_e2e.py
@@ -88,7 +88,7 @@ def test_demo_fixture_content_hash_is_pinned() -> None:
     """
     blob = MFI_DEMO_TSV.read_bytes()
     actual = hashlib.sha256(blob).hexdigest()
-    expected = "304612f1c45aa433522f221b4fcf28fc15d4969dac155013783b1e2f384c2e2b"
+    expected = "304612f1c45aa433522f221b4fcf28fc15d4969dac155013783b1e2f384c2e2b"  # pragma: allowlist secret
     assert actual == expected, (
         f"demo fixture drift: actual sha256 = {actual}, pinned = {expected}; "
         "intentionally update the pinned hash if the rewrite is expected."


### PR DESCRIPTION
## Summary

Combined fifth and sixth PRs of the X-10R-1 epic, stacked into one diff after PR #647 (DoV composition) auto-merged into this branch's base. Lands the *foundation closure* of the country-to-bank allocator: a frozen MFI fixture + the composed Domain-of-Validity gate that requires BOTH layers (allocator + reconstruction) to certify a bank-level claim.

Refs #638. Closes #638 PR-#5 and PR-#6 sub-tasks.

## What lands

### PR-#5 component — frozen MFI demo fixture (`research/reconstruction/allocator/data/`)

- **`mfi_demo.tsv`** — 25-bank × 5-country (DE / ES / FR / IT / NL) ECB-MFI-shaped registry with illustrative `total_assets`. Hermetic, license-clean, exercise-only.
- **`__init__.py`** exposes `DATA_DIR` and `MFI_DEMO_TSV` constants. Importable as `from research.reconstruction.allocator import MFI_DEMO_TSV`.
- **Pinned sha256 = `304612f1c45aa433522f221b4fcf28fc15d4969dac155013783b1e2f384c2e2b`** (Codex P2 closed; explicit `# pragma: allowlist secret` for detect-secrets).
- **`.gitignore` narrow allow-list**: `data/` is gitignored repo-wide; we whitelist `research/reconstruction/allocator/data/` for `__init__.py` + `*.tsv` / `*.csv` only.

### PR-#6 component — composed Domain-of-Validity gate (`research/reconstruction/allocator/dov_composition.py`)

- **`ComposedDomainStatus`** enum — 4-cell verdict matrix:

  | Reconstruction | Allocator | Verdict | Bank-level claim |
  |---|---|---|---|
  | WITHIN | WITHIN | `BOTH_WITHIN` | **admissible** |
  | OUT | WITHIN | `RECONSTRUCTION_OUT` | forbidden |
  | WITHIN | OUT | `ALLOCATOR_OUT` | forbidden |
  | OUT | OUT | `BOTH_OUT` | forbidden |

- **`ComposedDomainCheck`** — frozen verdict carrier with the per-layer `DomainCheck` embedded + allocator-side check / measure / envelope dictionaries + `is_admissible_for_downstream_bank_level_test` boolean for downstream consumers.
- **`check_composed_domain_of_validity()`** — the gate function.
- **`ALLOCATOR_COVERAGE_RATIO_MIN_DEFAULT = 0.80`** — default threshold; tunable via `allocator_coverage_ratio_min`.

### Provenance vs admissibility separation

`n_banks` and `n_countries` surface in `allocator_measured` for inspection but do NOT drive the verdict. Only `coverage_ratio` is gate-able. Mirrors the existing `recovery_audit.DomainCheck` pattern (provenance first, gating explicit).

### Fail-closed contract

**Anything other than `BOTH_WITHIN` forbids a bank-level claim.** `INV-IDENTIFICATION-1` stays in force until both:

1. `ComposedDomainStatus.BOTH_WITHIN` clears, AND
2. A downstream Gate 6 forward signal lands (epic PR #7 — final).

Until then, the bank-level inference claim is *forbidden* — see PR #635 `cimini_squartini.py::TARGET OBJECT` for the canonical statement.

## Tests

| Block | New | Total in `tests/reconstruction/allocator/` |
|---|---|---|
| PR-#5 fixture-e2e (`test_mfi_fixture_e2e.py`) | 9 | **117** after this layer (108 from #642–#645 + 9) |
| PR-#6 dov-composition (`test_dov_composition.py`) | 9 | **126** after this layer (117 + 9) |

### PR-#5 fixture-e2e tests (9)

- Fixture integrity (4): exists + canonical header, 25 banks × 5 countries shape, alphabetical country order, **sha256 byte-content snapshot pinned**.
- E2E pipeline (5): load → SizeWeightedPrior → CountryToBankAllocator conservation + prior_id flow; **falsification anchor over the frozen fixture** (aligned SW recovers exactly, UniformPrior loses by ≥ 6 OoM); full `audit_bank_level_recovery` passes on aligned, fails on UniformPrior; `cert_id` replay-stable across independent loads.

### PR-#6 dov-composition tests (9)

- All 4 cells of the verdict matrix.
- Default coverage threshold = 0.80; custom threshold flips verdict.
- `n_banks` / `n_countries` surface as measured-only, not gated.
- `allocator_envelope` records the applied threshold.
- **End-to-end**: load `MFI_DEMO_TSV` → real `BankLevelMarginalsCertificate` → composed gate → `BOTH_WITHIN` admits the bank-level *next test* with `coverage_ratio = 1.0`, `n_banks = 25`, `n_countries = 5`.

## Local results

- `pytest tests/reconstruction/allocator/`: **126 passed** in 2.4 s (108 baseline + 9 fixture-e2e + 9 dov-composition)
- `mypy --strict --follow-imports=silent`: **21 source files clean**
- `ruff check` + `black --check`: clean

## Codex review

- **P2 (closed)**: pinned-sha256 placeholder was empty → drift guard disabled. Fix in `93d13db`: pinned actual hash + removed early-return branch.
- **secrets-supply-chain (closed)**: detect-secrets flagged the hex sha256 as Hex-High-Entropy. Fix in `b02df7a`: `# pragma: allowlist secret` annotation per detect-secrets convention.

## What this PR does NOT land

- **E2E allocator → reconstruction → Gate 6 forward signal** (PR #7 of the epic — final; lifts `INV-IDENTIFICATION-1` only after `BOTH_WITHIN` AND Gate 6 PASS in tandem).
- Real ECB MFI dataset ingestion (license-clean download path).
- Real EBA transparency size weights.
- BankFocus license-gated path.

The bank-level inference claim REMAINS forbidden by `INV-IDENTIFICATION-1` until PR #7 (final) lands.

## Acceptance gates

- [x] `MFI_DEMO_TSV` and `DATA_DIR` exposed
- [x] Pinned sha256 hash matches the fixture content (Codex P2 closed)
- [x] `# pragma: allowlist secret` annotation on the hash literal (secrets-supply-chain green)
- [x] `ComposedDomainStatus` enum + `ComposedDomainCheck` dataclass + `check_composed_domain_of_validity` function exposed
- [x] 4-cell verdict matrix tested
- [x] Fail-closed contract: only `BOTH_WITHIN` returns `is_admissible_for_bank_level_claim = True`
- [x] Falsifier (epic-level): fixture loads to 25 rows × 5 countries
- [x] Falsifier (gate-level): coverage_ratio = 0.40 → `ALLOCATOR_OUT`

## Test plan (verifiable post-merge)

- [ ] CI green on `pytest tests/reconstruction/allocator/` (126 tests)
- [ ] CI green on `ruff check` + `mypy --strict` + `black --check`
- [ ] CI green on commit-acceptor for both `x10r-1-mfi-fixture-e2e.yaml` AND `x10r-1-dov-composition.yaml`
- [ ] CI green on `secrets-supply-chain` (was the only red after P2 fix)

## Stacking provenance

This PR's branch (`feat/x10r-1-mfi-fixture-e2e`) accumulated PR #647's diff after PR #647 auto-merged into it as a stacked PR. The combined diff is what reviewers see here. PR #647 is closed (merged) on GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Post-review hardening (commit `7d82ce4`)

Per ILS-2026 critique on the open PR — admissibility vs validation discipline:

- **Renamed** the property: `is_admissible_for_bank_level_claim` → `is_admissible_for_downstream_bank_level_test`. "Claim" is too strong; the gate certifies that the *next-step test* (Gate 6 forward signal in epic PR #7) is well-defined on these inputs, not that a claim is supported.
- **New property**: `is_scientifically_validated_bank_level_result` — hard-coded `False` at this layer. Exists so a downstream consumer that mistakenly treats admissibility as validation fails loudly. Validation lives at a *different* property and is set by a *different* layer (Gate 6, epic PR #7).
- **Module docstring** reframed: this is an *admissibility* gate, not a *validation* gate. `coverage_ratio` is **necessary, not sufficient** — it answers "did the prior have evidence for ≥ 80 % of countries?", not "is that evidence informative enough to allocate country aggregates correctly?".
- **Two new tests**: `test_both_within_does_not_imply_gate6_ready_or_validated`, `test_validated_flag_is_false_on_every_verdict` — pin the invariant that the validated flag stays False regardless of how many envelopes certify.

**Tests now: 128 passed** (was 126).

`BOTH_WITHIN` is a *necessary* prerequisite. `is_scientifically_validated_bank_level_result` will only flip True after epic PR #7 lands a Gate 6 forward signal — and even then on the *combined* certificate, not on this gate alone.