### PR TITLE
feat(x10r,D-002C,C2.1): pre-registration validator + acceptance lock (#654)

### DIFF
--- a/.claude/commit_acceptors/x10r-d002c-preregistration-lock.yaml
+++ b/.claude/commit_acceptors/x10r-d002c-preregistration-lock.yaml
@@ -1,0 +1,188 @@
+# Diff-bound commit acceptor for D-002C C2.1 (issue #654) —
+# Pre-registration validator + acceptance lock.
+#
+# What lands:
+#   * docs/governance/D002C_PREREGISTRATION.yaml
+#       Amends the pre-registered YAML with the formal locked
+#       decisions block under `acceptance.formal_decisions`:
+#       ci_method=bca_bootstrap, ci_alpha=0.05,
+#       signal_ci_ratio_threshold=1.0, direction_consistency_min_seeds=3,
+#       direction_stability_min_fraction=0.80,
+#       multiple_testing_correction={method: bonferroni, n_cells: 216},
+#       lambda_grid. This is the LAST allowed edit of the YAML
+#       per its own anti-edit clause; the merge sha is the
+#       anchor.
+#   * research/systemic_risk/d002c_preregistration.py
+#       D002CPreregistration frozen dataclass + load_and_lock +
+#       validate_sweep_config. Content-addressed preregistration_sha
+#       over raw YAML bytes; sweep driver MUST agree on every locked
+#       field or PreregistrationMismatch fires (fail-closed).
+#       Bonferroni effective_alpha_per_cell derived in code from
+#       ci_alpha / n_cells; drift between stored and expected is
+#       PreregistrationCorrupt.
+#   * tests/research/systemic_risk/test_d002c_preregistration.py
+#       49 fast tests pinning gates G1-G8 + corruption paths:
+#       load → frozen, sha determinism, sha changes on byte edit,
+#       full-config validation, every-single-field mismatch raises
+#       (parametrised over 15 fields), multi-mismatch list, numeric
+#       invariants (parametrised over 13 bad values), Bonferroni
+#       exactness, acceptance-rule determinism, malformed YAML
+#       corruption paths.
+#
+# Strict scope:
+#   Contract / validator layer ONLY. NO sweep execution. NO substrates,
+#   metrics, runners. NO claim layer. NO threshold tuning. The module
+#   is callable by C2.4 sweep runner but emits no claim of its own —
+#   it only refuses to proceed when the driver disagrees with the
+#   pre-registration.
+
+id: x10r-d002c-preregistration-lock
+status: ACTIVE
+claim_type: correctness
+promise: >-
+  After this PR lands, research/systemic_risk/d002c_preregistration
+  exposes load_and_lock(yaml_path) — returns a frozen
+  D002CPreregistration over docs/governance/D002C_PREREGISTRATION.yaml
+  with a sha256 over raw file bytes, and validate_sweep_config(prereg,
+  sweep_config) which raises PreregistrationMismatch listing every
+  disagreement (not first-fail) between the driver's config and the
+  locked contract. The Bonferroni effective-alpha-per-cell is derived
+  in code from ci_alpha / n_cells; drift between stored and expected
+  values is PreregistrationCorrupt. The YAML itself is amended to
+  expose the formal locked decisions block (ci_method, ci_alpha,
+  signal_ci_ratio_threshold, direction_consistency_min_seeds,
+  direction_stability_min_fraction, multiple_testing_correction with
+  n_cells=216, lambda_grid) — that amendment IS the lock point per
+  the YAML's own anchor-commit clause. No post-hoc edit of the YAML
+  is allowed after this PR merges; any future change is a fresh
+  pre-registration with a fresh sha.
+
+  Strict scope: validator / contract layer only. No sweep execution,
+  no substrates, no metrics, no runners. The module emits no claim
+  of its own — it is callable by C2.4 (sweep runner) and refuses to
+  proceed when the driver disagrees with the pre-registration.
+diff_scope:
+  changed_files:
+    - path: ".claude/commit_acceptors/x10r-d002c-preregistration-lock.yaml"
+    - path: "docs/governance/D002C_PREREGISTRATION.yaml"
+    - path: "research/systemic_risk/d002c_preregistration.py"
+    - path: "tests/research/systemic_risk/test_d002c_preregistration.py"
+  forbidden_paths:
+    - "trading/"
+    - "execution/"
+    - "forecast/"
+    - "policy/"
+    - "core/physics/"
+    - "core/kuramoto/"
+    - "research/reconstruction/"
+    - "research/systemic_risk/sweep_checkpoint.py"
+    - "scripts/run_x10r_"
+    - "application/governance/claim_ledger.py"
+    - "application/governance/commit_acceptor.py"
+required_python_symbols:
+  - "research/systemic_risk/d002c_preregistration.py::D002CPreregistration"
+  - "research/systemic_risk/d002c_preregistration.py::CIMethod"
+  - "research/systemic_risk/d002c_preregistration.py::MultipleTestingCorrection"
+  - "research/systemic_risk/d002c_preregistration.py::PreregistrationCorrupt"
+  - "research/systemic_risk/d002c_preregistration.py::PreregistrationMismatch"
+  - "research/systemic_risk/d002c_preregistration.py::load_and_lock"
+  - "research/systemic_risk/d002c_preregistration.py::validate_sweep_config"
+  - "tests/research/systemic_risk/test_d002c_preregistration.py::test_g1_canonical_yaml_loads_to_frozen_dataclass"
+  - "tests/research/systemic_risk/test_d002c_preregistration.py::test_g2_sha_deterministic_across_repeated_loads"
+  - "tests/research/systemic_risk/test_d002c_preregistration.py::test_g3_single_byte_edit_changes_sha"
+  - "tests/research/systemic_risk/test_d002c_preregistration.py::test_g4_well_formed_config_validates_cleanly"
+  - "tests/research/systemic_risk/test_d002c_preregistration.py::test_g5_missing_keys_listed_in_one_exception"
+  - "tests/research/systemic_risk/test_d002c_preregistration.py::test_g7_bonferroni_effective_alpha_is_exact"
+  - "tests/research/systemic_risk/test_d002c_preregistration.py::test_g8_acceptance_rule_deterministic_and_complete"
+expected_signal: >-
+  Local: `pytest tests/research/systemic_risk/test_d002c_preregistration.py -q`
+  reports "49 passed"; `mypy --strict --follow-imports=silent` clean
+  on the new files; `ruff check` and `black --check` both pass on
+  those paths; the YAML at docs/governance/D002C_PREREGISTRATION.yaml
+  contains the locked `acceptance.formal_decisions` block.
+measurement_command: >-
+  bash -c 'mypy --strict --follow-imports=silent
+  research/systemic_risk/d002c_preregistration.py
+  tests/research/systemic_risk/test_d002c_preregistration.py
+  && ruff check
+  research/systemic_risk/d002c_preregistration.py
+  tests/research/systemic_risk/test_d002c_preregistration.py
+  && black --check
+  research/systemic_risk/d002c_preregistration.py
+  tests/research/systemic_risk/test_d002c_preregistration.py
+  && grep -q "formal_decisions:" docs/governance/D002C_PREREGISTRATION.yaml
+  && grep -q "ci_method: bca_bootstrap" docs/governance/D002C_PREREGISTRATION.yaml
+  && grep -q "method: bonferroni" docs/governance/D002C_PREREGISTRATION.yaml
+  && grep -q "n_cells: 216" docs/governance/D002C_PREREGISTRATION.yaml
+  && pytest tests/research/systemic_risk/test_d002c_preregistration.py -q'
+signal_artifact: "tests/research/systemic_risk/test_d002c_preregistration.py"
+falsifier:
+  command: >-
+    bash -c 'PYTHONPATH=. python -c "
+    import tempfile
+    from pathlib import Path
+    from research.systemic_risk.d002c_preregistration import (
+        CIMethod, MultipleTestingCorrection, PreregistrationCorrupt,
+        PreregistrationMismatch, load_and_lock, validate_sweep_config,
+    )
+    canonical = Path('"'"'docs/governance/D002C_PREREGISTRATION.yaml'"'"')
+    prereg = load_and_lock(canonical)
+    # Identity probes
+    assert prereg.ci_method is CIMethod.BCA_BOOTSTRAP, prereg.ci_method
+    assert prereg.multiple_testing_correction is MultipleTestingCorrection.BONFERRONI
+    assert prereg.n_cells == 216, prereg.n_cells
+    assert abs(prereg.effective_alpha_per_cell - 0.05/216) < 1e-15
+    # Sha stability
+    sha_a = prereg.preregistration_sha
+    sha_b = load_and_lock(canonical).preregistration_sha
+    assert sha_a == sha_b, '"'"'sha unstable across re-load'"'"'
+    # Mismatch fires
+    cfg = {
+        '"'"'ci_method'"'"': '"'"'percentile_bootstrap'"'"',
+        '"'"'ci_alpha'"'"': prereg.ci_alpha,
+        '"'"'signal_ci_ratio_threshold'"'"': prereg.signal_ci_ratio_threshold,
+        '"'"'direction_consistency_min_seeds'"'"': prereg.direction_consistency_min_seeds,
+        '"'"'direction_stability_min_fraction'"'"': prereg.direction_stability_min_fraction,
+        '"'"'multiple_testing_correction'"'"': prereg.multiple_testing_correction.value,
+        '"'"'n_seeds'"'"': prereg.n_seeds,
+        '"'"'n_bootstrap'"'"': prereg.n_bootstrap,
+        '"'"'N_grid'"'"': list(prereg.N_grid),
+        '"'"'lambda_grid'"'"': list(prereg.lambda_grid),
+        '"'"'substrate_ids'"'"': list(prereg.substrate_ids),
+        '"'"'metric_ids'"'"': list(prereg.metric_ids),
+        '"'"'variance_reduction'"'"': list(prereg.variance_reduction),
+        '"'"'substrate_seed'"'"': prereg.substrate_seed,
+        '"'"'preregistration_sha'"'"': prereg.preregistration_sha,
+    }
+    try:
+        validate_sweep_config(prereg, cfg)
+        raise AssertionError('"'"'should have raised'"'"')
+    except PreregistrationMismatch as e:
+        assert '"'"'ci_method'"'"' in str(e), str(e)
+    # Byte-level YAML edit yields fresh sha
+    with tempfile.TemporaryDirectory() as td:
+        p = Path(td) / '"'"'edited.yaml'"'"'
+        p.write_bytes(canonical.read_bytes() + b'"'"'\n'"'"')
+        assert load_and_lock(p).preregistration_sha != sha_a
+    "'
+  description: >-
+    Probes the D-002C C2.1 contract: load_and_lock returns the locked
+    decisions, preregistration_sha is stable across re-load, every
+    sweep-config mismatch raises PreregistrationMismatch with the
+    mismatching key in the message, and any byte-level YAML edit
+    produces a fresh sha. If any of these regress, the pre-registration
+    lock is broken — the driver could silently disagree with the
+    contract.
+rollback_command: >-
+  bash -c 'git checkout HEAD~1 --
+  && rm -f research/systemic_risk/d002c_preregistration.py
+  tests/research/systemic_risk/test_d002c_preregistration.py
+  .claude/commit_acceptors/x10r-d002c-preregistration-lock.yaml'
+rollback_verification_command: >-
+  bash -c 'test ! -f research/systemic_risk/d002c_preregistration.py
+  && test ! -f tests/research/systemic_risk/test_d002c_preregistration.py
+  && test ! -f .claude/commit_acceptors/x10r-d002c-preregistration-lock.yaml'
+memory_update_type: append
+ledger_path: ".claude/commit_acceptors/x10r-d002c-preregistration-lock.yaml"
+report_path: "tests/research/systemic_risk/test_d002c_preregistration.py"
+evidence: []

--- a/docs/governance/D002C_PREREGISTRATION.yaml
+++ b/docs/governance/D002C_PREREGISTRATION.yaml
@@ -116,6 +116,21 @@ acceptance:
         rule: "FPR(lambda=0) <= 0.05 across all swept cells of that (N, substrate, metric)"
       - id: R3
         rule: "direction stability >= 0.80 (i.e. <= 20% direction flips across seeds at the selected cell)"
+  # Formal mathematical decisions locked at pre-registration time.
+  # These are NOT "defaults" — they are the contract the sweep driver
+  # must agree with at launch. validate_sweep_config() raises
+  # PreregistrationMismatch on any disagreement.
+  formal_decisions:
+    ci_method: bca_bootstrap                                # bias-corrected, accelerated
+    ci_alpha: 0.05                                          # family-wise α
+    signal_ci_ratio_threshold: 1.0                          # R1 numeric form
+    direction_consistency_min_seeds: 3                      # of n_seeds=20
+    direction_stability_min_fraction: 0.80                  # R3 numeric form
+    multiple_testing_correction:
+      method: bonferroni
+      n_cells: 216                                          # 3 substrates × 3 metrics × 3 N × 6 λ × stratified
+      # effective_alpha_per_cell = ci_alpha / n_cells       # derived in code
+    lambda_grid: [0.0, 0.05, 0.10, 0.20, 0.40, 1.0]         # explicit λ sweep dimension
   secondary_metrics_to_log:
     - per_substrate_per_metric_per_N_power_table
     - per_substrate_per_metric_per_N_CI_width_table

--- a/research/systemic_risk/d002c_preregistration.py
+++ b/research/systemic_risk/d002c_preregistration.py
@@ -1,0 +1,523 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""D-002C — Pre-registration validator + acceptance lock.
+
+Rationale
+=========
+The D-002C Signal Amplification Sweep (issue #654) is a 216-cell
+pre-committed falsification protocol. The pre-registration YAML
+at ``docs/governance/D002C_PREREGISTRATION.yaml`` is the SINGLE
+SOURCE OF TRUTH for:
+
+  * acceptance rule and tier mapping
+  * CI method (BCa bootstrap, locked) and α
+  * direction-consistency rule
+  * multiple-testing correction (Bonferroni on the cell-count
+    locked in the YAML — DO NOT recompute at launch time)
+  * falsifier text
+  * substrate / metric / variance-reduction grid identity
+
+This module:
+
+  * parses + freezes that YAML into :class:`D002CPreregistration`
+  * computes a content-addressed ``preregistration_sha`` over the
+    raw file bytes so any subsequent edit is detectable
+  * exposes :func:`validate_sweep_config` which the sweep runner
+    MUST call before checkpoint creation. A mismatch (e.g. driver
+    silently using ``percentile_bootstrap`` instead of the locked
+    ``bca_bootstrap``) raises :class:`PreregistrationMismatch`
+    listing every disagreement.
+
+Strict scope
+============
+Validator / contract layer ONLY. NO sweep execution. NO claim
+layer. NO threshold tuning. NO post-hoc relaxation. This module
+is callable by ``research/systemic_risk/d002c_sweep_runner.py``
+(C2.4) but emits no claim of its own — it only refuses to
+proceed when the driver disagrees with the pre-registration.
+
+The pre-registration is locked at the moment this PR merges
+(per the anchor-commit clause inside the YAML). Any edit to the
+YAML after this PR is a NEW pre-registration with a NEW sha — a
+fresh contract, not a mutation of the old one.
+"""
+
+from __future__ import annotations
+
+import enum
+import hashlib
+import math
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Final
+
+import yaml
+
+# ---------------------------------------------------------------------------
+# Schema version — bumped only on incompatible *contract* changes (renamed
+# field, removed acceptance rule). Adding a new optional logged metric is
+# NOT a schema bump.
+# ---------------------------------------------------------------------------
+PREREGISTRATION_SCHEMA_VERSION: Final[int] = 1
+
+
+class CIMethod(enum.Enum):
+    """CI estimator allowed in the D-002C contract.
+
+    BCa is locked because:
+
+    1. ``n_bootstrap = 16`` is small; percentile bootstrap is
+       biased at small B with skewed estimators, and our
+       signal estimator (mean difference of paired censored
+       observations) IS skewed.
+    2. CRN pairing yields strong correlation between signal
+       and null; BCa's acceleration correction adapts to that
+       skewness in a single coherent step.
+    3. Normal CI assumes a Gaussian sampling distribution
+       which we explicitly disclaim — Kuramoto onset times
+       are heavy-tailed.
+    """
+
+    BCA_BOOTSTRAP = "bca_bootstrap"
+    PERCENTILE_BOOTSTRAP = "percentile_bootstrap"
+    NORMAL = "normal"
+
+
+class MultipleTestingCorrection(enum.Enum):
+    """Family-wise / FDR correction across the pre-registered cell grid."""
+
+    BONFERRONI = "bonferroni"
+    FDR_BH = "fdr_bh"
+    NONE = "none"
+
+
+class PreregistrationCorrupt(RuntimeError):
+    """YAML missing/malformed/invariant-violating field."""
+
+
+class PreregistrationMismatch(RuntimeError):
+    """Sweep config disagrees with the locked pre-registration.
+
+    The exception message lists every disagreement (not just the
+    first) so a single re-launch fixes all of them. Fail-closed:
+    the sweep runner MUST NOT proceed past this exception.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Frozen dataclass — content is immutable once load_and_lock returns.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class D002CPreregistration:
+    """Immutable lock over the D-002C pre-registration YAML.
+
+    Fields mirror the canonical YAML structure; derived fields
+    (``effective_alpha_per_cell``) are computed in :func:`load_and_lock`
+    from the primary fields so they cannot drift.
+    """
+
+    schema_version: int
+    version: int
+    issue: int
+    follows: int
+    tier_if_pass: str
+    tier_if_fail: str
+    acceptance_rule: str
+    # Locked formal decisions
+    ci_method: CIMethod
+    ci_alpha: float
+    signal_ci_ratio_threshold: float
+    direction_consistency_min_seeds: int
+    direction_stability_min_fraction: float
+    multiple_testing_correction: MultipleTestingCorrection
+    n_cells: int
+    # Derived (Bonferroni: ci_alpha / n_cells; else ci_alpha)
+    effective_alpha_per_cell: float
+    # Sweep design (compared at validate_sweep_config time)
+    n_seeds: int
+    n_bootstrap: int
+    N_grid: tuple[int, ...]
+    lambda_grid: tuple[float, ...]
+    substrate_ids: tuple[str, ...]
+    metric_ids: tuple[str, ...]
+    variance_reduction: tuple[str, ...]
+    substrate_seed: int
+    # Falsifier + forbidden tiers
+    forbidden_outputs: tuple[str, ...]
+    # Content-addressed identity
+    preregistration_sha: str
+    yaml_path: str = field(compare=False)
+
+    # ---- invariants ---------------------------------------------------
+
+    def __post_init__(self) -> None:
+        if not (0.0 < self.ci_alpha < 1.0):
+            raise PreregistrationCorrupt(f"ci_alpha must be in (0, 1); got {self.ci_alpha}")
+        if not (
+            math.isfinite(self.signal_ci_ratio_threshold) and self.signal_ci_ratio_threshold > 0.0
+        ):
+            raise PreregistrationCorrupt(
+                f"signal_ci_ratio_threshold must be > 0; got {self.signal_ci_ratio_threshold}"
+            )
+        if self.direction_consistency_min_seeds < 1:
+            raise PreregistrationCorrupt(
+                "direction_consistency_min_seeds must be >= 1; got "
+                f"{self.direction_consistency_min_seeds}"
+            )
+        if self.direction_consistency_min_seeds > self.n_seeds:
+            raise PreregistrationCorrupt(
+                "direction_consistency_min_seeds "
+                f"({self.direction_consistency_min_seeds}) "
+                f"exceeds n_seeds ({self.n_seeds})"
+            )
+        if not (0.0 < self.direction_stability_min_fraction <= 1.0):
+            raise PreregistrationCorrupt(
+                "direction_stability_min_fraction must be in (0, 1]; got "
+                f"{self.direction_stability_min_fraction}"
+            )
+        if self.n_cells < 1:
+            raise PreregistrationCorrupt(f"n_cells must be >= 1; got {self.n_cells}")
+        # Bonferroni consistency: effective_alpha_per_cell must equal
+        # ci_alpha / n_cells (Bonferroni) or ci_alpha (no correction)
+        if self.multiple_testing_correction is MultipleTestingCorrection.BONFERRONI:
+            expected = self.ci_alpha / float(self.n_cells)
+        elif self.multiple_testing_correction is MultipleTestingCorrection.NONE:
+            expected = self.ci_alpha
+        else:
+            # FDR_BH alpha-per-cell is observation-dependent (BH step-up
+            # procedure), not a fixed value; sentinel is the family α.
+            expected = self.ci_alpha
+        if not math.isclose(expected, self.effective_alpha_per_cell, rel_tol=0.0, abs_tol=1e-15):
+            raise PreregistrationCorrupt(
+                "effective_alpha_per_cell drift: expected "
+                f"{expected!r}, got {self.effective_alpha_per_cell!r}"
+            )
+        if self.n_seeds < 2:
+            raise PreregistrationCorrupt(f"n_seeds must be >= 2; got {self.n_seeds}")
+        if self.n_bootstrap < 2:
+            raise PreregistrationCorrupt(f"n_bootstrap must be >= 2; got {self.n_bootstrap}")
+        if not self.N_grid or any(N < 2 for N in self.N_grid):
+            raise PreregistrationCorrupt(
+                f"N_grid must be non-empty and every N >= 2; got {self.N_grid}"
+            )
+        if not self.lambda_grid or any(
+            not math.isfinite(lam) or lam < 0.0 for lam in self.lambda_grid
+        ):
+            raise PreregistrationCorrupt(
+                f"lambda_grid must be non-empty and every λ finite + >= 0; got {self.lambda_grid}"
+            )
+        if not self.substrate_ids:
+            raise PreregistrationCorrupt("substrate_ids must be non-empty")
+        if not self.metric_ids:
+            raise PreregistrationCorrupt("metric_ids must be non-empty")
+        if len(self.preregistration_sha) != 64 or not all(
+            c in "0123456789abcdef" for c in self.preregistration_sha
+        ):
+            raise PreregistrationCorrupt(
+                f"preregistration_sha must be a hex sha256; got {self.preregistration_sha!r}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Loading
+# ---------------------------------------------------------------------------
+
+
+def _require(data: dict[str, Any], path: str, *keys: str) -> Any:
+    """Walk nested keys; raise PreregistrationCorrupt with a precise path."""
+    node: Any = data
+    walked: list[str] = []
+    for k in keys:
+        walked.append(k)
+        if not isinstance(node, dict) or k not in node:
+            raise PreregistrationCorrupt(f"{path}: missing required key '{'.'.join(walked)}'")
+        node = node[k]
+    return node
+
+
+def _canonical_rule_text(primary_cert_rule: dict[str, Any]) -> str:
+    """Build a stable acceptance-rule string from the YAML requirements.
+
+    The text is deterministic given the requirements list: we sort by
+    requirement id and join with newlines. Driver code compares
+    string-equal at validate_sweep_config time.
+    """
+    reqs = primary_cert_rule.get("requirements", [])
+    if not isinstance(reqs, list) or not reqs:
+        raise PreregistrationCorrupt(
+            "acceptance.primary_certification_rule.requirements must be a non-empty list"
+        )
+    parts: list[str] = []
+    for r in sorted(reqs, key=lambda x: str(x.get("id", ""))):
+        if not isinstance(r, dict) or "id" not in r or "rule" not in r:
+            raise PreregistrationCorrupt(
+                f"each requirement must be a mapping with 'id' and 'rule'; got {r!r}"
+            )
+        parts.append(f"{r['id']}: {r['rule']}")
+    return "\n".join(parts)
+
+
+def _yaml_sha256(yaml_bytes: bytes) -> str:
+    """Sha256 over raw file bytes. Git preserves byte content per-blob, so
+    the same merged YAML always produces the same sha across check-outs.
+    Any whitespace change (including trailing newline) yields a new sha;
+    this is intentional — the file IS the contract.
+    """
+    return hashlib.sha256(yaml_bytes).hexdigest()
+
+
+def load_and_lock(yaml_path: Path) -> D002CPreregistration:
+    """Parse YAML, compute content-addressed sha, return frozen lock.
+
+    Raises
+    ------
+    PreregistrationCorrupt
+        If the YAML is malformed, missing required fields, or its
+        contents violate the internal invariants.
+    """
+    if not yaml_path.is_file():
+        raise PreregistrationCorrupt(f"pre-registration YAML not found: {yaml_path}")
+    yaml_bytes = yaml_path.read_bytes()
+    try:
+        data: Any = yaml.safe_load(yaml_bytes.decode("utf-8"))
+    except yaml.YAMLError as exc:  # pragma: no cover - covered by test
+        raise PreregistrationCorrupt(f"YAML parse failed: {exc}") from exc
+    if not isinstance(data, dict):
+        raise PreregistrationCorrupt("pre-registration YAML must be a top-level mapping")
+
+    version = int(_require(data, str(yaml_path), "version"))
+    issue = int(_require(data, str(yaml_path), "issue"))
+    follows = int(_require(data, str(yaml_path), "follows"))
+
+    primary = _require(data, str(yaml_path), "acceptance", "primary_certification_rule")
+    if not isinstance(primary, dict):
+        raise PreregistrationCorrupt("acceptance.primary_certification_rule must be a mapping")
+    tier_if_pass = str(_require(primary, "acceptance.primary_certification_rule", "tier_if_pass"))
+    tier_if_fail = str(_require(primary, "acceptance.primary_certification_rule", "tier_if_fail"))
+    acceptance_rule = _canonical_rule_text(primary)
+
+    formal = _require(data, str(yaml_path), "acceptance", "formal_decisions")
+    if not isinstance(formal, dict):
+        raise PreregistrationCorrupt("acceptance.formal_decisions must be a mapping")
+    try:
+        ci_method = CIMethod(str(_require(formal, "formal_decisions", "ci_method")))
+    except ValueError as exc:
+        raise PreregistrationCorrupt(f"unknown ci_method: {formal.get('ci_method')!r}") from exc
+    ci_alpha = float(_require(formal, "formal_decisions", "ci_alpha"))
+    signal_ci_ratio_threshold = float(
+        _require(formal, "formal_decisions", "signal_ci_ratio_threshold")
+    )
+    direction_consistency_min_seeds = int(
+        _require(formal, "formal_decisions", "direction_consistency_min_seeds")
+    )
+    direction_stability_min_fraction = float(
+        _require(formal, "formal_decisions", "direction_stability_min_fraction")
+    )
+    mtc = _require(formal, "formal_decisions", "multiple_testing_correction")
+    if not isinstance(mtc, dict):
+        raise PreregistrationCorrupt(
+            "formal_decisions.multiple_testing_correction must be a mapping"
+        )
+    try:
+        mtc_method = MultipleTestingCorrection(
+            str(_require(mtc, "multiple_testing_correction", "method"))
+        )
+    except ValueError as exc:
+        raise PreregistrationCorrupt(
+            f"unknown multiple_testing_correction.method: {mtc.get('method')!r}"
+        ) from exc
+    n_cells = int(_require(mtc, "multiple_testing_correction", "n_cells"))
+    if mtc_method is MultipleTestingCorrection.BONFERRONI:
+        effective_alpha_per_cell = ci_alpha / float(n_cells)
+    else:
+        effective_alpha_per_cell = ci_alpha
+    lambda_grid_raw = _require(formal, "formal_decisions", "lambda_grid")
+    if not isinstance(lambda_grid_raw, list) or not lambda_grid_raw:
+        raise PreregistrationCorrupt("formal_decisions.lambda_grid must be a non-empty list")
+    lambda_grid = tuple(float(x) for x in lambda_grid_raw)
+
+    sweep = _require(data, str(yaml_path), "sweep")
+    if not isinstance(sweep, dict):
+        raise PreregistrationCorrupt("sweep must be a mapping")
+    n_seeds = int(_require(sweep, "sweep", "n_seeds"))
+    n_bootstrap = int(_require(sweep, "sweep", "n_bootstrap"))
+    N_grid_raw = _require(sweep, "sweep", "N_grid")
+    if not isinstance(N_grid_raw, list) or not N_grid_raw:
+        raise PreregistrationCorrupt("sweep.N_grid must be a non-empty list")
+    N_grid = tuple(int(x) for x in N_grid_raw)
+
+    substrates_raw = _require(sweep, "sweep", "substrates")
+    if not isinstance(substrates_raw, list) or not substrates_raw:
+        raise PreregistrationCorrupt("sweep.substrates must be a non-empty list")
+    substrate_ids: list[str] = []
+    for s in substrates_raw:
+        if not isinstance(s, dict) or "id" not in s:
+            raise PreregistrationCorrupt(f"each sweep.substrates entry must carry 'id'; got {s!r}")
+        substrate_ids.append(str(s["id"]))
+
+    metrics_raw = _require(sweep, "sweep", "metrics")
+    if not isinstance(metrics_raw, list) or not metrics_raw:
+        raise PreregistrationCorrupt("sweep.metrics must be a non-empty list")
+    metric_ids: list[str] = []
+    for m in metrics_raw:
+        if not isinstance(m, dict) or "id" not in m:
+            raise PreregistrationCorrupt(f"each sweep.metrics entry must carry 'id'; got {m!r}")
+        metric_ids.append(str(m["id"]))
+
+    vred_raw = _require(sweep, "sweep", "variance_reduction")
+    if not isinstance(vred_raw, list) or not vred_raw:
+        raise PreregistrationCorrupt("sweep.variance_reduction must be a non-empty list")
+    variance_reduction = tuple(str(v) for v in vred_raw)
+
+    substrate_seed = int(_require(data, str(yaml_path), "reproducibility", "substrate_seed"))
+
+    forbidden_raw = _require(data, str(yaml_path), "forbidden_outputs")
+    if not isinstance(forbidden_raw, list):
+        raise PreregistrationCorrupt("forbidden_outputs must be a list")
+    forbidden_outputs = tuple(str(x) for x in forbidden_raw)
+
+    sha = _yaml_sha256(yaml_bytes)
+
+    return D002CPreregistration(
+        schema_version=PREREGISTRATION_SCHEMA_VERSION,
+        version=version,
+        issue=issue,
+        follows=follows,
+        tier_if_pass=tier_if_pass,
+        tier_if_fail=tier_if_fail,
+        acceptance_rule=acceptance_rule,
+        ci_method=ci_method,
+        ci_alpha=ci_alpha,
+        signal_ci_ratio_threshold=signal_ci_ratio_threshold,
+        direction_consistency_min_seeds=direction_consistency_min_seeds,
+        direction_stability_min_fraction=direction_stability_min_fraction,
+        multiple_testing_correction=mtc_method,
+        n_cells=n_cells,
+        effective_alpha_per_cell=effective_alpha_per_cell,
+        n_seeds=n_seeds,
+        n_bootstrap=n_bootstrap,
+        N_grid=N_grid,
+        lambda_grid=lambda_grid,
+        substrate_ids=tuple(substrate_ids),
+        metric_ids=tuple(metric_ids),
+        variance_reduction=variance_reduction,
+        substrate_seed=substrate_seed,
+        forbidden_outputs=forbidden_outputs,
+        preregistration_sha=sha,
+        yaml_path=str(yaml_path),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+_EXPECTED_KEYS: Final[frozenset[str]] = frozenset(
+    {
+        "ci_method",
+        "ci_alpha",
+        "signal_ci_ratio_threshold",
+        "direction_consistency_min_seeds",
+        "direction_stability_min_fraction",
+        "multiple_testing_correction",
+        "n_seeds",
+        "n_bootstrap",
+        "N_grid",
+        "lambda_grid",
+        "substrate_ids",
+        "metric_ids",
+        "variance_reduction",
+        "substrate_seed",
+        "preregistration_sha",
+    }
+)
+
+
+def validate_sweep_config(
+    preregistration: D002CPreregistration,
+    sweep_config: dict[str, Any],
+) -> None:
+    """Compare sweep_config to the locked pre-registration.
+
+    Every disagreement is collected (not first-fail) so a single
+    re-launch can fix all of them. Raises
+    :class:`PreregistrationMismatch` if any disagreement is found.
+
+    The sweep_config dict MUST carry every key in
+    :data:`_EXPECTED_KEYS`; missing keys are themselves mismatches.
+
+    ``preregistration_sha`` is the load-bearing check: if the
+    driver's idea of the contract sha doesn't match the prereg
+    object the driver was constructed against, the YAML on disk
+    has been edited post-lock OR the driver was misconstructed —
+    either way, refuse.
+    """
+    missing = _EXPECTED_KEYS - set(sweep_config.keys())
+    mismatches: list[str] = []
+    if missing:
+        mismatches.append("sweep_config missing required keys: " + ", ".join(sorted(missing)))
+
+    def _cmp(key: str, expected: Any) -> None:
+        if key not in sweep_config:
+            return  # already reported above
+        got = sweep_config[key]
+        if isinstance(expected, tuple):
+            got_tuple = tuple(got) if isinstance(got, (list, tuple)) else got
+            if got_tuple != expected:
+                mismatches.append(f"{key}: expected {expected!r}, got {got_tuple!r}")
+        elif isinstance(expected, float):
+            if not (isinstance(got, (int, float)) and math.isfinite(float(got))):
+                mismatches.append(f"{key}: expected float {expected!r}, got {got!r}")
+                return
+            if not math.isclose(float(got), expected, rel_tol=0.0, abs_tol=1e-12):
+                mismatches.append(f"{key}: expected {expected!r}, got {got!r}")
+        else:
+            if got != expected:
+                mismatches.append(f"{key}: expected {expected!r}, got {got!r}")
+
+    _cmp("ci_method", preregistration.ci_method.value)
+    _cmp("ci_alpha", preregistration.ci_alpha)
+    _cmp("signal_ci_ratio_threshold", preregistration.signal_ci_ratio_threshold)
+    _cmp(
+        "direction_consistency_min_seeds",
+        preregistration.direction_consistency_min_seeds,
+    )
+    _cmp(
+        "direction_stability_min_fraction",
+        preregistration.direction_stability_min_fraction,
+    )
+    _cmp(
+        "multiple_testing_correction",
+        preregistration.multiple_testing_correction.value,
+    )
+    _cmp("n_seeds", preregistration.n_seeds)
+    _cmp("n_bootstrap", preregistration.n_bootstrap)
+    _cmp("N_grid", preregistration.N_grid)
+    _cmp("lambda_grid", preregistration.lambda_grid)
+    _cmp("substrate_ids", preregistration.substrate_ids)
+    _cmp("metric_ids", preregistration.metric_ids)
+    _cmp("variance_reduction", preregistration.variance_reduction)
+    _cmp("substrate_seed", preregistration.substrate_seed)
+    _cmp("preregistration_sha", preregistration.preregistration_sha)
+
+    if mismatches:
+        joined = "\n".join(f"  - {m}" for m in mismatches)
+        raise PreregistrationMismatch(
+            f"sweep_config disagrees with pre-registration "
+            f"sha={preregistration.preregistration_sha[:16]}…:\n{joined}"
+        )
+
+
+__all__ = [
+    "PREREGISTRATION_SCHEMA_VERSION",
+    "CIMethod",
+    "MultipleTestingCorrection",
+    "PreregistrationCorrupt",
+    "PreregistrationMismatch",
+    "D002CPreregistration",
+    "load_and_lock",
+    "validate_sweep_config",
+]

--- a/tests/research/systemic_risk/test_d002c_preregistration.py
+++ b/tests/research/systemic_risk/test_d002c_preregistration.py
@@ -1,0 +1,424 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""D-002C C2.1 — Pre-registration validator tests.
+
+Pins the C2.1 gates:
+
+  G1  load_and_lock parses the canonical YAML into a frozen dataclass
+  G2  preregistration_sha is deterministic across calls
+  G3  preregistration_sha changes on any byte-level edit of the YAML
+  G4  validate_sweep_config accepts a config that matches the lock
+  G5  validate_sweep_config raises on any single-field mismatch
+  G6  __post_init__ enforces all numeric invariants
+  G7  Bonferroni effective_alpha_per_cell is exactly ci_alpha / n_cells
+  G8  acceptance_rule text is deterministic and matches YAML requirements
+
+Strict scope: validator only. No sweep execution.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import math
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from research.systemic_risk.d002c_preregistration import (
+    PREREGISTRATION_SCHEMA_VERSION,
+    CIMethod,
+    D002CPreregistration,
+    MultipleTestingCorrection,
+    PreregistrationCorrupt,
+    PreregistrationMismatch,
+    load_and_lock,
+    validate_sweep_config,
+)
+
+# ---------------------------------------------------------------------------
+# Path to the canonical pre-registration YAML (single source of truth)
+# ---------------------------------------------------------------------------
+
+CANONICAL_YAML = (
+    Path(__file__).resolve().parents[3] / "docs" / "governance" / "D002C_PREREGISTRATION.yaml"
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _well_formed_sweep_config(prereg: D002CPreregistration) -> dict[str, Any]:
+    """Build a sweep config that should validate cleanly."""
+    return {
+        "ci_method": prereg.ci_method.value,
+        "ci_alpha": prereg.ci_alpha,
+        "signal_ci_ratio_threshold": prereg.signal_ci_ratio_threshold,
+        "direction_consistency_min_seeds": prereg.direction_consistency_min_seeds,
+        "direction_stability_min_fraction": prereg.direction_stability_min_fraction,
+        "multiple_testing_correction": prereg.multiple_testing_correction.value,
+        "n_seeds": prereg.n_seeds,
+        "n_bootstrap": prereg.n_bootstrap,
+        "N_grid": list(prereg.N_grid),
+        "lambda_grid": list(prereg.lambda_grid),
+        "substrate_ids": list(prereg.substrate_ids),
+        "metric_ids": list(prereg.metric_ids),
+        "variance_reduction": list(prereg.variance_reduction),
+        "substrate_seed": prereg.substrate_seed,
+        "preregistration_sha": prereg.preregistration_sha,
+    }
+
+
+# ---------------------------------------------------------------------------
+# G1 — load_and_lock parses the canonical YAML
+# ---------------------------------------------------------------------------
+
+
+def test_g1_canonical_yaml_loads_to_frozen_dataclass() -> None:
+    prereg = load_and_lock(CANONICAL_YAML)
+    # Identity / contract fields
+    assert prereg.schema_version == PREREGISTRATION_SCHEMA_VERSION
+    assert prereg.issue == 654
+    assert prereg.tier_if_pass == "SYNTHETIC_GATE6_CERTIFIED_REDESIGN_N_LE_200"
+    assert prereg.tier_if_fail == "D002C_REDESIGN_INSUFFICIENT_AT_TESTED_BUDGET"
+    # Locked formal decisions per the YAML
+    assert prereg.ci_method is CIMethod.BCA_BOOTSTRAP
+    assert prereg.ci_alpha == pytest.approx(0.05)
+    assert prereg.signal_ci_ratio_threshold == pytest.approx(1.0)
+    assert prereg.direction_consistency_min_seeds == 3
+    assert prereg.direction_stability_min_fraction == pytest.approx(0.80)
+    assert prereg.multiple_testing_correction is MultipleTestingCorrection.BONFERRONI
+    assert prereg.n_cells == 216
+    assert prereg.n_seeds == 20
+    assert prereg.n_bootstrap == 16
+    # Grids
+    assert prereg.N_grid == (50, 100, 200)
+    assert prereg.lambda_grid == (0.0, 0.05, 0.10, 0.20, 0.40, 1.0)
+    # Substrates / metrics (order matches YAML)
+    assert prereg.substrate_ids == (
+        "ricci_flow",
+        "block_structured",
+        "temporal_coupling",
+    )
+    assert prereg.metric_ids == ("tau_onset", "sync_auc", "phase_lag")
+    assert prereg.substrate_seed == 42
+    # sha format
+    assert len(prereg.preregistration_sha) == 64
+    assert all(c in "0123456789abcdef" for c in prereg.preregistration_sha)
+
+
+def test_g1_frozen_dataclass_is_immutable() -> None:
+    prereg = load_and_lock(CANONICAL_YAML)
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        prereg.ci_alpha = 0.10  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# G2 — preregistration_sha is deterministic across calls
+# ---------------------------------------------------------------------------
+
+
+def test_g2_sha_deterministic_across_repeated_loads() -> None:
+    a = load_and_lock(CANONICAL_YAML).preregistration_sha
+    b = load_and_lock(CANONICAL_YAML).preregistration_sha
+    c = load_and_lock(CANONICAL_YAML).preregistration_sha
+    assert a == b == c
+
+
+# ---------------------------------------------------------------------------
+# G3 — sha changes on any byte-level edit (content-addressed lock)
+# ---------------------------------------------------------------------------
+
+
+def test_g3_single_byte_edit_changes_sha(tmp_path: Path) -> None:
+    src = CANONICAL_YAML.read_bytes()
+    # baseline
+    canonical = tmp_path / "canonical.yaml"
+    canonical.write_bytes(src)
+    sha_canonical = load_and_lock(canonical).preregistration_sha
+    # 1-byte mutation: append a single newline at EOF
+    mutated = tmp_path / "mutated.yaml"
+    mutated.write_bytes(src + b"\n")
+    sha_mutated = load_and_lock(mutated).preregistration_sha
+    assert sha_canonical != sha_mutated
+
+
+def test_g3_whitespace_change_changes_sha(tmp_path: Path) -> None:
+    src = CANONICAL_YAML.read_bytes()
+    canonical = tmp_path / "canonical.yaml"
+    canonical.write_bytes(src)
+    sha_canonical = load_and_lock(canonical).preregistration_sha
+    # Add a single trailing space at end of first non-comment line
+    text = src.decode("utf-8")
+    lines = text.splitlines(keepends=True)
+    for i, line in enumerate(lines):
+        if line.strip() and not line.lstrip().startswith("#"):
+            lines[i] = line.rstrip("\n") + " \n"
+            break
+    mutated = tmp_path / "ws.yaml"
+    mutated.write_bytes("".join(lines).encode("utf-8"))
+    sha_mutated = load_and_lock(mutated).preregistration_sha
+    assert sha_canonical != sha_mutated
+
+
+# ---------------------------------------------------------------------------
+# G4 — validate_sweep_config accepts a matching config
+# ---------------------------------------------------------------------------
+
+
+def test_g4_well_formed_config_validates_cleanly() -> None:
+    prereg = load_and_lock(CANONICAL_YAML)
+    cfg = _well_formed_sweep_config(prereg)
+    # Must not raise
+    validate_sweep_config(prereg, cfg)
+
+
+def test_g4_tuple_or_list_grid_both_accepted() -> None:
+    """The driver may construct N_grid / lambda_grid as either list or tuple;
+    the validator normalises before comparison."""
+    prereg = load_and_lock(CANONICAL_YAML)
+    cfg = _well_formed_sweep_config(prereg)
+    cfg["N_grid"] = tuple(prereg.N_grid)
+    cfg["lambda_grid"] = tuple(prereg.lambda_grid)
+    validate_sweep_config(prereg, cfg)
+
+
+# ---------------------------------------------------------------------------
+# G5 — single-field mismatch raises with all disagreements listed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "key, mutation",
+    [
+        ("ci_method", "percentile_bootstrap"),
+        ("ci_alpha", 0.10),
+        ("signal_ci_ratio_threshold", 2.0),
+        ("direction_consistency_min_seeds", 5),
+        ("direction_stability_min_fraction", 0.50),
+        ("multiple_testing_correction", "fdr_bh"),
+        ("n_seeds", 50),
+        ("n_bootstrap", 100),
+        ("N_grid", [50, 100, 400]),
+        ("lambda_grid", [0.0, 1.0]),
+        ("substrate_ids", ["only_ricci"]),
+        ("metric_ids", ["tau_onset"]),
+        ("variance_reduction", ["common_random_numbers"]),
+        ("substrate_seed", 7),
+        ("preregistration_sha", "0" * 64),
+    ],
+)
+def test_g5_any_single_field_mismatch_raises(key: str, mutation: object) -> None:
+    prereg = load_and_lock(CANONICAL_YAML)
+    cfg = _well_formed_sweep_config(prereg)
+    cfg[key] = mutation
+    with pytest.raises(PreregistrationMismatch) as exc:
+        validate_sweep_config(prereg, cfg)
+    assert key in str(exc.value)
+
+
+def test_g5_missing_keys_listed_in_one_exception() -> None:
+    prereg = load_and_lock(CANONICAL_YAML)
+    cfg = _well_formed_sweep_config(prereg)
+    del cfg["ci_method"]
+    del cfg["preregistration_sha"]
+    with pytest.raises(PreregistrationMismatch) as exc:
+        validate_sweep_config(prereg, cfg)
+    msg = str(exc.value)
+    assert "ci_method" in msg
+    assert "preregistration_sha" in msg
+
+
+def test_g5_multiple_mismatches_all_reported() -> None:
+    """A single re-launch should be able to see EVERY disagreement,
+    not the first."""
+    prereg = load_and_lock(CANONICAL_YAML)
+    cfg = _well_formed_sweep_config(prereg)
+    cfg["ci_method"] = "percentile_bootstrap"
+    cfg["ci_alpha"] = 0.10
+    cfg["n_seeds"] = 999
+    with pytest.raises(PreregistrationMismatch) as exc:
+        validate_sweep_config(prereg, cfg)
+    msg = str(exc.value)
+    assert "ci_method" in msg
+    assert "ci_alpha" in msg
+    assert "n_seeds" in msg
+
+
+# ---------------------------------------------------------------------------
+# G6 — __post_init__ enforces numeric invariants
+# ---------------------------------------------------------------------------
+
+
+def _kwargs_for_prereg(**override: Any) -> dict[str, Any]:
+    """Minimal kwarg set for a valid D002CPreregistration; tests can
+    override one field at a time to violate exactly one invariant."""
+    base: dict[str, Any] = dict(
+        schema_version=PREREGISTRATION_SCHEMA_VERSION,
+        version=1,
+        issue=654,
+        follows=656,
+        tier_if_pass="X",
+        tier_if_fail="Y",
+        acceptance_rule="R1: …",
+        ci_method=CIMethod.BCA_BOOTSTRAP,
+        ci_alpha=0.05,
+        signal_ci_ratio_threshold=1.0,
+        direction_consistency_min_seeds=3,
+        direction_stability_min_fraction=0.80,
+        multiple_testing_correction=MultipleTestingCorrection.BONFERRONI,
+        n_cells=216,
+        effective_alpha_per_cell=0.05 / 216,
+        n_seeds=20,
+        n_bootstrap=16,
+        N_grid=(50, 100, 200),
+        lambda_grid=(0.0, 0.05, 0.10, 0.20, 0.40, 1.0),
+        substrate_ids=("a", "b", "c"),
+        metric_ids=("m1", "m2", "m3"),
+        variance_reduction=("crn",),
+        substrate_seed=42,
+        forbidden_outputs=("FOO",),
+        preregistration_sha="a" * 64,
+        yaml_path="/tmp/d002c.yaml",
+    )
+    base.update(override)
+    return base
+
+
+def test_g6_baseline_kwargs_construct_cleanly() -> None:
+    # Sanity: the helper itself is valid (no invariant is touched)
+    D002CPreregistration(**_kwargs_for_prereg())
+
+
+@pytest.mark.parametrize(
+    "field, bad_value",
+    [
+        ("ci_alpha", 0.0),
+        ("ci_alpha", 1.0),
+        ("ci_alpha", -0.1),
+        ("signal_ci_ratio_threshold", 0.0),
+        ("signal_ci_ratio_threshold", -1.0),
+        ("signal_ci_ratio_threshold", math.nan),
+        ("direction_consistency_min_seeds", 0),
+        ("direction_consistency_min_seeds", 21),  # > n_seeds
+        ("direction_stability_min_fraction", 0.0),
+        ("direction_stability_min_fraction", 1.5),
+        ("n_seeds", 1),
+        ("n_bootstrap", 1),
+        ("n_cells", 0),
+    ],
+)
+def test_g6_invariants_reject_bad_values(field: str, bad_value: Any) -> None:
+    with pytest.raises(PreregistrationCorrupt):
+        D002CPreregistration(**_kwargs_for_prereg(**{field: bad_value}))
+
+
+def test_g6_invariants_reject_short_or_non_hex_sha() -> None:
+    with pytest.raises(PreregistrationCorrupt):
+        D002CPreregistration(**_kwargs_for_prereg(preregistration_sha="abc"))
+    with pytest.raises(PreregistrationCorrupt):
+        D002CPreregistration(**_kwargs_for_prereg(preregistration_sha="z" * 64))
+
+
+def test_g6_invariants_reject_empty_grids() -> None:
+    with pytest.raises(PreregistrationCorrupt):
+        D002CPreregistration(**_kwargs_for_prereg(N_grid=()))
+    with pytest.raises(PreregistrationCorrupt):
+        D002CPreregistration(**_kwargs_for_prereg(lambda_grid=()))
+    with pytest.raises(PreregistrationCorrupt):
+        D002CPreregistration(**_kwargs_for_prereg(substrate_ids=()))
+    with pytest.raises(PreregistrationCorrupt):
+        D002CPreregistration(**_kwargs_for_prereg(metric_ids=()))
+
+
+# ---------------------------------------------------------------------------
+# G7 — Bonferroni effective_alpha_per_cell is exactly ci_alpha / n_cells
+# ---------------------------------------------------------------------------
+
+
+def test_g7_bonferroni_effective_alpha_is_exact() -> None:
+    prereg = load_and_lock(CANONICAL_YAML)
+    expected = prereg.ci_alpha / float(prereg.n_cells)
+    assert prereg.effective_alpha_per_cell == expected
+    # And the canonical value (sanity)
+    assert prereg.effective_alpha_per_cell == pytest.approx(0.05 / 216, abs=1e-15)
+
+
+def test_g7_bonferroni_drift_is_rejected_in_post_init() -> None:
+    """If a misconstruction passes a wrong derived value it must be rejected."""
+    with pytest.raises(PreregistrationCorrupt):
+        D002CPreregistration(**_kwargs_for_prereg(effective_alpha_per_cell=0.0001))
+
+
+def test_g7_none_correction_uses_family_alpha() -> None:
+    kw = _kwargs_for_prereg(
+        multiple_testing_correction=MultipleTestingCorrection.NONE,
+        effective_alpha_per_cell=0.05,
+    )
+    obj = D002CPreregistration(**kw)
+    assert obj.effective_alpha_per_cell == obj.ci_alpha
+
+
+# ---------------------------------------------------------------------------
+# G8 — acceptance_rule text is deterministic and contains R1/R2/R3
+# ---------------------------------------------------------------------------
+
+
+def test_g8_acceptance_rule_deterministic_and_complete() -> None:
+    a = load_and_lock(CANONICAL_YAML).acceptance_rule
+    b = load_and_lock(CANONICAL_YAML).acceptance_rule
+    assert a == b
+    # All three pre-committed requirements present
+    assert "R1:" in a
+    assert "R2:" in a
+    assert "R3:" in a
+    # And the canonical R1 text matches the YAML
+    assert "exists N in [50,100,200], substrate, metric: |signal|/CI > 1" in a
+
+
+# ---------------------------------------------------------------------------
+# Corruption + missing-key paths (additional fail-closed coverage)
+# ---------------------------------------------------------------------------
+
+
+def test_corrupt_yaml_path_does_not_exist(tmp_path: Path) -> None:
+    with pytest.raises(PreregistrationCorrupt):
+        load_and_lock(tmp_path / "does-not-exist.yaml")
+
+
+def test_corrupt_yaml_not_a_mapping(tmp_path: Path) -> None:
+    p = tmp_path / "bad.yaml"
+    p.write_text("- just\n- a\n- list\n", encoding="utf-8")
+    with pytest.raises(PreregistrationCorrupt):
+        load_and_lock(p)
+
+
+def test_corrupt_yaml_missing_acceptance(tmp_path: Path) -> None:
+    p = tmp_path / "no_acceptance.yaml"
+    p.write_text("version: 1\nissue: 654\nfollows: 656\n", encoding="utf-8")
+    with pytest.raises(PreregistrationCorrupt):
+        load_and_lock(p)
+
+
+def test_corrupt_yaml_unknown_ci_method(tmp_path: Path) -> None:
+    src = CANONICAL_YAML.read_text(encoding="utf-8").replace(
+        "ci_method: bca_bootstrap",
+        "ci_method: telepathy",
+    )
+    p = tmp_path / "bad_ci.yaml"
+    p.write_text(src, encoding="utf-8")
+    with pytest.raises(PreregistrationCorrupt):
+        load_and_lock(p)
+
+
+def test_corrupt_yaml_unknown_correction_method(tmp_path: Path) -> None:
+    src = CANONICAL_YAML.read_text(encoding="utf-8").replace(
+        "method: bonferroni",
+        "method: vibes",
+    )
+    p = tmp_path / "bad_corr.yaml"
+    p.write_text(src, encoding="utf-8")
+    with pytest.raises(PreregistrationCorrupt):
+        load_and_lock(p)


### PR DESCRIPTION
## Summary

**C2.1 of the D-002C execution chain.** Before the sweep can launch
(C2.4), the driver must agree with the contract — this PR builds the
contract.

The pre-registration YAML at `docs/governance/D002C_PREREGISTRATION.yaml`
is amended **one last time** to expose the formal locked decisions
block. The merge of this PR is the **anchor commit** per the YAML's
own anti-edit clause; any subsequent edit is a fresh pre-registration
with a fresh sha.

## What lands

| File | Purpose |
|---|---|
| `docs/governance/D002C_PREREGISTRATION.yaml` | Adds `acceptance.formal_decisions` block (final pre-lock edit) |
| `research/systemic_risk/d002c_preregistration.py` | `D002CPreregistration` frozen dataclass + `load_and_lock` + `validate_sweep_config` |
| `tests/research/systemic_risk/test_d002c_preregistration.py` | 49 fast tests (G1–G8 + corruption paths) |
| `.claude/commit_acceptors/x10r-d002c-preregistration-lock.yaml` | Diff-bound commit acceptor |

## Locked decisions (the contract)

| Field | Value | Rationale |
|---|---|---|
| `ci_method` | `bca_bootstrap` | n_bootstrap=16 small + skewed estimator + CRN pairing → BCa is the only unbiased choice |
| `ci_alpha` | 0.05 | family-wise α |
| `signal_ci_ratio_threshold` | 1.0 | R1 numeric form |
| `direction_consistency_min_seeds` | 3 of 20 | |
| `direction_stability_min_fraction` | 0.80 | R3 numeric form |
| `multiple_testing_correction` | bonferroni, n_cells=216 | effective α = 0.05/216 = 2.31e-4 |
| `lambda_grid` | [0.0, 0.05, 0.10, 0.20, 0.40, 1.0] | explicit λ dimension |

## Contract enforcement

- `preregistration_sha`: sha256 over **raw file bytes**. Any byte-level edit (whitespace included) yields a fresh sha → contract identity is content-addressed and tamper-evident.
- `validate_sweep_config(prereg, cfg)` collects **every** disagreement and reports them in a single exception (not first-fail) — one re-launch fixes all of them.
- `__post_init__` enforces all numeric invariants (alpha ∈ (0,1), threshold > 0 finite, min_seeds ≤ n_seeds, hex-64 sha, Bonferroni-derivation consistency).
- Every missing/malformed YAML field raises `PreregistrationCorrupt` with a precise key path.

## Quality gates (all PASS locally)

- [x] ruff check
- [x] black --check
- [x] mypy --strict --follow-imports=silent (0 errors, 2 files)
- [x] pytest tests/research/systemic_risk/test_d002c_preregistration.py — 49/49 PASS
- [x] acceptor falsifier — sha lock = `b1561ddde08a60a8…`

## Strict scope (INV-INSTRUMENT-1 recommitted)

- ✋ NO sweep execution
- ✋ NO substrates, metrics, runners
- ✋ NO claim layer (module emits no claim of its own)
- ✋ NO threshold tuning
- ✋ INV-IDENTIFICATION-1 untouched

## Execution chain

```
[merged] D-002D (#659)              checkpoint/resume
   ↓
[THIS]   C2.1                       pre-registration lock         ← contract
   ↓
         C2.2 (next PR)             substrates + metrics          ← science
   ↓
         C2.3                       CRN empirical GO/NO-GO        ← variance check
   ↓
         C2.4                       sweep runner + pre-flight     ← driver
   ↓
         C2.5                       full sweep launch             ← only if all GO
```

Closes part of #654 (C2.1 only).

## Test plan

- [x] Local mypy --strict
- [x] Local ruff + black
- [x] Local pytest 49/49
- [x] Local falsifier from acceptor
- [ ] CI: all 20 gates green
- [ ] CI: commit-acceptor-validation passes against the new acceptor
- [ ] Reviewer audit before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)