### PR TITLE
ci(pr-gate): bump python-fast-tests timeout-minutes 20→25

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -161,7 +161,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: python-quality
     continue-on-error: false
-    timeout-minutes: 20
+    # Job-level cap raised 20→25 to keep ~5min headroom over the inner
+    # `timeout 1200s pytest`. Repeated CI cancellations on PRs that
+    # otherwise complete pytest occurred when setup+post-pytest steps
+    # consumed the residual budget. The inner 1200s pytest timeout is
+    # unchanged — this only widens the wrapper.
+    timeout-minutes: 25
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/INVENTORY.json
+++ b/INVENTORY.json
@@ -11,7 +11,7 @@
   "files": [
     {
       "path": ".github/workflows/pr-gate.yml",
-      "sha256": "260d2fa2a8a1e65da2713f20bd9e3c6afdf2be2d3309185144855342351bb6cf"
+      "sha256": "f394874e09b806660925609a7e5a5f1f57174587b72bd3a27fd236976d51258b"
     },
     {
       "path": "scripts/ci/check_central_files_touched.py",


### PR DESCRIPTION
## Summary

CI hygiene only. Bumps the **wrapper** job-level `timeout-minutes`
on `python-fast-tests` from 20 → 25 to give ~5 min headroom over
the inner `timeout 1200s pytest`. The inner 1200s pytest timeout
is **unchanged** — this only widens the wrapper.

## Why

Repeated CI cancellations on PRs (e.g. #651) where pytest itself
finished within budget but the wrapper hit the 20-min cap.
GitHub Actions logs show pytest emitting the terminal
`===== short test summary info =====` banner within ~7 seconds
of the cancel — i.e. setup (Checkout + Setup Python + collect
verification) consumed too much of the wrapper budget before
pytest started, leaving no slack for post-pytest steps
(mandatory connector hygiene, formal verification).

## What this PR does NOT do

- Does NOT change any source code, test, or science.
- Does NOT change the inner pytest timeout (still 1200s).
- Does NOT relax the @slow / @heavy_math / @nightly / @flaky
  exclusion.

## Test plan

- [x] yaml syntax valid (single-line edit)
- [ ] Once merged, a PR-with-tests should run `python-fast-tests`
      with the new 25-min cap and finish SUCCESS not CANCELLED

🤖 Generated with [Claude Code](https://claude.com/claude-code)