### PR TITLE
feat(x10r-1-#6): composed Domain-of-Validity gate (epic #638 PR #6)

### DIFF
--- a/.claude/commit_acceptors/x10r-1-dov-composition.yaml
+++ b/.claude/commit_acceptors/x10r-1-dov-composition.yaml
@@ -1,0 +1,135 @@
+# Diff-bound commit acceptor for X-10R-1 PR #6 — composed
+# Domain-of-Validity gate that requires BOTH the allocator
+# certificate envelope AND the reconstruction certificate envelope
+# to certify a real BIS bank-level run.
+#
+# What lands:
+#   * research/reconstruction/allocator/dov_composition.py
+#       ComposedDomainStatus enum + ComposedDomainCheck dataclass +
+#       check_composed_domain_of_validity helper.
+#   * tests/reconstruction/allocator/test_dov_composition.py
+#       9 new tests pinning the 4-cell verdict matrix
+#       (BOTH_WITHIN / RECONSTRUCTION_OUT / ALLOCATOR_OUT /
+#       BOTH_OUT), coverage threshold customisation, provenance
+#       fields surfaced as measured-only, and a full E2E run
+#       through the frozen MFI demo fixture into BOTH_WITHIN.
+#
+# Locally verified:
+#   * pytest tests/reconstruction/allocator/: 126/126 passed
+#   * mypy --strict + ruff + black:           clean
+
+id: x10r-1-dov-composition
+status: ACTIVE
+claim_type: chore
+promise: >-
+  After this PR lands, research/reconstruction/allocator/ exposes
+  a composed Domain-of-Validity gate that combines the existing
+  X-10R reconstruction DoV verdict with the allocator-side
+  coverage_ratio envelope. ComposedDomainStatus is a 4-element
+  enum: BOTH_WITHIN (the only verdict admitting a bank-level
+  claim), RECONSTRUCTION_OUT, ALLOCATOR_OUT, BOTH_OUT.
+  ComposedDomainCheck.is_admissible_for_bank_level_claim is the
+  single boolean for downstream consumers. The default coverage
+  threshold is 0.80 (≥80% of countries with real prior evidence);
+  customisable via allocator_coverage_ratio_min. The composed
+  gate is FAIL-CLOSED — anything other than BOTH_WITHIN keeps
+  INV-IDENTIFICATION-1 in force and forbids bank-level claims.
+  9 new tests pin the contract: every cell of the verdict matrix,
+  coverage threshold customisation, default 0.80, provenance
+  surface (n_banks / n_countries surface as measured-only and
+  do NOT drive the verdict), envelope record carries the applied
+  threshold for audit, and a full E2E run from MFI demo fixture
+  through SizeWeightedPrior + CountryToBankAllocator into
+  BOTH_WITHIN.
+diff_scope:
+  changed_files:
+    - path: ".claude/commit_acceptors/x10r-1-dov-composition.yaml"
+    - path: "research/reconstruction/allocator/__init__.py"
+    - path: "research/reconstruction/allocator/dov_composition.py"
+    - path: "tests/reconstruction/allocator/test_dov_composition.py"
+  forbidden_paths:
+    - "trading/"
+    - "execution/"
+    - "forecast/"
+    - "policy/"
+    - "core/physics/"
+    - "core/kuramoto/"
+    - "application/governance/claim_ledger.py"
+    - "application/governance/commit_acceptor.py"
+required_python_symbols:
+  - "research/reconstruction/allocator/dov_composition.py::ComposedDomainStatus"
+  - "research/reconstruction/allocator/dov_composition.py::ComposedDomainCheck"
+  - "research/reconstruction/allocator/dov_composition.py::check_composed_domain_of_validity"
+expected_signal: >-
+  Local: `pytest tests/reconstruction/allocator/ -q` reports
+  "126 passed"; `mypy --strict` is clean on every file under
+  research/reconstruction/allocator/ and
+  tests/reconstruction/allocator/; `ruff check` and
+  `black --check` both pass on those paths.
+measurement_command: >-
+  bash -c 'mypy --strict --follow-imports=silent
+  research/reconstruction/allocator/ tests/reconstruction/allocator/
+  && ruff check research/reconstruction/allocator/ tests/reconstruction/allocator/
+  && black --check research/reconstruction/allocator/ tests/reconstruction/allocator/
+  && pytest tests/reconstruction/allocator/ -q'
+signal_artifact: "tmp/x10r_1_dov_composition.log"
+falsifier:
+  command: >-
+    bash -c 'python -c "
+    from research.reconstruction.allocator import (
+        ComposedDomainStatus,
+        check_composed_domain_of_validity,
+    )
+    from research.reconstruction.allocator.certificate import BankLevelMarginalsCertificate
+    from research.reconstruction.positive_control import (
+        ground_truth_core_periphery, run_recovery_on_substrate,
+    )
+    import numpy as np
+    rec_cert = run_recovery_on_substrate(
+        \"CP_80_falsifier\",
+        ground_truth_core_periphery(n=80, core_frac=0.30, seed=42),
+        seed=42,
+    )
+    alloc_cert = BankLevelMarginalsCertificate(
+        prior_id=\"stub\", n_countries=1, n_banks=1, coverage_ratio=0.40,
+        fallback_policy=\"uniform_within_country\",
+        bank_country_map=((\"B0\", \"C0\"),),
+        s_in=np.array([1.0]), s_out=np.array([1.0]),
+        country_aggregates_in=((\"C0\", 1.0),),
+        country_aggregates_out=((\"C0\", 1.0),),
+        cert_id=\"0\" * 64,
+    )
+    rng = np.random.default_rng(0)
+    s = rng.lognormal(mean=10.0, sigma=1.0, size=80)
+    s_in = s * (s.sum() / s.sum())
+    inside = float(
+        (min(rec_cert.tested_at_densities) + max(rec_cert.tested_at_densities)) / 2.0
+    )
+    composed = check_composed_domain_of_validity(
+        s, s_in, recovery_certificate=rec_cert,
+        allocator_certificate=alloc_cert,
+        reconstruction_inferred_density=inside,
+    )
+    assert composed.status is ComposedDomainStatus.ALLOCATOR_OUT
+    assert not composed.is_admissible_for_bank_level_claim
+    "'
+  description: >-
+    Probes the failure-direction of the composed gate: a real
+    coverage_ratio of 0.40 (well below 0.80 default) MUST surface
+    as ALLOCATOR_OUT and forbid the bank-level claim. If the gate
+    erroneously emits BOTH_WITHIN at this coverage, the
+    fail-closed contract is broken — bank-level claims could
+    leak through with insufficient prior evidence.
+rollback_command: >-
+  bash -c 'git checkout HEAD~1 --
+  && rm -f research/reconstruction/allocator/dov_composition.py
+  tests/reconstruction/allocator/test_dov_composition.py
+  .claude/commit_acceptors/x10r-1-dov-composition.yaml'
+rollback_verification_command: >-
+  bash -c 'test ! -f research/reconstruction/allocator/dov_composition.py
+  && test ! -f tests/reconstruction/allocator/test_dov_composition.py
+  && test ! -f .claude/commit_acceptors/x10r-1-dov-composition.yaml'
+memory_update_type: append
+ledger_path: ".claude/commit_acceptors/x10r-1-dov-composition.yaml"
+report_path: "tmp/x10r_1_dov_composition.log"
+evidence: []

--- a/research/reconstruction/allocator/__init__.py
+++ b/research/reconstruction/allocator/__init__.py
@@ -19,6 +19,12 @@ from research.reconstruction.allocator.certificate import (
     compute_cert_id,
 )
 from research.reconstruction.allocator.data import DATA_DIR, MFI_DEMO_TSV
+from research.reconstruction.allocator.dov_composition import (
+    ALLOCATOR_COVERAGE_RATIO_MIN_DEFAULT,
+    ComposedDomainCheck,
+    ComposedDomainStatus,
+    check_composed_domain_of_validity,
+)
 from research.reconstruction.allocator.mfi_loader import (
     DialectName,
     MFIRegistryLoad,
@@ -36,9 +42,12 @@ from research.reconstruction.allocator.synthetic import (
 )
 
 __all__ = [
+    "ALLOCATOR_COVERAGE_RATIO_MIN_DEFAULT",
     "AllocatorPrior",
     "BankLevelMarginalsCertificate",
     "BankLevelRecoveryReport",
+    "ComposedDomainCheck",
+    "ComposedDomainStatus",
     "CountryToBankAllocator",
     "DATA_DIR",
     "DialectName",
@@ -49,6 +58,7 @@ __all__ = [
     "UniformPrior",
     "audit_bank_level_recovery",
     "bank_level_recovery_l1",
+    "check_composed_domain_of_validity",
     "compute_cert_id",
     "load_mfi_registry",
     "registry_to_bank_country_map",

--- a/research/reconstruction/allocator/dov_composition.py
+++ b/research/reconstruction/allocator/dov_composition.py
@@ -1,0 +1,176 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""Composed Domain-of-Validity gate (X-10R-1 PR #6).
+
+Per epic #638: a real-data bank-level run is admissible only if BOTH
+the country-to-bank ALLOCATOR layer AND the X-10R RECONSTRUCTION
+layer certify the inputs. Each layer's domain-of-validity is
+independent — the allocator's certificate envelope (registry size,
+coverage_ratio, reciprocity / size-signal evidence) is orthogonal
+to the reconstruction's envelope (n_nodes, density, network
+reciprocity). Lifting one layer's WITHIN to a bank-level claim
+without the other's WITHIN would smuggle an unverified assumption
+into the verdict.
+
+This module ships the *composition surface*:
+
+    check_composed_domain_of_validity(
+        s_out_real, s_in_real,
+        recovery_certificate=...,         # X-10R reconstruction cert
+        allocator_certificate=...,        # bank-level allocator cert
+        reconstruction_inferred_density=...,
+    ) -> ComposedDomainCheck
+
+The composed verdict semantics:
+
+    BOTH_WITHIN          recovery + allocator both WITHIN
+    RECONSTRUCTION_OUT   recovery layer says OUT or INSUFFICIENT
+    ALLOCATOR_OUT        allocator layer says OUT or INSUFFICIENT
+    BOTH_OUT             both layers fail
+
+Composition is FAIL-CLOSED: anything other than BOTH_WITHIN means
+the bank-level claim is forbidden. INV-IDENTIFICATION-1 stays in
+force until at least BOTH_WITHIN clears, AND a downstream Gate 6
+forward signal lands (subsequent epic PR).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+
+import numpy as np
+
+from research.reconstruction.allocator.certificate import (
+    BankLevelMarginalsCertificate,
+)
+from research.reconstruction.recovery_audit import (
+    DomainCheck,
+    DomainOfValidityStatus,
+    check_domain_of_validity,
+)
+
+
+class ComposedDomainStatus(Enum):
+    """Verdict surface of the composed gate.
+
+    Disjoint from the per-layer DomainOfValidityStatus to keep
+    bank-level admissibility strictly ABOVE the per-layer surface
+    in the type hierarchy (a caller cannot accidentally pass a
+    DomainOfValidityStatus where ComposedDomainStatus is required).
+    """
+
+    BOTH_WITHIN = "both_within_validated_domain"
+    RECONSTRUCTION_OUT = "reconstruction_out_of_validated_domain"
+    ALLOCATOR_OUT = "allocator_out_of_validated_domain"
+    BOTH_OUT = "both_out_of_validated_domain"
+
+
+@dataclass(frozen=True)
+class ComposedDomainCheck:
+    """Frozen composite verdict.
+
+    Carries the per-layer DomainCheck (from recovery_audit) AND the
+    allocator-side per-dimension envelope checks. Both layers are
+    surfaced separately so a downstream consumer can show the user
+    *which* layer caused a NOT-BOTH-WITHIN verdict.
+    """
+
+    status: ComposedDomainStatus
+    reconstruction_check: DomainCheck
+    allocator_checks: dict[str, bool] = field(default_factory=dict)
+    allocator_measured: dict[str, float] = field(default_factory=dict)
+    allocator_envelope: dict[str, tuple[float, float]] = field(default_factory=dict)
+    notes: str = ""
+
+    @property
+    def is_admissible_for_bank_level_claim(self) -> bool:
+        """Single boolean for downstream consumers. True iff the
+        composed verdict is BOTH_WITHIN. Anything else forbids a
+        bank-level claim per INV-IDENTIFICATION-1."""
+        return self.status is ComposedDomainStatus.BOTH_WITHIN
+
+
+# Default thresholds for the allocator-side composition layer.
+# coverage_ratio_min: by default we require the allocator to have
+# real evidence for ≥ 80 % of the countries it allocated to (the
+# fallback policy explains the rest, but full evidence is the
+# admissibility bar).
+ALLOCATOR_COVERAGE_RATIO_MIN_DEFAULT: float = 0.80
+"""Default coverage_ratio threshold for the composed gate."""
+
+
+def check_composed_domain_of_validity(
+    s_out_real: np.ndarray,
+    s_in_real: np.ndarray,
+    *,
+    recovery_certificate: object,  # GroundTruthRecoveryCertificate
+    allocator_certificate: BankLevelMarginalsCertificate,
+    reconstruction_inferred_density: float,
+    allocator_coverage_ratio_min: float = ALLOCATOR_COVERAGE_RATIO_MIN_DEFAULT,
+) -> ComposedDomainCheck:
+    """Compose the X-10R reconstruction DoV gate with the allocator's
+    own coverage / fallback envelope.
+
+    Returns
+    -------
+    ComposedDomainCheck — see verdict matrix in module docstring.
+    """
+    # Layer 1: reconstruction-side DoV (existing X-10R surface).
+    recovery_check = check_domain_of_validity(
+        s_out_real,
+        s_in_real,
+        recovery_certificate,  # type: ignore[arg-type]
+        inferred_density=reconstruction_inferred_density,
+    )
+
+    # Layer 2: allocator-side admissibility envelope.
+    allocator_checks: dict[str, bool] = {}
+    allocator_measured: dict[str, float] = {}
+    allocator_envelope: dict[str, tuple[float, float]] = {}
+
+    # coverage_ratio is the gate-able allocator metric; defaults
+    # require ≥ 0.80 of countries to have real prior evidence.
+    coverage_ok = allocator_certificate.coverage_ratio >= allocator_coverage_ratio_min
+    allocator_checks["coverage_ratio"] = coverage_ok
+    allocator_measured["coverage_ratio"] = float(allocator_certificate.coverage_ratio)
+    allocator_envelope["coverage_ratio"] = (
+        float(allocator_coverage_ratio_min),
+        1.0,
+    )
+
+    # Provenance fields surfaced (informational, not gated):
+    allocator_measured["n_banks"] = float(allocator_certificate.n_banks)
+    allocator_measured["n_countries"] = float(allocator_certificate.n_countries)
+
+    allocator_within = all(allocator_checks.values())
+    reconstruction_within = recovery_check.status is DomainOfValidityStatus.WITHIN_VALIDATED_DOMAIN
+
+    if reconstruction_within and allocator_within:
+        status = ComposedDomainStatus.BOTH_WITHIN
+        notes = "both layers certify; bank-level claim admissible"
+    elif not reconstruction_within and not allocator_within:
+        status = ComposedDomainStatus.BOTH_OUT
+        notes = (
+            f"reconstruction: {recovery_check.notes}; "
+            f"allocator: coverage_ratio={allocator_certificate.coverage_ratio:.3f} "
+            f"< {allocator_coverage_ratio_min}"
+        )
+    elif not reconstruction_within:
+        status = ComposedDomainStatus.RECONSTRUCTION_OUT
+        notes = f"reconstruction layer out: {recovery_check.notes}"
+    else:
+        status = ComposedDomainStatus.ALLOCATOR_OUT
+        notes = (
+            f"allocator coverage_ratio={allocator_certificate.coverage_ratio:.3f} "
+            f"< {allocator_coverage_ratio_min}"
+        )
+
+    return ComposedDomainCheck(
+        status=status,
+        reconstruction_check=recovery_check,
+        allocator_checks=allocator_checks,
+        allocator_measured=allocator_measured,
+        allocator_envelope=allocator_envelope,
+        notes=notes,
+    )

--- a/tests/reconstruction/allocator/test_dov_composition.py
+++ b/tests/reconstruction/allocator/test_dov_composition.py
@@ -1,0 +1,271 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""Tests for the composed Domain-of-Validity gate (X-10R-1 PR #6).
+
+The composition is a 4-cell verdict matrix:
+
+    reconstruction WITHIN  &  allocator WITHIN  ⇒ BOTH_WITHIN
+    reconstruction OUT     &  allocator WITHIN  ⇒ RECONSTRUCTION_OUT
+    reconstruction WITHIN  &  allocator OUT     ⇒ ALLOCATOR_OUT
+    reconstruction OUT     &  allocator OUT     ⇒ BOTH_OUT
+
+Only BOTH_WITHIN admits a bank-level claim. Anything else keeps
+INV-IDENTIFICATION-1 in force.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from research.reconstruction.allocator import (
+    ALLOCATOR_COVERAGE_RATIO_MIN_DEFAULT,
+    BankLevelMarginalsCertificate,
+    ComposedDomainCheck,
+    ComposedDomainStatus,
+    CountryToBankAllocator,
+    SizeWeightedPrior,
+    check_composed_domain_of_validity,
+    load_mfi_registry,
+)
+from research.reconstruction.allocator.data import MFI_DEMO_TSV
+from research.reconstruction.positive_control import (
+    GroundTruthRecoveryCertificate,
+    ground_truth_core_periphery,
+    run_recovery_on_substrate,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _within_recovery_cert(n: int = 80, seed: int = 42) -> GroundTruthRecoveryCertificate:
+    w = ground_truth_core_periphery(n=n, core_frac=0.30, seed=seed)
+    return run_recovery_on_substrate(f"CP_{n}_dov_compose", w, seed=seed)
+
+
+def _stub_allocator_cert(coverage: float) -> BankLevelMarginalsCertificate:
+    """Construct a BankLevelMarginalsCertificate with the requested
+    coverage_ratio. Other fields filled with minimal valid values
+    so the dataclass post-init invariants pass."""
+    s = np.array([1.0], dtype=np.float64)
+    return BankLevelMarginalsCertificate(
+        prior_id="stub",
+        n_countries=1,
+        n_banks=1,
+        coverage_ratio=coverage,
+        fallback_policy="uniform_within_country",
+        bank_country_map=(("B0", "C0"),),
+        s_in=s,
+        s_out=s,
+        country_aggregates_in=(("C0", 1.0),),
+        country_aggregates_out=(("C0", 1.0),),
+        cert_id="0" * 64,
+    )
+
+
+def _balanced_marginals_at_n(n: int, seed: int = 0) -> tuple[np.ndarray, np.ndarray]:
+    rng = np.random.default_rng(seed)
+    s_out = rng.lognormal(mean=10.0, sigma=1.0, size=n)
+    s_in = rng.lognormal(mean=10.0, sigma=1.0, size=n)
+    s_in = s_in * (s_out.sum() / s_in.sum())
+    return s_out, s_in
+
+
+# ---------------------------------------------------------------------------
+# Verdict matrix — the four canonical paths
+# ---------------------------------------------------------------------------
+
+
+def test_both_within_when_both_layers_certify() -> None:
+    """Reconstruction WITHIN + allocator coverage ≥ 0.80 ⇒ BOTH_WITHIN.
+    This is the only verdict that admits a bank-level claim."""
+    rec_cert = _within_recovery_cert(n=80, seed=1)
+    alloc_cert = _stub_allocator_cert(coverage=1.0)
+    s_out, s_in = _balanced_marginals_at_n(n=80, seed=11)
+    inside = float((min(rec_cert.tested_at_densities) + max(rec_cert.tested_at_densities)) / 2.0)
+    composed = check_composed_domain_of_validity(
+        s_out,
+        s_in,
+        recovery_certificate=rec_cert,
+        allocator_certificate=alloc_cert,
+        reconstruction_inferred_density=inside,
+    )
+    assert isinstance(composed, ComposedDomainCheck)
+    assert composed.status is ComposedDomainStatus.BOTH_WITHIN
+    assert composed.is_admissible_for_bank_level_claim is True
+
+
+def test_reconstruction_out_when_only_allocator_certifies() -> None:
+    """Reconstruction OUT + allocator WITHIN ⇒ RECONSTRUCTION_OUT.
+    Bank-level claim still forbidden."""
+    rec_cert = _within_recovery_cert(n=80, seed=2)
+    alloc_cert = _stub_allocator_cert(coverage=1.0)
+    # Push reconstruction OUT: real N way above the certified envelope.
+    s_out, s_in = _balanced_marginals_at_n(n=400, seed=12)
+    inside = float((min(rec_cert.tested_at_densities) + max(rec_cert.tested_at_densities)) / 2.0)
+    composed = check_composed_domain_of_validity(
+        s_out,
+        s_in,
+        recovery_certificate=rec_cert,
+        allocator_certificate=alloc_cert,
+        reconstruction_inferred_density=inside,
+    )
+    assert composed.status is ComposedDomainStatus.RECONSTRUCTION_OUT
+    assert composed.is_admissible_for_bank_level_claim is False
+
+
+def test_allocator_out_when_coverage_below_threshold() -> None:
+    """Reconstruction WITHIN + allocator coverage < 0.80 ⇒
+    ALLOCATOR_OUT. Bank-level claim still forbidden."""
+    rec_cert = _within_recovery_cert(n=80, seed=3)
+    # Coverage 0.50 < 0.80 default threshold.
+    alloc_cert = _stub_allocator_cert(coverage=0.50)
+    s_out, s_in = _balanced_marginals_at_n(n=80, seed=13)
+    inside = float((min(rec_cert.tested_at_densities) + max(rec_cert.tested_at_densities)) / 2.0)
+    composed = check_composed_domain_of_validity(
+        s_out,
+        s_in,
+        recovery_certificate=rec_cert,
+        allocator_certificate=alloc_cert,
+        reconstruction_inferred_density=inside,
+    )
+    assert composed.status is ComposedDomainStatus.ALLOCATOR_OUT
+    assert composed.is_admissible_for_bank_level_claim is False
+    assert composed.allocator_checks["coverage_ratio"] is False
+
+
+def test_both_out_when_neither_layer_certifies() -> None:
+    """Reconstruction OUT + allocator OUT ⇒ BOTH_OUT.
+    Both reasons are surfaced in `notes`."""
+    rec_cert = _within_recovery_cert(n=80, seed=4)
+    alloc_cert = _stub_allocator_cert(coverage=0.40)
+    # Push reconstruction OUT.
+    s_out, s_in = _balanced_marginals_at_n(n=400, seed=14)
+    inside = float((min(rec_cert.tested_at_densities) + max(rec_cert.tested_at_densities)) / 2.0)
+    composed = check_composed_domain_of_validity(
+        s_out,
+        s_in,
+        recovery_certificate=rec_cert,
+        allocator_certificate=alloc_cert,
+        reconstruction_inferred_density=inside,
+    )
+    assert composed.status is ComposedDomainStatus.BOTH_OUT
+    assert composed.is_admissible_for_bank_level_claim is False
+    assert "reconstruction" in composed.notes
+    assert "coverage_ratio" in composed.notes
+
+
+# ---------------------------------------------------------------------------
+# Coverage threshold customisation
+# ---------------------------------------------------------------------------
+
+
+def test_default_coverage_threshold_is_0_80() -> None:
+    assert ALLOCATOR_COVERAGE_RATIO_MIN_DEFAULT == 0.80
+
+
+def test_custom_coverage_threshold_changes_verdict() -> None:
+    """A caller can tighten the coverage threshold to push an
+    otherwise-WITHIN allocator into OUT territory."""
+    rec_cert = _within_recovery_cert(n=80, seed=5)
+    alloc_cert = _stub_allocator_cert(coverage=0.95)
+    s_out, s_in = _balanced_marginals_at_n(n=80, seed=15)
+    inside = float((min(rec_cert.tested_at_densities) + max(rec_cert.tested_at_densities)) / 2.0)
+    composed = check_composed_domain_of_validity(
+        s_out,
+        s_in,
+        recovery_certificate=rec_cert,
+        allocator_certificate=alloc_cert,
+        reconstruction_inferred_density=inside,
+        allocator_coverage_ratio_min=0.99,  # tighter than default
+    )
+    assert composed.status is ComposedDomainStatus.ALLOCATOR_OUT
+
+
+# ---------------------------------------------------------------------------
+# Provenance fields surfaced in measured but not gated
+# ---------------------------------------------------------------------------
+
+
+def test_n_banks_and_n_countries_surface_as_measured_only() -> None:
+    """`n_banks` and `n_countries` are PROVENANCE — they appear in
+    `allocator_measured` for inspection but do NOT drive the verdict
+    (separate from `allocator_checks`)."""
+    rec_cert = _within_recovery_cert(n=80, seed=6)
+    alloc_cert = _stub_allocator_cert(coverage=1.0)
+    s_out, s_in = _balanced_marginals_at_n(n=80, seed=16)
+    inside = float((min(rec_cert.tested_at_densities) + max(rec_cert.tested_at_densities)) / 2.0)
+    composed = check_composed_domain_of_validity(
+        s_out,
+        s_in,
+        recovery_certificate=rec_cert,
+        allocator_certificate=alloc_cert,
+        reconstruction_inferred_density=inside,
+    )
+    assert "n_banks" in composed.allocator_measured
+    assert "n_countries" in composed.allocator_measured
+    assert "n_banks" not in composed.allocator_checks
+    assert "n_countries" not in composed.allocator_checks
+
+
+def test_allocator_envelope_carries_coverage_threshold() -> None:
+    """`allocator_envelope` records the threshold so reviewers can
+    audit which bound was applied."""
+    rec_cert = _within_recovery_cert(n=80, seed=7)
+    alloc_cert = _stub_allocator_cert(coverage=1.0)
+    s_out, s_in = _balanced_marginals_at_n(n=80, seed=17)
+    inside = float((min(rec_cert.tested_at_densities) + max(rec_cert.tested_at_densities)) / 2.0)
+    composed = check_composed_domain_of_validity(
+        s_out,
+        s_in,
+        recovery_certificate=rec_cert,
+        allocator_certificate=alloc_cert,
+        reconstruction_inferred_density=inside,
+        allocator_coverage_ratio_min=0.85,
+    )
+    assert composed.allocator_envelope["coverage_ratio"] == (0.85, 1.0)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: real fixture → real allocator cert → composed gate
+# ---------------------------------------------------------------------------
+
+
+def test_e2e_demo_fixture_produces_both_within_at_matched_envelopes() -> None:
+    """Final E2E: load the frozen MFI demo fixture, build a real
+    BankLevelMarginalsCertificate via SizeWeightedPrior + the
+    allocator, build a real reconstruction certificate at matched
+    N + density, and verify the composed gate emits BOTH_WITHIN
+    on within-envelope marginals."""
+    out = load_mfi_registry(MFI_DEMO_TSV)
+    n_banks = out.n_rows  # 25 banks
+    # Reconstruction certificate at the same N as the bank count.
+    rec_cert = _within_recovery_cert(n=n_banks, seed=42)
+
+    agg_in = {"DE": 100.0, "FR": 90.0, "IT": 70.0, "ES": 60.0, "NL": 50.0}
+    agg_out = {"DE": 95.0, "FR": 85.0, "IT": 65.0, "ES": 55.0, "NL": 45.0}
+    alloc_cert = CountryToBankAllocator(
+        prior=SizeWeightedPrior(
+            bank_country_map=out.bank_country_map,
+            bank_weights=out.bank_weights,
+        )
+    ).allocate(agg_in, agg_out, bank_country_map=out.bank_country_map)
+
+    s_out, s_in = _balanced_marginals_at_n(n=n_banks, seed=42)
+    inside = float((min(rec_cert.tested_at_densities) + max(rec_cert.tested_at_densities)) / 2.0)
+    composed = check_composed_domain_of_validity(
+        s_out,
+        s_in,
+        recovery_certificate=rec_cert,
+        allocator_certificate=alloc_cert,
+        reconstruction_inferred_density=inside,
+    )
+    assert composed.status is ComposedDomainStatus.BOTH_WITHIN
+    assert composed.is_admissible_for_bank_level_claim is True
+    # Allocator coverage on the demo fixture is 1.0 (every country
+    # has positive total weight).
+    assert composed.allocator_measured["coverage_ratio"] == pytest.approx(1.0)
+    assert composed.allocator_measured["n_banks"] == 25.0
+    assert composed.allocator_measured["n_countries"] == 5.0


### PR DESCRIPTION
## Summary

Sixth PR of the X-10R-1 epic. Composes the X-10R reconstruction DoV verdict with the allocator-side coverage_ratio envelope into a single bank-level admissibility verdict.

**Stacked on PR #646** (frozen MFI demo fixture). When #646 merges, GitHub auto-rebases this PR's base to `main`.

Refs #638.

## What lands

`research/reconstruction/allocator/dov_composition.py`:

- **`ComposedDomainStatus`** enum — 4-cell verdict matrix:

  | Reconstruction | Allocator | Verdict | Bank-level claim |
  |---|---|---|---|
  | WITHIN | WITHIN | `BOTH_WITHIN` | **admissible** |
  | OUT | WITHIN | `RECONSTRUCTION_OUT` | forbidden |
  | WITHIN | OUT | `ALLOCATOR_OUT` | forbidden |
  | OUT | OUT | `BOTH_OUT` | forbidden |

- **`ComposedDomainCheck`** — frozen verdict carrier with the per-layer `DomainCheck` embedded + allocator-side check / measure / envelope dictionaries + `is_admissible_for_bank_level_claim` boolean for downstream consumers.
- **`check_composed_domain_of_validity()`** — the gate function.
- **`ALLOCATOR_COVERAGE_RATIO_MIN_DEFAULT = 0.80`** — default threshold; tunable via `allocator_coverage_ratio_min` kwarg.

### Provenance vs admissibility separation

`n_banks` and `n_countries` surface in `allocator_measured` for inspection but do NOT drive the verdict. Only `coverage_ratio` is gate-able. This mirrors the existing `recovery_audit.DomainCheck` pattern.

### Fail-closed

Anything other than `BOTH_WITHIN` forbids a bank-level claim. `INV-IDENTIFICATION-1` stays in force until `BOTH_WITHIN` clears AND a downstream Gate 6 forward signal lands (PR #7 — final epic PR).

## Tests (9 new — 126 in `tests/reconstruction/allocator/` total)

- All 4 cells of the verdict matrix
- Default coverage threshold = 0.80
- Custom coverage threshold flips the verdict
- `n_banks` / `n_countries` surface as measured-only, not gated
- `allocator_envelope` records the applied threshold for audit
- **End-to-end**: load frozen `MFI_DEMO_TSV` → `SizeWeightedPrior` → `CountryToBankAllocator` (real cert) + reconstruction certificate at matched N → composed gate → `BOTH_WITHIN` admits the bank-level claim with `coverage_ratio = 1.0`, `n_banks = 25`, `n_countries = 5`

## Local results

- `pytest tests/reconstruction/allocator/`: **126 passed** in 2.4 s
- `mypy --strict --follow-imports=silent`: **21 source files clean**
- `ruff check` + `black --check`: clean

## What this PR does NOT land

- E2E allocator → reconstruction → Gate 6 forward signal (PR #7 of the epic — final; lifts `INV-IDENTIFICATION-1` once landed).
- Real EBA / BankFocus prior data ingestion (separate epic).

## Acceptance gates

- [x] `ComposedDomainStatus` exposed
- [x] `ComposedDomainCheck` exposed
- [x] `check_composed_domain_of_validity` exposed
- [x] Falsifier: coverage_ratio = 0.40 → ALLOCATOR_OUT (fail-closed contract)

## Test plan

- [ ] CI green on `pytest tests/reconstruction/allocator/`
- [ ] CI green on `ruff check` + `mypy --strict` + `black --check`
- [ ] Acceptor passes
- [ ] PR description matches code

🤖 Generated with [Claude Code](https://claude.com/claude-code)