### PR TITLE
test(x10r,D-001): weighted_allocation operational-regime fidelity (closes #637)

### DIFF
--- a/.claude/commit_acceptors/x10r-weighted-allocation-cimini-regime.yaml
+++ b/.claude/commit_acceptors/x10r-weighted-allocation-cimini-regime.yaml
@@ -1,0 +1,121 @@
+# Diff-bound commit acceptor for D-001 (Issue #637) —
+# weighted_allocation operational-regime fidelity test surface.
+#
+# What lands:
+#   * tests/reconstruction/test_weighted_allocation_under_cimini_regime.py
+#       11 tests pinning the operational regime: Cimini-calibrated
+#       p_ij + Bernoulli + IPF on lognormal marginals; ≥ 3/4
+#       densities clear Gate 5 row/col L1 ≤ 0.05; total mass
+#       conserved to 1 % at every density; multi-seed and heavy-
+#       tail (sigma=2) stress.
+#   * X10R_WEIGHTED_ALLOCATION_OPERATIONAL_REGIME_REPORT.md
+#       Empirical result + reproduction recipe + explicit
+#       "What this PR does NOT do" section.
+#
+# Locally verified:
+#   * pytest -m "not slow":  9 passed
+#   * pytest -m "slow":      2 passed
+#   * mypy --strict + ruff + black: clean
+
+id: x10r-weighted-allocation-cimini-regime
+status: ACTIVE
+claim_type: chore
+promise: >-
+  After this PR lands, tests/reconstruction/ ships
+  test_weighted_allocation_under_cimini_regime.py — the missing
+  operational-regime test surface flagged by Issue #637 and
+  D-001. Closes the gap where the original
+  test_weighted_allocation.py covers UNIFORM-Bernoulli supports
+  (p=0.30) but production uses Cimini-calibrated heterogeneous
+  p_ij. New tests pin the contract: at densities {0.03, 0.05,
+  0.08, 0.12} on lognormal marginals (mass-balanced), the full
+  fit_cimini_squartini → Bernoulli → IPF pipeline must clear
+  Gate 5 row/col L1 ≤ 0.05 in ≥ 3 of 4 cells (matches the
+  production gate where downstream Gate 5 catches any IPF
+  residual at d=0.03 on heavy-tailed marginals). Empirical
+  result at canonical seed=42, N=80, sigma=1.0:
+  d=0.03 FAIL (row_L1 0.0838); d=0.05 PASS (0.0162);
+  d=0.08 PASS (~4e-10); d=0.12 PASS (~3e-10) → 3/4.
+  Multi-seed and heavy-tail (sigma=2) stress tests guard
+  against canonical-seed cherry-picking and BIS-LBS-like
+  regime drift.
+diff_scope:
+  changed_files:
+    - path: ".claude/commit_acceptors/x10r-weighted-allocation-cimini-regime.yaml"
+    - path: "tests/reconstruction/test_weighted_allocation_under_cimini_regime.py"
+    - path: "X10R_WEIGHTED_ALLOCATION_OPERATIONAL_REGIME_REPORT.md"
+  forbidden_paths:
+    - "trading/"
+    - "execution/"
+    - "forecast/"
+    - "policy/"
+    - "core/physics/"
+    - "core/kuramoto/"
+    - "research/reconstruction/allocator/"  # D-001 is reconstruction-side, NOT allocator
+    - "research/reconstruction/weighted_allocation.py"  # NO source change
+    - "application/governance/claim_ledger.py"
+    - "application/governance/commit_acceptor.py"
+required_python_symbols:
+  - "tests/reconstruction/test_weighted_allocation_under_cimini_regime.py::test_operational_regime_passes_three_of_four_densities"
+  - "tests/reconstruction/test_weighted_allocation_under_cimini_regime.py::test_total_mass_conserved_in_cimini_regime"
+expected_signal: >-
+  Local: `pytest tests/reconstruction/test_weighted_allocation_under_cimini_regime.py -m "not slow" -q`
+  reports "9 passed"; with "-m slow" reports "2 passed";
+  `mypy --strict --follow-imports=silent` clean on the new test
+  file; `ruff check` and `black --check` both pass on
+  tests/reconstruction/test_weighted_allocation_under_cimini_regime.py.
+measurement_command: >-
+  bash -c 'mypy --strict --follow-imports=silent
+  tests/reconstruction/test_weighted_allocation_under_cimini_regime.py
+  && ruff check tests/reconstruction/test_weighted_allocation_under_cimini_regime.py
+  && black --check tests/reconstruction/test_weighted_allocation_under_cimini_regime.py
+  && pytest tests/reconstruction/test_weighted_allocation_under_cimini_regime.py -q'
+signal_artifact: "tmp/x10r_weighted_allocation_operational_regime.json"
+falsifier:
+  command: >-
+    bash -c 'python -c "
+    import numpy as np
+    from research.reconstruction.cimini_squartini import (
+        fit_cimini_squartini, p_link,
+    )
+    from research.reconstruction.weighted_allocation import (
+        allocate_weights, sample_adjacency_bernoulli,
+    )
+    rng = np.random.default_rng(42)
+    s_out = rng.lognormal(mean=10.0, sigma=1.0, size=80)
+    s_in = rng.lognormal(mean=10.0, sigma=1.0, size=80)
+    s_in = s_in * (s_out.sum() / s_in.sum())
+    n_pass = 0
+    for d in (0.03, 0.05, 0.08, 0.12):
+        fit = fit_cimini_squartini(s_out, s_in, target_density=d)
+        p = p_link(fit.x, fit.y, fit.z)
+        a = sample_adjacency_bernoulli(
+            p, rng=np.random.default_rng(42 * 31 + int(d * 1000))
+        )
+        w = allocate_weights(a, s_out, s_in)
+        mean_strength = float((s_out + s_in).mean() / 2.0)
+        row = float(np.abs(s_out - w.sum(axis=1)).sum() / 80 / mean_strength)
+        col = float(np.abs(s_in - w.sum(axis=0)).sum() / 80 / mean_strength)
+        if row <= 0.05 and col <= 0.05:
+            n_pass += 1
+    assert n_pass >= 3, f\"operational-regime broke: {n_pass}/4 densities\"
+    "'
+  description: >-
+    Probes the D-001 contract empirically: at the canonical
+    seed=42, N=80, sigma=1.0, the operational regime must clear
+    ≥ 3 of 4 default-sweep densities. If the falsifier exits
+    non-zero, the Cimini → Bernoulli → IPF pipeline regressed
+    on heavy-tailed lognormal marginals.
+rollback_command: >-
+  bash -c 'git checkout HEAD~1 --
+  && rm -f tests/reconstruction/test_weighted_allocation_under_cimini_regime.py
+  X10R_WEIGHTED_ALLOCATION_OPERATIONAL_REGIME_REPORT.md
+  .claude/commit_acceptors/x10r-weighted-allocation-cimini-regime.yaml'
+rollback_verification_command: >-
+  bash -c 'test ! -f tests/reconstruction/test_weighted_allocation_under_cimini_regime.py
+  && test ! -f X10R_WEIGHTED_ALLOCATION_OPERATIONAL_REGIME_REPORT.md
+  && test ! -f .claude/commit_acceptors/x10r-weighted-allocation-cimini-regime.yaml'
+memory_update_type: append
+ledger_path: ".claude/commit_acceptors/x10r-weighted-allocation-cimini-regime.yaml"
+report_path: "tmp/x10r_weighted_allocation_operational_regime.json"
+evidence: []

--- a/X10R_WEIGHTED_ALLOCATION_OPERATIONAL_REGIME_REPORT.md
+++ b/X10R_WEIGHTED_ALLOCATION_OPERATIONAL_REGIME_REPORT.md
@@ -1,0 +1,120 @@
+# D-001 — Weighted-allocation operational-regime fidelity
+
+**PR:** `feat/x10r-weighted-allocation-cimini-regime`
+**Defect:** D-001 (P0)
+**Source:** Issue #637
+
+---
+
+## Why this debt existed
+
+The original `tests/reconstruction/test_weighted_allocation.py`
+exercises `allocate_weights` against UNIFORM-Bernoulli supports
+(``p = 0.30``). That regime is convenient for unit-testing IPF
+convergence, but it does NOT match production: real X-10R runs
+generate ``p_ij`` from `fit_cimini_squartini` — heterogeneous,
+heavy-tailed, dominated by top-fitness pairs. A Gate 5 verdict
+that looked clean in the lab regime might break in the
+operational regime.
+
+This PR closes that gap with a dedicated test surface.
+
+---
+
+## What this PR does
+
+`tests/reconstruction/test_weighted_allocation_under_cimini_regime.py`
+pins the operational-regime contract:
+
+```
+For each density d in {0.03, 0.05, 0.08, 0.12}:
+    1. Synthesize lognormal s_out, s_in (mass-balanced).
+    2. fit_cimini_squartini(s_out, s_in, target_density=d).
+    3. p = p_link(fit.x, fit.y, fit.z).
+    4. a = sample_adjacency_bernoulli(p, rng=...).
+    5. w = allocate_weights(a, s_out, s_in).
+    6. Measure row_L1 / col_L1 (Gate 5 metric class).
+    7. Cell PASSES iff row_L1 ≤ 0.05 AND col_L1 ≤ 0.05.
+```
+
+Tests:
+- **Per-cell smoke** (4 fast, parametrised over density): each
+  density cell completes without crash; row/col L1 in [0, 1).
+- **`test_operational_regime_passes_three_of_four_densities`**
+  (1 fast): the headline gate. ≥ 3 of 4 cells must clear.
+- **`test_total_mass_conserved_in_cimini_regime`** (4 fast,
+  parametrised): even when row/col L1 clips the threshold, total
+  mass is conserved to 1 % relative — GATE_2 at the global level.
+- **`test_operational_regime_robust_across_seeds`** (1 slow):
+  three-seed multi-run version to catch a regime that only
+  works at the canonical seed.
+- **`test_operational_regime_heavy_tail_sigma_2`** (1 slow):
+  sigma=2.0 lognormal marginals approximate BIS LBS tails;
+  relaxed 2/4 floor (heavy-tail IS the regime where IPF
+  residual is hardest).
+
+---
+
+## Empirical result (canonical seed=42, N=80)
+
+| density | row_L1 | col_L1 | Gate 5 ≤ 0.05 |
+|---|---|---|---|
+| 0.03 | 0.0838 | ~0 | **FAIL** |
+| 0.05 | 0.0162 | ~0 | **PASS** |
+| 0.08 | 4.3e-10 | ~0 | **PASS** |
+| 0.12 | 3.1e-10 | ~0 | **PASS** |
+
+Pass rate: **3/4** — meets the ≥ 3 of 4 acceptance bar.
+
+Density 0.03 fails because at very low density the Cimini support
+concentrates on top-fitness pairs and the IPF projection (Almog-
+Squartini Sinkhorn-Knopp) leaves structural residual on the
+heavy-tailed marginals. This is documented debt — Gate 5 catches
+the residual at the verdict boundary; the allocator does NOT
+itself fail-closed. The 3/4 floor encodes that contract.
+
+A 4/4 floor would over-constrain — the regime test would fail on
+a single unlucky seed at d=0.03 even when downstream Gate 5
+still catches the issue. 3/4 matches the actual production
+behaviour: the operational regime ALMOST always passes IPF; one
+density cell may clip without the regime being unfit-for-purpose.
+
+---
+
+## What this PR does NOT do
+
+- Does NOT change `allocate_weights` or any other source code.
+  The test surface is the only new artefact.
+- Does NOT touch Gate 6 (Kuramoto precursor). Strict scope.
+- Does NOT operate on real data. Synthetic lognormal marginals
+  only.
+- Does NOT emit any bank-level claim or domain-of-validity
+  verdict.
+- Does NOT lift `INV-IDENTIFICATION-1` or change the
+  INSTRUMENTED-state declaration.
+
+---
+
+## Acceptance gates (per protocol D-001)
+
+- [x] `tests/reconstruction/test_weighted_allocation_under_cimini_regime.py` shipped
+- [x] Density sweep `{0.03, 0.05, 0.08, 0.12}`
+- [x] `fit_cimini_squartini` → calibrated `p_ij` → Bernoulli A → IPF
+- [x] row_L1 / col_L1 ≤ Gate 5 thresholds in ≥3/4 cells (3/4 actual)
+- [x] Report: this file (`X10R_WEIGHTED_ALLOCATION_OPERATIONAL_REGIME_REPORT.md`)
+- [x] mypy --strict + ruff + black clean
+- [x] Commit acceptor: `.claude/commit_acceptors/x10r-weighted-allocation-cimini-regime.yaml`
+
+---
+
+## Reproduction
+
+```bash
+git fetch origin feat/x10r-weighted-allocation-cimini-regime
+git checkout feat/x10r-weighted-allocation-cimini-regime
+pytest tests/reconstruction/test_weighted_allocation_under_cimini_regime.py -v
+cat tmp/x10r_weighted_allocation_operational_regime.json
+```
+
+The JSON ledger is regenerated on every test run; the values
+in the table above are deterministic at seed=42, N=80, sigma=1.0.

--- a/tests/reconstruction/test_weighted_allocation_under_cimini_regime.py
+++ b/tests/reconstruction/test_weighted_allocation_under_cimini_regime.py
@@ -1,0 +1,222 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""D-001 — `allocate_weights` under the OPERATIONAL Cimini regime.
+
+The original `test_weighted_allocation.py` exercises
+`allocate_weights` against UNIFORM-Bernoulli supports
+(``p = 0.30``). That regime is convenient for unit-testing IPF
+convergence but does NOT match production: real X-10R runs
+generate ``p_ij`` from `fit_cimini_squartini` — heterogeneous,
+heavy-tailed, dominated by top-fitness pairs.
+
+This module pins the operational-regime contract:
+
+    For every density d in {0.03, 0.05, 0.08, 0.12}:
+      1. Synthesize lognormal s_out, s_in (mass-balanced).
+      2. fit_cimini_squartini(s_out, s_in, target_density=d).
+      3. p = p_link(fit.x, fit.y, fit.z).
+      4. a = sample_adjacency_bernoulli(p, rng=...).
+      5. w = allocate_weights(a, s_out, s_in).
+      6. Measure row_L1 / col_L1 (Gate 5 metric class).
+      7. Cell PASSES iff row_L1 ≤ 0.05 AND col_L1 ≤ 0.05.
+
+Acceptance: ≥ 3 of 4 density cells pass.
+
+Why ``≥ 3 of 4`` and not 4/4
+=============================
+At very low density (0.03) the Cimini support concentrates on
+top-fitness pairs and IPF can leave structural residual on
+heavy-tailed marginals. This is `documented` debt — Gate 5
+catches the residual at the verdict boundary; the allocator does
+NOT itself fail-closed. The 3/4 floor encodes that contract:
+the operational regime must ALMOST always pass IPF; one density
+cell may clip the threshold without the regime being
+unfit-for-purpose.
+
+A 4/4 floor would over-constrain — the regime test would
+fail on a single unlucky seed at d=0.03 even when downstream
+Gate 5 still catches the issue. A 3/4 floor matches the actual
+production gate (Gate 5 is the verdict; this test is a
+*regression* on the helper).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from research.reconstruction.cimini_squartini import (
+    fit_cimini_squartini,
+    p_link,
+)
+from research.reconstruction.weighted_allocation import (
+    allocate_weights,
+    sample_adjacency_bernoulli,
+)
+
+_DENSITIES: tuple[float, ...] = (0.03, 0.05, 0.08, 0.12)
+_GATE5_L1_THRESHOLD: float = 0.05
+_REQUIRED_PASS_COUNT: int = 3  # ≥ 3 of 4 cells
+
+_REPORT_PATH = Path("tmp/x10r_weighted_allocation_operational_regime.json")
+
+
+def _operational_marginals(n: int, *, sigma: float, seed: int) -> tuple[np.ndarray, np.ndarray]:
+    """Heavy-tailed lognormal marginals, mass-balanced (Σs_in=Σs_out)."""
+    rng = np.random.default_rng(seed)
+    s_out = rng.lognormal(mean=10.0, sigma=sigma, size=n)
+    s_in = rng.lognormal(mean=10.0, sigma=sigma, size=n)
+    s_in = s_in * (s_out.sum() / s_in.sum())
+    return s_out, s_in
+
+
+def _row_col_l1(w: np.ndarray, s_out: np.ndarray, s_in: np.ndarray) -> tuple[float, float]:
+    """Return (row_L1, col_L1) per Gate 5 normalisation: relative to
+    mean strength so the threshold (0.05) is dimension-free."""
+    n = w.shape[0]
+    s_out_recon = w.sum(axis=1)
+    s_in_recon = w.sum(axis=0)
+    mean_strength = float((s_out + s_in).mean() / 2.0)
+    if mean_strength == 0:
+        mean_strength = 1.0
+    row = float(np.abs(s_out - s_out_recon).sum() / n / mean_strength)
+    col = float(np.abs(s_in - s_in_recon).sum() / n / mean_strength)
+    return row, col
+
+
+def _run_cell(*, density: float, n: int, sigma: float, seed: int) -> dict[str, float | bool]:
+    """One density cell: fit → sample → allocate → measure L1."""
+    s_out, s_in = _operational_marginals(n, sigma=sigma, seed=seed)
+    fit = fit_cimini_squartini(s_out, s_in, target_density=density)
+    p = p_link(fit.x, fit.y, fit.z)
+    rng = np.random.default_rng(seed * 31 + int(density * 1000))
+    a = sample_adjacency_bernoulli(p, rng=rng)
+    w = allocate_weights(a, s_out, s_in)
+    row_l1, col_l1 = _row_col_l1(w, s_out, s_in)
+    passed = (row_l1 <= _GATE5_L1_THRESHOLD) and (col_l1 <= _GATE5_L1_THRESHOLD)
+    return {
+        "density": float(density),
+        "n_nodes": int(n),
+        "sigma": float(sigma),
+        "seed": int(seed),
+        "row_l1": row_l1,
+        "col_l1": col_l1,
+        "passed": bool(passed),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Per-cell smoke tests — each density at the canonical seed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("density", _DENSITIES)
+def test_cell_runs_without_crashing_at_canonical_seed(density: float) -> None:
+    """Every density cell must complete without a crash at the
+    canonical seed. The fit / sample / allocate stack must be
+    operational-regime-stable."""
+    cell = _run_cell(density=density, n=80, sigma=1.0, seed=42)
+    assert "passed" in cell
+    assert 0.0 <= cell["row_l1"] < 1.0
+    assert 0.0 <= cell["col_l1"] < 1.0
+
+
+# ---------------------------------------------------------------------------
+# The operational-regime gate: ≥ 3 of 4 densities must clear Gate 5
+# ---------------------------------------------------------------------------
+
+
+def test_operational_regime_passes_three_of_four_densities() -> None:
+    """The contract: under Cimini-calibrated p_ij + Bernoulli + IPF
+    on lognormal marginals, ≥ 3 of 4 default-sweep densities must
+    clear the Gate 5 row/col L1 ≤ 0.05 threshold.
+
+    Producing a JSON report at tmp/x10r_weighted_allocation_
+    operational_regime.json so the report markdown can be regenerated
+    deterministically.
+    """
+    cells = [_run_cell(density=d, n=80, sigma=1.0, seed=42) for d in _DENSITIES]
+    n_pass = sum(1 for c in cells if c["passed"])
+
+    # Persist evidence (best-effort; tmp/ is gitignored).
+    try:
+        _REPORT_PATH.parent.mkdir(parents=True, exist_ok=True)
+        _REPORT_PATH.write_text(json.dumps({"densities": cells, "n_pass": n_pass}, indent=2))
+    except OSError:
+        pass
+
+    assert n_pass >= _REQUIRED_PASS_COUNT, (
+        f"operational-regime gate failed: only {n_pass}/{len(_DENSITIES)} "
+        f"densities cleared Gate 5 row/col L1 ≤ {_GATE5_L1_THRESHOLD}. "
+        f"Cells: {cells}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Multi-seed robustness — the regime should not be cherry-picked at seed=42
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+def test_operational_regime_robust_across_seeds() -> None:
+    """Across 3 seeds, the operational-regime gate must pass every
+    time (each seed gets its own ≥ 3/4 outcome). Catches a regime
+    that only works at the canonical seed."""
+    seeds = (42, 17, 101)
+    seed_outcomes: list[int] = []
+    for s in seeds:
+        cells = [_run_cell(density=d, n=80, sigma=1.0, seed=s) for d in _DENSITIES]
+        seed_outcomes.append(sum(1 for c in cells if c["passed"]))
+    assert all(n >= _REQUIRED_PASS_COUNT for n in seed_outcomes), (
+        f"operational regime brittle across seeds: per-seed pass counts = "
+        f"{dict(zip(seeds, seed_outcomes))}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Heavy-tail stress — sigma=2.0 marginals (BIS-LBS-like)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+def test_operational_regime_heavy_tail_sigma_2() -> None:
+    """At sigma=2.0 the lognormal marginals approximate the heavier
+    tails seen in BIS LBS country aggregates. The regime must still
+    clear ≥ 2 of 4 densities (relaxed bar — heavy-tail IS the regime
+    where IPF residual is hardest)."""
+    cells = [_run_cell(density=d, n=80, sigma=2.0, seed=42) for d in _DENSITIES]
+    n_pass = sum(1 for c in cells if c["passed"])
+    assert (
+        n_pass >= 2
+    ), f"heavy-tail (sigma=2) regime broke: {n_pass}/4 densities cleared. Cells: {cells}"
+
+
+# ---------------------------------------------------------------------------
+# Conservation of mass remains exact regardless of IPF residual
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("density", _DENSITIES)
+def test_total_mass_conserved_in_cimini_regime(density: float) -> None:
+    """Even when row/col L1 clip the threshold, the TOTAL mass
+    must be conserved exactly: Σ w_ij ≡ Σ s_out (= Σ s_in) to
+    floating-point tolerance. This is GATE_2 at the global level."""
+    s_out, s_in = _operational_marginals(80, sigma=1.0, seed=42)
+    fit = fit_cimini_squartini(s_out, s_in, target_density=density)
+    p = p_link(fit.x, fit.y, fit.z)
+    rng = np.random.default_rng(7919 + int(density * 1000))
+    a = sample_adjacency_bernoulli(p, rng=rng)
+    w = allocate_weights(a, s_out, s_in)
+    total_w = float(w.sum())
+    total_s = float(s_out.sum())
+    # IPF guarantees per-row / per-col within ipf_tol; the GLOBAL sum
+    # is the marginal sums, so deviation is bounded by N * ipf_tol.
+    # Use a generous bound (1%) — the test catches gross conservation
+    # breaks, not subtle row/col L1 clipping (which is gate-tested
+    # separately).
+    assert (
+        abs(total_w - total_s) / total_s < 0.01
+    ), f"total mass not conserved at density={density}: Σw={total_w:.4f} vs Σs={total_s:.4f}"


### PR DESCRIPTION
## Summary

D-001 (P0). Closes [Issue #637](https://github.com/neuron7xLab/GeoSync/issues/637). Adds the missing **operational-regime test surface** for `allocate_weights`. The original `test_weighted_allocation.py` covers UNIFORM-Bernoulli supports (`p=0.30`); production uses **Cimini-calibrated heterogeneous `p_ij`** from `fit_cimini_squartini`. Without this PR, Gate 5 could look clean in the lab regime and break in real reconstruction.

## What lands

- **`tests/reconstruction/test_weighted_allocation_under_cimini_regime.py`** (11 tests; 9 fast + 2 slow):
  - 4 parametric per-cell smoke tests (one per density).
  - The headline gate: **≥ 3 of 4 densities** clear Gate 5 `row/col L1 ≤ 0.05` at canonical seed=42, N=80, sigma=1.0.
  - 4 parametric per-cell GATE_2 conservation: `Σ w_ij ≡ Σ s_out` to 1 % regardless of IPF residual.
  - **Multi-seed robustness (slow):** 3 seeds × 4 densities, each seed must clear the ≥ 3/4 floor.
  - **Heavy-tail sigma=2 stress (slow):** BIS-LBS-shape; relaxed 2/4 floor.
- **`X10R_WEIGHTED_ALLOCATION_OPERATIONAL_REGIME_REPORT.md`** — empirical result table + reproduction recipe + explicit "What this PR does NOT do" section.
- **`.claude/commit_acceptors/x10r-weighted-allocation-cimini-regime.yaml`** — acceptor + falsifier that re-runs the contract empirically.

## Empirical result (canonical seed=42, N=80, sigma=1.0)

| density | row_L1 | col_L1 | Gate 5 ≤ 0.05 |
|---|---|---|---|
| 0.03 | 0.0838 | ~0 | **FAIL** |
| 0.05 | 0.0162 | ~0 | **PASS** |
| 0.08 | ~4e-10 | ~0 | **PASS** |
| 0.12 | ~3e-10 | ~0 | **PASS** |

**3/4 PASS** — meets the ≥ 3 of 4 acceptance bar.

`d=0.03` fails because at very low density the Cimini support concentrates on top-fitness pairs and IPF leaves structural residual on heavy-tailed marginals. This is documented debt — Gate 5 catches the residual at the verdict boundary; the allocator does NOT itself fail-closed. The 3/4 floor encodes that contract.

## What this PR does NOT do

- Does **NOT** change `allocate_weights` or any source code. Test surface only.
- Does **NOT** touch Gate 6.
- Does **NOT** operate on real data.
- Does **NOT** emit any bank-level claim or DoV verdict.
- Does **NOT** lift `INV-IDENTIFICATION-1` or change the INSTRUMENTED-state declaration.

## Acceptance gates (per defect protocol D-001)

- [x] `tests/reconstruction/test_weighted_allocation_under_cimini_regime.py` shipped
- [x] Density sweep `{0.03, 0.05, 0.08, 0.12}`
- [x] `fit_cimini_squartini` → calibrated `p_ij` → Bernoulli A → IPF
- [x] row_L1 / col_L1 ≤ Gate 5 thresholds in ≥3/4 cells (3/4 actual)
- [x] Report: `X10R_WEIGHTED_ALLOCATION_OPERATIONAL_REGIME_REPORT.md`
- [x] mypy --strict + ruff + black clean
- [x] Commit acceptor + falsifier shipped

## Local results

- `pytest tests/reconstruction/test_weighted_allocation_under_cimini_regime.py -m "not slow"`: **9 passed**
- `pytest tests/reconstruction/test_weighted_allocation_under_cimini_regime.py -m "slow"`: **2 passed**
- `mypy --strict --follow-imports=silent`: clean on the new test file
- `ruff check` + `black --check`: clean on the new test file

🤖 Generated with [Claude Code](https://claude.com/claude-code)