### PR TITLE
feat(x10r-1-#7,FINAL): E2E bank-level forward-signal pipeline (closes #638)

### DIFF
--- a/.claude/commit_acceptors/x10r-1-e2e-forward-signal.yaml
+++ b/.claude/commit_acceptors/x10r-1-e2e-forward-signal.yaml
@@ -1,0 +1,122 @@
+# Diff-bound commit acceptor for X-10R-1 PR #7 (FINAL) —
+# end-to-end bank-level forward-signal pipeline. Closes the
+# X-10R-1 epic foundation.
+#
+# What lands:
+#   * research/reconstruction/allocator/forward_signal.py
+#       BankLevelForwardSignalCertificate dataclass +
+#       assert_real_data_input_not_validated_here +
+#       composed_status_admits + emit_bank_level_forward_signal
+#   * tests/reconstruction/allocator/test_forward_signal.py
+#       10 new tests pinning admissibility ≠ validation, fail-closed
+#       on real-data path, helper semantics, E2E synthetic happy
+#       path, fail-closed direction (low coverage), shape contract,
+#       too-few-banks NO_SIGNAL guard.
+#
+# Locally verified (on top of merged PRs #642–#646):
+#   * pytest tests/reconstruction/allocator/: 138/138 passed
+#   * mypy --strict + ruff + black:           clean
+#
+# DOES NOT lift INV-IDENTIFICATION-1
+# ===================================
+# The pipeline emits a *certificate* with two distinct flags:
+#     is_admissible_for_downstream_bank_level_test   (necessary)
+#     is_scientifically_validated_bank_level_result  (sufficient)
+# Sufficiency requires Gate 6 PASS with a SIGNED precursor
+# direction. On the canonical 25-bank synthetic substrate
+# at default density the validation flag is False (CI overlaps
+# zero band) — this is HONEST OUTPUT: admissibility True,
+# validation False. INV-IDENTIFICATION-1 stays in force.
+# Validating real bank-level networks requires a separate
+# substrate where the precursor signal is strong enough to
+# clear Gate 6, AND real BIS data ingestion (out-of-epic).
+
+id: x10r-1-e2e-forward-signal
+status: ACTIVE
+claim_type: chore
+promise: >-
+  After this PR lands, research/reconstruction/allocator/ exposes
+  emit_bank_level_forward_signal() — the closing pipeline of the
+  X-10R-1 epic. Wires CountryToBankAllocator + SizeWeightedPrior
+  + Cimini-Squartini fit + Bernoulli + IPF + Gate 6 R(∞)
+  precursor + composed DoV gate into one deterministic function
+  that returns BankLevelForwardSignalCertificate. The cert
+  carries TWO distinct flags: is_admissible_for_downstream_bank_
+  level_test (necessary, True iff composed DoV is BOTH_WITHIN)
+  AND is_scientifically_validated_bank_level_result (sufficient,
+  True iff admissible AND Gate 6 PASS AND precursor direction is
+  SIGNED, NOT NO_SIGNAL). assert_real_data_input_not_validated_
+  here forbids the validation flag from leaking onto real data
+  (INV-RECONSTRUCTION-2 + INV-IDENTIFICATION-1 enforcement).
+  10 new tests pin: real-data input contract, composed_status_
+  admits semantics, E2E synthetic happy path on the frozen MFI
+  demo fixture, validated⇒admissible+signed implication,
+  admissible-without-validated gap, fail-closed direction (low
+  coverage), shape contract, too-few-banks NO_SIGNAL guard.
+diff_scope:
+  changed_files:
+    - path: ".claude/commit_acceptors/x10r-1-e2e-forward-signal.yaml"
+    - path: "research/reconstruction/allocator/__init__.py"
+    - path: "research/reconstruction/allocator/forward_signal.py"
+    - path: "tests/reconstruction/allocator/test_forward_signal.py"
+  forbidden_paths:
+    - "trading/"
+    - "execution/"
+    - "forecast/"
+    - "policy/"
+    - "core/physics/"
+    - "core/kuramoto/"
+    - "application/governance/claim_ledger.py"
+    - "application/governance/commit_acceptor.py"
+required_python_symbols:
+  - "research/reconstruction/allocator/forward_signal.py::BankLevelForwardSignalCertificate"
+  - "research/reconstruction/allocator/forward_signal.py::emit_bank_level_forward_signal"
+  - "research/reconstruction/allocator/forward_signal.py::assert_real_data_input_not_validated_here"
+  - "research/reconstruction/allocator/forward_signal.py::composed_status_admits"
+expected_signal: >-
+  Local: `pytest tests/reconstruction/allocator/ -q` reports
+  "138 passed"; `mypy --strict` is clean on every file under
+  research/reconstruction/allocator/ and
+  tests/reconstruction/allocator/; `ruff check` and
+  `black --check` both pass on those paths.
+measurement_command: >-
+  bash -c 'mypy --strict --follow-imports=silent
+  research/reconstruction/allocator/ tests/reconstruction/allocator/
+  && ruff check research/reconstruction/allocator/ tests/reconstruction/allocator/
+  && black --check research/reconstruction/allocator/ tests/reconstruction/allocator/
+  && pytest tests/reconstruction/allocator/ -q'
+signal_artifact: "tmp/x10r_1_e2e_forward_signal.log"
+falsifier:
+  command: >-
+    bash -c 'python -c "
+    from research.reconstruction.allocator import (
+        assert_real_data_input_not_validated_here,
+    )
+    raised = False
+    try:
+        assert_real_data_input_not_validated_here(False)
+    except ValueError as e:
+        if \"INV-RECONSTRUCTION-2\" in str(e):
+            raised = True
+    assert raised, \"real-data path must raise INV-RECONSTRUCTION-2\"
+    "'
+  description: >-
+    Probes the fail-closed contract: the validation flag has no
+    meaning on real data. Calling the pipeline with
+    is_synthetic_ground_truth=False MUST raise with INV-
+    RECONSTRUCTION-2 + INV-IDENTIFICATION-1 named. If the
+    contract is loose, the validation flag could leak onto real
+    BIS data — a category error this gate exists to prevent.
+rollback_command: >-
+  bash -c 'git checkout HEAD~1 --
+  && rm -f research/reconstruction/allocator/forward_signal.py
+  tests/reconstruction/allocator/test_forward_signal.py
+  .claude/commit_acceptors/x10r-1-e2e-forward-signal.yaml'
+rollback_verification_command: >-
+  bash -c 'test ! -f research/reconstruction/allocator/forward_signal.py
+  && test ! -f tests/reconstruction/allocator/test_forward_signal.py
+  && test ! -f .claude/commit_acceptors/x10r-1-e2e-forward-signal.yaml'
+memory_update_type: append
+ledger_path: ".claude/commit_acceptors/x10r-1-e2e-forward-signal.yaml"
+report_path: "tmp/x10r_1_e2e_forward_signal.log"
+evidence: []

--- a/research/reconstruction/allocator/__init__.py
+++ b/research/reconstruction/allocator/__init__.py
@@ -25,6 +25,12 @@ from research.reconstruction.allocator.dov_composition import (
     ComposedDomainStatus,
     check_composed_domain_of_validity,
 )
+from research.reconstruction.allocator.forward_signal import (
+    BankLevelForwardSignalCertificate,
+    assert_real_data_input_not_validated_here,
+    composed_status_admits,
+    emit_bank_level_forward_signal,
+)
 from research.reconstruction.allocator.mfi_loader import (
     DialectName,
     MFIRegistryLoad,
@@ -44,6 +50,7 @@ from research.reconstruction.allocator.synthetic import (
 __all__ = [
     "ALLOCATOR_COVERAGE_RATIO_MIN_DEFAULT",
     "AllocatorPrior",
+    "BankLevelForwardSignalCertificate",
     "BankLevelMarginalsCertificate",
     "BankLevelRecoveryReport",
     "ComposedDomainCheck",
@@ -56,10 +63,13 @@ __all__ = [
     "ShareDistribution",
     "SizeWeightedPrior",
     "UniformPrior",
+    "assert_real_data_input_not_validated_here",
     "audit_bank_level_recovery",
     "bank_level_recovery_l1",
     "check_composed_domain_of_validity",
+    "composed_status_admits",
     "compute_cert_id",
+    "emit_bank_level_forward_signal",
     "load_mfi_registry",
     "registry_to_bank_country_map",
     "synthetic_country_aggregates",

--- a/research/reconstruction/allocator/forward_signal.py
+++ b/research/reconstruction/allocator/forward_signal.py
@@ -1,0 +1,267 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""End-to-end bank-level forward-signal pipeline (X-10R-1 PR #7 — FINAL).
+
+This is the closing PR of the X-10R-1 epic. It wires the four
+layers built in PRs #642–#646 into a single deterministic
+function and emits a `BankLevelForwardSignalCertificate` that
+finally distinguishes admissibility from validation.
+
+Pipeline
+========
+
+    country aggregates                    (input)
+        ⬇  CountryToBankAllocator + AllocatorPrior      [#642 + #643]
+    bank-level marginals (s_in, s_out)
+        ⬇  fit_cimini_squartini + IPF                   [PR #635]
+    bank-level reconstructed adjacency W_recon
+        ⬇  audit_recovery (Gate 5)                      [PR #635]
+    GroundTruthRecoveryCertificate (synthetic side only)
+        ⬇  gate_6_precursor_discriminative              [PR #635]
+    Kuramoto R(∞) precursor verdict
+        ⬇  check_composed_domain_of_validity            [PR #6, this epic]
+    ComposedDomainCheck
+        ⬇
+    BankLevelForwardSignalCertificate
+
+Contract
+========
+
+The certificate has TWO flags that must NOT be conflated:
+
+    is_admissible_for_downstream_bank_level_test
+        True iff composed DoV verdict is BOTH_WITHIN. This is
+        the *necessary* prerequisite — the inputs are inside
+        the regime where Gate 6 is well-defined.
+
+    is_scientifically_validated_bank_level_result
+        True iff (admissible AND Gate 6 PASS with a SIGNED
+        precursor direction). This is the *sufficient* condition
+        for emitting a bank-level forward signal.
+
+Synthetic positive control vs real data
+========================================
+
+This module's PASS path covers SYNTHETIC ground truth — the only
+substrate where we have a known network to reconstruct against.
+On real BIS LBS marginals the validation flag has no meaning at
+this layer because there is no bank-level ground truth (see
+INV-RECONSTRUCTION-2 / INV-IDENTIFICATION-1). The flag is set
+SOLELY by the synthetic-substrate pipeline; running this on real
+data is a contract violation enforced by
+`assert_real_data_input_not_validated_here`.
+
+Lifting INV-IDENTIFICATION-1
+============================
+
+When this module's pipeline returns a certificate with
+`is_scientifically_validated_bank_level_result == True` on a
+SYNTHETIC substrate, the X-10R-1 epic is closed: the foundation
+proves that an end-to-end allocator → reconstruction → Gate 6
+forward signal CAN be emitted. Real-data inference is a
+separate question (epic X-10R-3 / X-10R-4) and remains forbidden
+by INV-IDENTIFICATION-1 until those epic layers land.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from research.reconstruction.allocator.allocator import CountryToBankAllocator
+from research.reconstruction.allocator.dov_composition import (
+    ComposedDomainCheck,
+    ComposedDomainStatus,
+    check_composed_domain_of_validity,
+)
+from research.reconstruction.cimini_squartini import (
+    fit_cimini_squartini,
+    p_link,
+)
+from research.reconstruction.kuramoto_on_reconstruction import (
+    KuramotoRecoveryCertificate,
+    PrecursorDirection,
+    issue_kuramoto_recovery_certificate,
+)
+from research.reconstruction.positive_control import (
+    GroundTruthRecoveryCertificate,
+)
+from research.reconstruction.weighted_allocation import (
+    allocate_weights,
+    sample_adjacency_bernoulli,
+)
+
+
+@dataclass(frozen=True)
+class BankLevelForwardSignalCertificate:
+    """Final closing certificate of the X-10R-1 epic.
+
+    Carries both:
+      * the per-layer artefacts (allocator + reconstruction +
+        composed DoV verdict + Gate 6 verdict) for full audit
+      * the two-property admissibility / validation surface the
+        downstream consumer reads
+    """
+
+    composed_check: ComposedDomainCheck
+    kuramoto_certificate: KuramotoRecoveryCertificate
+    bank_level_w_reconstructed_shape: tuple[int, int]
+    bank_level_inferred_density_estimate: float
+
+    @property
+    def is_admissible_for_downstream_bank_level_test(self) -> bool:
+        """Necessary condition. True iff composed DoV verdict is
+        BOTH_WITHIN — meaning the Gate 6 forward signal is
+        well-defined on these inputs."""
+        return self.composed_check.is_admissible_for_downstream_bank_level_test
+
+    @property
+    def is_scientifically_validated_bank_level_result(self) -> bool:
+        """Sufficient condition. True iff:
+
+        * `is_admissible_for_downstream_bank_level_test` is True
+          (composed DoV verdict is BOTH_WITHIN), AND
+        * Gate 6 precursor PASSES with a *signed* direction —
+          either FACILITATED or HINDERED, NOT NO_SIGNAL.
+        """
+        if not self.is_admissible_for_downstream_bank_level_test:
+            return False
+        if not self.kuramoto_certificate.passed:
+            return False
+        return self.kuramoto_certificate.report.direction is not PrecursorDirection.NO_SIGNAL
+
+    @property
+    def precursor_direction(self) -> PrecursorDirection:
+        return self.kuramoto_certificate.report.direction
+
+
+def assert_real_data_input_not_validated_here(
+    is_synthetic_ground_truth: bool,
+) -> None:
+    """Contract: this module sets `is_scientifically_validated_bank_
+    level_result == True` only on SYNTHETIC substrates with known
+    ground truth. On real BIS LBS marginals there is no bank-level
+    truth (INV-RECONSTRUCTION-2), so this flag has no meaning and
+    the caller must NOT use this pipeline as a real-data validator.
+    """
+    if not is_synthetic_ground_truth:
+        raise ValueError(
+            "INV-RECONSTRUCTION-2 + INV-IDENTIFICATION-1 VIOLATED: "
+            "BankLevelForwardSignalCertificate is only valid on "
+            "synthetic substrates with known ground truth. Real BIS "
+            "LBS path requires a separate (out-of-epic) layer; do "
+            "NOT call this module on real marginals."
+        )
+
+
+def emit_bank_level_forward_signal(
+    *,
+    country_aggregates_in: dict[str, float],
+    country_aggregates_out: dict[str, float],
+    bank_country_map: tuple[tuple[str, str], ...],
+    allocator: CountryToBankAllocator,
+    recovery_certificate: GroundTruthRecoveryCertificate,
+    cimini_target_density: float = 0.05,
+    bernoulli_seed: int = 42,
+    kuramoto_seed: int = 42,
+    kuramoto_n_bootstrap: int = 8,
+    is_synthetic_ground_truth: bool = True,
+) -> BankLevelForwardSignalCertificate:
+    """Run the full X-10R-1 forward-signal pipeline.
+
+    Steps:
+      1. Allocator splits country aggregates → bank-level marginals.
+      2. Cimini-Squartini fitness fit + Bernoulli sampling + IPF
+         projection reconstruct a directed weighted bank-level
+         adjacency W_recon.
+      3. Kuramoto R(∞) precursor (Gate 6) on W_recon vs
+         topology-randomised null.
+      4. Composed DoV gate: real-like bank-level marginals against
+         the supplied recovery_certificate envelope AND the
+         allocator's own coverage envelope.
+      5. Build BankLevelForwardSignalCertificate carrying both
+         per-layer artefacts and the two-property admissibility/
+         validation surface.
+
+    `is_synthetic_ground_truth` is mandatory (default True) — this
+    pipeline's validation flag has no meaning on real data; the
+    contract is enforced upstream by
+    `assert_real_data_input_not_validated_here`.
+    """
+    assert_real_data_input_not_validated_here(is_synthetic_ground_truth)
+
+    # Step 1 — allocator
+    bank_cert = allocator.allocate(
+        country_aggregates_in,
+        country_aggregates_out,
+        bank_country_map=bank_country_map,
+    )
+
+    # Step 2 — bank-level reconstruction (Cimini + Bernoulli + IPF)
+    fit = fit_cimini_squartini(
+        bank_cert.s_out, bank_cert.s_in, target_density=cimini_target_density
+    )
+    p = p_link(fit.x, fit.y, fit.z)
+    rng = np.random.default_rng(bernoulli_seed)
+    a = sample_adjacency_bernoulli(p, rng=rng)
+    w_recon = allocate_weights(a, bank_cert.s_out, bank_cert.s_in)
+    inferred_density = float((w_recon > 0).sum() / max(w_recon.size - w_recon.shape[0], 1))
+
+    # Step 3 — Gate 6
+    n_required = 8
+    gate6_cert: KuramotoRecoveryCertificate
+    if w_recon.shape[0] >= n_required:
+        gate6_cert = issue_kuramoto_recovery_certificate(
+            w_recon, seed=kuramoto_seed, n_bootstrap=kuramoto_n_bootstrap
+        )
+    else:
+        # Too few banks for Gate 6 (engine requires N ≥ 8). Build a
+        # certificate that explicitly signals NO_SIGNAL.
+        from research.reconstruction.kuramoto_on_reconstruction import (
+            PrecursorReport,
+        )
+
+        report = PrecursorReport(
+            n_nodes=w_recon.shape[0],
+            k_test=0.0,
+            n_bootstrap=0,
+            r_recon_median=0.0,
+            r_shuffled_median=0.0,
+            delta_r_median=0.0,
+            delta_r_ci_low=0.0,
+            delta_r_ci_high=0.0,
+            min_precursor_gap=0.0,
+            passed=False,
+            failure_reason=f"too few banks for Gate 6: N={w_recon.shape[0]} < 8",
+            direction=PrecursorDirection.NO_SIGNAL,
+        )
+        gate6_cert = KuramotoRecoveryCertificate(
+            n_nodes=w_recon.shape[0],
+            report=report,
+            passed=False,
+            cert_id="0" * 64,
+        )
+
+    # Step 4 — composed DoV gate
+    composed = check_composed_domain_of_validity(
+        bank_cert.s_out,
+        bank_cert.s_in,
+        recovery_certificate=recovery_certificate,
+        allocator_certificate=bank_cert,
+        reconstruction_inferred_density=cimini_target_density,
+    )
+
+    return BankLevelForwardSignalCertificate(
+        composed_check=composed,
+        kuramoto_certificate=gate6_cert,
+        bank_level_w_reconstructed_shape=(w_recon.shape[0], w_recon.shape[1]),
+        bank_level_inferred_density_estimate=inferred_density,
+    )
+
+
+def composed_status_admits(
+    status: ComposedDomainStatus,
+) -> bool:
+    """Helper: only BOTH_WITHIN admits the next-step test."""
+    return status is ComposedDomainStatus.BOTH_WITHIN

--- a/tests/reconstruction/allocator/test_forward_signal.py
+++ b/tests/reconstruction/allocator/test_forward_signal.py
@@ -1,0 +1,285 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""Tests for the X-10R-1 final epic PR #7 — E2E forward-signal pipeline.
+
+This is the closing test surface of the X-10R-1 epic. The pipeline
+under test wires four merged layers into one deterministic
+function:
+
+    allocator → bank-level marginals → reconstruction → Gate 6
+        → composed DoV → BankLevelForwardSignalCertificate
+
+Two flags must NOT be conflated:
+
+    is_admissible_for_downstream_bank_level_test  (necessary)
+    is_scientifically_validated_bank_level_result (sufficient)
+
+Sufficiency requires: composed DoV BOTH_WITHIN AND Gate 6 PASS
+with a SIGNED precursor direction (FACILITATED or HINDERED, NOT
+NO_SIGNAL).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from research.reconstruction.allocator import (
+    ALLOCATOR_COVERAGE_RATIO_MIN_DEFAULT,
+    BankLevelForwardSignalCertificate,
+    ComposedDomainStatus,
+    CountryToBankAllocator,
+    SizeWeightedPrior,
+    UniformPrior,
+    assert_real_data_input_not_validated_here,
+    composed_status_admits,
+    emit_bank_level_forward_signal,
+)
+from research.reconstruction.allocator.data import MFI_DEMO_TSV
+from research.reconstruction.allocator.mfi_loader import load_mfi_registry
+from research.reconstruction.kuramoto_on_reconstruction import PrecursorDirection
+from research.reconstruction.positive_control import (
+    GroundTruthRecoveryCertificate,
+    ground_truth_core_periphery,
+    run_recovery_on_substrate,
+)
+
+
+def _within_recovery_cert(n: int, seed: int = 42) -> GroundTruthRecoveryCertificate:
+    w = ground_truth_core_periphery(n=n, core_frac=0.30, seed=seed)
+    return run_recovery_on_substrate(f"CP_{n}_e2e", w, seed=seed)
+
+
+def _agg_for_demo() -> tuple[dict[str, float], dict[str, float]]:
+    return (
+        {"DE": 800.0, "FR": 700.0, "IT": 500.0, "ES": 450.0, "NL": 350.0},
+        {"DE": 750.0, "FR": 660.0, "IT": 470.0, "ES": 420.0, "NL": 320.0},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Real-data contract
+# ---------------------------------------------------------------------------
+
+
+def test_real_data_input_path_is_explicitly_blocked() -> None:
+    """Calling the pipeline with `is_synthetic_ground_truth=False`
+    raises with INV-RECONSTRUCTION-2 + INV-IDENTIFICATION-1 named.
+    Forbids the validation flag from leaking onto real data."""
+    with pytest.raises(ValueError, match="INV-RECONSTRUCTION-2"):
+        assert_real_data_input_not_validated_here(False)
+
+
+def test_synthetic_path_is_admitted() -> None:
+    """The synthetic-ground-truth path must NOT raise; it just
+    returns None (the function is a fail-closed guard, not a value
+    producer)."""
+    assert_real_data_input_not_validated_here(True)
+
+
+# ---------------------------------------------------------------------------
+# Helper: composed_status_admits
+# ---------------------------------------------------------------------------
+
+
+def test_composed_status_admits_only_both_within() -> None:
+    assert composed_status_admits(ComposedDomainStatus.BOTH_WITHIN) is True
+    for s in (
+        ComposedDomainStatus.RECONSTRUCTION_OUT,
+        ComposedDomainStatus.ALLOCATOR_OUT,
+        ComposedDomainStatus.BOTH_OUT,
+    ):
+        assert composed_status_admits(s) is False
+
+
+# ---------------------------------------------------------------------------
+# E2E pipeline — synthetic happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+def test_e2e_demo_fixture_emits_bank_level_certificate() -> None:
+    """Load the frozen MFI demo fixture, build a SizeWeighted allocator,
+    run the full pipeline. Must return a BankLevelForwardSignalCertificate
+    with the two-property surface populated."""
+    out = load_mfi_registry(MFI_DEMO_TSV)
+    rec_cert = _within_recovery_cert(n=out.n_rows, seed=42)
+    agg_in, agg_out = _agg_for_demo()
+    allocator = CountryToBankAllocator(
+        prior=SizeWeightedPrior(
+            bank_country_map=out.bank_country_map,
+            bank_weights=out.bank_weights,
+            prior_id_tag="mfi_demo_v1",
+        )
+    )
+    cert = emit_bank_level_forward_signal(
+        country_aggregates_in=agg_in,
+        country_aggregates_out=agg_out,
+        bank_country_map=out.bank_country_map,
+        allocator=allocator,
+        recovery_certificate=rec_cert,
+        cimini_target_density=0.05,
+        bernoulli_seed=42,
+        kuramoto_seed=42,
+        kuramoto_n_bootstrap=8,
+    )
+    assert isinstance(cert, BankLevelForwardSignalCertificate)
+    assert cert.bank_level_w_reconstructed_shape == (out.n_rows, out.n_rows)
+    # Both flags must be present and bool.
+    assert cert.is_admissible_for_downstream_bank_level_test in (True, False)
+    assert cert.is_scientifically_validated_bank_level_result in (True, False)
+
+
+@pytest.mark.slow
+def test_e2e_validated_implies_admissible_and_signed_direction() -> None:
+    """If the validation flag is True, the admissibility flag MUST
+    be True AND the precursor direction MUST be signed (not NO_SIGNAL)."""
+    out = load_mfi_registry(MFI_DEMO_TSV)
+    rec_cert = _within_recovery_cert(n=out.n_rows, seed=42)
+    agg_in, agg_out = _agg_for_demo()
+    cert = emit_bank_level_forward_signal(
+        country_aggregates_in=agg_in,
+        country_aggregates_out=agg_out,
+        bank_country_map=out.bank_country_map,
+        allocator=CountryToBankAllocator(
+            prior=SizeWeightedPrior(
+                bank_country_map=out.bank_country_map,
+                bank_weights=out.bank_weights,
+            )
+        ),
+        recovery_certificate=rec_cert,
+    )
+    if cert.is_scientifically_validated_bank_level_result:
+        assert cert.is_admissible_for_downstream_bank_level_test is True
+        assert cert.precursor_direction in (
+            PrecursorDirection.SYNCHRONIZATION_FACILITATED,
+            PrecursorDirection.SYNCHRONIZATION_HINDERED,
+        )
+
+
+@pytest.mark.slow
+def test_e2e_admissible_does_not_imply_validated() -> None:
+    """An admissible certificate MAY have validation False —
+    Gate 6 PASS / NO_SIGNAL is independent of DoV. Pin the gap."""
+    out = load_mfi_registry(MFI_DEMO_TSV)
+    rec_cert = _within_recovery_cert(n=out.n_rows, seed=42)
+    agg_in, agg_out = _agg_for_demo()
+    cert = emit_bank_level_forward_signal(
+        country_aggregates_in=agg_in,
+        country_aggregates_out=agg_out,
+        bank_country_map=out.bank_country_map,
+        allocator=CountryToBankAllocator(
+            prior=SizeWeightedPrior(
+                bank_country_map=out.bank_country_map,
+                bank_weights=out.bank_weights,
+            )
+        ),
+        recovery_certificate=rec_cert,
+    )
+    # Admissibility is True (composed DoV BOTH_WITHIN at matched
+    # envelope). Validation may be either; the property is allowed
+    # to be False without contradicting admissibility.
+    assert cert.is_admissible_for_downstream_bank_level_test is True
+    if not cert.is_scientifically_validated_bank_level_result:
+        # NO_SIGNAL OR Gate 6 FAIL — both are legitimate "not yet
+        # validated" outcomes.
+        assert cert.kuramoto_certificate.passed is False or (
+            cert.precursor_direction is PrecursorDirection.NO_SIGNAL
+        )
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed direction: when DoV not BOTH_WITHIN, validation is False
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+def test_e2e_uniform_prior_low_coverage_yields_not_validated() -> None:
+    """A `UniformPrior` over a SUBSET of countries (so coverage drops
+    below 0.80) MUST yield is_scientifically_validated_bank_level_result
+    = False, regardless of Gate 6. The gate is fail-closed on the
+    necessary-condition layer."""
+    out = load_mfi_registry(MFI_DEMO_TSV)
+    rec_cert = _within_recovery_cert(n=out.n_rows, seed=42)
+    agg_in, agg_out = _agg_for_demo()
+    # Uniform with the same registry: coverage_ratio = 1.0 by
+    # UniformPrior contract — it has "evidence" for every country
+    # in its bank_country_map. To get LOW coverage we need a mismatch
+    # between aggregates and the bank_country_map. Forge that:
+    # only 2 of 5 countries get banks.
+    truncated_bcm = tuple((b, c) for b, c in out.bank_country_map if c in {"DE", "FR"})
+    allocator = CountryToBankAllocator(
+        prior=UniformPrior(bank_country_map=truncated_bcm),
+        fallback_policy="drop_country",
+    )
+    cert = emit_bank_level_forward_signal(
+        country_aggregates_in=agg_in,
+        country_aggregates_out=agg_out,
+        bank_country_map=truncated_bcm,
+        allocator=allocator,
+        recovery_certificate=rec_cert,
+    )
+    # On a smaller bank_country_map the reconstruction's n_nodes
+    # will not match the recovery_certificate's tested_at_n_nodes
+    # envelope OR the allocator coverage will trip — either way,
+    # validation must be False.
+    assert cert.is_scientifically_validated_bank_level_result is False
+
+
+# ---------------------------------------------------------------------------
+# Pipeline shape contract
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+def test_e2e_reconstructed_w_shape_matches_n_banks() -> None:
+    out = load_mfi_registry(MFI_DEMO_TSV)
+    rec_cert = _within_recovery_cert(n=out.n_rows, seed=42)
+    agg_in, agg_out = _agg_for_demo()
+    cert = emit_bank_level_forward_signal(
+        country_aggregates_in=agg_in,
+        country_aggregates_out=agg_out,
+        bank_country_map=out.bank_country_map,
+        allocator=CountryToBankAllocator(
+            prior=SizeWeightedPrior(
+                bank_country_map=out.bank_country_map,
+                bank_weights=out.bank_weights,
+            )
+        ),
+        recovery_certificate=rec_cert,
+    )
+    n = out.n_rows
+    assert cert.bank_level_w_reconstructed_shape == (n, n)
+    assert 0.0 <= cert.bank_level_inferred_density_estimate <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# Kuramoto cert N >= 8 guard
+# ---------------------------------------------------------------------------
+
+
+def test_e2e_too_few_banks_yields_no_signal_not_crash() -> None:
+    """If the bank-level network has < 8 banks the Kuramoto engine
+    cannot run (it requires N ≥ 8). The pipeline must surface a
+    NO_SIGNAL precursor direction and a non-validated certificate
+    rather than crashing."""
+    bcm = tuple((f"B{i}", "C0") for i in range(4))  # 4 banks → too few
+    rec_cert = _within_recovery_cert(n=4, seed=42)  # mismatched on purpose
+    cert = emit_bank_level_forward_signal(
+        country_aggregates_in={"C0": 100.0},
+        country_aggregates_out={"C0": 100.0},
+        bank_country_map=bcm,
+        allocator=CountryToBankAllocator(prior=UniformPrior(bank_country_map=bcm)),
+        recovery_certificate=rec_cert,
+    )
+    assert cert.precursor_direction is PrecursorDirection.NO_SIGNAL
+    assert cert.is_scientifically_validated_bank_level_result is False
+
+
+# ---------------------------------------------------------------------------
+# Default coverage threshold check via the helper
+# ---------------------------------------------------------------------------
+
+
+def test_default_coverage_threshold_value() -> None:
+    """Sanity: the helper module exposes the same default."""
+    assert ALLOCATOR_COVERAGE_RATIO_MIN_DEFAULT == 0.80


### PR DESCRIPTION
## Summary

**Closing PR of the X-10R-1 epic.** Wires the four merged layers (allocator, prior, reconstruction, composed DoV) into one deterministic function that emits a `BankLevelForwardSignalCertificate`.

Closes #638.

## Pipeline

```
country aggregates
    ⬇  CountryToBankAllocator + AllocatorPrior        [PRs #642 + #643]
bank-level marginals (s_in, s_out)
    ⬇  fit_cimini_squartini + Bernoulli + IPF         [PR #635]
bank-level reconstructed adjacency W_recon
    ⬇  audit_recovery (Gate 5)                        [PR #635]
    ⬇  gate_6_precursor_discriminative                [PR #635]
Kuramoto R(∞) precursor verdict
    ⬇  check_composed_domain_of_validity              [PR #6]
ComposedDomainCheck
    ⬇
BankLevelForwardSignalCertificate
```

## Two-property surface — **admissibility ≠ validation**

| Property | Meaning | True iff |
|---|---|---|
| `is_admissible_for_downstream_bank_level_test` | **necessary** — inputs in regime where Gate 6 is well-defined | composed DoV verdict is `BOTH_WITHIN` |
| `is_scientifically_validated_bank_level_result` | **sufficient** — bank-level forward signal admissible AND validated | admissible AND Gate 6 PASS AND signed precursor direction |

Sufficiency requires a SIGNED Gate 6 direction (`FACILITATED` or `HINDERED`, not `NO_SIGNAL`).

## Fail-closed contract

`assert_real_data_input_not_validated_here(is_synthetic_ground_truth=False)` raises with `INV-RECONSTRUCTION-2 + INV-IDENTIFICATION-1` named. The validation flag has no meaning on real data and CANNOT leak.

## Tests (10 new — 138 in `tests/reconstruction/allocator/` total)

- Real-data input path explicitly blocked.
- Synthetic path admitted (no raise).
- `composed_status_admits` semantics (only `BOTH_WITHIN` admits).
- E2E synthetic happy path on frozen MFI demo fixture (`@slow`).
- `validated ⇒ admissible AND signed direction` (`@slow`).
- `admissible NOT⇒ validated` — the gap that Gate 6 must close (`@slow`).
- Fail-closed direction: low-coverage `UniformPrior` + truncated `bcm` yields `validated=False` regardless of Gate 6 (`@slow`).
- Reconstructed `W` shape contract; inferred density ∈ [0, 1] (`@slow`).
- Too-few-banks (N < 8 Kuramoto guard) yields NO_SIGNAL + `validated=False`, no crash.
- Default coverage threshold sanity.

## Empirical result — **HONEST OUTPUT**

On the canonical 25-bank synthetic substrate at default density (`cimini_target_density=0.05`):

```
composed status:    both_within_validated_domain
Kuramoto Gate 6:    FAIL (CI overlaps zero band)
precursor direction: ci_overlaps_zero
admissible:         True
validated:          False  ← honest
```

The pipeline correctly admits the inputs (DoV `BOTH_WITHIN`) but does **NOT** validate the bank-level result (Gate 6 cannot distinguish the precursor from null on N=25 with 8 bootstrap seeds — finite-N noise too large).

This is the *correct* design behaviour: the gate **exists** and **emits the right verdict**; it does NOT fabricate a signal that isn't there.

## INV-IDENTIFICATION-1 stays in force

The validation flag flips True only when ALL of:
1. `is_synthetic_ground_truth=True` (substrate has known truth)
2. composed DoV `BOTH_WITHIN`
3. Gate 6 PASS with SIGNED direction

On real BIS LBS data, (1) is False by contract — the validation flag has no meaning. **INV-IDENTIFICATION-1 stays in force.** Real-data validation requires either:
- a separate substrate-discovery layer (out-of-epic), OR
- finding a synthetic regime where Gate 6 *does* clear, demonstrating the pipeline's positive discriminative capacity (current finding: 25-bank does NOT clear; substrate-search is out-of-scope here)

## Local results

- `pytest tests/reconstruction/allocator/`: **138 passed** in 19 s (130 fast + 8 slow @e2e)
- `mypy --strict --follow-imports=silent`: **23 source files clean**
- `ruff check` + `black --check`: clean

## Acceptance gates

- [x] `BankLevelForwardSignalCertificate` exposed
- [x] `emit_bank_level_forward_signal` exposed
- [x] `assert_real_data_input_not_validated_here` exposed
- [x] `composed_status_admits` exposed
- [x] Falsifier: real-data path raises with `INV-RECONSTRUCTION-2`

## Test plan

- [ ] CI green on `pytest tests/reconstruction/allocator/`
- [ ] CI green on `ruff check` + `mypy --strict` + `black --check`
- [ ] Acceptor passes
- [ ] PR description matches code

## What this PR does NOT do

- Does NOT lift `INV-IDENTIFICATION-1` (the bank-level inference claim remains forbidden on real data)
- Does NOT find a synthetic substrate where Gate 6 clears (substrate-discovery is out-of-epic)
- Does NOT ingest real ECB MFI / EBA / BankFocus data

The X-10R-1 epic foundation is now COMPLETE: load → prior → allocator → audit → reconstruction → Gate 6 → composed DoV → forward-signal certificate. Real-data inference and substrate-discovery layers are deferred to subsequent epics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)