### PR TITLE
feat(x10r,D-002C,C2.2): substrates + metrics for Signal Amplification Sweep (#654)

### DIFF
--- a/.claude/commit_acceptors/x10r-d002c-substrates-metrics.yaml
+++ b/.claude/commit_acceptors/x10r-d002c-substrates-metrics.yaml
@@ -1,0 +1,224 @@
+# Diff-bound commit acceptor for D-002C C2.2 (issue #654) —
+# Substrate generators + metric estimators for the Signal
+# Amplification Sweep.
+#
+# What lands:
+#   * research/systemic_risk/d002c_substrates.py
+#       Three substrate generators producing Kuramoto coupling
+#       matrices K of shape (T_HORIZON, N, N) parameterised by
+#       (N, lambda, seed):
+#         - RicciFlowSubstrate: Erdős-Rényi base, Forman-Ricci
+#           weights, top-10% κ precursor injection
+#         - BlockStructuredSubstrate: core/mid/periphery tiered
+#           block matrix with locked multipliers (1.5/1.0/0.5/0.2)
+#         - TemporalKtSubstrate: block base with sinusoidal K(t)
+#           modulation + additive precursor envelope
+#       Each realisation passes gates G6 (density ∈ [0.05, 0.15]
+#       for the sparse family) + G7 (symmetric every slice) +
+#       G8 (no NaN/Inf) + G9 (spectral radius / N ∈ [0.95, 1.05])
+#       + G10 (positive Frobenius delta iff λ > 0). Calibration
+#       is enforced — a realisation that violates any gate raises
+#       SubstrateInvalid (fail-closed).
+#   * research/systemic_risk/d002c_metrics.py
+#       Three metric estimators on a KuramotoTrajectory:
+#         - TauOnsetMetric: first crossing of R(t) > threshold_R
+#           in pre-event window; right-censored if no crossing
+#         - AucPreEventMetric: trapezoidal AUC of R(t) over the
+#           pre-event window; always observed
+#         - DeltaPhiSyncMetric (phase_lag): first crossing of
+#           pointwise phase coherence Φ(t) = |Σ w_j exp(i θ_j)|
+#           with weights defaulting to uniform (= R(t)) and the
+#           sweep runner passing the substrate principal
+#           eigenvector for the structural variant
+#       Cohort aggregator signal_mean() handles right-censoring
+#       via Kaplan-Meier restricted mean survival time (RMST);
+#       censoring fractions are reported per cohort so non-
+#       comparable cells are visibly flagged. Thresholds default
+#       to the locked YAML values (tau_onset=0.50, phase_lag=0.50);
+#       sweep configs that disagree are caught upstream by the
+#       C2.1 preregistration validator.
+#   * tests/research/systemic_risk/test_d002c_substrates.py
+#       58 tests pinning gates G6-G10 + G12-G14 over the
+#       full N × λ × substrate grid + precursor-window
+#       confinement + frozen-dataclass + degenerate-param
+#       refusal + block tier-multiplier ratio + temporal
+#       envelope modulation.
+#   * tests/research/systemic_risk/test_d002c_metrics.py
+#       64 tests pinning right-censoring discipline (G11 KM
+#       RMST contract + non-comparable cohort flagging),
+#       reproducibility (G12 bit-exact), monotone sanity (G13
+#       on signal_mean), trajectory validation + threshold
+#       defaults matching the YAML + custom reference weights +
+#       cohort-size + signal-method reporting.
+#
+# Strict scope:
+#   Substrate + metric layer ONLY. NO Kuramoto integrator (that
+#   lives in C2.4 sweep runner). NO CRN variance reduction (that
+#   lives in C2.3). NO sweep execution. NO claim layer. NO
+#   threshold tuning — the thresholds match the locked YAML.
+
+id: x10r-d002c-substrates-metrics
+status: ACTIVE
+claim_type: correctness
+promise: >-
+  After this PR lands, research/systemic_risk/d002c_substrates
+  exposes RicciFlowSubstrate, BlockStructuredSubstrate, and
+  TemporalKtSubstrate — three Kuramoto coupling-matrix
+  generators each satisfying the calibration gates (spectral
+  radius / N ∈ [0.95, 1.05], symmetric, finite, density ∈
+  [0.05, 0.15] for the sparse Ricci family, precursor delta
+  strictly zero at λ=0 and strictly positive at λ>0).
+  research/systemic_risk/d002c_metrics exposes TauOnsetMetric,
+  AucPreEventMetric, and DeltaPhiSyncMetric — three observables
+  on a KuramotoTrajectory plus the cohort-level signal_mean
+  aggregator that handles right-censoring via Kaplan-Meier
+  restricted mean survival time. Default thresholds match the
+  locked D-002C pre-registration YAML (tau_onset=0.50,
+  phase_lag=0.50). 122 fast tests pass.
+
+  Strict scope: substrate + metric layer only. No Kuramoto
+  integrator (deferred to C2.4). No sweep execution. No CRN
+  variance reduction (C2.3). No claim layer. No threshold
+  tuning. The modules are callable by C2.4 sweep runner; they
+  emit no claim of their own.
+diff_scope:
+  changed_files:
+    - path: ".claude/commit_acceptors/x10r-d002c-substrates-metrics.yaml"
+    - path: "research/systemic_risk/d002c_substrates.py"
+    - path: "research/systemic_risk/d002c_metrics.py"
+    - path: "tests/research/systemic_risk/test_d002c_substrates.py"
+    - path: "tests/research/systemic_risk/test_d002c_metrics.py"
+  forbidden_paths:
+    - "trading/"
+    - "execution/"
+    - "forecast/"
+    - "policy/"
+    - "core/physics/"
+    - "core/kuramoto/"
+    - "research/reconstruction/"
+    - "research/systemic_risk/sweep_checkpoint.py"
+    - "research/systemic_risk/d002c_preregistration.py"
+    - "scripts/run_x10r_"
+    - "application/governance/claim_ledger.py"
+    - "application/governance/commit_acceptor.py"
+required_python_symbols:
+  - "research/systemic_risk/d002c_substrates.py::SubstrateRealization"
+  - "research/systemic_risk/d002c_substrates.py::SubstrateInvalid"
+  - "research/systemic_risk/d002c_substrates.py::RicciFlowSubstrate"
+  - "research/systemic_risk/d002c_substrates.py::BlockStructuredSubstrate"
+  - "research/systemic_risk/d002c_substrates.py::TemporalKtSubstrate"
+  - "research/systemic_risk/d002c_substrates.py::ALL_SUBSTRATES"
+  - "research/systemic_risk/d002c_metrics.py::KuramotoTrajectory"
+  - "research/systemic_risk/d002c_metrics.py::MetricEvaluation"
+  - "research/systemic_risk/d002c_metrics.py::TauOnsetMetric"
+  - "research/systemic_risk/d002c_metrics.py::AucPreEventMetric"
+  - "research/systemic_risk/d002c_metrics.py::DeltaPhiSyncMetric"
+  - "research/systemic_risk/d002c_metrics.py::SignalEstimate"
+  - "research/systemic_risk/d002c_metrics.py::kaplan_meier_restricted_mean"
+  - "research/systemic_risk/d002c_metrics.py::signal_mean"
+  - "research/systemic_risk/d002c_metrics.py::ALL_METRICS"
+  - "tests/research/systemic_risk/test_d002c_substrates.py::test_g7_g8_K_symmetric_finite_correct_shape"
+  - "tests/research/systemic_risk/test_d002c_substrates.py::test_g9_spectral_radius_calibrated"
+  - "tests/research/systemic_risk/test_d002c_substrates.py::test_g6_ricci_density_in_range"
+  - "tests/research/systemic_risk/test_d002c_substrates.py::test_g10_lambda_zero_is_pure_baseline"
+  - "tests/research/systemic_risk/test_d002c_substrates.py::test_g10_positive_lambda_yields_positive_delta"
+  - "tests/research/systemic_risk/test_d002c_substrates.py::test_g12_same_seed_reproducible_bit_exact"
+  - "tests/research/systemic_risk/test_d002c_substrates.py::test_g13_delta_monotone_in_lambda"
+  - "tests/research/systemic_risk/test_d002c_substrates.py::test_g14_three_substrates_pairable_with_three_metrics"
+  - "tests/research/systemic_risk/test_d002c_metrics.py::test_km_rmst_no_censoring_equals_simple_mean"
+  - "tests/research/systemic_risk/test_d002c_metrics.py::test_km_rmst_monotone_in_censoring_fraction"
+  - "tests/research/systemic_risk/test_d002c_metrics.py::test_signal_mean_uses_km_when_either_cohort_censored"
+  - "tests/research/systemic_risk/test_d002c_metrics.py::test_g13_signal_mean_monotone_in_precursor_strength"
+expected_signal: >-
+  Local: `pytest tests/research/systemic_risk/test_d002c_substrates.py
+  tests/research/systemic_risk/test_d002c_metrics.py -q` reports
+  "122 passed"; `mypy --strict --follow-imports=silent` clean on
+  the four new files; `ruff check` and `black --check` both pass.
+measurement_command: >-
+  bash -c 'mypy --strict --follow-imports=silent
+  research/systemic_risk/d002c_substrates.py
+  research/systemic_risk/d002c_metrics.py
+  tests/research/systemic_risk/test_d002c_substrates.py
+  tests/research/systemic_risk/test_d002c_metrics.py
+  && ruff check
+  research/systemic_risk/d002c_substrates.py
+  research/systemic_risk/d002c_metrics.py
+  tests/research/systemic_risk/test_d002c_substrates.py
+  tests/research/systemic_risk/test_d002c_metrics.py
+  && black --check
+  research/systemic_risk/d002c_substrates.py
+  research/systemic_risk/d002c_metrics.py
+  tests/research/systemic_risk/test_d002c_substrates.py
+  tests/research/systemic_risk/test_d002c_metrics.py
+  && pytest
+  tests/research/systemic_risk/test_d002c_substrates.py
+  tests/research/systemic_risk/test_d002c_metrics.py -q'
+signal_artifact: "tests/research/systemic_risk/test_d002c_substrates.py"
+falsifier:
+  command: >-
+    bash -c 'PYTHONPATH=. python -c "
+    import numpy as np
+    from research.systemic_risk.d002c_substrates import (
+        ALL_SUBSTRATES, SPECTRAL_RANGE, DENSITY_RANGE, RicciFlowSubstrate,
+    )
+    from research.systemic_risk.d002c_metrics import (
+        ALL_METRICS, TauOnsetMetric, AucPreEventMetric, DeltaPhiSyncMetric,
+        kaplan_meier_restricted_mean, signal_mean, MetricEvaluation,
+    )
+    # 9 substrate × metric pairs callable
+    assert len(ALL_SUBSTRATES) == 3
+    assert len(ALL_METRICS) == 3
+    # All substrates calibrate cleanly at canonical (N, lambda=0, seed=42)
+    for s in ALL_SUBSTRATES:
+        r = s.realize(N=100, lambda_=0.0, seed=42)
+        lo, hi = SPECTRAL_RANGE
+        assert lo <= r.spectral_radius_over_N <= hi, (s.id, r.spectral_radius_over_N)
+        assert r.precursor_frobenius_delta == 0.0
+    # Ricci density in range
+    r = RicciFlowSubstrate().realize(N=100, lambda_=0.0, seed=42)
+    dlo, dhi = DENSITY_RANGE
+    assert dlo <= r.density <= dhi
+    # Positive lambda yields positive delta
+    for s in ALL_SUBSTRATES:
+        r = s.realize(N=100, lambda_=0.40, seed=42)
+        assert r.precursor_frobenius_delta > 0.0
+    # Reproducibility bit-exact
+    a = RicciFlowSubstrate().realize(N=100, lambda_=0.40, seed=7)
+    b = RicciFlowSubstrate().realize(N=100, lambda_=0.40, seed=7)
+    assert np.array_equal(a.K_baseline, b.K_baseline)
+    # KM RMST: no censoring → cohort mean
+    rmst = kaplan_meier_restricted_mean(np.array([1., 2., 3., 4.]), np.zeros(4, dtype=bool), 10.0)
+    assert abs(rmst - 2.5) < 1e-12
+    # signal_mean fires KM when censored
+    pre = [MetricEvaluation(metric_id='"'"'tau_onset'"'"', value=3.0, is_censored=False)]*10 + [MetricEvaluation(metric_id='"'"'tau_onset'"'"', value=8.0, is_censored=True)]*10
+    null = [MetricEvaluation(metric_id='"'"'tau_onset'"'"', value=7.0, is_censored=False)]*20
+    est = signal_mean(TauOnsetMetric(), pre, null, horizon=8.0)
+    assert est.method == '"'"'km_restricted_mean'"'"'
+    "'
+  description: >-
+    Probes the D-002C C2.2 contract: 3 substrates × 3 metrics
+    available; all substrates calibrate clean at (N=100, λ=0, seed=42);
+    Ricci density in gate range; positive λ yields positive Frobenius
+    delta; substrate seed reproducibility is bit-exact; KM RMST
+    with zero censoring equals the cohort mean; signal_mean uses
+    KM aggregator when either cohort is censored. If any of these
+    regress, the substrate calibration or right-censoring discipline
+    is broken — the sweep would launch on uncalibrated K or report
+    biased signal means.
+rollback_command: >-
+  bash -c 'git checkout HEAD~1 --
+  && rm -f research/systemic_risk/d002c_substrates.py
+  research/systemic_risk/d002c_metrics.py
+  tests/research/systemic_risk/test_d002c_substrates.py
+  tests/research/systemic_risk/test_d002c_metrics.py
+  .claude/commit_acceptors/x10r-d002c-substrates-metrics.yaml'
+rollback_verification_command: >-
+  bash -c 'test ! -f research/systemic_risk/d002c_substrates.py
+  && test ! -f research/systemic_risk/d002c_metrics.py
+  && test ! -f tests/research/systemic_risk/test_d002c_substrates.py
+  && test ! -f tests/research/systemic_risk/test_d002c_metrics.py
+  && test ! -f .claude/commit_acceptors/x10r-d002c-substrates-metrics.yaml'
+memory_update_type: append
+ledger_path: ".claude/commit_acceptors/x10r-d002c-substrates-metrics.yaml"
+report_path: "tests/research/systemic_risk/test_d002c_substrates.py"
+evidence: []

--- a/research/systemic_risk/d002c_metrics.py
+++ b/research/systemic_risk/d002c_metrics.py
@@ -1,0 +1,454 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""D-002C — Metric estimators on a Kuramoto trajectory.
+
+Three observables computed on a :class:`KuramotoTrajectory` produced
+upstream (by the C2.4 Kuramoto integrator over a
+:class:`SubstrateRealization`):
+
+  * :class:`TauOnsetMetric` — first crossing time of ``R(t) > θ`` in
+    the pre-event window. Right-censored if no crossing in window.
+  * :class:`AucPreEventMetric` — trapezoidal integral of ``R(t)``
+    over the pre-event window. Always observed.
+  * :class:`DeltaPhiSyncMetric` — first crossing time of pointwise
+    phase coherence relative to a reference (substrate principal
+    eigenvector by default). Right-censored if no crossing.
+
+Right-censoring discipline
+==========================
+``tau_onset`` and ``phase_lag`` are time-to-event observables. If a
+realisation never crosses the threshold inside the window, the
+observation is right-censored at the window horizon — NOT silently
+treated as ``horizon`` itself. The :func:`signal_mean` aggregator
+uses the Kaplan-Meier product-limit estimator's *restricted mean
+survival time*
+
+    RMST = ∫₀^τ S(t) dt
+
+over the window, with full censoring accounting per cohort. The
+returned :class:`SignalEstimate` carries the censoring fraction
+explicitly so a sweep cell with non-comparable censoring (e.g.
+precursor 0% censored, null 80% censored) is visibly flagged
+rather than producing a biased difference of observed means.
+
+Strict scope
+============
+Pure estimators. NO Kuramoto integration. NO claim layer. NO
+threshold tuning — the threshold defaults come from the locked
+D-002C pre-registration; a sweep config that disagrees is caught
+upstream by :func:`d002c_preregistration.validate_sweep_config`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Final, Protocol
+
+import numpy as np
+from numpy.typing import NDArray
+
+from .d002c_substrates import (
+    EVENT_QUARTER,
+    PRE_EVENT_START_QUARTER,
+    T_HORIZON,
+)
+
+# ---------------------------------------------------------------------------
+# Locked threshold defaults — read from the D-002C pre-registration YAML.
+# A driver that needs to override must do so via the prereg path.
+# ---------------------------------------------------------------------------
+DEFAULT_TAU_ONSET_THRESHOLD_R: Final[float] = 0.50  # YAML: tau_onset.threshold_R
+DEFAULT_PHASE_LAG_THRESHOLD: Final[float] = 0.50  # YAML: phase_lag
+
+
+class MetricInvalid(RuntimeError):
+    """Trajectory does not satisfy the metric's input contract."""
+
+
+@dataclass(frozen=True)
+class KuramotoTrajectory:
+    """One realisation of a Kuramoto integration.
+
+    ``R`` is the Kuramoto order parameter ``|⟨exp(i θ_j)⟩|``
+    sampled at every integration step. ``theta`` is the full
+    per-node phase trajectory; required for ``phase_lag`` and
+    optional for the other metrics.
+
+    ``steps_per_quarter`` is the integrator step count per quarter
+    so the metric layer can map quarter-level windows to step
+    indices without re-discovering the integration grid.
+    """
+
+    R: NDArray[np.float64]  # shape (T_steps,)
+    theta: NDArray[np.float64] | None  # shape (T_steps, N) or None
+    steps_per_quarter: int
+    horizon_quarters: int = T_HORIZON
+
+    def __post_init__(self) -> None:
+        if self.R.ndim != 1:
+            raise MetricInvalid(f"R must be 1-D; got shape {self.R.shape}")
+        if not np.all(np.isfinite(self.R)):
+            raise MetricInvalid("R contains non-finite values")
+        if np.any(self.R < -1e-9) or np.any(self.R > 1.0 + 1e-9):
+            raise MetricInvalid(
+                f"R must lie in [0, 1]; got min={self.R.min():.4e} max={self.R.max():.4e}"
+            )
+        if self.steps_per_quarter < 1:
+            raise MetricInvalid(f"steps_per_quarter must be >= 1; got {self.steps_per_quarter}")
+        expected_steps = self.horizon_quarters * self.steps_per_quarter
+        if self.R.shape[0] != expected_steps:
+            raise MetricInvalid(
+                f"R length {self.R.shape[0]} != "
+                f"horizon_quarters * steps_per_quarter = {expected_steps}"
+            )
+        if self.theta is not None:
+            if self.theta.ndim != 2 or self.theta.shape[0] != self.R.shape[0]:
+                raise MetricInvalid(
+                    f"theta must be 2-D with first axis == len(R); got {self.theta.shape}"
+                )
+            if not np.all(np.isfinite(self.theta)):
+                raise MetricInvalid("theta contains non-finite values")
+
+    @property
+    def pre_event_slice(self) -> slice:
+        """Step-index slice of the pre-event window [PRE_EVENT_START, EVENT)."""
+        spq = self.steps_per_quarter
+        return slice(PRE_EVENT_START_QUARTER * spq, EVENT_QUARTER * spq)
+
+
+@dataclass(frozen=True)
+class MetricEvaluation:
+    """Single-realisation metric output."""
+
+    metric_id: str
+    value: float
+    is_censored: bool
+    detail: dict[str, float] = field(default_factory=dict)
+
+
+class Metric(Protocol):
+    """Protocol for metric estimators."""
+
+    @property
+    def id(self) -> str: ...
+
+    def evaluate(self, trajectory: KuramotoTrajectory) -> MetricEvaluation: ...
+
+
+# ---------------------------------------------------------------------------
+# M1: tau_onset
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class TauOnsetMetric:
+    """First time R(t) crosses ``threshold_R`` in the pre-event window.
+
+    Returns:
+      * value = first crossing step index relative to window start
+      * is_censored = True if R never crosses in window
+      * detail.R_max_in_window, detail.window_steps
+    """
+
+    threshold_R: float = DEFAULT_TAU_ONSET_THRESHOLD_R
+
+    @property
+    def id(self) -> str:
+        return "tau_onset"
+
+    def evaluate(self, trajectory: KuramotoTrajectory) -> MetricEvaluation:
+        sl = trajectory.pre_event_slice
+        R_win = trajectory.R[sl]
+        window_steps = R_win.shape[0]
+        crossings = np.flatnonzero(R_win > self.threshold_R)
+        if crossings.size == 0:
+            value = float(window_steps)
+            censored = True
+        else:
+            value = float(crossings[0])
+            censored = False
+        return MetricEvaluation(
+            metric_id=self.id,
+            value=value,
+            is_censored=censored,
+            detail={
+                "R_max_in_window": float(R_win.max()),
+                "window_steps": float(window_steps),
+                "threshold_R": float(self.threshold_R),
+            },
+        )
+
+
+# ---------------------------------------------------------------------------
+# M2: auc_pre_event
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class AucPreEventMetric:
+    """Trapezoidal AUC of R(t) over the pre-event window. Always observed."""
+
+    @property
+    def id(self) -> str:
+        return "sync_auc"
+
+    def evaluate(self, trajectory: KuramotoTrajectory) -> MetricEvaluation:
+        sl = trajectory.pre_event_slice
+        R_win = trajectory.R[sl]
+        # Uniform step grid; dt = 1 step
+        auc = float(np.trapezoid(R_win, dx=1.0))
+        return MetricEvaluation(
+            metric_id=self.id,
+            value=auc,
+            is_censored=False,
+            detail={
+                "R_max_in_window": float(R_win.max()),
+                "R_mean_in_window": float(R_win.mean()),
+                "window_steps": float(R_win.shape[0]),
+            },
+        )
+
+
+# ---------------------------------------------------------------------------
+# M3: delta_phi_sync (phase_lag) — pointwise phase coherence to a reference
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class DeltaPhiSyncMetric:
+    """First time the pointwise phase coherence
+
+        Φ(t) = | (1/N) Σ_j w_j · exp(i θ_j(t)) |
+
+    crosses ``threshold_phi`` in the pre-event window. The reference
+    weight vector ``w`` defaults to uniform (which collapses to the
+    standard Kuramoto order parameter R(t)); the sweep runner passes
+    the substrate principal eigenvector to project on a structurally
+    motivated direction.
+    """
+
+    threshold_phi: float = DEFAULT_PHASE_LAG_THRESHOLD
+    reference_weights: NDArray[np.float64] | None = None
+
+    @property
+    def id(self) -> str:
+        return "phase_lag"
+
+    def evaluate(self, trajectory: KuramotoTrajectory) -> MetricEvaluation:
+        if trajectory.theta is None:
+            raise MetricInvalid("phase_lag requires per-node phases (theta)")
+        theta = trajectory.theta
+        N = theta.shape[1]
+        if self.reference_weights is None:
+            w = np.full(N, 1.0 / float(N), dtype=np.float64)
+        else:
+            w = np.asarray(self.reference_weights, dtype=np.float64)
+            if w.shape != (N,):
+                raise MetricInvalid(f"reference_weights must have shape ({N},); got {w.shape}")
+            wnorm = float(np.linalg.norm(w, ord=1))
+            if not np.isfinite(wnorm) or wnorm == 0.0:
+                raise MetricInvalid("reference_weights must be finite and sum to nonzero L1")
+            w = w / wnorm
+        # Φ(t) = | Σ_j w_j exp(i θ_j(t)) |
+        proj = np.exp(1j * theta) @ w
+        phi = np.abs(proj)
+        sl = trajectory.pre_event_slice
+        phi_win = phi[sl]
+        window_steps = phi_win.shape[0]
+        crossings = np.flatnonzero(phi_win > self.threshold_phi)
+        if crossings.size == 0:
+            value = float(window_steps)
+            censored = True
+        else:
+            value = float(crossings[0])
+            censored = False
+        return MetricEvaluation(
+            metric_id=self.id,
+            value=value,
+            is_censored=censored,
+            detail={
+                "phi_max_in_window": float(phi_win.max()),
+                "window_steps": float(window_steps),
+                "threshold_phi": float(self.threshold_phi),
+            },
+        )
+
+
+# ---------------------------------------------------------------------------
+# Cohort-level signal aggregation
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SignalEstimate:
+    """Cohort-level signal: mean(precursor) - mean(null) of the metric.
+
+    For right-censored metrics the means are *restricted-mean survival
+    times* from a Kaplan-Meier product-limit estimator over the
+    pre-event window. Censoring fractions are reported per cohort
+    so a downstream consumer can flag non-comparable cells (e.g.
+    precursor 0% censored vs null 80% censored — the comparison
+    of observed means would be biased).
+    """
+
+    metric_id: str
+    signal_mean: float
+    mean_precursor: float
+    mean_null: float
+    censoring_fraction_precursor: float
+    censoring_fraction_null: float
+    n_precursor: int
+    n_null: int
+    method: str  # "observed_mean" | "km_restricted_mean"
+
+
+def kaplan_meier_restricted_mean(
+    times: NDArray[np.float64],
+    censored: NDArray[np.bool_],
+    horizon: float,
+) -> float:
+    """Kaplan-Meier restricted mean survival time over [0, horizon].
+
+    Product-limit estimator (Kaplan-Meier 1958):
+
+        S(t) = ∏_{t_i ≤ t, observed} (1 - d_i / n_i)
+
+    where ``d_i`` is the count of *observed* events at distinct event
+    time ``t_i`` and ``n_i`` is the at-risk count just before ``t_i``.
+    The restricted mean is
+
+        RMST(τ) = ∫₀^τ S(t) dt
+
+    discretised over the sorted event times.
+
+    Convention: an "event" here is a threshold *crossing* (R > θ).
+    ``censored=True`` means no crossing observed within ``[0, horizon)``;
+    such a realisation does NOT contribute an event time, only to the
+    at-risk denominator.
+    """
+    times = np.asarray(times, dtype=np.float64)
+    censored = np.asarray(censored, dtype=bool)
+    if times.shape != censored.shape:
+        raise ValueError(f"times {times.shape} and censored {censored.shape} shape mismatch")
+    if times.size == 0:
+        raise ValueError("kaplan_meier_restricted_mean: empty cohort")
+    if horizon <= 0.0:
+        raise ValueError(f"horizon must be > 0; got {horizon}")
+    if np.any(~np.isfinite(times)) or np.any(times < 0.0):
+        raise ValueError("times must be finite and >= 0")
+    # Clip event times to the horizon (no events beyond the window are
+    # observable by construction)
+    t_clip = np.minimum(times, horizon)
+    # Sort by event time
+    order = np.argsort(t_clip, kind="stable")
+    t_sorted = t_clip[order]
+    c_sorted = censored[order]
+    n_total = t_sorted.size
+    # Sweep
+    S = 1.0
+    rmst = 0.0
+    prev_t = 0.0
+    i = 0
+    while i < n_total:
+        t_i = float(t_sorted[i])
+        # contribution to RMST up to t_i at the current S level
+        rmst += S * (t_i - prev_t)
+        # find tied block
+        j = i
+        d_i = 0  # observed events at t_i
+        while j < n_total and t_sorted[j] == t_i:
+            if not c_sorted[j]:
+                d_i += 1
+            j += 1
+        n_i = n_total - i  # at-risk count just before t_i
+        if d_i > 0 and n_i > 0:
+            S *= 1.0 - d_i / float(n_i)
+        prev_t = t_i
+        i = j
+    # tail from prev_t to horizon (only contributes if some realisations
+    # extended past the last event time — their censoring keeps S > 0)
+    rmst += S * (horizon - prev_t)
+    return float(rmst)
+
+
+def signal_mean(
+    metric: Metric,
+    evaluations_precursor: list[MetricEvaluation],
+    evaluations_null: list[MetricEvaluation],
+    *,
+    horizon: float,
+) -> SignalEstimate:
+    """Aggregate per-realisation evaluations into a cohort signal.
+
+    Right-censored metrics (``tau_onset``, ``phase_lag``) use
+    Kaplan-Meier RMST. Non-censored metrics (``sync_auc``) use the
+    simple cohort mean.
+    """
+    if not evaluations_precursor:
+        raise ValueError("signal_mean: empty precursor cohort")
+    if not evaluations_null:
+        raise ValueError("signal_mean: empty null cohort")
+
+    def _cohort(evals: list[MetricEvaluation]) -> tuple[float, float, str]:
+        any_censored = any(e.is_censored for e in evals)
+        if any_censored:
+            times = np.array([e.value for e in evals], dtype=np.float64)
+            censored = np.array([e.is_censored for e in evals], dtype=bool)
+            return (
+                kaplan_meier_restricted_mean(times, censored, horizon=horizon),
+                float(np.mean(censored)),
+                "km_restricted_mean",
+            )
+        values = np.array([e.value for e in evals], dtype=np.float64)
+        return float(values.mean()), 0.0, "observed_mean"
+
+    mu_p, c_p, method_p = _cohort(evaluations_precursor)
+    mu_n, c_n, method_n = _cohort(evaluations_null)
+    # If one cohort is censored and the other isn't, the comparable
+    # method is still km_restricted_mean — fall back to that for both.
+    method = (
+        "km_restricted_mean" if "km_restricted_mean" in (method_p, method_n) else "observed_mean"
+    )
+    return SignalEstimate(
+        metric_id=metric.id,
+        signal_mean=mu_p - mu_n,
+        mean_precursor=mu_p,
+        mean_null=mu_n,
+        censoring_fraction_precursor=c_p,
+        censoring_fraction_null=c_n,
+        n_precursor=len(evaluations_precursor),
+        n_null=len(evaluations_null),
+        method=method,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+ALL_METRICS: Final[tuple[Metric, ...]] = (
+    TauOnsetMetric(),
+    AucPreEventMetric(),
+    DeltaPhiSyncMetric(),
+)
+
+METRIC_BY_ID: Final[dict[str, Metric]] = {m.id: m for m in ALL_METRICS}
+
+
+__all__ = [
+    "DEFAULT_TAU_ONSET_THRESHOLD_R",
+    "DEFAULT_PHASE_LAG_THRESHOLD",
+    "MetricInvalid",
+    "KuramotoTrajectory",
+    "MetricEvaluation",
+    "Metric",
+    "TauOnsetMetric",
+    "AucPreEventMetric",
+    "DeltaPhiSyncMetric",
+    "SignalEstimate",
+    "kaplan_meier_restricted_mean",
+    "signal_mean",
+    "ALL_METRICS",
+    "METRIC_BY_ID",
+]

--- a/research/systemic_risk/d002c_substrates.py
+++ b/research/systemic_risk/d002c_substrates.py
@@ -1,0 +1,505 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""D-002C — Substrate generators for the Signal Amplification Sweep.
+
+Rationale
+=========
+Three substrate families, each producing a Kuramoto coupling
+matrix K of shape ``(T_HORIZON, N, N)`` parameterised by
+``(N, lambda_, seed)``. The temporal dimension is the
+quarter-level horizon over which the sweep simulates a
+precursor event; the precursor is injected into ``K`` during
+the pre-event window, leaving ``K_baseline`` untouched.
+
+  * :class:`RicciFlowSubstrate` — Erdős-Rényi base, Forman-Ricci
+    curvature per edge, K_ij = K_c * (1 + 0.5 * κ̂_ij) where κ̂
+    is curvature normalised to [-1, 1]. Precursor: positive κ
+    shift on the top-10% strongest edges during the 2Q
+    pre-event window.
+
+  * :class:`BlockStructuredSubstrate` — tiered core/mid/periphery
+    block matrix with the locked multiplier pattern
+    (1.5/1.0/0.5/0.2 K_c). Precursor: additive λ-shift to the
+    inter-block off-diagonal sub-blocks during the 2Q pre-event.
+
+  * :class:`TemporalKtSubstrate` — block-structured baseline
+    plus a deterministic sinusoidal modulation
+    ``K(t) = K_c * (1 + 0.20 * sin(2π t / 4))``. Precursor:
+    baseline-level λ shift applied to the temporal envelope
+    during the 2Q pre-event.
+
+Strict scope
+============
+Substrate construction ONLY. NO Kuramoto integration (that
+lives in the sweep runner, C2.4). NO metric computation (that
+lives in :mod:`d002c_metrics`). NO claim layer. Output is a
+frozen :class:`SubstrateRealization` consumed downstream.
+
+Calibration contract
+====================
+For each realisation, both ``K_baseline`` and ``K_precursor``
+satisfy
+
+  * symmetric (Hermitian) at every time slice
+  * finite (no NaN / Inf)
+  * mean-over-time spectral radius ``λ_max(K) / N ∈ [0.95, 1.05]``
+    (gate G9). Calibrated post-construction via scalar scaling
+    so the regime is reproducible across substrate families.
+  * baseline density (off-diagonal nonzero fraction) within
+    [0.05, 0.15] for substrates that have an underlying sparse
+    topology (G6).
+  * precursor injection produces a measurable Frobenius-norm
+    delta ``||K_precursor - K_baseline||_F > 0`` for any
+    ``lambda_ > 0`` (G10).
+
+These are gates, not soft suggestions — a realisation that
+violates any of them raises :class:`SubstrateInvalid`. The
+sweep cannot proceed past such a failure.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final, Protocol
+
+import numpy as np
+from numpy.typing import NDArray
+
+# ---------------------------------------------------------------------------
+# Horizon constants — pinned to the D-002C pre-registration intent.
+#
+# The horizon is 8 quarters (2 years), with the event at quarter 6 and a
+# 4Q pre-event window [2, 6). The precursor is injected into the LAST 2
+# quarters of the pre-event window, i.e. quarters {4, 5}.
+# ---------------------------------------------------------------------------
+T_HORIZON: Final[int] = 8
+EVENT_QUARTER: Final[int] = 6
+PRE_EVENT_START_QUARTER: Final[int] = 2
+PRE_EVENT_WINDOW: Final[range] = range(PRE_EVENT_START_QUARTER, EVENT_QUARTER)
+PRECURSOR_INJECTION_WINDOW: Final[range] = range(EVENT_QUARTER - 2, EVENT_QUARTER)
+
+# Gates G6 / G9
+DENSITY_RANGE: Final[tuple[float, float]] = (0.05, 0.15)
+SPECTRAL_RANGE: Final[tuple[float, float]] = (0.95, 1.05)
+
+# Default Erdős-Rényi density for the Ricci substrate
+DEFAULT_ER_DENSITY: Final[float] = 0.10
+
+# Block structure (fractions sum to 1.0)
+BLOCK_FRACTIONS: Final[tuple[float, float, float]] = (0.20, 0.30, 0.50)
+
+
+class SubstrateInvalid(RuntimeError):
+    """Substrate realisation violates the calibration / shape contract."""
+
+
+@dataclass(frozen=True)
+class SubstrateRealization:
+    """Frozen output of one substrate realisation.
+
+    ``K_baseline`` is the null trajectory (no precursor).
+    ``K_precursor`` carries the precursor injection during
+    :data:`PRECURSOR_INJECTION_WINDOW`. Outside that window the
+    two trajectories are identical.
+    """
+
+    substrate_id: str
+    N: int
+    lambda_: float
+    seed: int
+    K_baseline: NDArray[np.float64]  # shape (T_HORIZON, N, N)
+    K_precursor: NDArray[np.float64]  # shape (T_HORIZON, N, N)
+    K_c: float
+    density: float
+    spectral_radius_over_N: float
+    precursor_frobenius_delta: float
+
+
+class Substrate(Protocol):
+    """Protocol for substrate generators."""
+
+    @property
+    def id(self) -> str: ...
+
+    def realize(self, *, N: int, lambda_: float, seed: int) -> SubstrateRealization: ...
+
+
+# ---------------------------------------------------------------------------
+# Shared validation
+# ---------------------------------------------------------------------------
+
+
+def _verify_K_trajectory(K: NDArray[np.float64], *, where: str) -> None:
+    """Raise SubstrateInvalid unless K is shape (T,N,N), finite, symmetric."""
+    if K.ndim != 3:
+        raise SubstrateInvalid(f"{where}: K must be 3-D (T,N,N); got {K.shape}")
+    if not np.all(np.isfinite(K)):
+        raise SubstrateInvalid(f"{where}: K contains non-finite values")
+    # symmetric at every time slice
+    asym = np.max(np.abs(K - np.swapaxes(K, -1, -2)))
+    if asym > 1e-9:
+        raise SubstrateInvalid(f"{where}: K not symmetric (max asymmetry {asym:.3e})")
+
+
+def _spectral_radius_mean(K: NDArray[np.float64]) -> float:
+    """Mean of largest absolute eigenvalue across time slices."""
+    radii = [float(np.abs(np.linalg.eigvalsh(K[t])).max()) for t in range(K.shape[0])]
+    return float(np.mean(radii))
+
+
+def _enforce_calibration_gates(
+    *,
+    K_baseline: NDArray[np.float64],
+    K_precursor: NDArray[np.float64],
+    lambda_: float,
+    density: float | None,
+    substrate_id: str,
+    N: int,
+) -> tuple[float, float]:
+    """Run gates G6, G7, G8, G9, G10. Return (spectral_radius_over_N, delta)."""
+    _verify_K_trajectory(K_baseline, where=f"{substrate_id}.K_baseline")
+    _verify_K_trajectory(K_precursor, where=f"{substrate_id}.K_precursor")
+
+    spec = _spectral_radius_mean(K_baseline) / float(N)
+    lo, hi = SPECTRAL_RANGE
+    if not (lo <= spec <= hi):
+        raise SubstrateInvalid(
+            f"{substrate_id}: spectral_radius_over_N={spec:.4f} outside "
+            f"[{lo}, {hi}] (gate G9 failed)"
+        )
+
+    if density is not None:
+        d_lo, d_hi = DENSITY_RANGE
+        if not (d_lo <= density <= d_hi):
+            raise SubstrateInvalid(
+                f"{substrate_id}: density={density:.4f} outside [{d_lo}, {d_hi}] (gate G6 failed)"
+            )
+
+    delta = float(np.linalg.norm(K_precursor - K_baseline))
+    # Gate G10: any lambda_ > 0 must produce strictly positive Frobenius delta.
+    if lambda_ > 0.0 and delta <= 0.0:
+        raise SubstrateInvalid(
+            f"{substrate_id}: lambda_={lambda_:.4f} > 0 but precursor delta "
+            f"is {delta:.3e} (gate G10 failed)"
+        )
+    # And lambda_ == 0 means null run — delta MUST be exactly zero.
+    if lambda_ == 0.0 and delta != 0.0:
+        raise SubstrateInvalid(
+            f"{substrate_id}: lambda_=0 but precursor delta is {delta:.3e} "
+            "(null run must be identical to baseline)"
+        )
+    return spec, delta
+
+
+def _calibrate_spectral_radius(
+    M: NDArray[np.float64], *, target_N: int
+) -> tuple[NDArray[np.float64], float]:
+    """Scale M so its largest absolute eigenvalue equals N. Returns (K, K_c)."""
+    lam = float(np.abs(np.linalg.eigvalsh(M)).max())
+    if lam <= 0.0:
+        raise SubstrateInvalid(f"cannot calibrate: spectral radius {lam:.3e} <= 0")
+    K_c = float(target_N) / lam
+    return M * K_c, K_c
+
+
+# ---------------------------------------------------------------------------
+# S1: Ricci-flow weighted Erdős-Rényi
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RicciFlowSubstrate:
+    """Erdős-Rényi base, Forman-Ricci-weighted coupling, top-10% κ precursor.
+
+    Forman-Ricci on an unweighted graph:
+
+        κ_F(i,j) = 4 - deg(i) - deg(j) + 3 · #{triangles containing (i,j)}
+
+    O(N²) construction (matrix product gives triangles_ij) — fast for
+    the swept N ≤ 200 regime. Raw κ_F is unbounded; we normalise to
+    ``κ̂ ∈ [-1, 1]`` before applying ``K = M_struct · (1 + 0.5 κ̂)``
+    so the multiplier stays strictly positive (a sign-flipped K_ij
+    would invert Kuramoto's attractive coupling — masked as a soft
+    bug we explicitly refuse).
+    """
+
+    er_density: float = DEFAULT_ER_DENSITY
+
+    @property
+    def id(self) -> str:
+        return "ricci_flow"
+
+    def realize(self, *, N: int, lambda_: float, seed: int) -> SubstrateRealization:
+        if N < 4:
+            raise SubstrateInvalid("ricci_flow: N must be >= 4")
+        rng = np.random.default_rng(seed)
+        # 1) Erdős-Rényi adjacency (symmetric, no self-loops)
+        upper = rng.random((N, N)) < self.er_density
+        A_bool = np.triu(upper, k=1)
+        A_bool = A_bool | A_bool.T
+        np.fill_diagonal(A_bool, False)
+        A = A_bool.astype(np.float64)
+        if not A.any():
+            raise SubstrateInvalid(
+                f"ricci_flow: ER realisation at p={self.er_density} produced "
+                f"an empty graph (seed={seed}, N={N})"
+            )
+        # 2) Forman-Ricci κ per edge
+        deg = A.sum(axis=1)
+        triangles = A @ A  # triangles_ij = # common neighbours when (i,j)∈E
+        kappa = 4.0 - deg[:, None] - deg[None, :] + 3.0 * triangles
+        kappa = kappa * A  # zero where no edge
+        # 3) Normalise κ to [-1, 1] over the edge set
+        finite_kappa = kappa[A.astype(bool)]
+        scale = max(float(np.abs(finite_kappa).max()), 1.0)
+        kappa_hat = kappa / scale
+        # 4) Structural matrix M = adjacency * (1 + 0.5 κ̂)
+        M = A * (1.0 + 0.5 * kappa_hat)
+        K_calibrated, K_c = _calibrate_spectral_radius(M, target_N=N)
+        K_baseline = np.broadcast_to(K_calibrated, (T_HORIZON, N, N)).astype(np.float64).copy()
+        # 5) Precursor: shift top-10% strongest edges by +0.20·λ during the
+        #    precursor injection window. Top-10% selected on the upper
+        #    triangle to avoid duplication.
+        K_precursor = K_baseline.copy()
+        if lambda_ > 0.0:
+            iu = np.triu_indices(N, k=1)
+            strengths = K_calibrated[iu]
+            mask_edges = strengths > 0
+            if not mask_edges.any():
+                raise SubstrateInvalid(
+                    "ricci_flow: no positive-strength edges to inject precursor on"
+                )
+            thresh = float(np.quantile(strengths[mask_edges], 0.90))
+            top_mask = np.zeros_like(K_calibrated, dtype=bool)
+            sel = (strengths >= thresh) & mask_edges
+            top_mask[iu[0][sel], iu[1][sel]] = True
+            top_mask = top_mask | top_mask.T  # symmetric
+            shift = 0.20 * lambda_ * top_mask.astype(np.float64)
+            K_event = K_calibrated * (1.0 + shift)
+            for t in PRECURSOR_INJECTION_WINDOW:
+                K_precursor[t] = K_event
+        density = float(A.sum() / (N * (N - 1)))
+        spec, delta = _enforce_calibration_gates(
+            K_baseline=K_baseline,
+            K_precursor=K_precursor,
+            lambda_=lambda_,
+            density=density,
+            substrate_id=self.id,
+            N=N,
+        )
+        return SubstrateRealization(
+            substrate_id=self.id,
+            N=N,
+            lambda_=lambda_,
+            seed=seed,
+            K_baseline=K_baseline,
+            K_precursor=K_precursor,
+            K_c=K_c,
+            density=density,
+            spectral_radius_over_N=spec,
+            precursor_frobenius_delta=delta,
+        )
+
+
+# ---------------------------------------------------------------------------
+# S2: Block-structured tiered (core / mid / periphery)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class BlockStructuredSubstrate:
+    """Tiered block matrix with the locked core/mid/periphery multiplier
+    pattern. Precursor: additive λ-shift on the inter-block off-diagonal
+    sub-blocks (core↔mid, core↔periphery, mid↔periphery) during the 2Q
+    pre-event window. Within-block multipliers remain at their locked
+    values; the precursor models a structural coupling lift between
+    tiers, which is the regime D-002C predicts to be detectable.
+    """
+
+    block_fractions: tuple[float, float, float] = BLOCK_FRACTIONS
+
+    @property
+    def id(self) -> str:
+        return "block_structured"
+
+    def realize(self, *, N: int, lambda_: float, seed: int) -> SubstrateRealization:
+        if N < 6:
+            raise SubstrateInvalid("block_structured: N must be >= 6")
+        f_core, f_mid, _f_per = self.block_fractions
+        n_core = max(1, int(round(f_core * N)))
+        n_mid = max(1, int(round(f_mid * N)))
+        n_per = N - n_core - n_mid
+        if n_per <= 0:
+            raise SubstrateInvalid(
+                f"block_structured: degenerate split (core={n_core}, "
+                f"mid={n_mid}, periphery={n_per}) at N={N}"
+            )
+        # Multiplier matrix W (NxN) before K_c calibration
+        # core-core=1.5, core-mid=1.0, core-per=1.0, mid-mid=1.0,
+        # mid-per=0.5, per-per=0.2
+        W = np.zeros((N, N), dtype=np.float64)
+        i_core = slice(0, n_core)
+        i_mid = slice(n_core, n_core + n_mid)
+        i_per = slice(n_core + n_mid, N)
+        W[i_core, i_core] = 1.5
+        W[i_core, i_mid] = 1.0
+        W[i_mid, i_core] = 1.0
+        W[i_core, i_per] = 1.0
+        W[i_per, i_core] = 1.0
+        W[i_mid, i_mid] = 1.0
+        W[i_mid, i_per] = 0.5
+        W[i_per, i_mid] = 0.5
+        W[i_per, i_per] = 0.2
+        np.fill_diagonal(W, 0.0)
+        _ = seed  # block substrate is fully deterministic in N, lambda_
+        K_calibrated, K_c = _calibrate_spectral_radius(W, target_N=N)
+        K_baseline = np.broadcast_to(K_calibrated, (T_HORIZON, N, N)).astype(np.float64).copy()
+        # Precursor: additive lift on the inter-block sub-blocks
+        K_precursor = K_baseline.copy()
+        if lambda_ > 0.0:
+            lift = np.zeros((N, N), dtype=np.float64)
+            shift_mag = 0.25 * lambda_ * K_c
+            lift[i_core, i_mid] = shift_mag
+            lift[i_mid, i_core] = shift_mag
+            lift[i_core, i_per] = shift_mag
+            lift[i_per, i_core] = shift_mag
+            lift[i_mid, i_per] = shift_mag
+            lift[i_per, i_mid] = shift_mag
+            np.fill_diagonal(lift, 0.0)
+            K_event = K_calibrated + lift
+            for t in PRECURSOR_INJECTION_WINDOW:
+                K_precursor[t] = K_event
+        # density is structural (no random graph) — equal to fraction
+        # of nonzero off-diagonal entries in the locked pattern.
+        density = float(np.count_nonzero(W) / (N * (N - 1)))
+        spec, delta = _enforce_calibration_gates(
+            K_baseline=K_baseline,
+            K_precursor=K_precursor,
+            lambda_=lambda_,
+            density=None,  # block substrate is fully connected, density gate N/A
+            substrate_id=self.id,
+            N=N,
+        )
+        _ = density
+        return SubstrateRealization(
+            substrate_id=self.id,
+            N=N,
+            lambda_=lambda_,
+            seed=seed,
+            K_baseline=K_baseline,
+            K_precursor=K_precursor,
+            K_c=K_c,
+            density=density,
+            spectral_radius_over_N=spec,
+            precursor_frobenius_delta=delta,
+        )
+
+
+# ---------------------------------------------------------------------------
+# S3: Temporal K(t) modulation on a block-structured base
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class TemporalKtSubstrate:
+    """Block-structured base + deterministic sinusoidal modulation.
+
+        K(t) = K_c_baseline · (1 + 0.20 · sin(2π t / period_quarters))
+
+    where period_quarters is the locked period of the K(t) envelope
+    (default 4 quarters → one full cycle per year). The amplitude
+    0.20 is the locked modulation depth; the spectral radius
+    averaged over the period equals the base block-structured
+    radius (sinusoid integrates to zero over a full period).
+
+    Precursor: a constant additive lift on the baseline envelope
+    during the 2Q pre-event window, scaled by lambda_. The
+    precursor and the sinusoid are orthogonal mechanisms (additive),
+    not multiplicative — they probe distinct physical effects.
+    """
+
+    period_quarters: int = 4
+    amplitude: float = 0.20
+
+    @property
+    def id(self) -> str:
+        return "temporal_coupling"
+
+    def realize(self, *, N: int, lambda_: float, seed: int) -> SubstrateRealization:
+        if N < 6:
+            raise SubstrateInvalid("temporal_coupling: N must be >= 6")
+        if self.period_quarters < 2:
+            raise SubstrateInvalid("temporal_coupling: period_quarters must be >= 2")
+        # Base structure = block substrate at λ=0 (no precursor in the base)
+        base = BlockStructuredSubstrate(block_fractions=BLOCK_FRACTIONS).realize(
+            N=N, lambda_=0.0, seed=seed
+        )
+        K_base_static = base.K_baseline[0]  # all time slices identical at λ=0
+        envelope = 1.0 + self.amplitude * np.sin(
+            2.0 * np.pi * np.arange(T_HORIZON) / float(self.period_quarters)
+        )
+        K_baseline = np.stack(
+            [K_base_static * float(envelope[t]) for t in range(T_HORIZON)],
+            axis=0,
+        )
+        K_precursor = K_baseline.copy()
+        if lambda_ > 0.0:
+            additive = 0.15 * lambda_ * base.K_c
+            lift = np.where(K_base_static > 0, additive, 0.0)
+            for t in PRECURSOR_INJECTION_WINDOW:
+                K_precursor[t] = K_baseline[t] + lift
+        spec, delta = _enforce_calibration_gates(
+            K_baseline=K_baseline,
+            K_precursor=K_precursor,
+            lambda_=lambda_,
+            density=None,
+            substrate_id=self.id,
+            N=N,
+        )
+        return SubstrateRealization(
+            substrate_id=self.id,
+            N=N,
+            lambda_=lambda_,
+            seed=seed,
+            K_baseline=K_baseline,
+            K_precursor=K_precursor,
+            K_c=base.K_c,
+            density=base.density,
+            spectral_radius_over_N=spec,
+            precursor_frobenius_delta=delta,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+ALL_SUBSTRATES: Final[tuple[Substrate, ...]] = (
+    RicciFlowSubstrate(),
+    BlockStructuredSubstrate(),
+    TemporalKtSubstrate(),
+)
+
+SUBSTRATE_BY_ID: Final[dict[str, Substrate]] = {s.id: s for s in ALL_SUBSTRATES}
+
+
+__all__ = [
+    "T_HORIZON",
+    "EVENT_QUARTER",
+    "PRE_EVENT_START_QUARTER",
+    "PRE_EVENT_WINDOW",
+    "PRECURSOR_INJECTION_WINDOW",
+    "DENSITY_RANGE",
+    "SPECTRAL_RANGE",
+    "DEFAULT_ER_DENSITY",
+    "BLOCK_FRACTIONS",
+    "SubstrateInvalid",
+    "SubstrateRealization",
+    "Substrate",
+    "RicciFlowSubstrate",
+    "BlockStructuredSubstrate",
+    "TemporalKtSubstrate",
+    "ALL_SUBSTRATES",
+    "SUBSTRATE_BY_ID",
+]

--- a/research/systemic_risk/d002c_substrates.py
+++ b/research/systemic_risk/d002c_substrates.py
@@ -78,9 +78,19 @@ PRE_EVENT_START_QUARTER: Final[int] = 2
 PRE_EVENT_WINDOW: Final[range] = range(PRE_EVENT_START_QUARTER, EVENT_QUARTER)
 PRECURSOR_INJECTION_WINDOW: Final[range] = range(EVENT_QUARTER - 2, EVENT_QUARTER)
 
-# Gates G6 / G9
+# Gates G6 / G9 / G9-precursor
 DENSITY_RANGE: Final[tuple[float, float]] = (0.05, 0.15)
+# Baseline must sit at the critical-onset regime (ρ/N ≈ 1.0). Tight band so
+# the three substrate families are spectrally comparable AT THE NULL.
 SPECTRAL_RANGE: Final[tuple[float, float]] = (0.95, 1.05)
+# Precursor is BY DESIGN an amplification — a precursor that didn't lift
+# coupling would have nothing to detect. We allow up to +15% spectral
+# radius lift but refuse contraction (ρ/N < 0.95) and any pathological
+# explosion (ρ/N > 1.15) that would push the regime so far past onset
+# that the metric saturates trivially. The precursor gate is asserted
+# at lambda=1 (the maximum); lambdas in (0, 1) lift continuously and
+# stay strictly inside the corresponding sub-interval.
+PRECURSOR_SPECTRAL_RANGE: Final[tuple[float, float]] = (0.95, 1.15)
 
 # Default Erdős-Rényi density for the Ricci substrate
 DEFAULT_ER_DENSITY: Final[float] = 0.10
@@ -112,6 +122,13 @@ class SubstrateRealization:
     K_c: float
     density: float
     spectral_radius_over_N: float
+    # New (Codex P1 fix, 2026-05-11): gate G9 was previously asserted only
+    # on K_baseline; this is now also asserted on K_precursor with a
+    # wider but bounded range (PRECURSOR_SPECTRAL_RANGE). A precursor
+    # that pushed K outside the comparable regime would bias the
+    # downstream metric comparison; the gate refuses such realisations
+    # fail-closed.
+    spectral_radius_over_N_precursor: float
     precursor_frobenius_delta: float
 
 
@@ -155,17 +172,46 @@ def _enforce_calibration_gates(
     density: float | None,
     substrate_id: str,
     N: int,
-) -> tuple[float, float]:
-    """Run gates G6, G7, G8, G9, G10. Return (spectral_radius_over_N, delta)."""
+) -> tuple[float, float, float]:
+    """Run gates G6, G7, G8, G9 (baseline + precursor), G10.
+
+    Returns
+    -------
+    (spectral_radius_over_N_baseline, spectral_radius_over_N_precursor, delta)
+
+    Notes
+    -----
+    Codex P1 fix (2026-05-11): gate G9 was previously asserted only on
+    ``K_baseline``; the precursor trajectory was constructed but never
+    spectrally validated. That allowed a realisation whose precursor
+    exceeded the comparable-regime band to pass silently (e.g.
+    ``BlockStructuredSubstrate(lambda_=1.0)`` was producing
+    ``ρ/N ≈ 1.052`` on the precursor, beyond the baseline gate hi).
+    Both trajectories are now spectrally validated, against their own
+    ranges (:data:`SPECTRAL_RANGE` for baseline,
+    :data:`PRECURSOR_SPECTRAL_RANGE` for precursor — wider but bounded,
+    reflecting that the precursor IS by design an amplification).
+    """
     _verify_K_trajectory(K_baseline, where=f"{substrate_id}.K_baseline")
     _verify_K_trajectory(K_precursor, where=f"{substrate_id}.K_precursor")
 
-    spec = _spectral_radius_mean(K_baseline) / float(N)
+    spec_baseline = _spectral_radius_mean(K_baseline) / float(N)
     lo, hi = SPECTRAL_RANGE
-    if not (lo <= spec <= hi):
+    if not (lo <= spec_baseline <= hi):
         raise SubstrateInvalid(
-            f"{substrate_id}: spectral_radius_over_N={spec:.4f} outside "
-            f"[{lo}, {hi}] (gate G9 failed)"
+            f"{substrate_id}: baseline spectral_radius_over_N={spec_baseline:.4f} "
+            f"outside [{lo}, {hi}] (gate G9 baseline failed)"
+        )
+
+    spec_precursor = _spectral_radius_mean(K_precursor) / float(N)
+    p_lo, p_hi = PRECURSOR_SPECTRAL_RANGE
+    if not (p_lo <= spec_precursor <= p_hi):
+        raise SubstrateInvalid(
+            f"{substrate_id}: precursor spectral_radius_over_N={spec_precursor:.4f} "
+            f"outside [{p_lo}, {p_hi}] (gate G9 precursor failed) — "
+            f"at lambda_={lambda_:.4f}. The precursor injection pushed K "
+            f"past the comparable-regime band; downstream metric "
+            f"comparison would be biased."
         )
 
     if density is not None:
@@ -188,7 +234,7 @@ def _enforce_calibration_gates(
             f"{substrate_id}: lambda_=0 but precursor delta is {delta:.3e} "
             "(null run must be identical to baseline)"
         )
-    return spec, delta
+    return spec_baseline, spec_precursor, delta
 
 
 def _calibrate_spectral_radius(
@@ -279,7 +325,7 @@ class RicciFlowSubstrate:
             for t in PRECURSOR_INJECTION_WINDOW:
                 K_precursor[t] = K_event
         density = float(A.sum() / (N * (N - 1)))
-        spec, delta = _enforce_calibration_gates(
+        spec_b, spec_p, delta = _enforce_calibration_gates(
             K_baseline=K_baseline,
             K_precursor=K_precursor,
             lambda_=lambda_,
@@ -296,7 +342,8 @@ class RicciFlowSubstrate:
             K_precursor=K_precursor,
             K_c=K_c,
             density=density,
-            spectral_radius_over_N=spec,
+            spectral_radius_over_N=spec_b,
+            spectral_radius_over_N_precursor=spec_p,
             precursor_frobenius_delta=delta,
         )
 
@@ -372,7 +419,7 @@ class BlockStructuredSubstrate:
         # density is structural (no random graph) — equal to fraction
         # of nonzero off-diagonal entries in the locked pattern.
         density = float(np.count_nonzero(W) / (N * (N - 1)))
-        spec, delta = _enforce_calibration_gates(
+        spec_b, spec_p, delta = _enforce_calibration_gates(
             K_baseline=K_baseline,
             K_precursor=K_precursor,
             lambda_=lambda_,
@@ -380,7 +427,6 @@ class BlockStructuredSubstrate:
             substrate_id=self.id,
             N=N,
         )
-        _ = density
         return SubstrateRealization(
             substrate_id=self.id,
             N=N,
@@ -390,7 +436,8 @@ class BlockStructuredSubstrate:
             K_precursor=K_precursor,
             K_c=K_c,
             density=density,
-            spectral_radius_over_N=spec,
+            spectral_radius_over_N=spec_b,
+            spectral_radius_over_N_precursor=spec_p,
             precursor_frobenius_delta=delta,
         )
 
@@ -448,7 +495,7 @@ class TemporalKtSubstrate:
             lift = np.where(K_base_static > 0, additive, 0.0)
             for t in PRECURSOR_INJECTION_WINDOW:
                 K_precursor[t] = K_baseline[t] + lift
-        spec, delta = _enforce_calibration_gates(
+        spec_b, spec_p, delta = _enforce_calibration_gates(
             K_baseline=K_baseline,
             K_precursor=K_precursor,
             lambda_=lambda_,
@@ -465,7 +512,8 @@ class TemporalKtSubstrate:
             K_precursor=K_precursor,
             K_c=base.K_c,
             density=base.density,
-            spectral_radius_over_N=spec,
+            spectral_radius_over_N=spec_b,
+            spectral_radius_over_N_precursor=spec_p,
             precursor_frobenius_delta=delta,
         )
 
@@ -492,6 +540,7 @@ __all__ = [
     "PRECURSOR_INJECTION_WINDOW",
     "DENSITY_RANGE",
     "SPECTRAL_RANGE",
+    "PRECURSOR_SPECTRAL_RANGE",
     "DEFAULT_ER_DENSITY",
     "BLOCK_FRACTIONS",
     "SubstrateInvalid",

--- a/tests/research/systemic_risk/test_d002c_metrics.py
+++ b/tests/research/systemic_risk/test_d002c_metrics.py
@@ -1,0 +1,462 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""D-002C C2.2 — Metric estimator tests.
+
+Pins gates G11-G15 for the metric layer:
+
+  G11  right-censoring is handled honestly (NOT silent NaN, NOT
+       horizon-imputation); KM RMST is the canonical aggregator
+  G12  reproducible: same R(t) → same metric value bit-exact
+  G13  monotone sanity: a stronger signal in R(t) yields a larger
+       |signal_mean| on a 3-point smoke test
+  G14  9 substrate × metric combinations all callable
+  G15  30+ unit tests total across substrates + metrics
+
+Strict scope: pure estimator tests. NO Kuramoto integration.
+Trajectories are synthesized directly with known properties.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from research.systemic_risk.d002c_metrics import (
+    ALL_METRICS,
+    DEFAULT_PHASE_LAG_THRESHOLD,
+    DEFAULT_TAU_ONSET_THRESHOLD_R,
+    METRIC_BY_ID,
+    AucPreEventMetric,
+    DeltaPhiSyncMetric,
+    KuramotoTrajectory,
+    MetricEvaluation,
+    MetricInvalid,
+    SignalEstimate,
+    TauOnsetMetric,
+    kaplan_meier_restricted_mean,
+    signal_mean,
+)
+from research.systemic_risk.d002c_substrates import (
+    EVENT_QUARTER,
+    PRE_EVENT_START_QUARTER,
+    T_HORIZON,
+)
+
+# ---------------------------------------------------------------------------
+# Trajectory builders
+# ---------------------------------------------------------------------------
+
+
+def _flat_R(value: float, steps_per_quarter: int = 16) -> KuramotoTrajectory:
+    """R(t) = const at every step. No theta."""
+    R = np.full(T_HORIZON * steps_per_quarter, value, dtype=np.float64)
+    return KuramotoTrajectory(R=R, theta=None, steps_per_quarter=steps_per_quarter)
+
+
+def _step_R(
+    *,
+    low: float,
+    high: float,
+    crossing_quarter: int,
+    steps_per_quarter: int = 16,
+) -> KuramotoTrajectory:
+    """R(t) jumps from `low` to `high` at the start of `crossing_quarter`."""
+    total = T_HORIZON * steps_per_quarter
+    R = np.full(total, low, dtype=np.float64)
+    R[crossing_quarter * steps_per_quarter :] = high
+    return KuramotoTrajectory(R=R, theta=None, steps_per_quarter=steps_per_quarter)
+
+
+def _trajectory_with_theta(
+    *,
+    theta_t_n: np.ndarray,
+    steps_per_quarter: int = 16,
+) -> KuramotoTrajectory:
+    R = np.abs(np.mean(np.exp(1j * theta_t_n), axis=1))
+    return KuramotoTrajectory(R=R, theta=theta_t_n, steps_per_quarter=steps_per_quarter)
+
+
+# ---------------------------------------------------------------------------
+# KuramotoTrajectory contract
+# ---------------------------------------------------------------------------
+
+
+def test_trajectory_validates_R_shape_1d() -> None:
+    with pytest.raises(MetricInvalid):
+        KuramotoTrajectory(
+            R=np.zeros((10, 2), dtype=np.float64),
+            theta=None,
+            steps_per_quarter=2,
+        )
+
+
+def test_trajectory_validates_R_finite() -> None:
+    bad = np.zeros(T_HORIZON * 4, dtype=np.float64)
+    bad[3] = np.nan
+    with pytest.raises(MetricInvalid):
+        KuramotoTrajectory(R=bad, theta=None, steps_per_quarter=4)
+
+
+def test_trajectory_validates_R_in_unit_interval() -> None:
+    bad = np.zeros(T_HORIZON * 4, dtype=np.float64)
+    bad[5] = 1.5
+    with pytest.raises(MetricInvalid):
+        KuramotoTrajectory(R=bad, theta=None, steps_per_quarter=4)
+
+
+def test_trajectory_validates_steps_per_quarter_consistency() -> None:
+    R = np.zeros(31, dtype=np.float64)  # 31 doesn't factor T_HORIZON
+    with pytest.raises(MetricInvalid):
+        KuramotoTrajectory(R=R, theta=None, steps_per_quarter=4)
+
+
+def test_trajectory_validates_theta_shape() -> None:
+    R = np.zeros(T_HORIZON * 4, dtype=np.float64)
+    theta_bad = np.zeros((T_HORIZON * 4, 5, 2), dtype=np.float64)
+    with pytest.raises(MetricInvalid):
+        KuramotoTrajectory(R=R, theta=theta_bad, steps_per_quarter=4)
+
+
+def test_trajectory_pre_event_slice_matches_window() -> None:
+    tr = _flat_R(0.1, steps_per_quarter=8)
+    sl = tr.pre_event_slice
+    assert sl.start == PRE_EVENT_START_QUARTER * 8
+    assert sl.stop == EVENT_QUARTER * 8
+
+
+# ---------------------------------------------------------------------------
+# M1: tau_onset
+# ---------------------------------------------------------------------------
+
+
+def test_tau_onset_default_threshold_matches_locked_yaml() -> None:
+    assert TauOnsetMetric().threshold_R == DEFAULT_TAU_ONSET_THRESHOLD_R
+    assert DEFAULT_TAU_ONSET_THRESHOLD_R == 0.50
+
+
+def test_tau_onset_returns_first_crossing_in_window() -> None:
+    tr = _step_R(low=0.1, high=0.9, crossing_quarter=3, steps_per_quarter=8)
+    ev = TauOnsetMetric().evaluate(tr)
+    # window starts at quarter PRE_EVENT_START_QUARTER (=2), crossing at q=3
+    # → relative offset = (3-2)*8 = 8
+    assert ev.value == pytest.approx(8.0)
+    assert ev.is_censored is False
+    assert ev.metric_id == "tau_onset"
+
+
+def test_tau_onset_censors_when_no_crossing_in_window() -> None:
+    tr = _flat_R(0.1, steps_per_quarter=8)
+    ev = TauOnsetMetric().evaluate(tr)
+    assert ev.is_censored is True
+    assert ev.value == pytest.approx(float((EVENT_QUARTER - PRE_EVENT_START_QUARTER) * 8))
+
+
+def test_tau_onset_bit_exact_reproducible() -> None:
+    tr1 = _step_R(low=0.1, high=0.9, crossing_quarter=3)
+    tr2 = _step_R(low=0.1, high=0.9, crossing_quarter=3)
+    ev1 = TauOnsetMetric().evaluate(tr1)
+    ev2 = TauOnsetMetric().evaluate(tr2)
+    assert ev1.value == ev2.value
+    assert ev1.is_censored == ev2.is_censored
+
+
+def test_tau_onset_ignores_crossings_outside_window() -> None:
+    """A crossing at the EVENT quarter (=6) is OUTSIDE the pre-event window
+    [2, 6) — it should be censored."""
+    tr = _step_R(low=0.1, high=0.9, crossing_quarter=6, steps_per_quarter=8)
+    ev = TauOnsetMetric().evaluate(tr)
+    assert ev.is_censored is True
+
+
+def test_tau_onset_custom_threshold() -> None:
+    tr = _step_R(low=0.1, high=0.35, crossing_quarter=3, steps_per_quarter=8)
+    # default 0.50 → censored; custom 0.30 → crossed
+    assert TauOnsetMetric(threshold_R=0.50).evaluate(tr).is_censored is True
+    ev = TauOnsetMetric(threshold_R=0.30).evaluate(tr)
+    assert ev.is_censored is False
+
+
+# ---------------------------------------------------------------------------
+# M2: auc_pre_event
+# ---------------------------------------------------------------------------
+
+
+def test_auc_constant_R_gives_predictable_area() -> None:
+    tr = _flat_R(0.4, steps_per_quarter=16)
+    ev = AucPreEventMetric().evaluate(tr)
+    # window length in steps = (6-2)*16 = 64; np.trapezoid with dx=1
+    # over a constant 0.4 of length 64 = 0.4 * (64-1) = 25.2
+    assert ev.value == pytest.approx(0.4 * 63.0)
+    assert ev.is_censored is False
+
+
+def test_auc_never_censored() -> None:
+    for v in (0.0, 0.5, 1.0):
+        ev = AucPreEventMetric().evaluate(_flat_R(v))
+        assert ev.is_censored is False
+
+
+def test_auc_monotone_in_R() -> None:
+    """G13 sanity: stronger sustained R → larger AUC."""
+    aucs = [AucPreEventMetric().evaluate(_flat_R(R)).value for R in (0.1, 0.3, 0.7)]
+    assert aucs[0] < aucs[1] < aucs[2]
+
+
+# ---------------------------------------------------------------------------
+# M3: delta_phi_sync (phase_lag)
+# ---------------------------------------------------------------------------
+
+
+def test_phase_lag_default_threshold_matches_locked_yaml() -> None:
+    assert DeltaPhiSyncMetric().threshold_phi == DEFAULT_PHASE_LAG_THRESHOLD
+
+
+def test_phase_lag_requires_theta() -> None:
+    tr = _flat_R(0.1)
+    with pytest.raises(MetricInvalid):
+        DeltaPhiSyncMetric().evaluate(tr)
+
+
+def test_phase_lag_uniform_weights_collapse_to_R_threshold() -> None:
+    """With uniform reference weights Φ(t) = |⟨exp(i θ)⟩| = R(t).
+    So phase_lag with default reference must agree with a tau_onset
+    threshold at the same level."""
+    N = 10
+    spq = 8
+    total = T_HORIZON * spq
+    # Construct theta s.t. R(t) is 0.1 for t < q=3, then 0.9 for t >= q=3
+    rng = np.random.default_rng(0)
+    theta = np.empty((total, N), dtype=np.float64)
+    # Phase spread → low R
+    spread_low = rng.uniform(0.0, 2 * np.pi, size=N)
+    # Phase clustered → high R
+    spread_high = 0.01 * rng.standard_normal(N)
+    boundary = 3 * spq
+    theta[:boundary] = spread_low[None, :]
+    theta[boundary:] = spread_high[None, :]
+    tr = _trajectory_with_theta(theta_t_n=theta, steps_per_quarter=spq)
+    ev = DeltaPhiSyncMetric(threshold_phi=0.50).evaluate(tr)
+    assert ev.is_censored is False
+    # Crossing must be at the boundary, relative to window-start (q=2):
+    # boundary - 2*spq = 8
+    assert ev.value == pytest.approx(8.0)
+
+
+def test_phase_lag_custom_reference_weights() -> None:
+    N = 6
+    spq = 4
+    total = T_HORIZON * spq
+    theta = np.full((total, N), 0.0, dtype=np.float64)
+    # Two nodes coherent, rest scrambled — projecting on the coherent
+    # subset's eigenvector should yield Φ=1, while uniform projection
+    # gives Φ < 1
+    theta[:, 2:] = np.pi  # phase π for the 4 "noisy" nodes
+    tr = _trajectory_with_theta(theta_t_n=theta, steps_per_quarter=spq)
+    # Default (uniform) — Φ = | (2 · 1 + 4 · e^{iπ}) / 6 | = | -2/6 | = 1/3
+    ev_default = DeltaPhiSyncMetric(threshold_phi=0.50).evaluate(tr)
+    assert ev_default.is_censored is True
+    # Custom weights focused on the coherent subset → Φ = 1
+    w = np.zeros(N, dtype=np.float64)
+    w[:2] = 1.0
+    ev_custom = DeltaPhiSyncMetric(threshold_phi=0.50, reference_weights=w).evaluate(tr)
+    assert ev_custom.is_censored is False
+    assert ev_custom.value == pytest.approx(0.0)
+
+
+def test_phase_lag_censors_when_no_crossing() -> None:
+    """If Φ(t) never crosses the threshold (e.g. phases stay scrambled)
+    the metric is right-censored."""
+    N = 50
+    spq = 4
+    rng = np.random.default_rng(123)
+    theta = rng.uniform(0.0, 2 * np.pi, size=(T_HORIZON * spq, N))
+    tr = _trajectory_with_theta(theta_t_n=theta, steps_per_quarter=spq)
+    ev = DeltaPhiSyncMetric(threshold_phi=0.95).evaluate(tr)
+    assert ev.is_censored is True
+
+
+def test_phase_lag_rejects_bad_reference_weights() -> None:
+    spq = 4
+    theta = np.zeros((T_HORIZON * spq, 5), dtype=np.float64)
+    tr = _trajectory_with_theta(theta_t_n=theta, steps_per_quarter=spq)
+    # Wrong length
+    with pytest.raises(MetricInvalid):
+        DeltaPhiSyncMetric(reference_weights=np.ones(3)).evaluate(tr)
+    # Zero L1
+    with pytest.raises(MetricInvalid):
+        DeltaPhiSyncMetric(reference_weights=np.zeros(5)).evaluate(tr)
+
+
+# ---------------------------------------------------------------------------
+# G11: Kaplan-Meier restricted mean
+# ---------------------------------------------------------------------------
+
+
+def test_km_rmst_no_censoring_equals_simple_mean() -> None:
+    """With zero censoring, RMST equals the cohort mean (a known KM
+    property when the horizon is larger than the largest event time)."""
+    times = np.array([1.0, 2.0, 3.0, 4.0])
+    censored = np.zeros(4, dtype=bool)
+    rmst = kaplan_meier_restricted_mean(times, censored, horizon=10.0)
+    assert rmst == pytest.approx(np.mean(times), rel=1e-12)
+
+
+def test_km_rmst_all_censored_returns_horizon() -> None:
+    times = np.array([5.0, 5.0, 5.0])  # all hit censor cap
+    censored = np.ones(3, dtype=bool)
+    rmst = kaplan_meier_restricted_mean(times, censored, horizon=5.0)
+    assert rmst == pytest.approx(5.0, rel=1e-12)
+
+
+def test_km_rmst_partial_censoring_strictly_between_mean_and_horizon() -> None:
+    times = np.array([2.0, 3.0, 5.0, 5.0])
+    censored = np.array([False, False, True, True])
+    rmst = kaplan_meier_restricted_mean(times, censored, horizon=5.0)
+    observed_mean = float(np.mean([2.0, 3.0]))
+    # KM RMST under right-censoring is ≥ observed mean (censored
+    # observations push the survival curve up) and ≤ horizon
+    assert observed_mean < rmst < 5.0
+
+
+def test_km_rmst_monotone_in_censoring_fraction() -> None:
+    times = np.array([2.0, 2.0, 2.0, 2.0])
+    rm_none = kaplan_meier_restricted_mean(times, np.zeros(4, dtype=bool), horizon=10.0)
+    rm_some = kaplan_meier_restricted_mean(
+        times, np.array([False, False, True, True]), horizon=10.0
+    )
+    rm_all = kaplan_meier_restricted_mean(times, np.ones(4, dtype=bool), horizon=10.0)
+    assert rm_none < rm_some < rm_all
+
+
+def test_km_rmst_rejects_empty_cohort() -> None:
+    with pytest.raises(ValueError):
+        kaplan_meier_restricted_mean(
+            np.array([], dtype=np.float64),
+            np.array([], dtype=bool),
+            horizon=5.0,
+        )
+
+
+def test_km_rmst_rejects_nonpositive_horizon() -> None:
+    with pytest.raises(ValueError):
+        kaplan_meier_restricted_mean(np.array([1.0]), np.array([False]), horizon=0.0)
+
+
+def test_km_rmst_rejects_negative_times() -> None:
+    with pytest.raises(ValueError):
+        kaplan_meier_restricted_mean(np.array([-1.0]), np.array([False]), horizon=5.0)
+
+
+# ---------------------------------------------------------------------------
+# Cohort-level signal aggregation
+# ---------------------------------------------------------------------------
+
+
+def _make_eval(value: float, censored: bool, metric_id: str = "tau_onset") -> MetricEvaluation:
+    return MetricEvaluation(metric_id=metric_id, value=value, is_censored=censored)
+
+
+def test_signal_mean_zero_when_cohorts_identical() -> None:
+    pre = [_make_eval(5.0, False) for _ in range(20)]
+    null = [_make_eval(5.0, False) for _ in range(20)]
+    est = signal_mean(TauOnsetMetric(), pre, null, horizon=10.0)
+    assert est.signal_mean == 0.0
+    assert est.method == "observed_mean"
+    assert est.censoring_fraction_precursor == 0.0
+    assert est.censoring_fraction_null == 0.0
+
+
+def test_signal_mean_reports_negative_when_precursor_smaller() -> None:
+    pre = [_make_eval(3.0, False) for _ in range(20)]
+    null = [_make_eval(7.0, False) for _ in range(20)]
+    est = signal_mean(TauOnsetMetric(), pre, null, horizon=10.0)
+    assert est.signal_mean == pytest.approx(-4.0)
+
+
+def test_signal_mean_uses_km_when_either_cohort_censored() -> None:
+    pre = [_make_eval(3.0, False)] * 10 + [_make_eval(8.0, True)] * 10
+    null = [_make_eval(7.0, False)] * 20
+    est = signal_mean(TauOnsetMetric(), pre, null, horizon=8.0)
+    assert est.method == "km_restricted_mean"
+    assert est.censoring_fraction_precursor == pytest.approx(0.5)
+    assert est.censoring_fraction_null == 0.0
+
+
+def test_signal_mean_reports_cohort_sizes() -> None:
+    pre = [_make_eval(1.0, False) for _ in range(7)]
+    null = [_make_eval(1.0, False) for _ in range(13)]
+    est = signal_mean(AucPreEventMetric(), pre, null, horizon=10.0)
+    assert est.n_precursor == 7
+    assert est.n_null == 13
+
+
+def test_signal_mean_rejects_empty_cohorts() -> None:
+    pre = [_make_eval(1.0, False)]
+    with pytest.raises(ValueError):
+        signal_mean(TauOnsetMetric(), pre, [], horizon=5.0)
+    with pytest.raises(ValueError):
+        signal_mean(TauOnsetMetric(), [], pre, horizon=5.0)
+
+
+# ---------------------------------------------------------------------------
+# G13: monotone-signal sanity — stronger crossing yields larger |signal|
+# ---------------------------------------------------------------------------
+
+
+def test_g13_signal_mean_monotone_in_precursor_strength() -> None:
+    """Smoke test: as precursor cohort crosses earlier (smaller tau values)
+    while the null stays late, |signal_mean| must grow."""
+    null = [_make_eval(8.0, False) for _ in range(20)]
+    weak_pre = [_make_eval(7.0, False) for _ in range(20)]
+    mid_pre = [_make_eval(4.0, False) for _ in range(20)]
+    strong_pre = [_make_eval(1.0, False) for _ in range(20)]
+    weak = signal_mean(TauOnsetMetric(), weak_pre, null, horizon=10.0).signal_mean
+    mid = signal_mean(TauOnsetMetric(), mid_pre, null, horizon=10.0).signal_mean
+    strong = signal_mean(TauOnsetMetric(), strong_pre, null, horizon=10.0).signal_mean
+    assert abs(weak) < abs(mid) < abs(strong)
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+def test_registry_has_three_metrics() -> None:
+    assert len(ALL_METRICS) == 3
+    assert {m.id for m in ALL_METRICS} == {"tau_onset", "sync_auc", "phase_lag"}
+
+
+def test_metric_by_id_round_trip() -> None:
+    for m in ALL_METRICS:
+        assert METRIC_BY_ID[m.id].id == m.id
+
+
+# ---------------------------------------------------------------------------
+# G14: tau_onset + sync_auc evaluable on the same R-only trajectory
+# ---------------------------------------------------------------------------
+
+
+def test_g14_tau_onset_and_auc_share_trajectory_shape() -> None:
+    tr = _step_R(low=0.1, high=0.7, crossing_quarter=3, steps_per_quarter=8)
+    ev_tau = TauOnsetMetric().evaluate(tr)
+    ev_auc = AucPreEventMetric().evaluate(tr)
+    assert ev_tau.metric_id == "tau_onset"
+    assert ev_auc.metric_id == "sync_auc"
+    assert math.isfinite(ev_tau.value)
+    assert math.isfinite(ev_auc.value)
+
+
+# ---------------------------------------------------------------------------
+# SignalEstimate basic invariants
+# ---------------------------------------------------------------------------
+
+
+def test_signal_estimate_carries_method_and_metric_id() -> None:
+    pre = [_make_eval(1.0, False)]
+    null = [_make_eval(2.0, False)]
+    est = signal_mean(TauOnsetMetric(), pre, null, horizon=5.0)
+    assert isinstance(est, SignalEstimate)
+    assert est.metric_id == "tau_onset"
+    assert est.method == "observed_mean"

--- a/tests/research/systemic_risk/test_d002c_metrics.py
+++ b/tests/research/systemic_risk/test_d002c_metrics.py
@@ -211,6 +211,9 @@ def test_auc_monotone_in_R() -> None:
 
 def test_phase_lag_default_threshold_matches_locked_yaml() -> None:
     assert DeltaPhiSyncMetric().threshold_phi == DEFAULT_PHASE_LAG_THRESHOLD
+    # And the canonical numeric value (sanity against accidental edit of
+    # the module-level constant)
+    assert DEFAULT_PHASE_LAG_THRESHOLD == 0.50
 
 
 def test_phase_lag_requires_theta() -> None:

--- a/tests/research/systemic_risk/test_d002c_substrates.py
+++ b/tests/research/systemic_risk/test_d002c_substrates.py
@@ -1,0 +1,333 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""D-002C C2.2 — Substrate generator tests.
+
+Pins gates G6-G10 + G12-G14 for the substrate layer:
+
+  G6   density ∈ [0.05, 0.15] for the sparse substrate family
+  G7   K matrix symmetric at every time slice
+  G8   no NaN / Inf in K
+  G9   mean spectral radius / N ∈ [0.95, 1.05]
+  G10  precursor injection produces a measurable Δ in K_F norm
+       when lambda > 0; zero delta when lambda == 0
+  G12  reproducible: same seed → identical realisation
+  G13  monotone sanity: larger lambda → larger |Frobenius delta|
+  G14  9 substrate × metric combos are pairable (registry sanity)
+
+Strict scope: substrate construction tests only.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import numpy as np
+import pytest
+
+from research.systemic_risk.d002c_substrates import (
+    ALL_SUBSTRATES,
+    BLOCK_FRACTIONS,
+    DENSITY_RANGE,
+    PRE_EVENT_WINDOW,
+    PRECURSOR_INJECTION_WINDOW,
+    SPECTRAL_RANGE,
+    SUBSTRATE_BY_ID,
+    T_HORIZON,
+    BlockStructuredSubstrate,
+    RicciFlowSubstrate,
+    Substrate,
+    SubstrateInvalid,
+    SubstrateRealization,
+    TemporalKtSubstrate,
+)
+
+# ---------------------------------------------------------------------------
+# Canonical sweep grid (subset; full grid lives in the prereg YAML)
+# ---------------------------------------------------------------------------
+N_GRID = (50, 100, 200)
+LAMBDA_GRID = (0.0, 0.05, 0.40, 1.0)
+SUBSTRATES: tuple[Substrate, ...] = tuple(ALL_SUBSTRATES)
+SUBSTRATE_IDS = tuple(s.id for s in SUBSTRATES)
+
+
+# ---------------------------------------------------------------------------
+# Registry sanity
+# ---------------------------------------------------------------------------
+
+
+def test_registry_has_three_substrates() -> None:
+    assert len(ALL_SUBSTRATES) == 3
+    assert SUBSTRATE_IDS == ("ricci_flow", "block_structured", "temporal_coupling")
+
+
+def test_substrate_by_id_round_trip() -> None:
+    for s in ALL_SUBSTRATES:
+        assert SUBSTRATE_BY_ID[s.id].id == s.id
+
+
+# ---------------------------------------------------------------------------
+# G7+G8: shape + finiteness + symmetry at every time slice
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("substrate", SUBSTRATES, ids=SUBSTRATE_IDS)
+@pytest.mark.parametrize("N", N_GRID)
+@pytest.mark.parametrize("lambda_", LAMBDA_GRID)
+def test_g7_g8_K_symmetric_finite_correct_shape(
+    substrate: Substrate, N: int, lambda_: float
+) -> None:
+    r = substrate.realize(N=N, lambda_=lambda_, seed=42)
+    assert r.K_baseline.shape == (T_HORIZON, N, N)
+    assert r.K_precursor.shape == (T_HORIZON, N, N)
+    for K in (r.K_baseline, r.K_precursor):
+        assert np.all(np.isfinite(K))
+        # symmetry at every slice (allow float jitter)
+        for t in range(T_HORIZON):
+            assert np.max(np.abs(K[t] - K[t].T)) < 1e-9
+
+
+# ---------------------------------------------------------------------------
+# G9: spectral radius / N ∈ [0.95, 1.05]
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("substrate", SUBSTRATES, ids=SUBSTRATE_IDS)
+@pytest.mark.parametrize("N", N_GRID)
+def test_g9_spectral_radius_calibrated(substrate: Substrate, N: int) -> None:
+    r = substrate.realize(N=N, lambda_=0.0, seed=42)
+    lo, hi = SPECTRAL_RANGE
+    assert (
+        lo <= r.spectral_radius_over_N <= hi
+    ), f"{substrate.id} N={N}: spectral_radius/N = {r.spectral_radius_over_N:.4f}"
+
+
+# ---------------------------------------------------------------------------
+# G6: density in [0.05, 0.15] for the sparse substrate family (Ricci)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("N", N_GRID)
+def test_g6_ricci_density_in_range(N: int) -> None:
+    r = RicciFlowSubstrate().realize(N=N, lambda_=0.0, seed=42)
+    d_lo, d_hi = DENSITY_RANGE
+    assert (
+        d_lo <= r.density <= d_hi
+    ), f"ricci_flow N={N}: density = {r.density:.4f} outside [{d_lo}, {d_hi}]"
+
+
+def test_block_substrate_density_full() -> None:
+    """The block substrate is dense by construction; density gate N/A."""
+    r = BlockStructuredSubstrate().realize(N=100, lambda_=0.0, seed=42)
+    # fraction of non-zero off-diagonals — block matrix has nonzeros in
+    # every off-diagonal entry by construction
+    assert r.density == pytest.approx(1.0)
+
+
+# ---------------------------------------------------------------------------
+# G10: precursor delta — strict zero at lambda=0, strict positive at lambda>0
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("substrate", SUBSTRATES, ids=SUBSTRATE_IDS)
+def test_g10_lambda_zero_is_pure_baseline(substrate: Substrate) -> None:
+    r = substrate.realize(N=100, lambda_=0.0, seed=42)
+    assert r.precursor_frobenius_delta == 0.0
+    # Strict: K_baseline == K_precursor element-wise
+    assert np.array_equal(r.K_baseline, r.K_precursor)
+
+
+@pytest.mark.parametrize("substrate", SUBSTRATES, ids=SUBSTRATE_IDS)
+@pytest.mark.parametrize("lambda_", [0.05, 0.40, 1.0])
+def test_g10_positive_lambda_yields_positive_delta(substrate: Substrate, lambda_: float) -> None:
+    r = substrate.realize(N=100, lambda_=lambda_, seed=42)
+    assert r.precursor_frobenius_delta > 0.0
+
+
+# ---------------------------------------------------------------------------
+# G12: bit-exact reproducibility on same seed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("substrate", SUBSTRATES, ids=SUBSTRATE_IDS)
+def test_g12_same_seed_reproducible_bit_exact(substrate: Substrate) -> None:
+    a = substrate.realize(N=100, lambda_=0.40, seed=7)
+    b = substrate.realize(N=100, lambda_=0.40, seed=7)
+    assert np.array_equal(a.K_baseline, b.K_baseline)
+    assert np.array_equal(a.K_precursor, b.K_precursor)
+    assert a.K_c == b.K_c
+    assert a.density == b.density
+
+
+def test_g12_different_seeds_yield_different_ricci() -> None:
+    """Ricci substrate is the only one with stochastic ER topology;
+    different seeds must give different K (else seed is not wired)."""
+    a = RicciFlowSubstrate().realize(N=100, lambda_=0.0, seed=1)
+    b = RicciFlowSubstrate().realize(N=100, lambda_=0.0, seed=2)
+    assert not np.array_equal(a.K_baseline, b.K_baseline)
+
+
+def test_block_substrate_seed_independent() -> None:
+    """The block substrate is fully deterministic from (N, lambda_) — the
+    seed must not change K. (If it does, that's a science bug — we'd be
+    silently randomising the structural pattern.)"""
+    a = BlockStructuredSubstrate().realize(N=100, lambda_=0.40, seed=1)
+    b = BlockStructuredSubstrate().realize(N=100, lambda_=0.40, seed=999)
+    assert np.array_equal(a.K_baseline, b.K_baseline)
+    assert np.array_equal(a.K_precursor, b.K_precursor)
+
+
+# ---------------------------------------------------------------------------
+# G13: monotone sanity — larger lambda → larger |Frobenius delta|
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("substrate", SUBSTRATES, ids=SUBSTRATE_IDS)
+def test_g13_delta_monotone_in_lambda(substrate: Substrate) -> None:
+    d05 = substrate.realize(N=100, lambda_=0.05, seed=42).precursor_frobenius_delta
+    d40 = substrate.realize(N=100, lambda_=0.40, seed=42).precursor_frobenius_delta
+    d10 = substrate.realize(N=100, lambda_=1.00, seed=42).precursor_frobenius_delta
+    assert 0.0 < d05 < d40 < d10
+
+
+# ---------------------------------------------------------------------------
+# G14: 9 substrate × metric combos pairable (registry sanity — metrics imported)
+# ---------------------------------------------------------------------------
+
+
+def test_g14_three_substrates_pairable_with_three_metrics() -> None:
+    from research.systemic_risk.d002c_metrics import ALL_METRICS
+
+    assert len(ALL_SUBSTRATES) == 3
+    assert len(ALL_METRICS) == 3
+    # All 9 combos are addressable by id
+    pairs = [(s.id, m.id) for s in ALL_SUBSTRATES for m in ALL_METRICS]
+    assert len(pairs) == 9
+    assert len(set(pairs)) == 9
+
+
+# ---------------------------------------------------------------------------
+# Frozen-dataclass / mutation refusal
+# ---------------------------------------------------------------------------
+
+
+def test_substrate_realization_is_frozen() -> None:
+    r = RicciFlowSubstrate().realize(N=50, lambda_=0.0, seed=42)
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        r.density = 0.0  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Precursor window confinement: outside PRECURSOR_INJECTION_WINDOW the
+# baseline and precursor trajectories must be element-wise identical
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("substrate", SUBSTRATES, ids=SUBSTRATE_IDS)
+def test_precursor_confined_to_injection_window(substrate: Substrate) -> None:
+    r = substrate.realize(N=100, lambda_=1.0, seed=42)
+    inject = set(PRECURSOR_INJECTION_WINDOW)
+    for t in range(T_HORIZON):
+        if t in inject:
+            # Within injection window: precursor differs from baseline
+            assert not np.array_equal(
+                r.K_baseline[t], r.K_precursor[t]
+            ), f"t={t} in injection window but baseline==precursor"
+        else:
+            assert np.array_equal(
+                r.K_baseline[t], r.K_precursor[t]
+            ), f"t={t} outside injection window but baseline!=precursor"
+
+
+def test_precursor_injection_window_subset_of_pre_event_window() -> None:
+    """The injection window must lie inside the pre-event observation window
+    (otherwise the precursor lands on or past the event itself)."""
+    assert set(PRECURSOR_INJECTION_WINDOW).issubset(set(PRE_EVENT_WINDOW))
+
+
+# ---------------------------------------------------------------------------
+# Contract: small-N and degenerate-param refusal
+# ---------------------------------------------------------------------------
+
+
+def test_ricci_rejects_N_too_small() -> None:
+    with pytest.raises(SubstrateInvalid):
+        RicciFlowSubstrate().realize(N=3, lambda_=0.0, seed=42)
+
+
+def test_block_rejects_N_too_small() -> None:
+    with pytest.raises(SubstrateInvalid):
+        BlockStructuredSubstrate().realize(N=5, lambda_=0.0, seed=42)
+
+
+def test_temporal_rejects_period_too_small() -> None:
+    with pytest.raises(SubstrateInvalid):
+        TemporalKtSubstrate(period_quarters=1).realize(N=100, lambda_=0.0, seed=42)
+
+
+# ---------------------------------------------------------------------------
+# Block structure: locked tier multipliers (sanity on the within-block pattern)
+# ---------------------------------------------------------------------------
+
+
+def test_block_structure_tier_multipliers_present() -> None:
+    """The block substrate must have three distinct multiplier levels (1.5
+    core/core, 1.0 core/mid, 0.5 mid/per, 0.2 per/per). After spectral
+    calibration the absolute values change but the RATIOS must be
+    preserved."""
+    r = BlockStructuredSubstrate().realize(N=100, lambda_=0.0, seed=42)
+    f_core, f_mid, _ = BLOCK_FRACTIONS
+    n_core = max(1, int(round(f_core * 100)))
+    n_mid = max(1, int(round(f_mid * 100)))
+    K = r.K_baseline[0]
+    # Core-core block off-diagonal mean
+    core = K[:n_core, :n_core]
+    off_core = core[np.triu_indices(n_core, k=1)]
+    cm = K[:n_core, n_core : n_core + n_mid]
+    pp = K[n_core + n_mid :, n_core + n_mid :]
+    off_pp = pp[np.triu_indices(pp.shape[0], k=1)]
+    mu_core_core = float(off_core.mean())
+    mu_core_mid = float(cm.mean())
+    mu_per_per = float(off_pp.mean())
+    # Ratios must match 1.5 / 1.0 and 0.2 / 1.0 to within float jitter
+    assert mu_core_core / mu_core_mid == pytest.approx(1.5, rel=1e-9)
+    assert mu_per_per / mu_core_mid == pytest.approx(0.2, rel=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# Temporal envelope: K(t) modulation amplitude (not over the full period
+# the gate uses, but qualitative envelope check)
+# ---------------------------------------------------------------------------
+
+
+def test_temporal_envelope_modulates_K() -> None:
+    r = TemporalKtSubstrate(period_quarters=4, amplitude=0.20).realize(N=100, lambda_=0.0, seed=42)
+    # Some pair of time slices must differ by at least ~the modulation
+    # amplitude in Frobenius norm
+    fro_diffs = []
+    for t in range(T_HORIZON):
+        for s in range(t + 1, T_HORIZON):
+            fro_diffs.append(np.linalg.norm(r.K_baseline[t] - r.K_baseline[s]))
+    assert max(fro_diffs) > 0.0
+
+
+def test_temporal_baseline_at_lambda_zero_is_identical_to_precursor() -> None:
+    """Temporal-K substrate: λ=0 means the precursor field equals the
+    baseline field at every slice — not just outside the injection
+    window. (Otherwise the sinusoidal envelope itself would leak as a
+    'precursor'.)"""
+    r = TemporalKtSubstrate().realize(N=100, lambda_=0.0, seed=42)
+    assert np.array_equal(r.K_baseline, r.K_precursor)
+
+
+# ---------------------------------------------------------------------------
+# SubstrateRealization basic invariants
+# ---------------------------------------------------------------------------
+
+
+def test_substrate_realization_carries_seed_and_lambda() -> None:
+    r = RicciFlowSubstrate().realize(N=50, lambda_=0.40, seed=42)
+    assert isinstance(r, SubstrateRealization)
+    assert r.seed == 42
+    assert r.lambda_ == pytest.approx(0.40)
+    assert r.N == 50
+    assert r.substrate_id == "ricci_flow"

--- a/tests/research/systemic_risk/test_d002c_substrates.py
+++ b/tests/research/systemic_risk/test_d002c_substrates.py
@@ -30,6 +30,7 @@ from research.systemic_risk.d002c_substrates import (
     DENSITY_RANGE,
     PRE_EVENT_WINDOW,
     PRECURSOR_INJECTION_WINDOW,
+    PRECURSOR_SPECTRAL_RANGE,
     SPECTRAL_RANGE,
     SUBSTRATE_BY_ID,
     T_HORIZON,
@@ -39,6 +40,7 @@ from research.systemic_risk.d002c_substrates import (
     SubstrateInvalid,
     SubstrateRealization,
     TemporalKtSubstrate,
+    _enforce_calibration_gates,
 )
 
 # ---------------------------------------------------------------------------
@@ -331,3 +333,84 @@ def test_substrate_realization_carries_seed_and_lambda() -> None:
     assert r.lambda_ == pytest.approx(0.40)
     assert r.N == 50
     assert r.substrate_id == "ricci_flow"
+
+
+# ---------------------------------------------------------------------------
+# G9 precursor — Codex P1 regression (2026-05-11).
+#
+# The original implementation enforced the spectral gate ONLY on
+# K_baseline; K_precursor was constructed but never spectrally
+# validated. BlockStructuredSubstrate(..., lambda_=1.0) was producing
+# ρ/N ≈ 1.052 — past the baseline gate hi of 1.05. The gate now
+# applies a wider but bounded range to the precursor (
+# PRECURSOR_SPECTRAL_RANGE = [0.95, 1.15]) reflecting that the precursor
+# IS by design an amplification, while still refusing any pathological
+# explosion that would push K past the comparable regime.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("substrate", SUBSTRATES, ids=SUBSTRATE_IDS)
+@pytest.mark.parametrize("lambda_", [0.0, 0.05, 0.40, 1.0])
+def test_g9_precursor_spectral_radius_in_range(substrate: Substrate, lambda_: float) -> None:
+    """For every (substrate, λ) the PRECURSOR trajectory's mean spectral
+    radius / N must lie inside :data:`PRECURSOR_SPECTRAL_RANGE`. This is
+    the Codex P1 regression — without this gate a substrate at λ=1.0
+    could silently push K outside the comparable regime and bias the
+    downstream metric comparison."""
+    r = substrate.realize(N=100, lambda_=lambda_, seed=42)
+    p_lo, p_hi = PRECURSOR_SPECTRAL_RANGE
+    assert (
+        p_lo <= r.spectral_radius_over_N_precursor <= p_hi
+    ), f"{substrate.id} λ={lambda_}: precursor ρ/N = {r.spectral_radius_over_N_precursor:.4f}"
+
+
+def test_g9_precursor_spectral_radius_lambda_zero_equals_baseline() -> None:
+    """At λ=0 the precursor field equals the baseline by construction —
+    so the two spectral radii MUST be exactly equal (not just within
+    each gate's range)."""
+    for s in SUBSTRATES:
+        r = s.realize(N=100, lambda_=0.0, seed=42)
+        assert r.spectral_radius_over_N == pytest.approx(
+            r.spectral_radius_over_N_precursor, abs=1e-12
+        )
+
+
+def test_g9_precursor_spectral_radius_monotone_in_lambda() -> None:
+    """For every substrate, larger λ → larger precursor spectral radius
+    (the precursor is constructed to amplify coupling). A non-monotone
+    response would indicate the lift mechanism cancels with itself."""
+    for s in SUBSTRATES:
+        rho = [
+            s.realize(N=100, lambda_=lam, seed=42).spectral_radius_over_N_precursor
+            for lam in (0.0, 0.05, 0.40, 1.0)
+        ]
+        assert all(rho[i] <= rho[i + 1] for i in range(len(rho) - 1)), (
+            s.id,
+            rho,
+        )
+
+
+def test_g9_precursor_gate_refuses_out_of_range_synthetic() -> None:
+    """Construct a synthetic (baseline, precursor) pair whose precursor
+    sits *past* :data:`PRECURSOR_SPECTRAL_RANGE` and verify the gate
+    refuses it. This is the fail-closed contract for any future
+    substrate whose lift mechanism is mis-calibrated."""
+    N = 8
+    # Calibrated baseline: identity * 1.0 → ρ = 1.0, ρ/N = 0.125 (way
+    # below baseline gate). We want a baseline INSIDE the range so the
+    # baseline check passes, then a precursor OUTSIDE.
+    K_baseline = np.broadcast_to(np.eye(N) * 1.0, (T_HORIZON, N, N)).copy()
+    # Baseline ρ/N = 1.0/N = 0.125 — below the 0.95 floor. Need a
+    # baseline whose ρ/N is inside [0.95, 1.05].
+    K_baseline = np.broadcast_to(np.eye(N) * 1.0 * N, (T_HORIZON, N, N)).copy()
+    # Precursor amplified by 30% (well past 1.15 cap)
+    K_precursor = K_baseline.copy() * 1.30
+    with pytest.raises(SubstrateInvalid, match="gate G9 precursor failed"):
+        _enforce_calibration_gates(
+            K_baseline=K_baseline,
+            K_precursor=K_precursor,
+            lambda_=1.0,
+            density=None,
+            substrate_id="synthetic",
+            N=N,
+        )


### PR DESCRIPTION
## Summary

**C2.2 of the D-002C execution chain.** Builds the **science layer** (substrate generators + metric estimators) that C2.4 will wire to the Kuramoto integrator and the C2.1-locked acceptance contract.

## What lands

| File | Purpose |
|---|---|
| `research/systemic_risk/d002c_substrates.py` | 3 substrate generators (Ricci/block/temporal), all calibrated to λ_max/N=1.0, fail-closed on G6/G7/G8/G9/G10 |
| `research/systemic_risk/d002c_metrics.py` | 3 metric estimators (τ_onset/AUC/φ_lag), KM RMST aggregator, censoring-aware `signal_mean` |
| `tests/research/systemic_risk/test_d002c_substrates.py` | 58 tests pinning G6–G14 |
| `tests/research/systemic_risk/test_d002c_metrics.py` | 64 tests including right-censoring discipline (G11) and monotone sanity (G13) |
| `.claude/commit_acceptors/x10r-d002c-substrates-metrics.yaml` | Diff-bound acceptor with multi-step falsifier |

## Substrates (calibration contract)

For every realisation, fail-closed on:
- **G6** density ∈ [0.05, 0.15] (sparse family only)
- **G7** symmetric every time slice
- **G8** no NaN/Inf
- **G9** mean spectral radius / N ∈ [0.95, 1.05]
- **G10** Frobenius delta strictly zero at λ=0, strictly positive at λ>0

Three substrates:
1. **RicciFlowSubstrate** — Erdős-Rényi base + Forman-Ricci weighting, κ̂ normalised to [-1,1] (keeps K positive). Precursor on top-10% strongest edges.
2. **BlockStructuredSubstrate** — locked tier multipliers 1.5/1.0/0.5/0.2 across core/mid/periphery. Deterministic in (N, λ); seed irrelevant (pinned by test).
3. **TemporalKtSubstrate** — block base + sinusoidal envelope K(t)=K_c·(1+0.20·sin(2πt/4)); additive precursor envelope.

## Metrics (right-censoring is the load-bearing contract)

**G11**: time-to-event metrics (τ_onset, φ_lag) are right-censored when R never crosses the threshold in window. `signal_mean` switches to **Kaplan-Meier RMST** (implemented from first principles) whenever either cohort carries censored observations, and reports censoring fractions per cohort so non-comparable cells are visibly flagged.

Thresholds default to the C2.1-locked YAML (tau_onset=0.50, phase_lag=0.50); sweep configs disagreeing are caught upstream by the C2.1 prereg validator.

## Quality gates (all PASS locally)

- [x] ruff check
- [x] black --check  
- [x] mypy --strict (0 errors, 4 files)
- [x] pytest — **122/122 PASS**
- [x] acceptor falsifier PASS

## Strict scope (INV-INSTRUMENT-1)

- ✋ NO Kuramoto integrator (C2.4)
- ✋ NO CRN variance reduction (C2.3)
- ✋ NO sweep execution
- ✋ NO claim layer
- ✋ NO threshold tuning — defaults match the C2.1-locked YAML
- ✋ INV-IDENTIFICATION-1 untouched

## Execution chain

```
[merged] D-002D (#659)                  checkpoint/resume
[merged] C2.1   (#660)                  pre-registration lock      ✅
[THIS]   C2.2                           substrates + metrics       ← science
         C2.3   (next PR)               CRN empirical GO/NO-GO     ← variance check
         C2.4                           sweep runner + pre-flight  ← driver
         C2.5                           full sweep launch          ← only if all GO
```

Closes part of #654 (C2.2 only).

## Test plan

- [x] Local mypy --strict
- [x] Local ruff + black
- [x] Local pytest 122/122
- [x] Local falsifier
- [ ] CI: all 20 gates green
- [ ] CI: commit-acceptor-validation passes
- [ ] Reviewer audit before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)