### PR TITLE
feat(x10r,D-002C,C2.4D): preflight enforcement — truth-binding integration layer (#654)

### DIFF
--- a/.claude/commit_acceptors/x10r-d002c-preflight-enforcement.yaml
+++ b/.claude/commit_acceptors/x10r-d002c-preflight-enforcement.yaml
@@ -1,0 +1,310 @@
+# Diff-bound commit acceptor for D-002C C2.4-D (issue #654) —
+# pre-flight enforcement (truth-binding integration layer).
+#
+# What lands:
+#   * research/systemic_risk/d002c_preflight.py
+#       Frozen-dataclass preflight enforcement layer.
+#       PreflightCapsulePaths, PreflightDecision, SkippedCell,
+#       RunnableCell + load_and_validate_preflight_capsules /
+#       apply_preflight_to_grid / assert_preflight_launch_allowed /
+#       canonical_preflight_json / verify_capsule_sha256.
+#       Every capsule MUST exist, parse, declare its emitted kind
+#       (pos_control: d002c_pos_control_capsule_v1; neg_control:
+#       d002c_neg_control_capsule_v1; null_audit:
+#       d002c_null_audit_capsule_v1; smoke_test: structural — the
+#       writer module emits no `kind`, so identified by the required
+#       field set), and pass canonical-JSON sha256 recomputation.
+#       Validation is accumulating (never short-circuits) so a
+#       single re-run fixes every refusal at once.
+#   * research/systemic_risk/d002c_sweep_runner.py
+#       run_sweep gains preflight_capsules + require_preflight (default
+#       True). The runner now refuses launch unless every preflight
+#       gate passes, reduces the execution grid by POS excluded_combos
+#       and NEG excluded_cells, persists SKIPPED_BY_PREFLIGHT entries
+#       (CellResult variant) to the D-002D checkpoint, and folds the
+#       preflight decision sha into the aggregate sweep sha (capsule
+#       tampering between runs ⇒ different sweep sha). Legacy
+#       behaviour is preserved behind require_preflight=False.
+#   * tests/research/systemic_risk/test_d002c_preflight.py
+#       33 unit tests covering missing/bad-json/bad-kind/bad-sha
+#       capsules, smoke/null FAIL refusals, POS/NEG exclusion grid
+#       reduction, unknown-substrate/metric/N refusals, deterministic
+#       decision sha, frozen-dataclass invariance, canonical-JSON
+#       non-finite sentinel handling, capsule-sha recompute matches
+#       emitter, accumulated refusal reasons.
+#   * tests/research/systemic_risk/test_d002c_sweep_runner_preflight_integration.py
+#       15 integration tests pinning the run_sweep × preflight
+#       contract: strict-mode refusal, valid-preflight grid reduction,
+#       skipped cells in checkpoint, instrumented run_one_cell proves
+#       SKIPPED cells are not computed, resume preserves skipped
+#       cells, aggregate sha includes preflight decision sha, sha
+#       tampering refuses, smoke-PASS-but-null-FAIL refuses,
+#       unknown-cell refuses, excluded cell cannot reappear as
+#       computed on resume.
+#   * docs/governance/D002C_PREFLIGHT_CONTRACT.md
+#       Governance document: capsule schemas, launch refusal matrix,
+#       grid exclusion semantics, checkpoint skipped-cell semantics,
+#       deterministic hashing rules, required tests, CI requirements,
+#       rollback command, known limitations, claim boundary.
+#   * .claude/commit_acceptors/x10r-d002c-preflight-enforcement.yaml
+#       This file.
+#
+# Legacy-shim edits (documented in PR body):
+#   * tests/research/systemic_risk/test_d002c_sweep_runner.py
+#       Each pre-C2.4-D run_sweep call site grew a single
+#       `require_preflight=False,  # legacy-shim — pre-C2.4-D test`
+#       kwarg. No existing assertion was relaxed.
+#
+# Strict scope:
+#   Truth-binding integration ONLY. NO claim layer. NO sweep launch.
+#   NO threshold tuning. NO post-hoc relaxation. The preflight emits
+#   no claim of its own — it only refuses launch or reduces the
+#   execution grid based on the gate verdicts.
+
+id: x10r-d002c-preflight-enforcement
+status: ACTIVE
+claim_type: correctness
+promise: >-
+  After this PR lands, research/systemic_risk/d002c_preflight exposes a
+  frozen-dataclass preflight enforcement layer
+  (PreflightCapsulePaths, PreflightDecision, SkippedCell,
+  RunnableCell) plus load_and_validate_preflight_capsules,
+  apply_preflight_to_grid, and assert_preflight_launch_allowed.
+
+  research/systemic_risk/d002c_sweep_runner.run_sweep gains two new
+  keyword arguments — preflight_capsules and require_preflight — and
+  in strict mode (default) refuses to launch unless every preflight
+  gate passes, reduces the execution grid by POS excluded_combos and
+  NEG excluded_cells, persists SKIPPED_BY_PREFLIGHT entries to the
+  D-002D checkpoint, and folds the preflight decision sha into the
+  aggregate sweep sha. Capsule tampering between runs changes the
+  sweep sha by construction.
+
+  Legacy callers (pre-C2.4-D unit tests of run_one_cell plumbing)
+  retain their old behaviour behind require_preflight=False. No
+  existing assertion in tests/research/systemic_risk/test_d002c_sweep_runner.py
+  was relaxed — each affected call site grew a single legacy-shim
+  kwarg.
+
+  Strict scope: integration / truth-binding layer only. No claim
+  layer. No threshold tuning. The preflight refuses launch or
+  reduces the grid; it emits no claim of its own.
+diff_scope:
+  changed_files:
+    - path: ".claude/commit_acceptors/x10r-d002c-preflight-enforcement.yaml"
+    - path: "research/systemic_risk/d002c_preflight.py"
+    - path: "research/systemic_risk/d002c_sweep_runner.py"
+    - path: "tests/research/systemic_risk/test_d002c_preflight.py"
+    - path: "tests/research/systemic_risk/test_d002c_sweep_runner_preflight_integration.py"
+    - path: "tests/research/systemic_risk/test_d002c_sweep_runner.py"
+    - path: "docs/governance/D002C_PREFLIGHT_CONTRACT.md"
+  forbidden_paths:
+    - "trading/"
+    - "execution/"
+    - "forecast/"
+    - "policy/"
+    - "core/physics/"
+    - "core/kuramoto/"
+    - "research/reconstruction/"
+    - "scripts/run_x10r_"
+    - "application/governance/claim_ledger.py"
+    - "application/governance/commit_acceptor.py"
+    - "research/systemic_risk/sweep_checkpoint.py"
+    - "research/systemic_risk/d002c_preregistration.py"
+    - "research/systemic_risk/d002c_substrates.py"
+    - "research/systemic_risk/d002c_metrics.py"
+    - "research/systemic_risk/d002c_kuramoto.py"
+    - "research/systemic_risk/d002c_crn_validator.py"
+    - "research/systemic_risk/d002c_pos_control.py"
+    - "research/systemic_risk/d002c_neg_control.py"
+    - "research/systemic_risk/d002c_null_audit.py"
+    - "research/systemic_risk/d002c_smoke_test.py"
+required_python_symbols:
+  - "research/systemic_risk/d002c_preflight.py::PreflightCapsulePaths"
+  - "research/systemic_risk/d002c_preflight.py::PreflightDecision"
+  - "research/systemic_risk/d002c_preflight.py::SkippedCell"
+  - "research/systemic_risk/d002c_preflight.py::RunnableCell"
+  - "research/systemic_risk/d002c_preflight.py::PreflightLaunchRefused"
+  - "research/systemic_risk/d002c_preflight.py::CapsuleShaMismatch"
+  - "research/systemic_risk/d002c_preflight.py::load_and_validate_preflight_capsules"
+  - "research/systemic_risk/d002c_preflight.py::apply_preflight_to_grid"
+  - "research/systemic_risk/d002c_preflight.py::assert_preflight_launch_allowed"
+  - "research/systemic_risk/d002c_preflight.py::canonical_preflight_json"
+  - "research/systemic_risk/d002c_preflight.py::verify_capsule_sha256"
+  - "tests/research/systemic_risk/test_d002c_preflight.py::test_missing_pos_capsule_refuses_launch"
+  - "tests/research/systemic_risk/test_d002c_preflight.py::test_smoke_fail_refuses_launch"
+  - "tests/research/systemic_risk/test_d002c_preflight.py::test_null_fail_refuses_launch"
+  - "tests/research/systemic_risk/test_d002c_preflight.py::test_pos_excluded_combo_removes_all_matching_cells"
+  - "tests/research/systemic_risk/test_d002c_preflight.py::test_neg_excluded_cell_removes_exact_cell_only"
+  - "tests/research/systemic_risk/test_d002c_preflight.py::test_preflight_decision_sha_is_deterministic"
+  - "tests/research/systemic_risk/test_d002c_preflight.py::test_capsule_sha_recompute_matches_emitter"
+  - "tests/research/systemic_risk/test_d002c_sweep_runner_preflight_integration.py::test_run_sweep_requires_preflight_when_enabled"
+  - "tests/research/systemic_risk/test_d002c_sweep_runner_preflight_integration.py::test_run_sweep_with_valid_preflight_runs_reduced_grid"
+  - "tests/research/systemic_risk/test_d002c_sweep_runner_preflight_integration.py::test_run_sweep_records_skipped_cells_in_checkpoint"
+  - "tests/research/systemic_risk/test_d002c_sweep_runner_preflight_integration.py::test_run_sweep_does_not_compute_skipped_cells"
+  - "tests/research/systemic_risk/test_d002c_sweep_runner_preflight_integration.py::test_aggregate_sha_includes_preflight_decision_sha"
+  - "tests/research/systemic_risk/test_d002c_sweep_runner_preflight_integration.py::test_tampered_pos_capsule_sha_refuses"
+expected_signal: >-
+  Local: `pytest tests/research/systemic_risk/test_d002c_preflight.py
+  tests/research/systemic_risk/test_d002c_sweep_runner_preflight_integration.py
+  tests/research/systemic_risk/test_d002c_sweep_runner.py -q` reports
+  "85 passed"; `mypy --strict --follow-imports=silent` clean on the
+  4 new/edited Python files; `ruff check` and `black --check` both
+  pass.
+measurement_command: >-
+  bash -c 'mypy --strict --follow-imports=silent
+  research/systemic_risk/d002c_preflight.py
+  research/systemic_risk/d002c_sweep_runner.py
+  tests/research/systemic_risk/test_d002c_preflight.py
+  tests/research/systemic_risk/test_d002c_sweep_runner_preflight_integration.py
+  && ruff check
+  research/systemic_risk/d002c_preflight.py
+  research/systemic_risk/d002c_sweep_runner.py
+  tests/research/systemic_risk/test_d002c_preflight.py
+  tests/research/systemic_risk/test_d002c_sweep_runner_preflight_integration.py
+  && black --check
+  research/systemic_risk/d002c_preflight.py
+  research/systemic_risk/d002c_sweep_runner.py
+  tests/research/systemic_risk/test_d002c_preflight.py
+  tests/research/systemic_risk/test_d002c_sweep_runner_preflight_integration.py
+  && pytest tests/research/systemic_risk/test_d002c_preflight.py
+  tests/research/systemic_risk/test_d002c_sweep_runner_preflight_integration.py
+  tests/research/systemic_risk/test_d002c_sweep_runner.py -q'
+signal_artifact: "tests/research/systemic_risk/test_d002c_sweep_runner_preflight_integration.py"
+falsifier:
+  command: >-
+    bash -c 'PYTHONPATH=. python -c "
+    import hashlib, json
+    from pathlib import Path
+    import tempfile
+    from research.systemic_risk.d002c_preflight import (
+        POS_CONTROL_KIND, NEG_CONTROL_KIND, NULL_AUDIT_KIND,
+        PreflightCapsulePaths, PreflightLaunchRefused,
+        canonical_preflight_json,
+        load_and_validate_preflight_capsules, apply_preflight_to_grid,
+        assert_preflight_launch_allowed,
+    )
+
+    def seal(body):
+        sha = hashlib.sha256(canonical_preflight_json(body).encode()).hexdigest()
+        out = dict(body); out['"'"'sha256'"'"'] = sha; return out
+
+    def pos(combos=None):
+        b = {'"'"'kind'"'"': POS_CONTROL_KIND, '"'"'all_pass'"'"': not combos,
+             '"'"'excluded_combos'"'"': combos or [], '"'"'results'"'"': [],
+             '"'"'generated_at'"'"': '"'"'2026-05-11T12:00:00Z'"'"'}
+        return seal(b)
+
+    def neg(cells=None):
+        b = {'"'"'kind'"'"': NEG_CONTROL_KIND, '"'"'all_pass'"'"': not cells,
+             '"'"'excluded_cells'"'"': cells or [], '"'"'results'"'"': [],
+             '"'"'generated_at'"'"': '"'"'2026-05-11T12:01:00Z'"'"'}
+        return seal(b)
+
+    def nullc(verdicts):
+        rs = [{'"'"'verdict'"'"': v, '"'"'p_value_empirical'"'"': 0.01,
+               '"'"'n_seeds'"'"': 20, '"'"'n_shuffles'"'"': 100,
+               '"'"'unshuffled_abs_signal'"'"': 0.5,
+               '"'"'shuffled_abs_signal_median'"'"': 0.05,
+               '"'"'shuffled_abs_signal_p95'"'"': 0.1,
+               '"'"'unshuffled_greater_than_median'"'"': True,
+               '"'"'rng_seed'"'"': 42, '"'"'p_value_threshold'"'"': 0.05,
+               '"'"'sha256'"'"': '"'"'0'"'"'*64} for v in verdicts]
+        return seal({'"'"'kind'"'"': NULL_AUDIT_KIND, '"'"'results'"'"': rs,
+                     '"'"'all_pass'"'"': all(v == '"'"'PASS'"'"' for v in verdicts),
+                     '"'"'n_cells_audited'"'"': len(rs),
+                     '"'"'generated_at'"'"': '"'"'2026-05-11T12:02:00Z'"'"'})
+
+    def smoke(verdict='"'"'PASS'"'"', failed=0):
+        b = {'"'"'verdict'"'"': verdict, '"'"'grid_N'"'"': [50],
+             '"'"'grid_lambda'"'"': [0.0], '"'"'n_seeds'"'"': 1,
+             '"'"'n_cells_total'"'"': 9, '"'"'n_cells_ok'"'"': 9-failed,
+             '"'"'n_cells_failed'"'"': failed, '"'"'cells'"'"': [],
+             '"'"'generated_at'"'"': '"'"'2026-05-11T12:03:00Z'"'"'}
+        return seal(b)
+
+    def write(p, payload):
+        Path(p).write_text(json.dumps(payload, sort_keys=True, indent=2))
+
+    with tempfile.TemporaryDirectory() as td:
+        td = Path(td)
+        pp, np_, nu, sm = td/'"'"'pos.json'"'"', td/'"'"'neg.json'"'"', td/'"'"'null.json'"'"', td/'"'"'smoke.json'"'"'
+
+        # (1) missing capsule refuses
+        write(pp, pos()); write(np_, neg()); write(nu, nullc(['"'"'PASS'"'"'])); write(sm, smoke())
+        pp.unlink()
+        d = load_and_validate_preflight_capsules(PreflightCapsulePaths(pp, np_, nu, sm))
+        assert not d.launch_allowed, '"'"'missing capsule should refuse'"'"'
+
+        # (2) smoke FAIL refuses
+        write(pp, pos()); write(sm, smoke('"'"'FAIL'"'"', failed=1))
+        d = load_and_validate_preflight_capsules(PreflightCapsulePaths(pp, np_, nu, sm))
+        assert not d.launch_allowed, '"'"'smoke FAIL should refuse'"'"'
+
+        # (3) null FAIL refuses
+        write(sm, smoke()); write(nu, nullc(['"'"'PASS'"'"', '"'"'FAIL'"'"']))
+        d = load_and_validate_preflight_capsules(PreflightCapsulePaths(pp, np_, nu, sm))
+        assert not d.launch_allowed, '"'"'null FAIL should refuse'"'"'
+
+        # (4) POS exclusion removes cell from grid
+        write(nu, nullc(['"'"'PASS'"'"']))
+        write(pp, pos([['"'"'block_structured'"'"', '"'"'tau_onset'"'"']]))
+        d = load_and_validate_preflight_capsules(PreflightCapsulePaths(pp, np_, nu, sm))
+        assert d.launch_allowed
+        grid = [(50, 0.4, '"'"'block_structured'"'"', '"'"'tau_onset'"'"'), (50, 0.4, '"'"'ricci_flow'"'"', '"'"'sync_auc'"'"')]
+        runnable, skipped = apply_preflight_to_grid(grid, d)
+        assert len(runnable) == 1, '"'"'pos exclusion should keep 1'"'"'
+        assert len(skipped) == 1 and skipped[0].reason == '"'"'POS_EXCLUDED_COMBO'"'"'
+
+        # (5) NEG exclusion removes exact cell only
+        write(pp, pos())
+        write(np_, neg([['"'"'block_structured'"'"', '"'"'tau_onset'"'"', 50]]))
+        d = load_and_validate_preflight_capsules(PreflightCapsulePaths(pp, np_, nu, sm))
+        assert d.launch_allowed
+        grid = [(50, 0.4, '"'"'block_structured'"'"', '"'"'tau_onset'"'"'), (100, 0.4, '"'"'block_structured'"'"', '"'"'tau_onset'"'"')]
+        runnable, skipped = apply_preflight_to_grid(grid, d)
+        assert len(runnable) == 1 and runnable[0].N == 100
+        assert len(skipped) == 1 and skipped[0].reason == '"'"'NEG_EXCLUDED_CELL'"'"'
+
+        # (6) sha tampering refuses
+        write(np_, neg())
+        raw = json.loads(pp.read_text())
+        raw['"'"'sha256'"'"'] = '"'"'0'"'"'*64
+        pp.write_text(json.dumps(raw, sort_keys=True, indent=2))
+        d = load_and_validate_preflight_capsules(PreflightCapsulePaths(pp, np_, nu, sm))
+        assert not d.launch_allowed
+        try:
+            assert_preflight_launch_allowed(d)
+            raise AssertionError('"'"'should have raised'"'"')
+        except PreflightLaunchRefused:
+            pass
+
+    print('"'"'falsifier PASS'"'"')
+    "'
+  description: >-
+    Probes the D-002C C2.4-D preflight contract: (1) missing capsule
+    refuses launch; (2) smoke FAIL refuses; (3) null FAIL refuses;
+    (4) POS exclusion removes the (substrate, metric) cell from the
+    grid; (5) NEG exclusion removes the exact (substrate, metric, N)
+    cell only — siblings with different N survive; (6) sha tampering
+    on any capsule refuses launch and assert_preflight_launch_allowed
+    raises PreflightLaunchRefused. If any of these regress, the
+    truth-binding integration is broken — the sweep would launch on
+    a stale or tampered preflight verdict.
+rollback_command: >-
+  bash -c 'git checkout HEAD~1 --
+  && rm -f research/systemic_risk/d002c_preflight.py
+  tests/research/systemic_risk/test_d002c_preflight.py
+  tests/research/systemic_risk/test_d002c_sweep_runner_preflight_integration.py
+  docs/governance/D002C_PREFLIGHT_CONTRACT.md
+  .claude/commit_acceptors/x10r-d002c-preflight-enforcement.yaml'
+rollback_verification_command: >-
+  bash -c 'test ! -f research/systemic_risk/d002c_preflight.py
+  && test ! -f tests/research/systemic_risk/test_d002c_preflight.py
+  && test ! -f tests/research/systemic_risk/test_d002c_sweep_runner_preflight_integration.py
+  && test ! -f docs/governance/D002C_PREFLIGHT_CONTRACT.md
+  && test ! -f .claude/commit_acceptors/x10r-d002c-preflight-enforcement.yaml'
+memory_update_type: append
+ledger_path: ".claude/commit_acceptors/x10r-d002c-preflight-enforcement.yaml"
+report_path: "tests/research/systemic_risk/test_d002c_sweep_runner_preflight_integration.py"
+evidence: []

--- a/docs/governance/D002C_PREFLIGHT_CONTRACT.md
+++ b/docs/governance/D002C_PREFLIGHT_CONTRACT.md
@@ -1,0 +1,301 @@
+# D-002C C2.4-D — Preflight Enforcement Contract
+
+Status: preflight-enforced, synthetic-only, fail-closed, deterministic
+under fixed inputs, claim-neutral.
+
+This document defines the **launch-gating layer** that binds the
+D-002C C2.4 sibling sessions A/B/C to the sweep runner. The contract
+is enforced at runtime by
+`research.systemic_risk.d002c_preflight` and consumed by
+`research.systemic_risk.d002c_sweep_runner.run_sweep`.
+
+## Purpose
+
+A 69,120-cell falsification sweep must not launch on a stale, missing,
+or tampered preflight verdict. Before C2.4-D, the runner only checked
+the sweep config against the pre-registration; the four preflight
+capsules (`pos_control`, `neg_control`, `null_audit`, `smoke_test`)
+were emitted by sessions A/B/C but **never consulted at launch time**.
+C2.4-D closes that gap.
+
+The preflight enforcement layer:
+
+1. loads, parses, and validates the four capsules,
+2. recomputes the canonical-JSON sha256 of each capsule body sans the
+   `sha256` field and refuses on mismatch,
+3. checks substrate / metric / N identities against the runtime
+   registries (`ALL_SUBSTRATES`, `ALL_METRICS`,
+   `DEFAULT_NEG_N_GRID`),
+4. interprets each capsule's verdict per the rules in this document,
+5. emits a frozen `PreflightDecision` whose own sha256 is folded into
+   the aggregate sweep sha — so capsule tampering between runs changes
+   the sweep sha by construction.
+
+## Non-goals
+
+- The preflight emits **no claim** of its own.
+- The preflight does **not** mutate the pre-registration.
+- The preflight does **not** retune any scientific threshold.
+- The preflight does **not** tolerate warnings as acceptable for
+  launch-critical state.
+- The preflight does **not** silently skip a missing or malformed
+  capsule.
+
+## Capsule schemas
+
+### `pos_control` — `kind: d002c_pos_control_capsule_v1`
+
+Emitted by `d002c_pos_control.run_pos_control_all`. Required fields
+consulted by the preflight:
+
+- `kind == "d002c_pos_control_capsule_v1"`
+- `sha256` (canonical-JSON sha256 over the body sans `sha256`)
+- `generated_at` (ISO-like timestamp)
+- `excluded_combos: list[[substrate_id, metric_id]]`
+- `results: list[{substrate_id, metric_id, signal_ci_ratio, threshold,
+   censoring_fraction, …}]`
+
+Refusal: bad/missing kind, sha mismatch, missing timestamp, unknown
+substrate / metric id in any combo or result, non-finite numeric in a
+load-bearing field.
+
+### `neg_control` — `kind: d002c_neg_control_capsule_v1`
+
+Emitted by `d002c_neg_control.run_neg_control_all`. Required fields:
+
+- `kind == "d002c_neg_control_capsule_v1"`
+- `sha256`, `generated_at`
+- `excluded_cells: list[[substrate_id, metric_id, N]]`
+- `results: list[{substrate_id, metric_id, N, fpr, alpha_bonferroni,
+   threshold_tolerance, …}]`
+
+Refusal: bad kind, sha mismatch, missing timestamp, unknown
+substrate / metric / N in any cell or result, non-finite numeric.
+
+### `null_audit` — `kind: d002c_null_audit_capsule_v1`
+
+Emitted by an orchestrator that wraps per-cell
+`d002c_null_audit.NullAuditResult` payloads. Required fields:
+
+- `kind == "d002c_null_audit_capsule_v1"`
+- `sha256`, `generated_at`
+- `results: list[{verdict: "PASS" | "FAIL", p_value_empirical, …}]`
+  (each entry is a `NullAuditResult` payload)
+- Optional `aggregate_only: bool` — set `True` if the capsule
+  legitimately carries no auditable cells (C2.3-style aggregate-only
+  output). When absent, an empty `results` list refuses launch.
+
+Refusal: any cell's `verdict != "PASS"`, empty `results` (unless
+`aggregate_only=True`), bad kind, sha mismatch, non-finite p-value.
+
+### `smoke_test` — structural kind `d002c_smoke_test_capsule_v1`
+
+Emitted by `d002c_smoke_test.run_smoke_test`. The writer module emits
+**no `kind` field**; the preflight identifies the capsule
+structurally by the presence of the canonical field set
+(`verdict`, `grid_N`, `grid_lambda`, `n_cells_total`, `n_cells_ok`,
+`n_cells_failed`, `cells`, `sha256`, `generated_at`).
+
+Required:
+
+- `verdict == "PASS"`
+- `n_cells_failed == 0`
+
+Refusal: missing structural fields, sha mismatch, `verdict != "PASS"`,
+any non-zero `n_cells_failed`.
+
+## Launch refusal matrix
+
+| Condition                                                                 | launch_allowed |
+| ------------------------------------------------------------------------- | -------------- |
+| Any of the four capsule files is missing                                  | False          |
+| Any capsule is non-JSON or its root is not a JSON object                  | False          |
+| Any capsule's declared `kind` does not match the expected marker          | False          |
+| Any capsule's recomputed canonical-JSON sha256 disagrees with `sha256`    | False          |
+| Any capsule lacks a `generated_at` timestamp                              | False          |
+| Smoke capsule `verdict != "PASS"` OR `n_cells_failed > 0`                 | False          |
+| Null-audit `results` is empty (and `aggregate_only` not set)              | False          |
+| Any null-audit cell `verdict != "PASS"`                                   | False          |
+| Any capsule references an unknown substrate / metric id, or unknown N    | False          |
+| Any load-bearing numeric field is non-finite (NaN / Inf)                  | False          |
+| POS `excluded_combos` is non-empty                                        | **True**       |
+| NEG `excluded_cells` is non-empty                                         | **True**       |
+
+POS / NEG exclusions are by design **grid reducers**, not launch
+blockers — the preflight contract is "if these gates ran and the gate
+emitted exclusions, run the rest, not nothing".
+
+## Grid exclusion semantics
+
+- **POS** `excluded_combos: list[(substrate_id, metric_id)]` —
+  every sweep cell whose `(substrate_id, metric_id)` matches is
+  removed from the runnable grid. This affects **all** `(N, λ)`
+  combinations of the matched cell.
+- **NEG** `excluded_cells: list[(substrate_id, metric_id, N)]` —
+  every sweep cell whose `(substrate_id, metric_id, N)` triple
+  matches is removed. Siblings at different `N` survive.
+
+Skipped cells are emitted as `SkippedCell` records carrying
+`source_capsule`, `source_capsule_sha256`, and `reason`
+(`POS_EXCLUDED_COMBO` or `NEG_EXCLUDED_CELL`).
+
+## Checkpoint skipped-cell semantics
+
+The `CheckpointManager` ledger gains a `SKIPPED_BY_PREFLIGHT`
+`CellResult` variant. The payload schema is:
+
+```json
+{
+  "cell_key": "[N,lambda,substrate_id,metric_id]",
+  "substrate_id": "...",
+  "metric_id": "...",
+  "N": ...,
+  "lambda_": ...,
+  "status": "SKIPPED_BY_PREFLIGHT",
+  "reason": "POS_EXCLUDED_COMBO|NEG_EXCLUDED_CELL",
+  "source_capsule": "pos_control|neg_control",
+  "source_capsule_sha256": "..."
+}
+```
+
+A SKIPPED entry has `duration_seconds == 0.0`. The
+`IDEMPOTENT_ONLY` overwrite policy ensures a resume cannot
+silently turn a SKIPPED cell into a computed one — the second pass
+would attempt to save an identical SKIPPED payload (idempotent
+no-op).
+
+The aggregate sweep sha is computed over:
+
+- `preregistration_sha`
+- per-computed-cell sha list (sorted)
+- `completed_cells`, `total_cells`, `rng_seed_base`,
+  `steps_per_quarter`, `omega_gamma`
+- `preflight_decision_sha` — the preflight's content-addressed sha
+- `skipped_cell_keys` (sorted)
+- `skipped_cell_source_shas`
+
+Capsule tampering between runs changes the preflight decision sha,
+which changes the sweep sha.
+
+## Deterministic hashing rules
+
+Canonical preflight JSON (`canonical_preflight_json`):
+
+- `json.dumps(..., sort_keys=True, separators=(",", ":"))`
+- Non-finite floats are replaced by stable string sentinels:
+  - `NaN` → `"NaN"`
+  - `+Inf` → `"Infinity"`
+  - `-Inf` → `"-Infinity"`
+- Tuples normalised to lists.
+- `dict` keys are stringified by `sort_keys`.
+
+`verify_capsule_sha256(capsule)` recomputes the sha over the
+canonical-JSON of `{k: v for k, v in capsule.items() if k != "sha256"}`
+and raises `CapsuleShaMismatch` on disagreement.
+
+`PreflightDecision.sha256` is the canonical-JSON sha over:
+
+```
+{
+  "launch_allowed": bool,
+  "excluded_combos": sorted list of [sid, mid],
+  "excluded_cells": sorted list of [sid, mid, N],
+  "refusal_reasons": list of strings (preserve discovery order),
+  "capsule_shas": {pos_control, neg_control, null_audit, smoke_test → sha or "UNVERIFIED"}
+}
+```
+
+Same inputs → bit-exact identical decision sha across calls,
+processes, machines.
+
+## Required tests
+
+The preflight contract is pinned by 48 tests across two suites:
+
+- `tests/research/systemic_risk/test_d002c_preflight.py` (33 tests)
+- `tests/research/systemic_risk/test_d002c_sweep_runner_preflight_integration.py` (15 tests)
+
+Plus the legacy `tests/research/systemic_risk/test_d002c_sweep_runner.py`
+suite (37 tests), unchanged in assertions, must continue to pass under
+`require_preflight=False` legacy-shim mode.
+
+## CI requirements
+
+The PR's `measurement_command` runs `mypy --strict
+--follow-imports=silent`, `ruff check`, `black --check`, and `pytest`
+on the four edited Python files plus the legacy suite. All four gates
+must be green before merge.
+
+## Rollback command
+
+```bash
+git revert <commit-sha>
+```
+
+Or, to reproduce the manual rollback:
+
+```bash
+git checkout HEAD~1 -- \
+  && rm -f research/systemic_risk/d002c_preflight.py \
+     tests/research/systemic_risk/test_d002c_preflight.py \
+     tests/research/systemic_risk/test_d002c_sweep_runner_preflight_integration.py \
+     docs/governance/D002C_PREFLIGHT_CONTRACT.md \
+     .claude/commit_acceptors/x10r-d002c-preflight-enforcement.yaml
+```
+
+The legacy-shim edits in `tests/research/systemic_risk/test_d002c_sweep_runner.py`
+are restored by the `git checkout HEAD~1 --` step.
+
+## Known limitations
+
+1. **Null-audit capsule schema is C2.4-D-defined.** The null-audit
+   module (`d002c_null_audit`) emits per-cell `NullAuditResult`
+   payloads but does not currently write an aggregate capsule. The
+   preflight requires a wrapper of `kind:
+   d002c_null_audit_capsule_v1` containing a `results: list[...]`
+   field. An orchestrator (or a future C2.4-C addendum) is responsible
+   for producing this wrapper. The preflight refuses launch if the
+   wrapper is absent — there is no fallback.
+
+2. **Smoke capsule kind is structural.** The smoke-test writer emits
+   no `kind` field. The preflight identifies the smoke capsule by the
+   presence of the canonical field set. This is the writer's emitted
+   shape; the preflight matches it verbatim.
+
+3. **POS / NEG exclusions are non-veto.** A non-empty
+   `excluded_combos` or `excluded_cells` reduces the grid but does
+   not refuse launch. This is by design — gating on "any exclusion at
+   all = refuse" would void the purpose of the controls (which are
+   themselves grid-reducers).
+
+4. **Per-cell preflight identity is not bound to per-cell sweep
+   identity.** The preflight verifies substrate / metric / N
+   identities against the global registries. It does **not** verify
+   that every preflight cell's identity matches a sweep grid cell;
+   the converse direction (sweep grid → preflight) is enforced via
+   the pre-registration's lock on the same registries.
+
+5. **The preflight does not check inter-capsule consistency** beyond
+   identity — e.g. it does not refuse if POS and NEG report conflicting
+   verdicts on the same combo. The science-layer reading of "POS PASS
+   + NEG EXCLUDE on the same combo" is for the sweep result reader to
+   interpret, not the launch gate.
+
+## Claim boundary
+
+This module is **claim-neutral**. It does not produce, promote, or
+endorse any scientific claim. Its only output is:
+
+- a frozen `PreflightDecision` consumed by `run_sweep`,
+- a tuple of `SkippedCell` records persisted to the checkpoint
+  ledger as `SKIPPED_BY_PREFLIGHT` entries.
+
+The sweep result reader (C2.5, pending) is the layer that may
+interpret these outputs for claim purposes; the preflight enforcement
+layer never does.
+
+Forbidden vocabulary in this document (audit-enforced): "certified",
+"validated", "bank-level", "production-ready", "real-data confirmed",
+"universal", "proven". Permitted: "preflight-enforced",
+"synthetic-only", "fail-closed", "deterministic under fixed inputs",
+"claim-neutral", "launch-gating layer".

--- a/research/systemic_risk/d002c_preflight.py
+++ b/research/systemic_risk/d002c_preflight.py
@@ -1,0 +1,758 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""D-002C C2.4-D — Pre-flight enforcement layer (truth-binding integration).
+
+Mission
+=======
+The D-002C C2.4 sibling sessions A/B/C emit four pre-flight capsules:
+
+  * ``pos_control``  — :mod:`d002c_pos_control` aggregate capsule
+    (``kind: d002c_pos_control_capsule_v1``) carrying
+    ``excluded_combos: list[(substrate_id, metric_id)]``.
+  * ``neg_control``  — :mod:`d002c_neg_control` aggregate capsule
+    (``kind: d002c_neg_control_capsule_v1``) carrying
+    ``excluded_cells: list[(substrate_id, metric_id, N)]``.
+  * ``null_audit``   — aggregate over per-cell
+    :class:`d002c_null_audit.NullAuditResult` payloads
+    (``kind: d002c_null_audit_capsule_v1``) carrying a list of
+    ``verdict: PASS|FAIL`` per audited cell.
+  * ``smoke_test``   — :mod:`d002c_smoke_test` aggregate capsule
+    (structural kind: emitted shape carries ``verdict``,
+    ``grid_N``, ``grid_lambda``, ``cells``) — no ``kind`` field
+    is emitted upstream, so the preflight identifies it
+    structurally.
+
+Until this module merges, ``run_sweep`` only validates the
+sweep_config against the pre-registration. It does NOT consult
+the gate capsules. C2.4-D closes that gap by loading, validating,
+hashing, and interpreting all four capsules before any sweep cell
+is computed.
+
+Strict scope
+============
+Truth-binding integration ONLY. NO sweep launch. NO claim layer.
+NO threshold tuning. NO post-hoc relaxation. The preflight emits
+no claim of its own — it only refuses launch or reduces the
+execution grid based on the gate verdicts.
+
+Determinism contract
+====================
+* Capsule SHA recomputation uses canonical JSON: ``sort_keys=True``,
+  separators=(",", ":"), non-finite floats replaced by stable
+  string sentinels.
+* :class:`PreflightDecision`'s sha256 is content-addressed over its
+  load-bearing fields (excluded_combos, excluded_cells, refusal
+  reasons, capsule shas, launch_allowed flag).
+* Same inputs → bit-exact identical decision sha across calls,
+  processes, machines.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Final
+
+from .d002c_metrics import ALL_METRICS
+from .d002c_neg_control import DEFAULT_NEG_N_GRID
+from .d002c_substrates import ALL_SUBSTRATES
+
+# ---------------------------------------------------------------------------
+# Capsule kind / schema markers
+# ---------------------------------------------------------------------------
+
+#: Emitted by :func:`d002c_pos_control.run_pos_control_all`.
+POS_CONTROL_KIND: Final[str] = "d002c_pos_control_capsule_v1"
+
+#: Emitted by :func:`d002c_neg_control.run_neg_control_all`.
+NEG_CONTROL_KIND: Final[str] = "d002c_neg_control_capsule_v1"
+
+#: C2.4-D-defined wrapper schema for null-audit results. The null-audit
+#: module emits per-cell :class:`NullAuditResult` payloads but does not
+#: write an aggregate capsule itself. Orchestrators that drive the
+#: null-audit step must wrap the per-cell results in a capsule of this
+#: kind for the preflight to consume.
+NULL_AUDIT_KIND: Final[str] = "d002c_null_audit_capsule_v1"
+
+#: Structural identity for the smoke-test capsule. The smoke-test
+#: module emits a capsule WITHOUT a ``kind`` field; we identify it by
+#: required structural fields.
+SMOKE_TEST_STRUCTURAL_KIND: Final[str] = "d002c_smoke_test_capsule_v1"
+
+_SMOKE_REQUIRED_FIELDS: Final[frozenset[str]] = frozenset(
+    {
+        "verdict",
+        "grid_N",
+        "grid_lambda",
+        "n_cells_total",
+        "n_cells_ok",
+        "n_cells_failed",
+        "cells",
+        "sha256",
+        "generated_at",
+    }
+)
+
+#: Float sentinels used by :func:`canonical_preflight_json`.
+_NAN_SENTINEL: Final[str] = "NaN"
+_POS_INF_SENTINEL: Final[str] = "Infinity"
+_NEG_INF_SENTINEL: Final[str] = "-Infinity"
+
+#: Refusal-reason text catalogue (stable strings for tests and audit).
+_R_MISSING_FILE: Final[str] = "capsule_missing_file"
+_R_BAD_JSON: Final[str] = "capsule_bad_json"
+_R_NOT_OBJECT: Final[str] = "capsule_not_json_object"
+_R_BAD_KIND: Final[str] = "capsule_kind_mismatch"
+_R_MISSING_SHA: Final[str] = "capsule_missing_sha256"
+_R_SHA_MISMATCH: Final[str] = "capsule_sha256_mismatch"
+_R_MISSING_TIMESTAMP: Final[str] = "capsule_missing_generated_at"
+_R_NON_FINITE_FIELD: Final[str] = "capsule_non_finite_load_bearing_field"
+_R_UNKNOWN_SUBSTRATE: Final[str] = "capsule_unknown_substrate_id"
+_R_UNKNOWN_METRIC: Final[str] = "capsule_unknown_metric_id"
+_R_UNKNOWN_N: Final[str] = "capsule_unknown_N"
+_R_SMOKE_NOT_PASS: Final[str] = "smoke_verdict_not_pass"
+_R_NULL_NOT_PASS: Final[str] = "null_audit_verdict_not_pass"
+_R_NULL_EMPTY: Final[str] = "null_audit_empty_results"
+_R_MISSING_VERDICT: Final[str] = "capsule_missing_verdict"
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class PreflightCapsuleError(RuntimeError):
+    """Generic capsule-loading error. Always accumulated, never thrown
+    mid-validation — except for :meth:`verify_capsule_sha256` which is
+    callable directly by tests and must raise on mismatch."""
+
+
+class CapsuleShaMismatch(PreflightCapsuleError):
+    """Recomputed sha256 disagrees with the on-disk sha256 field."""
+
+
+class PreflightLaunchRefused(RuntimeError):
+    """Raised by :func:`assert_preflight_launch_allowed` when the
+    decision's ``launch_allowed`` is False. Carries the full list of
+    refusal reasons in its message so a single re-run can fix all of
+    them."""
+
+
+# ---------------------------------------------------------------------------
+# Frozen dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PreflightCapsulePaths:
+    """The four on-disk capsule paths the preflight consumes."""
+
+    pos_control: Path
+    neg_control: Path
+    null_audit: Path
+    smoke_test: Path
+
+
+@dataclass(frozen=True)
+class SkippedCell:
+    """One sweep cell skipped because a preflight gate excluded it."""
+
+    cell_key: str
+    substrate_id: str
+    metric_id: str
+    N: int
+    lambda_: float
+    reason: str  # POS_EXCLUDED_COMBO | NEG_EXCLUDED_CELL
+    source_capsule: str  # "pos_control" | "neg_control"
+    source_capsule_sha256: str
+
+
+@dataclass(frozen=True)
+class RunnableCell:
+    """One sweep cell that survives the preflight reduction."""
+
+    cell_key: str
+    substrate_id: str
+    metric_id: str
+    N: int
+    lambda_: float
+
+
+@dataclass(frozen=True)
+class PreflightDecision:
+    """Frozen verdict over the four preflight capsules.
+
+    Fields
+    ------
+    launch_allowed
+        True iff every capsule loaded cleanly AND every load-bearing
+        invariant held (smoke PASS, null-audit all PASS, capsule
+        SHAs match, identities are known). POS/NEG exclusions DO NOT
+        flip this flag — they only reduce the grid.
+    excluded_combos
+        ``((substrate_id, metric_id), ...)`` from the POS-control
+        capsule. Sweep cells matching these are skipped.
+    excluded_cells
+        ``((substrate_id, metric_id, N), ...)`` from the NEG-control
+        capsule. Sweep cells matching these are skipped (exact triple).
+    refusal_reasons
+        Full ordered list of reasons launch is refused. Empty iff
+        ``launch_allowed`` is True. Tests rely on the stable text
+        catalogue (``_R_*`` constants) for assertion stability.
+    capsule_shas
+        ``{"pos_control": ..., "neg_control": ..., "null_audit": ...,
+        "smoke_test": ...}`` — each value is the recomputed canonical
+        sha256 if the capsule loaded; the sentinel "UNVERIFIED" if not.
+    sha256
+        Content-addressed sha256 of the decision payload. Same inputs
+        → same decision sha. Used to bind the sweep aggregate sha so
+        capsule tampering between runs changes the sweep sha.
+    """
+
+    launch_allowed: bool
+    excluded_combos: tuple[tuple[str, str], ...]
+    excluded_cells: tuple[tuple[str, str, int], ...]
+    refusal_reasons: tuple[str, ...]
+    capsule_shas: dict[str, str]
+    sha256: str
+
+
+# ---------------------------------------------------------------------------
+# Canonical JSON + hashing
+# ---------------------------------------------------------------------------
+
+
+def _sanitize(obj: Any) -> Any:
+    """Recursively replace non-finite floats with stable string sentinels.
+
+    Tuples are normalised to lists (JSON arrays are ordered). dict keys
+    are stringified by ``sort_keys`` in :func:`canonical_preflight_json`.
+    """
+    if isinstance(obj, float):
+        if math.isnan(obj):
+            return _NAN_SENTINEL
+        if math.isinf(obj):
+            return _POS_INF_SENTINEL if obj > 0 else _NEG_INF_SENTINEL
+        return obj
+    if isinstance(obj, (list, tuple)):
+        return [_sanitize(x) for x in obj]
+    if isinstance(obj, dict):
+        return {str(k): _sanitize(v) for k, v in obj.items()}
+    return obj
+
+
+def canonical_preflight_json(payload: dict[str, Any]) -> str:
+    """Canonical JSON for preflight artifacts.
+
+    Rules
+    -----
+    * ``sort_keys=True``
+    * Tight separators ``(",", ":")``
+    * Non-finite floats replaced by stable string sentinels
+      (``"NaN"`` / ``"Infinity"`` / ``"-Infinity"``)
+    * Tuples normalised to lists
+
+    Same logical content → bit-exact identical encoding.
+    """
+    sanitized = _sanitize(payload)
+    return json.dumps(sanitized, sort_keys=True, separators=(",", ":"))
+
+
+def _sha_over(payload: dict[str, Any]) -> str:
+    return hashlib.sha256(canonical_preflight_json(payload).encode("utf-8")).hexdigest()
+
+
+def verify_capsule_sha256(capsule: dict[str, Any]) -> str:
+    """Recompute the canonical sha256 over the capsule payload sans sha256.
+
+    Raises
+    ------
+    CapsuleShaMismatch
+        If the on-disk ``sha256`` does not match the recomputed value
+        or is missing/non-string.
+    """
+    if "sha256" not in capsule or not isinstance(capsule["sha256"], str):
+        raise CapsuleShaMismatch("capsule missing sha256 string field")
+    on_disk = capsule["sha256"]
+    body = {k: v for k, v in capsule.items() if k != "sha256"}
+    recomputed = _sha_over(body)
+    if recomputed != on_disk:
+        raise CapsuleShaMismatch(
+            f"capsule sha256 mismatch: on-disk={on_disk!r} recomputed={recomputed!r}"
+        )
+    return recomputed
+
+
+# ---------------------------------------------------------------------------
+# Known-identity registries
+# ---------------------------------------------------------------------------
+
+_ALL_SUBSTRATE_IDS: Final[frozenset[str]] = frozenset(s.id for s in ALL_SUBSTRATES)
+_ALL_METRIC_IDS: Final[frozenset[str]] = frozenset(m.id for m in ALL_METRICS)
+#: N values the pre-registration accepts. NEG_N_GRID is the
+#: pre-registration-locked N grid (the same grid the negative control
+#: sweeps); the preflight refuses unknown N values referenced from
+#: capsules.
+_ALL_KNOWN_N: Final[frozenset[int]] = frozenset(DEFAULT_NEG_N_GRID)
+
+
+# ---------------------------------------------------------------------------
+# Internal capsule readers
+# ---------------------------------------------------------------------------
+
+
+def _read_capsule(path: Path) -> tuple[dict[str, Any] | None, list[str]]:
+    """Load a capsule JSON; return (data | None, reasons) without raising."""
+    reasons: list[str] = []
+    if not path.exists():
+        reasons.append(f"{_R_MISSING_FILE}: {path}")
+        return None, reasons
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        reasons.append(f"{_R_MISSING_FILE}: {path}: {exc}")
+        return None, reasons
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as exc:
+        reasons.append(f"{_R_BAD_JSON}: {path}: {exc}")
+        return None, reasons
+    if not isinstance(data, dict):
+        reasons.append(f"{_R_NOT_OBJECT}: {path}: root is {type(data).__name__}")
+        return None, reasons
+    return data, reasons
+
+
+def _verify_sha_collecting(data: dict[str, Any], path: Path, reasons: list[str]) -> str | None:
+    """Run :func:`verify_capsule_sha256` and collect failures.
+
+    Returns the recomputed sha on success; ``None`` on failure (with a
+    refusal reason appended to ``reasons``).
+    """
+    if "sha256" not in data:
+        reasons.append(f"{_R_MISSING_SHA}: {path}")
+        return None
+    if not isinstance(data["sha256"], str):
+        reasons.append(f"{_R_MISSING_SHA}: {path}: sha256 not a string")
+        return None
+    try:
+        return verify_capsule_sha256(data)
+    except CapsuleShaMismatch as exc:
+        reasons.append(f"{_R_SHA_MISMATCH}: {path}: {exc}")
+        return None
+
+
+def _check_generated_at(data: dict[str, Any], path: Path, reasons: list[str]) -> None:
+    ts = data.get("generated_at")
+    if not isinstance(ts, str) or not ts:
+        reasons.append(f"{_R_MISSING_TIMESTAMP}: {path}")
+
+
+def _check_kind(
+    data: dict[str, Any],
+    expected: str,
+    path: Path,
+    reasons: list[str],
+) -> bool:
+    got = data.get("kind")
+    if got != expected:
+        reasons.append(f"{_R_BAD_KIND}: {path}: expected {expected!r}, got {got!r}")
+        return False
+    return True
+
+
+def _is_finite_number(x: Any) -> bool:
+    return isinstance(x, (int, float)) and math.isfinite(float(x))
+
+
+# ---------------------------------------------------------------------------
+# Per-capsule processing
+# ---------------------------------------------------------------------------
+
+
+def _process_pos_control(
+    data: dict[str, Any],
+    path: Path,
+    reasons: list[str],
+) -> tuple[tuple[tuple[str, str], ...], str | None]:
+    """Returns (excluded_combos, capsule_sha or None).
+
+    Refuses launch on: bad kind, missing/mismatched sha, missing
+    generated_at, unknown substrate/metric id in excluded_combos
+    or results list.
+    """
+    if not _check_kind(data, POS_CONTROL_KIND, path, reasons):
+        return (), None
+    sha = _verify_sha_collecting(data, path, reasons)
+    _check_generated_at(data, path, reasons)
+
+    excluded_raw = data.get("excluded_combos", [])
+    if not isinstance(excluded_raw, list):
+        reasons.append(f"{_R_BAD_KIND}: {path}: excluded_combos not a list")
+        excluded_raw = []
+    excluded: list[tuple[str, str]] = []
+    for combo in excluded_raw:
+        if not (isinstance(combo, list) and len(combo) == 2):
+            reasons.append(f"{_R_BAD_KIND}: {path}: malformed combo {combo!r}")
+            continue
+        sid = str(combo[0])
+        mid = str(combo[1])
+        if sid not in _ALL_SUBSTRATE_IDS:
+            reasons.append(f"{_R_UNKNOWN_SUBSTRATE}: {path}: pos_excluded combo {sid!r}")
+        if mid not in _ALL_METRIC_IDS:
+            reasons.append(f"{_R_UNKNOWN_METRIC}: {path}: pos_excluded combo {mid!r}")
+        excluded.append((sid, mid))
+
+    # Validate every per-cell result identity (load-bearing — an
+    # unknown id in the results list means the gate ran on a
+    # universe inconsistent with the sweep).
+    results_raw = data.get("results", [])
+    if isinstance(results_raw, list):
+        for r in results_raw:
+            if not isinstance(r, dict):
+                continue
+            sid = str(r.get("substrate_id", ""))
+            mid = str(r.get("metric_id", ""))
+            if sid not in _ALL_SUBSTRATE_IDS:
+                reasons.append(f"{_R_UNKNOWN_SUBSTRATE}: {path}: pos_result {sid!r}")
+            if mid not in _ALL_METRIC_IDS:
+                reasons.append(f"{_R_UNKNOWN_METRIC}: {path}: pos_result {mid!r}")
+            for fld in ("signal_ci_ratio", "threshold", "censoring_fraction"):
+                v = r.get(fld)
+                if v is not None and not _is_finite_number(v):
+                    reasons.append(f"{_R_NON_FINITE_FIELD}: {path}: pos_result.{fld}={v!r}")
+
+    return tuple(excluded), sha
+
+
+def _process_neg_control(
+    data: dict[str, Any],
+    path: Path,
+    reasons: list[str],
+) -> tuple[tuple[tuple[str, str, int], ...], str | None]:
+    """Returns (excluded_cells, capsule_sha or None)."""
+    if not _check_kind(data, NEG_CONTROL_KIND, path, reasons):
+        return (), None
+    sha = _verify_sha_collecting(data, path, reasons)
+    _check_generated_at(data, path, reasons)
+
+    excluded_raw = data.get("excluded_cells", [])
+    if not isinstance(excluded_raw, list):
+        reasons.append(f"{_R_BAD_KIND}: {path}: excluded_cells not a list")
+        excluded_raw = []
+    excluded: list[tuple[str, str, int]] = []
+    for cell in excluded_raw:
+        if not (isinstance(cell, list) and len(cell) == 3):
+            reasons.append(f"{_R_BAD_KIND}: {path}: malformed cell {cell!r}")
+            continue
+        sid = str(cell[0])
+        mid = str(cell[1])
+        try:
+            n_val = int(cell[2])
+        except (TypeError, ValueError):
+            reasons.append(f"{_R_BAD_KIND}: {path}: neg_excluded N not int: {cell[2]!r}")
+            continue
+        if sid not in _ALL_SUBSTRATE_IDS:
+            reasons.append(f"{_R_UNKNOWN_SUBSTRATE}: {path}: neg_excluded {sid!r}")
+        if mid not in _ALL_METRIC_IDS:
+            reasons.append(f"{_R_UNKNOWN_METRIC}: {path}: neg_excluded {mid!r}")
+        if n_val not in _ALL_KNOWN_N:
+            reasons.append(f"{_R_UNKNOWN_N}: {path}: neg_excluded N={n_val}")
+        excluded.append((sid, mid, n_val))
+
+    # Validate per-cell results identities + finite fields
+    results_raw = data.get("results", [])
+    if isinstance(results_raw, list):
+        for r in results_raw:
+            if not isinstance(r, dict):
+                continue
+            sid = str(r.get("substrate_id", ""))
+            mid = str(r.get("metric_id", ""))
+            n_raw = r.get("N")
+            if sid not in _ALL_SUBSTRATE_IDS:
+                reasons.append(f"{_R_UNKNOWN_SUBSTRATE}: {path}: neg_result {sid!r}")
+            if mid not in _ALL_METRIC_IDS:
+                reasons.append(f"{_R_UNKNOWN_METRIC}: {path}: neg_result {mid!r}")
+            if isinstance(n_raw, int) and n_raw not in _ALL_KNOWN_N:
+                reasons.append(f"{_R_UNKNOWN_N}: {path}: neg_result N={n_raw}")
+            for fld in ("fpr", "alpha_bonferroni", "threshold_tolerance"):
+                v = r.get(fld)
+                if v is not None and not _is_finite_number(v):
+                    reasons.append(f"{_R_NON_FINITE_FIELD}: {path}: neg_result.{fld}={v!r}")
+
+    return tuple(excluded), sha
+
+
+def _process_null_audit(
+    data: dict[str, Any],
+    path: Path,
+    reasons: list[str],
+) -> str | None:
+    """Returns capsule_sha or None. Appends refusal reasons on FAIL or empty."""
+    if not _check_kind(data, NULL_AUDIT_KIND, path, reasons):
+        return None
+    sha = _verify_sha_collecting(data, path, reasons)
+    _check_generated_at(data, path, reasons)
+
+    results_raw = data.get("results", [])
+    if not isinstance(results_raw, list):
+        reasons.append(f"{_R_BAD_KIND}: {path}: results not a list")
+        return sha
+
+    aggregate_only = bool(data.get("aggregate_only", False))
+    if not results_raw and not aggregate_only:
+        reasons.append(f"{_R_NULL_EMPTY}: {path}")
+        return sha
+
+    for idx, r in enumerate(results_raw):
+        if not isinstance(r, dict):
+            reasons.append(f"{_R_MISSING_VERDICT}: {path}: results[{idx}] not a dict")
+            continue
+        verdict = r.get("verdict")
+        if not isinstance(verdict, str):
+            reasons.append(f"{_R_MISSING_VERDICT}: {path}: results[{idx}]")
+            continue
+        if verdict != "PASS":
+            reasons.append(f"{_R_NULL_NOT_PASS}: {path}: results[{idx}].verdict={verdict!r}")
+        # Finite check on p_value if present
+        p = r.get("p_value_empirical")
+        if p is not None and not _is_finite_number(p):
+            reasons.append(f"{_R_NON_FINITE_FIELD}: {path}: results[{idx}].p_value_empirical={p!r}")
+
+    return sha
+
+
+def _process_smoke(
+    data: dict[str, Any],
+    path: Path,
+    reasons: list[str],
+) -> str | None:
+    """Returns capsule_sha or None. The smoke capsule has no ``kind`` field
+    (the writer module does not emit one) — we identify it structurally
+    by requiring the canonical field set the smoke writer emits."""
+    missing = _SMOKE_REQUIRED_FIELDS - set(data.keys())
+    if missing:
+        reasons.append(
+            f"{_R_BAD_KIND}: {path}: smoke capsule missing required fields: {sorted(missing)}"
+        )
+        return None
+    sha = _verify_sha_collecting(data, path, reasons)
+    _check_generated_at(data, path, reasons)
+
+    verdict = data.get("verdict")
+    if not isinstance(verdict, str):
+        reasons.append(f"{_R_MISSING_VERDICT}: {path}: smoke verdict missing")
+    elif verdict != "PASS":
+        reasons.append(f"{_R_SMOKE_NOT_PASS}: {path}: verdict={verdict!r}")
+
+    # n_cells_failed must be 0 for a meaningful PASS
+    failed = data.get("n_cells_failed")
+    if isinstance(failed, int) and failed > 0:
+        reasons.append(f"{_R_SMOKE_NOT_PASS}: {path}: n_cells_failed={failed}")
+
+    return sha
+
+
+# ---------------------------------------------------------------------------
+# Public API — load + apply
+# ---------------------------------------------------------------------------
+
+
+def load_and_validate_preflight_capsules(
+    paths: PreflightCapsulePaths,
+) -> PreflightDecision:
+    """Load + validate all four capsules; return a frozen :class:`PreflightDecision`.
+
+    Never raises mid-validation — every error is accumulated into
+    ``refusal_reasons`` so a single re-run fixes them all. The decision
+    is content-addressed: same inputs → bit-exact identical
+    ``decision.sha256``.
+
+    POS/NEG exclusions DO NOT flip ``launch_allowed`` (the gates are
+    "reduce the grid, do not abort" by contract); ANY other refusal
+    flips it.
+    """
+    refusal_reasons: list[str] = []
+    capsule_shas: dict[str, str] = {
+        "pos_control": "UNVERIFIED",
+        "neg_control": "UNVERIFIED",
+        "null_audit": "UNVERIFIED",
+        "smoke_test": "UNVERIFIED",
+    }
+
+    # POS
+    excluded_combos: tuple[tuple[str, str], ...] = ()
+    pos_data, pos_reasons = _read_capsule(paths.pos_control)
+    refusal_reasons.extend(pos_reasons)
+    if pos_data is not None:
+        combos, pos_sha = _process_pos_control(pos_data, paths.pos_control, refusal_reasons)
+        excluded_combos = combos
+        if pos_sha is not None:
+            capsule_shas["pos_control"] = pos_sha
+
+    # NEG
+    excluded_cells: tuple[tuple[str, str, int], ...] = ()
+    neg_data, neg_reasons = _read_capsule(paths.neg_control)
+    refusal_reasons.extend(neg_reasons)
+    if neg_data is not None:
+        cells, neg_sha = _process_neg_control(neg_data, paths.neg_control, refusal_reasons)
+        excluded_cells = cells
+        if neg_sha is not None:
+            capsule_shas["neg_control"] = neg_sha
+
+    # NULL
+    null_data, null_reasons = _read_capsule(paths.null_audit)
+    refusal_reasons.extend(null_reasons)
+    if null_data is not None:
+        null_sha = _process_null_audit(null_data, paths.null_audit, refusal_reasons)
+        if null_sha is not None:
+            capsule_shas["null_audit"] = null_sha
+
+    # SMOKE
+    smoke_data, smoke_reasons = _read_capsule(paths.smoke_test)
+    refusal_reasons.extend(smoke_reasons)
+    if smoke_data is not None:
+        smoke_sha = _process_smoke(smoke_data, paths.smoke_test, refusal_reasons)
+        if smoke_sha is not None:
+            capsule_shas["smoke_test"] = smoke_sha
+
+    # ``launch_allowed`` is True ONLY if every load-bearing check passed.
+    # POS/NEG exclusions DO NOT flip the flag — those are grid reducers,
+    # not launch blockers. The refusal_reasons list is what flips it.
+    launch_allowed = len(refusal_reasons) == 0
+
+    # Stable, sorted output for deterministic decision sha
+    sorted_combos = tuple(sorted(set(excluded_combos)))
+    sorted_cells = tuple(sorted(set(excluded_cells)))
+    sorted_reasons = tuple(refusal_reasons)  # preserve discovery order
+
+    decision_payload: dict[str, Any] = {
+        "launch_allowed": bool(launch_allowed),
+        "excluded_combos": [list(c) for c in sorted_combos],
+        "excluded_cells": [list(c) for c in sorted_cells],
+        "refusal_reasons": list(sorted_reasons),
+        "capsule_shas": dict(capsule_shas),
+    }
+    sha = _sha_over(decision_payload)
+
+    return PreflightDecision(
+        launch_allowed=launch_allowed,
+        excluded_combos=sorted_combos,
+        excluded_cells=sorted_cells,
+        refusal_reasons=sorted_reasons,
+        capsule_shas=dict(capsule_shas),
+        sha256=sha,
+    )
+
+
+def apply_preflight_to_grid(
+    full_grid: Iterable[tuple[int, float, str, str]],
+    decision: PreflightDecision,
+) -> tuple[tuple[RunnableCell, ...], tuple[SkippedCell, ...]]:
+    """Apply POS/NEG exclusions to the cartesian sweep grid.
+
+    Parameters
+    ----------
+    full_grid
+        Iterable of ``(N, lambda_, substrate_id, metric_id)`` tuples in
+        canonical traversal order.
+    decision
+        Frozen :class:`PreflightDecision` carrying ``excluded_combos``
+        (POS) and ``excluded_cells`` (NEG).
+
+    Returns
+    -------
+    (runnable, skipped)
+        ``runnable`` carries the cells that survive the preflight
+        reduction (preserved in input traversal order). ``skipped``
+        carries the cells removed by POS or NEG, each tagged with the
+        source capsule + its sha256 — so the audit trail is preserved
+        in the checkpoint.
+    """
+    from .sweep_checkpoint import cell_key
+
+    pos_excluded: set[tuple[str, str]] = set(decision.excluded_combos)
+    neg_excluded: set[tuple[str, str, int]] = set(decision.excluded_cells)
+    pos_sha = decision.capsule_shas.get("pos_control", "UNVERIFIED")
+    neg_sha = decision.capsule_shas.get("neg_control", "UNVERIFIED")
+
+    runnable: list[RunnableCell] = []
+    skipped: list[SkippedCell] = []
+    for N, lam, sid, mid in full_grid:
+        ck = cell_key((int(N), float(lam), str(sid), str(mid)))
+        if (sid, mid) in pos_excluded:
+            skipped.append(
+                SkippedCell(
+                    cell_key=ck,
+                    substrate_id=sid,
+                    metric_id=mid,
+                    N=int(N),
+                    lambda_=float(lam),
+                    reason="POS_EXCLUDED_COMBO",
+                    source_capsule="pos_control",
+                    source_capsule_sha256=pos_sha,
+                )
+            )
+            continue
+        if (sid, mid, int(N)) in neg_excluded:
+            skipped.append(
+                SkippedCell(
+                    cell_key=ck,
+                    substrate_id=sid,
+                    metric_id=mid,
+                    N=int(N),
+                    lambda_=float(lam),
+                    reason="NEG_EXCLUDED_CELL",
+                    source_capsule="neg_control",
+                    source_capsule_sha256=neg_sha,
+                )
+            )
+            continue
+        runnable.append(
+            RunnableCell(
+                cell_key=ck,
+                substrate_id=sid,
+                metric_id=mid,
+                N=int(N),
+                lambda_=float(lam),
+            )
+        )
+    return tuple(runnable), tuple(skipped)
+
+
+def assert_preflight_launch_allowed(decision: PreflightDecision) -> None:
+    """Raise :class:`PreflightLaunchRefused` if ``decision.launch_allowed`` is False.
+
+    The exception message carries the full refusal-reasons list so a
+    single re-run can fix all of them.
+    """
+    if decision.launch_allowed:
+        return
+    joined = "\n".join(f"  - {r}" for r in decision.refusal_reasons)
+    raise PreflightLaunchRefused(
+        f"preflight launch refused; sha={decision.sha256[:16]}…:\n{joined}"
+    )
+
+
+__all__ = [
+    "POS_CONTROL_KIND",
+    "NEG_CONTROL_KIND",
+    "NULL_AUDIT_KIND",
+    "SMOKE_TEST_STRUCTURAL_KIND",
+    "PreflightCapsuleError",
+    "CapsuleShaMismatch",
+    "PreflightLaunchRefused",
+    "PreflightCapsulePaths",
+    "PreflightDecision",
+    "SkippedCell",
+    "RunnableCell",
+    "canonical_preflight_json",
+    "verify_capsule_sha256",
+    "load_and_validate_preflight_capsules",
+    "apply_preflight_to_grid",
+    "assert_preflight_launch_allowed",
+]

--- a/research/systemic_risk/d002c_sweep_runner.py
+++ b/research/systemic_risk/d002c_sweep_runner.py
@@ -901,6 +901,77 @@ def run_sweep(
         else:
             restored[k] = _restore_cell_from_payload(v.payload)
 
+    # Codex P1 fix (2026-05-12): when resuming a checkpoint under a NEW
+    # preflight decision, every persisted cell must still agree with the
+    # current decision. Three drift modes are possible and ALL are
+    # fail-closed:
+    #
+    #   (a) persisted_skipped AND now runnable —
+    #       the operator updated POS/NEG capsules so exclusion was
+    #       lifted, but ``remaining_cells`` would treat the cell as
+    #       already done and silently skip recomputation. The new
+    #       sweep would return an incomplete grid under a fresh
+    #       aggregate sha, defeating the tamper-evidence contract.
+    #
+    #   (b) persisted_computed AND now skipped —
+    #       the cell already has a real metric value, but the new
+    #       decision says it should never have run. Persisting both
+    #       a SKIPPED row and the real result is internally
+    #       contradictory; the operator must explicitly resolve.
+    #
+    #   (c) persisted_skipped AND still skipped BUT source_capsule
+    #       sha drifted — exclusion happened to be preserved but the
+    #       capsule was rotated. The exclusion provenance has
+    #       changed under our feet; the operator must acknowledge
+    #       this rather than have the runner silently rewrite the
+    #       audit row.
+    #
+    # In every case the runner refuses launch and tells the
+    # operator to start a fresh checkpoint path (or run with
+    # ``require_preflight=False`` for the legacy ungated path).
+    if preflight_capsules is not None:
+        current_skipped_keys: dict[str, SkippedCell] = {s.cell_key: s for s in skipped_cells}
+        current_runnable_keys: set[str] = set(cell_key_to_tuple.keys())
+        drift_reasons: list[str] = []
+        for k in sorted(checkpoint.results.keys()):
+            is_persisted_skip = k in persisted_skipped
+            is_currently_skip = k in current_skipped_keys
+            is_currently_runnable = k in current_runnable_keys
+            if is_persisted_skip and is_currently_runnable:
+                drift_reasons.append(
+                    f"persisted_skipped_cell_no_longer_excluded:{k} — "
+                    "the previous run skipped this cell under a preflight "
+                    "exclusion that the current decision does not assert; "
+                    "resume would silently treat the cell as completed."
+                )
+            elif (not is_persisted_skip) and is_currently_skip:
+                drift_reasons.append(
+                    f"persisted_computed_cell_now_excluded:{k} — "
+                    "this cell already has a real metric value on disk "
+                    "but the current preflight decision now excludes it; "
+                    "the audit trail cannot be both 'computed' and "
+                    "'skipped' for the same cell."
+                )
+            elif is_persisted_skip and is_currently_skip:
+                persisted = persisted_skipped[k]
+                current = current_skipped_keys[k]
+                if persisted.source_capsule_sha256 != current.source_capsule_sha256:
+                    drift_reasons.append(
+                        f"persisted_skipped_cell_source_capsule_sha_drifted:"
+                        f"{k} — exclusion preserved but capsule provenance "
+                        f"changed (was {persisted.source_capsule_sha256[:8]}…, "
+                        f"now {current.source_capsule_sha256[:8]}…); "
+                        "the audit row cannot be silently rewritten."
+                    )
+        if drift_reasons:
+            raise PreflightLaunchRefused(
+                "checkpoint contradicts current preflight decision; the "
+                "saved sweep state cannot be safely resumed under the new "
+                "contract. Start a fresh checkpoint path or run with "
+                "require_preflight=False (legacy mode). Drift:\n"
+                + "\n".join(f"  - {r}" for r in drift_reasons)
+            )
+
     # Persist any preflight-skipped cells that aren't yet on disk. This
     # makes the checkpoint a complete audit trail: SKIPPED_BY_PREFLIGHT
     # rows survive a kill and bind the source_capsule_sha256 so resume

--- a/research/systemic_risk/d002c_sweep_runner.py
+++ b/research/systemic_risk/d002c_sweep_runner.py
@@ -100,6 +100,15 @@ from .d002c_metrics import (
     MetricEvaluation,
     signal_mean,
 )
+from .d002c_preflight import (
+    PreflightCapsulePaths,
+    PreflightDecision,
+    PreflightLaunchRefused,
+    SkippedCell,
+    apply_preflight_to_grid,
+    assert_preflight_launch_allowed,
+    load_and_validate_preflight_capsules,
+)
 from .d002c_preregistration import (
     D002CPreregistration,
     validate_sweep_config,
@@ -201,7 +210,16 @@ class SweepCellOutput:
 
 @dataclass(frozen=True)
 class SweepResult:
-    """Frozen aggregate over a full sweep."""
+    """Frozen aggregate over a full sweep.
+
+    ``skipped_cells`` (added in C2.4-D) carries the cells removed by
+    the preflight POS/NEG gates; ``preflight_decision_sha`` is the
+    content-addressed sha of the preflight decision and is folded into
+    the aggregate sha256, so capsule tampering between runs changes the
+    sweep sha. Both fields default to empty / empty string for
+    backward-compatibility with legacy callers that run with
+    ``require_preflight=False``.
+    """
 
     preregistration_sha: str
     completed_cells: int
@@ -210,6 +228,8 @@ class SweepResult:
     sha256: str
     generated_at: str
     wallclock_seconds: float
+    skipped_cells: tuple[SkippedCell, ...] = ()
+    preflight_decision_sha: str = ""
 
 
 # ---------------------------------------------------------------------------
@@ -716,6 +736,38 @@ def _restore_cell_from_payload(payload: dict[str, Any]) -> SweepCellOutput:
     )
 
 
+def _skipped_cell_to_payload(s: SkippedCell) -> dict[str, Any]:
+    """JSON-pure payload for a SKIPPED_BY_PREFLIGHT checkpoint entry."""
+    return {
+        "cell_key": s.cell_key,
+        "substrate_id": s.substrate_id,
+        "metric_id": s.metric_id,
+        "N": int(s.N),
+        "lambda_": float(s.lambda_),
+        "status": "SKIPPED_BY_PREFLIGHT",
+        "reason": s.reason,
+        "source_capsule": s.source_capsule,
+        "source_capsule_sha256": s.source_capsule_sha256,
+    }
+
+
+def _payload_is_skipped(payload: dict[str, Any]) -> bool:
+    return payload.get("status") == "SKIPPED_BY_PREFLIGHT"
+
+
+def _restore_skipped_from_payload(payload: dict[str, Any]) -> SkippedCell:
+    return SkippedCell(
+        cell_key=str(payload["cell_key"]),
+        substrate_id=str(payload["substrate_id"]),
+        metric_id=str(payload["metric_id"]),
+        N=int(payload["N"]),
+        lambda_=float(payload["lambda_"]),
+        reason=str(payload["reason"]),
+        source_capsule=str(payload["source_capsule"]),
+        source_capsule_sha256=str(payload["source_capsule_sha256"]),
+    )
+
+
 def run_sweep(
     *,
     preregistration: D002CPreregistration,
@@ -726,6 +778,8 @@ def run_sweep(
     omega_gamma: float = DEFAULT_OMEGA_GAMMA,
     progress_callback: Callable[[int, int], None] | None = None,
     code_sha: str = DEFAULT_CODE_SHA,
+    preflight_capsules: PreflightCapsulePaths | None = None,
+    require_preflight: bool = True,
 ) -> SweepResult:
     """Drive the full pre-registered grid with per-cell checkpointing.
 
@@ -757,28 +811,75 @@ def run_sweep(
         Soft metadata for the checkpoint ledger. Drift versus the
         on-disk file is a WARNING from :class:`CheckpointManager`,
         not a refusal.
+    preflight_capsules
+        Optional :class:`PreflightCapsulePaths` for the four C2.4-D
+        gate capsules (pos_control, neg_control, null_audit,
+        smoke_test). When supplied the runner loads + validates them
+        via :func:`load_and_validate_preflight_capsules`, refuses
+        launch on a refusal verdict, and reduces the execution grid
+        by ``excluded_combos`` (POS) and ``excluded_cells`` (NEG).
+    require_preflight
+        Default ``True`` — preflight is mandatory and a missing
+        ``preflight_capsules`` argument refuses launch. Set ``False``
+        ONLY for legacy callers (e.g. unit tests of run_one_cell
+        plumbing) that pre-date C2.4-D; in that mode the runner
+        behaves identically to the pre-C2.4-D version.
 
     Returns
     -------
     SweepResult
-        Carries every cell output (sorted by cell_key for stability)
-        and a stable aggregate sha256.
+        Carries every cell output (sorted by cell_key for stability),
+        the preflight-skipped cells, the preflight decision sha, and a
+        stable aggregate sha256 (which folds in the preflight sha so
+        capsule tampering between runs changes the sweep sha).
 
     Raises
     ------
     PreregistrationMismatch
         From :func:`validate_sweep_config` — refuses to launch on any
         disagreement with the locked contract.
+    PreflightLaunchRefused
+        From :func:`assert_preflight_launch_allowed` — refuses launch
+        on any preflight failure (missing/bad capsule, smoke FAIL,
+        null audit FAIL, unknown identity). The exception carries the
+        full refusal-reasons list.
     SweepRunnerInvalid
         On unresolvable substrate / metric ids or bad inputs.
     """
     validate_sweep_config(preregistration, sweep_config)
 
+    # ---- preflight gate ----------------------------------------------------
+    decision: PreflightDecision | None = None
+    if require_preflight:
+        if preflight_capsules is None:
+            raise PreflightLaunchRefused(
+                "preflight is required (require_preflight=True) but "
+                "preflight_capsules is None; pass a PreflightCapsulePaths"
+            )
+        decision = load_and_validate_preflight_capsules(preflight_capsules)
+        assert_preflight_launch_allowed(decision)
+    elif preflight_capsules is not None:
+        # Caller opted in despite require_preflight=False — honour the
+        # gate but do not synthesise one if absent.
+        decision = load_and_validate_preflight_capsules(preflight_capsules)
+        assert_preflight_launch_allowed(decision)
+
+    # ---- grid construction + preflight-driven reduction -------------------
     full_grid = _build_full_grid(preregistration)
     total_cells = len(full_grid)
 
+    if decision is not None:
+        runnable, skipped = apply_preflight_to_grid(full_grid, decision)
+        runnable_tuples: list[tuple[int, float, str, str]] = [
+            (rc.N, rc.lambda_, rc.substrate_id, rc.metric_id) for rc in runnable
+        ]
+        skipped_cells: tuple[SkippedCell, ...] = skipped
+    else:
+        runnable_tuples = list(full_grid)
+        skipped_cells = ()
+
     cell_key_to_tuple: dict[str, tuple[int, float, str, str]] = {
-        cell_key((N, lam, sid, mid)): (N, lam, sid, mid) for (N, lam, sid, mid) in full_grid
+        cell_key((N, lam, sid, mid)): (N, lam, sid, mid) for (N, lam, sid, mid) in runnable_tuples
     }
     all_keys: list[str] = list(cell_key_to_tuple.keys())
 
@@ -788,14 +889,40 @@ def run_sweep(
     checkpoint = mgr.load_or_create()
 
     # Restore already-completed cells from the on-disk checkpoint so
-    # the aggregate sha is stable across resume.
-    restored: dict[str, SweepCellOutput] = {
-        k: _restore_cell_from_payload(v.payload) for k, v in checkpoint.results.items()
-    }
+    # the aggregate sha is stable across resume. Persisted
+    # SKIPPED_BY_PREFLIGHT entries are restored into the skipped tuple
+    # (idempotent with the in-memory ``skipped_cells``); legacy entries
+    # (no ``status`` field) become SweepCellOutput as before.
+    restored: dict[str, SweepCellOutput] = {}
+    persisted_skipped: dict[str, SkippedCell] = {}
+    for k, v in checkpoint.results.items():
+        if _payload_is_skipped(v.payload):
+            persisted_skipped[k] = _restore_skipped_from_payload(v.payload)
+        else:
+            restored[k] = _restore_cell_from_payload(v.payload)
+
+    # Persist any preflight-skipped cells that aren't yet on disk. This
+    # makes the checkpoint a complete audit trail: SKIPPED_BY_PREFLIGHT
+    # rows survive a kill and bind the source_capsule_sha256 so resume
+    # cannot silently recompute a previously-skipped cell.
+    for s in skipped_cells:
+        if s.cell_key in persisted_skipped:
+            continue
+        mgr.save_cell(
+            s.cell_key,
+            CellResult(
+                cell_key=s.cell_key,
+                payload=_skipped_cell_to_payload(s),
+                duration_seconds=0.0,
+            ),
+        )
+        persisted_skipped[s.cell_key] = s
 
     t0 = time.monotonic()
     remaining = mgr.remaining_cells(all_keys)
-    done_count = total_cells - len(remaining)
+    # Subtract the runnable cells already computed from the work count;
+    # SKIPPED rows are accounted for separately.
+    done_count = len(all_keys) - len(remaining)
 
     for ck in remaining:
         N, lam, sid, mid = cell_key_to_tuple[ck]
@@ -830,9 +957,13 @@ def run_sweep(
     wall = time.monotonic() - t0
 
     # Stable order: sort by cell_key so the aggregate sha is invariant
-    # under the traversal order (and stable across resume).
+    # under the traversal order (and stable across resume). Skipped
+    # cells appear in their own deterministic tuple, also sorted.
     ordered_keys = sorted(restored.keys())
     results = tuple(restored[k] for k in ordered_keys)
+    final_skipped = tuple(persisted_skipped[k] for k in sorted(persisted_skipped.keys()))
+    preflight_sha = decision.sha256 if decision is not None else ""
+
     aggregate = {
         "preregistration_sha": preregistration.preregistration_sha,
         "per_cell_shas": [r.sha256 for r in results],
@@ -841,6 +972,10 @@ def run_sweep(
         "rng_seed_base": int(rng_seed_base),
         "steps_per_quarter": int(steps_per_quarter),
         "omega_gamma": float(omega_gamma),
+        # Truth-binding: capsule tampering between runs changes the sweep sha.
+        "preflight_decision_sha": preflight_sha,
+        "skipped_cell_keys": [s.cell_key for s in final_skipped],
+        "skipped_cell_source_shas": [s.source_capsule_sha256 for s in final_skipped],
     }
     sha = _sha256_over_payload(aggregate)
 
@@ -852,6 +987,8 @@ def run_sweep(
         sha256=sha,
         generated_at=_now_iso(),
         wallclock_seconds=wall,
+        skipped_cells=final_skipped,
+        preflight_decision_sha=preflight_sha,
     )
 
 

--- a/tests/research/systemic_risk/test_d002c_preflight.py
+++ b/tests/research/systemic_risk/test_d002c_preflight.py
@@ -1,0 +1,668 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""D-002C C2.4-D — Unit tests for the preflight enforcement layer."""
+
+from __future__ import annotations
+
+import dataclasses
+import hashlib
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from research.systemic_risk.d002c_preflight import (
+    NEG_CONTROL_KIND,
+    NULL_AUDIT_KIND,
+    POS_CONTROL_KIND,
+    CapsuleShaMismatch,
+    PreflightCapsulePaths,
+    PreflightLaunchRefused,
+    RunnableCell,
+    SkippedCell,
+    apply_preflight_to_grid,
+    assert_preflight_launch_allowed,
+    canonical_preflight_json,
+    load_and_validate_preflight_capsules,
+    verify_capsule_sha256,
+)
+
+# ---------------------------------------------------------------------------
+# Capsule fixture helpers
+# ---------------------------------------------------------------------------
+
+
+def _sha(payload: dict[str, Any]) -> str:
+    """Mirror the preflight canonical-JSON discipline."""
+    canon = canonical_preflight_json(payload)
+    return hashlib.sha256(canon.encode("utf-8")).hexdigest()
+
+
+def _seal(capsule_body: dict[str, Any]) -> dict[str, Any]:
+    """Compute sha256 over the payload (sans the sha field) and return
+    a sealed capsule whose verify_capsule_sha256 succeeds."""
+    sha = _sha(capsule_body)
+    out = dict(capsule_body)
+    out["sha256"] = sha
+    return out
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, sort_keys=True, indent=2), encoding="utf-8")
+
+
+def _pos_capsule(
+    *,
+    excluded_combos: list[list[str]] | None = None,
+    extra_results: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    body: dict[str, Any] = {
+        "kind": POS_CONTROL_KIND,
+        "all_pass": excluded_combos in (None, []),
+        "n_pass": 9,
+        "n_exclude": 0 if not excluded_combos else len(excluded_combos),
+        "excluded_combos": excluded_combos or [],
+        "n_seeds": 50,
+        "N": 400,
+        "lambda_": 1.0,
+        "threshold": 2.0,
+        "steps_per_quarter": 10,
+        "omega_gamma": 0.5,
+        "rng_seed_base": 42,
+        "wallclock_seconds": 0.0,
+        "results": extra_results
+        or [
+            {
+                "substrate_id": "block_structured",
+                "metric_id": "sync_auc",
+                "N": 400,
+                "lambda_": 1.0,
+                "n_seeds": 50,
+                "signal_mean": 1.0,
+                "signal_std": 0.1,
+                "signal_ci_ratio": 70.0,
+                "threshold": 2.0,
+                "verdict": "PASS",
+                "censoring_fraction": 0.0,
+                "wallclock_seconds": 0.1,
+                "sha256": "deadbeef" * 8,
+            }
+        ],
+        "generated_at": "2026-05-11T12:00:00Z",
+        "substrate_ids": ["ricci_flow", "block_structured", "temporal_coupling"],
+        "metric_ids": ["tau_onset", "sync_auc", "phase_lag"],
+    }
+    return _seal(body)
+
+
+def _neg_capsule(
+    *,
+    excluded_cells: list[list[Any]] | None = None,
+    extra_results: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    body: dict[str, Any] = {
+        "kind": NEG_CONTROL_KIND,
+        "all_pass": excluded_cells in (None, []),
+        "n_pass": 27,
+        "n_exclude": 0 if not excluded_cells else len(excluded_cells),
+        "excluded_cells": excluded_cells or [],
+        "n_seeds": 50,
+        "N_grid": [50, 100, 200],
+        "alpha_bonferroni": 2.31e-4,
+        "tolerance": 1e-3,
+        "steps_per_quarter": 10,
+        "omega_gamma": 0.5,
+        "rng_seed_base": 42,
+        "independent_seed_stride": 10000,
+        "wallclock_seconds": 0.0,
+        "results": extra_results
+        or [
+            {
+                "substrate_id": "block_structured",
+                "metric_id": "sync_auc",
+                "N": 50,
+                "lambda_": 0.0,
+                "n_seeds": 50,
+                "false_positive_count": 0,
+                "fpr": 0.0,
+                "alpha_bonferroni": 2.31e-4,
+                "threshold_tolerance": 1e-3,
+                "verdict": "PASS",
+                "wallclock_seconds": 0.1,
+                "sha256": "cafebabe" * 8,
+            }
+        ],
+        "generated_at": "2026-05-11T12:01:00Z",
+        "substrate_ids": ["ricci_flow", "block_structured", "temporal_coupling"],
+        "metric_ids": ["tau_onset", "sync_auc", "phase_lag"],
+    }
+    return _seal(body)
+
+
+def _null_capsule(*, verdicts: list[str] | None = None) -> dict[str, Any]:
+    verdicts = verdicts if verdicts is not None else ["PASS", "PASS"]
+    results: list[dict[str, Any]] = []
+    for i, v in enumerate(verdicts):
+        results.append(
+            {
+                "n_seeds": 20,
+                "n_shuffles": 100,
+                "unshuffled_abs_signal": 0.5,
+                "shuffled_abs_signal_median": 0.05,
+                "shuffled_abs_signal_p95": 0.1,
+                "unshuffled_greater_than_median": True,
+                "p_value_empirical": 0.01 if v == "PASS" else 0.5,
+                "verdict": v,
+                "rng_seed": 42 + i,
+                "p_value_threshold": 0.05,
+                "sha256": f"{i:0>64x}",
+            }
+        )
+    body: dict[str, Any] = {
+        "kind": NULL_AUDIT_KIND,
+        "results": results,
+        "n_cells_audited": len(results),
+        "all_pass": all(v == "PASS" for v in verdicts),
+        "generated_at": "2026-05-11T12:02:00Z",
+    }
+    return _seal(body)
+
+
+def _smoke_capsule(*, verdict: str = "PASS", failed: int = 0) -> dict[str, Any]:
+    body: dict[str, Any] = {
+        "verdict": verdict,
+        "grid_N": [50, 100],
+        "grid_lambda": [0.0, 0.5],
+        "n_seeds": 5,
+        "n_cells_total": 36,
+        "n_cells_ok": 36 - failed,
+        "n_cells_failed": failed,
+        "total_wallclock_seconds": 1.0,
+        "max_wallclock_seconds": 60.0,
+        "over_budget": False,
+        "steps_per_quarter": 6,
+        "omega_gamma": 0.5,
+        "rng_seed_base": 42,
+        "cells": [],
+        "generated_at": "2026-05-11T12:03:00Z",
+    }
+    return _seal(body)
+
+
+def _valid_paths(tmp_path: Path) -> PreflightCapsulePaths:
+    pos = tmp_path / "pos.json"
+    neg = tmp_path / "neg.json"
+    null = tmp_path / "null.json"
+    smoke = tmp_path / "smoke.json"
+    _write_json(pos, _pos_capsule())
+    _write_json(neg, _neg_capsule())
+    _write_json(null, _null_capsule())
+    _write_json(smoke, _smoke_capsule())
+    return PreflightCapsulePaths(
+        pos_control=pos, neg_control=neg, null_audit=null, smoke_test=smoke
+    )
+
+
+# ---------------------------------------------------------------------------
+# Missing-capsule refusals
+# ---------------------------------------------------------------------------
+
+
+def test_missing_pos_capsule_refuses_launch(tmp_path: Path) -> None:
+    paths = _valid_paths(tmp_path)
+    paths.pos_control.unlink()
+    decision = load_and_validate_preflight_capsules(paths)
+    assert decision.launch_allowed is False
+    assert any("capsule_missing_file" in r for r in decision.refusal_reasons)
+    assert decision.capsule_shas["pos_control"] == "UNVERIFIED"
+
+
+def test_missing_neg_capsule_refuses_launch(tmp_path: Path) -> None:
+    paths = _valid_paths(tmp_path)
+    paths.neg_control.unlink()
+    decision = load_and_validate_preflight_capsules(paths)
+    assert decision.launch_allowed is False
+    assert any("capsule_missing_file" in r for r in decision.refusal_reasons)
+    assert decision.capsule_shas["neg_control"] == "UNVERIFIED"
+
+
+def test_missing_null_capsule_refuses_launch(tmp_path: Path) -> None:
+    paths = _valid_paths(tmp_path)
+    paths.null_audit.unlink()
+    decision = load_and_validate_preflight_capsules(paths)
+    assert decision.launch_allowed is False
+    assert any("capsule_missing_file" in r for r in decision.refusal_reasons)
+    assert decision.capsule_shas["null_audit"] == "UNVERIFIED"
+
+
+def test_missing_smoke_capsule_refuses_launch(tmp_path: Path) -> None:
+    paths = _valid_paths(tmp_path)
+    paths.smoke_test.unlink()
+    decision = load_and_validate_preflight_capsules(paths)
+    assert decision.launch_allowed is False
+    assert any("capsule_missing_file" in r for r in decision.refusal_reasons)
+    assert decision.capsule_shas["smoke_test"] == "UNVERIFIED"
+
+
+# ---------------------------------------------------------------------------
+# Malformed-capsule refusals
+# ---------------------------------------------------------------------------
+
+
+def test_bad_json_capsule_refuses_launch(tmp_path: Path) -> None:
+    paths = _valid_paths(tmp_path)
+    paths.pos_control.write_text("{not-json", encoding="utf-8")
+    decision = load_and_validate_preflight_capsules(paths)
+    assert decision.launch_allowed is False
+    assert any("capsule_bad_json" in r for r in decision.refusal_reasons)
+
+
+def test_bad_kind_refuses_launch(tmp_path: Path) -> None:
+    paths = _valid_paths(tmp_path)
+    bad = _pos_capsule()
+    bad["kind"] = "wrong_kind_v0"
+    bad["sha256"] = _sha({k: v for k, v in bad.items() if k != "sha256"})
+    _write_json(paths.pos_control, bad)
+    decision = load_and_validate_preflight_capsules(paths)
+    assert decision.launch_allowed is False
+    assert any("capsule_kind_mismatch" in r for r in decision.refusal_reasons)
+
+
+def test_bad_sha_refuses_launch(tmp_path: Path) -> None:
+    paths = _valid_paths(tmp_path)
+    bad = _pos_capsule()
+    bad["sha256"] = "0" * 64  # forged
+    _write_json(paths.pos_control, bad)
+    decision = load_and_validate_preflight_capsules(paths)
+    assert decision.launch_allowed is False
+    assert any("capsule_sha256_mismatch" in r for r in decision.refusal_reasons)
+
+
+# ---------------------------------------------------------------------------
+# Verdict refusals
+# ---------------------------------------------------------------------------
+
+
+def test_smoke_fail_refuses_launch(tmp_path: Path) -> None:
+    paths = _valid_paths(tmp_path)
+    _write_json(paths.smoke_test, _smoke_capsule(verdict="FAIL", failed=3))
+    decision = load_and_validate_preflight_capsules(paths)
+    assert decision.launch_allowed is False
+    assert any("smoke_verdict_not_pass" in r for r in decision.refusal_reasons)
+
+
+def test_null_fail_refuses_launch(tmp_path: Path) -> None:
+    paths = _valid_paths(tmp_path)
+    _write_json(paths.null_audit, _null_capsule(verdicts=["PASS", "FAIL"]))
+    decision = load_and_validate_preflight_capsules(paths)
+    assert decision.launch_allowed is False
+    assert any("null_audit_verdict_not_pass" in r for r in decision.refusal_reasons)
+
+
+def test_null_audit_empty_refuses_launch(tmp_path: Path) -> None:
+    paths = _valid_paths(tmp_path)
+    _write_json(paths.null_audit, _null_capsule(verdicts=[]))
+    decision = load_and_validate_preflight_capsules(paths)
+    assert decision.launch_allowed is False
+    assert any("null_audit_empty_results" in r for r in decision.refusal_reasons)
+
+
+# ---------------------------------------------------------------------------
+# POS / NEG exclusion semantics
+# ---------------------------------------------------------------------------
+
+
+def test_pos_excluded_combo_removes_all_matching_cells(tmp_path: Path) -> None:
+    paths = _valid_paths(tmp_path)
+    _write_json(
+        paths.pos_control,
+        _pos_capsule(excluded_combos=[["block_structured", "tau_onset"]]),
+    )
+    decision = load_and_validate_preflight_capsules(paths)
+    assert decision.launch_allowed is True
+    assert decision.excluded_combos == (("block_structured", "tau_onset"),)
+
+    # Build a tiny grid spanning two N values and the excluded combo
+    full = [
+        (50, 0.0, "block_structured", "tau_onset"),
+        (100, 0.5, "block_structured", "tau_onset"),
+        (50, 0.0, "ricci_flow", "sync_auc"),
+    ]
+    runnable, skipped = apply_preflight_to_grid(full, decision)
+    assert len(runnable) == 1
+    assert runnable[0].substrate_id == "ricci_flow"
+    assert len(skipped) == 2
+    assert all(s.reason == "POS_EXCLUDED_COMBO" for s in skipped)
+    assert all(s.source_capsule == "pos_control" for s in skipped)
+
+
+def test_neg_excluded_cell_removes_exact_cell_only(tmp_path: Path) -> None:
+    paths = _valid_paths(tmp_path)
+    _write_json(
+        paths.neg_control,
+        _neg_capsule(excluded_cells=[["block_structured", "tau_onset", 50]]),
+    )
+    decision = load_and_validate_preflight_capsules(paths)
+    assert decision.launch_allowed is True
+    assert decision.excluded_cells == (("block_structured", "tau_onset", 50),)
+
+    full = [
+        (50, 0.0, "block_structured", "tau_onset"),  # excluded
+        (100, 0.0, "block_structured", "tau_onset"),  # different N — KEPT
+        (50, 0.0, "block_structured", "sync_auc"),  # different metric — KEPT
+    ]
+    runnable, skipped = apply_preflight_to_grid(full, decision)
+    assert len(runnable) == 2
+    assert len(skipped) == 1
+    assert skipped[0].N == 50
+    assert skipped[0].reason == "NEG_EXCLUDED_CELL"
+
+
+# ---------------------------------------------------------------------------
+# Identity validation
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_substrate_refuses_launch(tmp_path: Path) -> None:
+    paths = _valid_paths(tmp_path)
+    _write_json(
+        paths.pos_control,
+        _pos_capsule(excluded_combos=[["NONEXISTENT_SUBSTRATE", "tau_onset"]]),
+    )
+    decision = load_and_validate_preflight_capsules(paths)
+    assert decision.launch_allowed is False
+    assert any("capsule_unknown_substrate_id" in r for r in decision.refusal_reasons)
+
+
+def test_unknown_metric_refuses_launch(tmp_path: Path) -> None:
+    paths = _valid_paths(tmp_path)
+    _write_json(
+        paths.pos_control,
+        _pos_capsule(excluded_combos=[["block_structured", "NONEXISTENT_METRIC"]]),
+    )
+    decision = load_and_validate_preflight_capsules(paths)
+    assert decision.launch_allowed is False
+    assert any("capsule_unknown_metric_id" in r for r in decision.refusal_reasons)
+
+
+def test_unknown_N_refuses_launch(tmp_path: Path) -> None:
+    paths = _valid_paths(tmp_path)
+    _write_json(
+        paths.neg_control,
+        _neg_capsule(excluded_cells=[["block_structured", "tau_onset", 99999]]),
+    )
+    decision = load_and_validate_preflight_capsules(paths)
+    assert decision.launch_allowed is False
+    assert any("capsule_unknown_N" in r for r in decision.refusal_reasons)
+
+
+# ---------------------------------------------------------------------------
+# Determinism + frozen invariants
+# ---------------------------------------------------------------------------
+
+
+def test_preflight_decision_sha_is_deterministic(tmp_path: Path) -> None:
+    # Two identical capsule sets in different tmp dirs → same decision sha
+    paths_a = _valid_paths(tmp_path / "a")
+    paths_b = _valid_paths(tmp_path / "b")
+    d_a = load_and_validate_preflight_capsules(paths_a)
+    d_b = load_and_validate_preflight_capsules(paths_b)
+    assert d_a.launch_allowed is True
+    assert d_b.launch_allowed is True
+    assert d_a.sha256 == d_b.sha256
+    assert d_a.capsule_shas == d_b.capsule_shas
+
+
+def test_preflight_decision_is_frozen(tmp_path: Path) -> None:
+    paths = _valid_paths(tmp_path)
+    decision = load_and_validate_preflight_capsules(paths)
+    assert dataclasses.is_dataclass(decision)
+    assert decision.launch_allowed is True
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        decision.launch_allowed = False  # type: ignore[misc]
+
+
+def test_skipped_cell_and_runnable_cell_frozen() -> None:
+    s = SkippedCell(
+        cell_key='[50,0.0,"x","y"]',
+        substrate_id="x",
+        metric_id="y",
+        N=50,
+        lambda_=0.0,
+        reason="POS_EXCLUDED_COMBO",
+        source_capsule="pos_control",
+        source_capsule_sha256="ab" * 32,
+    )
+    r = RunnableCell(
+        cell_key='[100,0.5,"x","y"]',
+        substrate_id="x",
+        metric_id="y",
+        N=100,
+        lambda_=0.5,
+    )
+    assert s.reason == "POS_EXCLUDED_COMBO"
+    assert r.N == 100
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        s.N = 99  # type: ignore[misc]
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        r.N = 99  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Capsule sha contract (matches emitter discipline)
+# ---------------------------------------------------------------------------
+
+
+def test_capsule_sha_recompute_matches_emitter() -> None:
+    body = {
+        "kind": POS_CONTROL_KIND,
+        "all_pass": True,
+        "n_pass": 9,
+        "n_exclude": 0,
+        "excluded_combos": [],
+        "generated_at": "2026-05-11T12:00:00Z",
+    }
+    sealed = _seal(body)
+    # Recompute must match the seal exactly
+    recomputed = verify_capsule_sha256(sealed)
+    assert recomputed == sealed["sha256"]
+    # And mutating any field must break the recomputation
+    mutated = dict(sealed)
+    mutated["all_pass"] = False
+    with pytest.raises(CapsuleShaMismatch):
+        verify_capsule_sha256(mutated)
+
+
+def test_capsule_sha_missing_sha_field_raises() -> None:
+    body: dict[str, Any] = {"kind": POS_CONTROL_KIND}
+    with pytest.raises(CapsuleShaMismatch):
+        verify_capsule_sha256(body)
+    with pytest.raises(CapsuleShaMismatch):
+        verify_capsule_sha256({"kind": POS_CONTROL_KIND, "sha256": 12345})
+
+
+# ---------------------------------------------------------------------------
+# Canonical-JSON behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_canonical_json_handles_non_finite_sentinel() -> None:
+    payload_a = {"x": float("nan"), "y": float("inf"), "z": float("-inf")}
+    payload_b = {"x": float("nan"), "y": float("inf"), "z": float("-inf")}
+    canon_a = canonical_preflight_json(payload_a)
+    canon_b = canonical_preflight_json(payload_b)
+    assert canon_a == canon_b
+    assert "NaN" in canon_a
+    assert "Infinity" in canon_a
+    assert "-Infinity" in canon_a
+
+
+def test_canonical_json_is_sort_keys_stable() -> None:
+    a = canonical_preflight_json({"b": 1, "a": 2, "c": [3, 4]})
+    b = canonical_preflight_json({"c": [3, 4], "a": 2, "b": 1})
+    assert a == b
+    # Tight separators — no spaces
+    assert ", " not in a
+    assert ": " not in a
+
+
+# ---------------------------------------------------------------------------
+# Launch-refusal raise path
+# ---------------------------------------------------------------------------
+
+
+def test_assert_preflight_launch_allowed_raises_with_reasons(tmp_path: Path) -> None:
+    paths = _valid_paths(tmp_path)
+    paths.pos_control.unlink()
+    decision = load_and_validate_preflight_capsules(paths)
+    with pytest.raises(PreflightLaunchRefused) as excinfo:
+        assert_preflight_launch_allowed(decision)
+    assert "preflight launch refused" in str(excinfo.value)
+    assert "capsule_missing_file" in str(excinfo.value)
+
+
+def test_assert_preflight_launch_allowed_noop_on_valid(tmp_path: Path) -> None:
+    paths = _valid_paths(tmp_path)
+    decision = load_and_validate_preflight_capsules(paths)
+    # Must not raise; must be content-addressed
+    assert_preflight_launch_allowed(decision)
+    assert decision.launch_allowed is True
+    assert len(decision.refusal_reasons) == 0
+
+
+# ---------------------------------------------------------------------------
+# Combined-failure accumulation
+# ---------------------------------------------------------------------------
+
+
+def test_multiple_failures_all_accumulated(tmp_path: Path) -> None:
+    """Three independent failures must all surface in refusal_reasons —
+    no first-fail short-circuit."""
+    paths = _valid_paths(tmp_path)
+    paths.pos_control.unlink()
+    _write_json(paths.smoke_test, _smoke_capsule(verdict="FAIL", failed=1))
+    _write_json(paths.null_audit, _null_capsule(verdicts=["FAIL"]))
+    decision = load_and_validate_preflight_capsules(paths)
+    assert decision.launch_allowed is False
+    reasons = "\n".join(decision.refusal_reasons)
+    assert "capsule_missing_file" in reasons
+    assert "smoke_verdict_not_pass" in reasons
+    assert "null_audit_verdict_not_pass" in reasons
+
+
+# ---------------------------------------------------------------------------
+# Non-finite numeric field in pos/neg result
+# ---------------------------------------------------------------------------
+
+
+def test_non_finite_numeric_field_refuses(tmp_path: Path) -> None:
+    paths = _valid_paths(tmp_path)
+    bad_pos = _pos_capsule(
+        extra_results=[
+            {
+                "substrate_id": "block_structured",
+                "metric_id": "sync_auc",
+                "N": 400,
+                "lambda_": 1.0,
+                "n_seeds": 50,
+                "signal_mean": float("nan"),  # forbidden
+                "signal_std": 0.1,
+                "signal_ci_ratio": float("inf"),  # forbidden
+                "threshold": 2.0,
+                "verdict": "PASS",
+                "censoring_fraction": 0.0,
+                "wallclock_seconds": 0.1,
+                "sha256": "deadbeef" * 8,
+            }
+        ]
+    )
+    _write_json(paths.pos_control, bad_pos)
+    decision = load_and_validate_preflight_capsules(paths)
+    assert decision.launch_allowed is False
+    assert any("capsule_non_finite_load_bearing_field" in r for r in decision.refusal_reasons)
+
+
+# ---------------------------------------------------------------------------
+# Grid reduction: pure POS / pure NEG / both
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("excluded_combos", "excluded_cells", "n_runnable", "n_skipped"),
+    [
+        ([], [], 4, 0),
+        ([["block_structured", "tau_onset"]], [], 2, 2),
+        ([], [["block_structured", "tau_onset", 50]], 3, 1),
+        ([["block_structured", "tau_onset"]], [["ricci_flow", "sync_auc", 50]], 1, 3),
+    ],
+)
+def test_parametrized_grid_reduction(
+    tmp_path: Path,
+    excluded_combos: list[list[str]],
+    excluded_cells: list[list[Any]],
+    n_runnable: int,
+    n_skipped: int,
+) -> None:
+    paths = _valid_paths(tmp_path)
+    _write_json(paths.pos_control, _pos_capsule(excluded_combos=excluded_combos))
+    _write_json(paths.neg_control, _neg_capsule(excluded_cells=excluded_cells))
+    decision = load_and_validate_preflight_capsules(paths)
+    assert decision.launch_allowed is True
+    full = [
+        (50, 0.0, "block_structured", "tau_onset"),
+        (100, 0.0, "block_structured", "tau_onset"),
+        (50, 0.0, "ricci_flow", "sync_auc"),
+        (50, 0.0, "temporal_coupling", "phase_lag"),
+    ]
+    runnable, skipped = apply_preflight_to_grid(full, decision)
+    assert len(runnable) == n_runnable
+    assert len(skipped) == n_skipped
+
+
+# ---------------------------------------------------------------------------
+# Decision sha changes when any capsule changes
+# ---------------------------------------------------------------------------
+
+
+def test_decision_sha_changes_with_pos_capsule(tmp_path: Path) -> None:
+    paths_a = _valid_paths(tmp_path / "a")
+    paths_b = _valid_paths(tmp_path / "b")
+    # Force one to carry an exclusion
+    _write_json(
+        paths_b.pos_control,
+        _pos_capsule(excluded_combos=[["block_structured", "tau_onset"]]),
+    )
+    d_a = load_and_validate_preflight_capsules(paths_a)
+    d_b = load_and_validate_preflight_capsules(paths_b)
+    assert d_a.launch_allowed is True
+    assert d_b.launch_allowed is True
+    assert d_a.sha256 != d_b.sha256
+
+
+def test_apply_preflight_preserves_cell_keys(tmp_path: Path) -> None:
+    paths = _valid_paths(tmp_path)
+    decision = load_and_validate_preflight_capsules(paths)
+    full = [
+        (50, 0.5, "block_structured", "sync_auc"),
+        (100, 0.0, "ricci_flow", "tau_onset"),
+    ]
+    runnable, skipped = apply_preflight_to_grid(full, decision)
+    assert len(runnable) == 2
+    assert len(skipped) == 0
+    # Cell keys must follow the canonical sweep_checkpoint.cell_key form
+    assert all(rc.cell_key.startswith("[") and rc.cell_key.endswith("]") for rc in runnable)
+    assert math.isfinite(runnable[0].lambda_)
+
+
+def test_missing_generated_at_refuses(tmp_path: Path) -> None:
+    paths = _valid_paths(tmp_path)
+    bad = _pos_capsule()
+    del bad["generated_at"]
+    bad["sha256"] = _sha({k: v for k, v in bad.items() if k != "sha256"})
+    _write_json(paths.pos_control, bad)
+    decision = load_and_validate_preflight_capsules(paths)
+    assert decision.launch_allowed is False
+    assert any("capsule_missing_generated_at" in r for r in decision.refusal_reasons)

--- a/tests/research/systemic_risk/test_d002c_sweep_runner.py
+++ b/tests/research/systemic_risk/test_d002c_sweep_runner.py
@@ -498,6 +498,7 @@ def test_run_sweep_completes_full_mini_grid_under_60s(tmp_path: Path) -> None:
         sweep_config=cfg,
         checkpoint_path=tmp_path / "ckpt.json",
         steps_per_quarter=4,
+        require_preflight=False,  # legacy-shim — pre-C2.4-D test
     )
     elapsed = time.monotonic() - t0
     assert result.total_cells == 9
@@ -515,6 +516,7 @@ def test_run_sweep_persists_via_checkpoint(tmp_path: Path) -> None:
         sweep_config=cfg,
         checkpoint_path=ckpt,
         steps_per_quarter=4,
+        require_preflight=False,  # legacy-shim — pre-C2.4-D test
     )
     assert ckpt.exists()
     # Reload through CheckpointManager and confirm every cell is on disk
@@ -537,6 +539,7 @@ def test_run_sweep_resume_after_partial_completion(tmp_path: Path) -> None:
         sweep_config=cfg,
         checkpoint_path=tmp_path / "ref_ckpt.json",
         steps_per_quarter=4,
+        require_preflight=False,  # legacy-shim — pre-C2.4-D test
     )
 
     # Cold run on a second path that records which cells were
@@ -546,6 +549,7 @@ def test_run_sweep_resume_after_partial_completion(tmp_path: Path) -> None:
         sweep_config=cfg,
         checkpoint_path=ckpt,
         steps_per_quarter=4,
+        require_preflight=False,  # legacy-shim — pre-C2.4-D test
     )
     n_completed = first.completed_cells
 
@@ -555,6 +559,7 @@ def test_run_sweep_resume_after_partial_completion(tmp_path: Path) -> None:
         sweep_config=cfg,
         checkpoint_path=ckpt,
         steps_per_quarter=4,
+        require_preflight=False,  # legacy-shim — pre-C2.4-D test
     )
     assert resumed.completed_cells == n_completed
     assert resumed.sha256 == full.sha256
@@ -571,6 +576,7 @@ def test_run_sweep_resume_after_kill_completes_remainder(tmp_path: Path) -> None
         sweep_config=cfg,
         checkpoint_path=tmp_path / "ref.json",
         steps_per_quarter=4,
+        require_preflight=False,  # legacy-shim — pre-C2.4-D test
     )
 
     # Pre-seed a checkpoint with the FIRST cell already done (from ref)
@@ -614,6 +620,7 @@ def test_run_sweep_resume_after_kill_completes_remainder(tmp_path: Path) -> None
         sweep_config=cfg,
         checkpoint_path=target_ckpt,
         steps_per_quarter=4,
+        require_preflight=False,  # legacy-shim — pre-C2.4-D test
     )
     assert resumed.completed_cells == ref.completed_cells
     assert resumed.sha256 == ref.sha256
@@ -627,12 +634,14 @@ def test_run_sweep_deterministic_aggregate_sha(tmp_path: Path) -> None:
         sweep_config=cfg,
         checkpoint_path=tmp_path / "a.json",
         steps_per_quarter=4,
+        require_preflight=False,  # legacy-shim — pre-C2.4-D test
     )
     b = run_sweep(
         preregistration=prereg,
         sweep_config=cfg,
         checkpoint_path=tmp_path / "b.json",
         steps_per_quarter=4,
+        require_preflight=False,  # legacy-shim — pre-C2.4-D test
     )
     assert a.sha256 == b.sha256
     assert len(a.results) == len(b.results)
@@ -654,6 +663,7 @@ def test_run_sweep_progress_callback_fires_once_per_cell(tmp_path: Path) -> None
         checkpoint_path=tmp_path / "ckpt.json",
         steps_per_quarter=4,
         progress_callback=cb,
+        require_preflight=False,  # legacy-shim — pre-C2.4-D test
     )
     assert len(events) == 9
     # Monotone increasing done; total constant
@@ -672,6 +682,7 @@ def test_run_sweep_callback_not_called_on_already_complete_resume(
         sweep_config=cfg,
         checkpoint_path=ckpt,
         steps_per_quarter=4,
+        require_preflight=False,  # legacy-shim — pre-C2.4-D test
     )
     events: list[tuple[int, int]] = []
     run_sweep(
@@ -680,6 +691,7 @@ def test_run_sweep_callback_not_called_on_already_complete_resume(
         checkpoint_path=ckpt,
         steps_per_quarter=4,
         progress_callback=lambda d, t: events.append((d, t)),
+        require_preflight=False,  # legacy-shim — pre-C2.4-D test
     )
     assert events == []  # nothing remaining to compute
 
@@ -692,6 +704,7 @@ def test_run_sweep_result_serializable_to_json(tmp_path: Path) -> None:
         sweep_config=cfg,
         checkpoint_path=tmp_path / "ckpt.json",
         steps_per_quarter=4,
+        require_preflight=False,  # legacy-shim — pre-C2.4-D test
     )
     on_disk = json.loads((tmp_path / "ckpt.json").read_text(encoding="utf-8"))
     assert on_disk["config_sha"]  # checkpoint identity exists
@@ -717,6 +730,7 @@ def test_sweep_result_is_frozen(tmp_path: Path) -> None:
         sweep_config=_well_formed_config(prereg),
         checkpoint_path=tmp_path / "ckpt.json",
         steps_per_quarter=4,
+        require_preflight=False,  # legacy-shim — pre-C2.4-D test
     )
     assert dataclasses.is_dataclass(result)
     with pytest.raises(dataclasses.FrozenInstanceError):
@@ -735,6 +749,7 @@ def test_all_substrates_and_metrics_routed_in_mini_grid(tmp_path: Path) -> None:
         sweep_config=_well_formed_config(prereg),
         checkpoint_path=tmp_path / "ckpt.json",
         steps_per_quarter=4,
+        require_preflight=False,  # legacy-shim — pre-C2.4-D test
     )
     seen_substrates = {r.substrate_id for r in result.results}
     seen_metrics = {r.metric_id for r in result.results}

--- a/tests/research/systemic_risk/test_d002c_sweep_runner_preflight_integration.py
+++ b/tests/research/systemic_risk/test_d002c_sweep_runner_preflight_integration.py
@@ -1,0 +1,481 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""D-002C C2.4-D — Integration tests for preflight enforcement in run_sweep."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from research.systemic_risk.d002c_preflight import (
+    NEG_CONTROL_KIND,
+    NULL_AUDIT_KIND,
+    POS_CONTROL_KIND,
+    PreflightCapsulePaths,
+    PreflightLaunchRefused,
+    canonical_preflight_json,
+)
+from research.systemic_risk.d002c_preregistration import (
+    D002CPreregistration,
+    load_and_lock,
+)
+from research.systemic_risk.d002c_sweep_runner import (
+    SweepResult,
+    run_sweep,
+)
+from research.systemic_risk.sweep_checkpoint import CheckpointManager, cell_key
+
+CANONICAL_YAML = (
+    Path(__file__).resolve().parents[3] / "docs" / "governance" / "D002C_PREREGISTRATION.yaml"
+)
+
+
+# ---------------------------------------------------------------------------
+# Capsule fixture helpers (mirror the preflight unit-test fixtures)
+# ---------------------------------------------------------------------------
+
+
+def _sha(payload: dict[str, Any]) -> str:
+    canon = canonical_preflight_json(payload)
+    return hashlib.sha256(canon.encode("utf-8")).hexdigest()
+
+
+def _seal(capsule_body: dict[str, Any]) -> dict[str, Any]:
+    sha = _sha(capsule_body)
+    out = dict(capsule_body)
+    out["sha256"] = sha
+    return out
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, sort_keys=True, indent=2), encoding="utf-8")
+
+
+def _pos_capsule(excluded_combos: list[list[str]] | None = None) -> dict[str, Any]:
+    body: dict[str, Any] = {
+        "kind": POS_CONTROL_KIND,
+        "all_pass": excluded_combos in (None, []),
+        "n_pass": 9,
+        "n_exclude": 0 if not excluded_combos else len(excluded_combos),
+        "excluded_combos": excluded_combos or [],
+        "n_seeds": 50,
+        "N": 400,
+        "lambda_": 1.0,
+        "threshold": 2.0,
+        "steps_per_quarter": 10,
+        "omega_gamma": 0.5,
+        "rng_seed_base": 42,
+        "wallclock_seconds": 0.0,
+        "results": [],
+        "generated_at": "2026-05-11T12:00:00Z",
+        "substrate_ids": ["ricci_flow", "block_structured", "temporal_coupling"],
+        "metric_ids": ["tau_onset", "sync_auc", "phase_lag"],
+    }
+    return _seal(body)
+
+
+def _neg_capsule(excluded_cells: list[list[Any]] | None = None) -> dict[str, Any]:
+    body: dict[str, Any] = {
+        "kind": NEG_CONTROL_KIND,
+        "all_pass": excluded_cells in (None, []),
+        "n_pass": 27,
+        "n_exclude": 0 if not excluded_cells else len(excluded_cells),
+        "excluded_cells": excluded_cells or [],
+        "n_seeds": 50,
+        "N_grid": [50, 100, 200],
+        "alpha_bonferroni": 2.31e-4,
+        "tolerance": 1e-3,
+        "steps_per_quarter": 10,
+        "omega_gamma": 0.5,
+        "rng_seed_base": 42,
+        "independent_seed_stride": 10000,
+        "wallclock_seconds": 0.0,
+        "results": [],
+        "generated_at": "2026-05-11T12:01:00Z",
+        "substrate_ids": ["ricci_flow", "block_structured", "temporal_coupling"],
+        "metric_ids": ["tau_onset", "sync_auc", "phase_lag"],
+    }
+    return _seal(body)
+
+
+def _null_capsule(verdicts: list[str] | None = None) -> dict[str, Any]:
+    verdicts = verdicts if verdicts is not None else ["PASS", "PASS"]
+    results = [
+        {
+            "n_seeds": 20,
+            "n_shuffles": 100,
+            "unshuffled_abs_signal": 0.5,
+            "shuffled_abs_signal_median": 0.05,
+            "shuffled_abs_signal_p95": 0.1,
+            "unshuffled_greater_than_median": True,
+            "p_value_empirical": 0.01 if v == "PASS" else 0.5,
+            "verdict": v,
+            "rng_seed": 42 + i,
+            "p_value_threshold": 0.05,
+            "sha256": f"{i:0>64x}",
+        }
+        for i, v in enumerate(verdicts)
+    ]
+    body: dict[str, Any] = {
+        "kind": NULL_AUDIT_KIND,
+        "results": results,
+        "n_cells_audited": len(results),
+        "all_pass": all(v == "PASS" for v in verdicts),
+        "generated_at": "2026-05-11T12:02:00Z",
+    }
+    return _seal(body)
+
+
+def _smoke_capsule(verdict: str = "PASS", failed: int = 0) -> dict[str, Any]:
+    body: dict[str, Any] = {
+        "verdict": verdict,
+        "grid_N": [50, 100],
+        "grid_lambda": [0.0, 0.5],
+        "n_seeds": 5,
+        "n_cells_total": 36,
+        "n_cells_ok": 36 - failed,
+        "n_cells_failed": failed,
+        "total_wallclock_seconds": 1.0,
+        "max_wallclock_seconds": 60.0,
+        "over_budget": False,
+        "steps_per_quarter": 6,
+        "omega_gamma": 0.5,
+        "rng_seed_base": 42,
+        "cells": [],
+        "generated_at": "2026-05-11T12:03:00Z",
+    }
+    return _seal(body)
+
+
+def _valid_capsule_paths(
+    tmp_path: Path,
+    *,
+    pos_excluded_combos: list[list[str]] | None = None,
+    neg_excluded_cells: list[list[Any]] | None = None,
+    smoke_verdict: str = "PASS",
+    smoke_failed: int = 0,
+    null_verdicts: list[str] | None = None,
+) -> PreflightCapsulePaths:
+    pos = tmp_path / "pos.json"
+    neg = tmp_path / "neg.json"
+    null = tmp_path / "null.json"
+    smoke = tmp_path / "smoke.json"
+    _write_json(pos, _pos_capsule(pos_excluded_combos))
+    _write_json(neg, _neg_capsule(neg_excluded_cells))
+    _write_json(null, _null_capsule(null_verdicts))
+    _write_json(smoke, _smoke_capsule(smoke_verdict, smoke_failed))
+    return PreflightCapsulePaths(
+        pos_control=pos, neg_control=neg, null_audit=null, smoke_test=smoke
+    )
+
+
+# ---------------------------------------------------------------------------
+# Mini prereg + sweep config helpers (mirror legacy test fixture)
+# ---------------------------------------------------------------------------
+
+
+def _mini_prereg() -> D002CPreregistration:
+    canonical = load_and_lock(CANONICAL_YAML)
+    return D002CPreregistration(
+        schema_version=canonical.schema_version,
+        version=canonical.version,
+        issue=canonical.issue,
+        follows=canonical.follows,
+        tier_if_pass=canonical.tier_if_pass,
+        tier_if_fail=canonical.tier_if_fail,
+        acceptance_rule=canonical.acceptance_rule,
+        ci_method=canonical.ci_method,
+        ci_alpha=canonical.ci_alpha,
+        signal_ci_ratio_threshold=canonical.signal_ci_ratio_threshold,
+        direction_consistency_min_seeds=2,
+        direction_stability_min_fraction=canonical.direction_stability_min_fraction,
+        multiple_testing_correction=canonical.multiple_testing_correction,
+        n_cells=9,
+        effective_alpha_per_cell=canonical.ci_alpha / 9.0,
+        n_seeds=4,
+        n_bootstrap=4,
+        N_grid=(50,),
+        lambda_grid=(0.40,),
+        substrate_ids=canonical.substrate_ids,
+        metric_ids=canonical.metric_ids,
+        variance_reduction=canonical.variance_reduction,
+        substrate_seed=canonical.substrate_seed,
+        forbidden_outputs=canonical.forbidden_outputs,
+        preregistration_sha=canonical.preregistration_sha,
+        yaml_path=canonical.yaml_path,
+    )
+
+
+def _well_formed_config(prereg: D002CPreregistration) -> dict[str, Any]:
+    return {
+        "ci_method": prereg.ci_method.value,
+        "ci_alpha": prereg.ci_alpha,
+        "signal_ci_ratio_threshold": prereg.signal_ci_ratio_threshold,
+        "direction_consistency_min_seeds": prereg.direction_consistency_min_seeds,
+        "direction_stability_min_fraction": prereg.direction_stability_min_fraction,
+        "multiple_testing_correction": prereg.multiple_testing_correction.value,
+        "n_seeds": prereg.n_seeds,
+        "n_bootstrap": prereg.n_bootstrap,
+        "N_grid": list(prereg.N_grid),
+        "lambda_grid": list(prereg.lambda_grid),
+        "substrate_ids": list(prereg.substrate_ids),
+        "metric_ids": list(prereg.metric_ids),
+        "variance_reduction": list(prereg.variance_reduction),
+        "substrate_seed": prereg.substrate_seed,
+        "preregistration_sha": prereg.preregistration_sha,
+    }
+
+
+def _run(
+    tmp_path: Path,
+    *,
+    capsules: PreflightCapsulePaths | None,
+    require_preflight: bool = True,
+    checkpoint_name: str = "ckpt.json",
+) -> SweepResult:
+    prereg = _mini_prereg()
+    cfg = _well_formed_config(prereg)
+    return run_sweep(
+        preregistration=prereg,
+        sweep_config=cfg,
+        checkpoint_path=tmp_path / checkpoint_name,
+        steps_per_quarter=4,
+        preflight_capsules=capsules,
+        require_preflight=require_preflight,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Required tests
+# ---------------------------------------------------------------------------
+
+
+def test_run_sweep_requires_preflight_when_enabled(tmp_path: Path) -> None:
+    """Strict mode: require_preflight=True + no capsules → refuse."""
+    with pytest.raises(PreflightLaunchRefused) as excinfo:
+        _run(tmp_path, capsules=None, require_preflight=True)
+    assert "preflight is required" in str(excinfo.value)
+    assert "PreflightCapsulePaths" in str(excinfo.value)
+
+
+def test_run_sweep_without_preflight_refuses_in_strict_mode(tmp_path: Path) -> None:
+    """Same contract, second-axis assertion — fail-closed."""
+    with pytest.raises(PreflightLaunchRefused):
+        _run(tmp_path, capsules=None, require_preflight=True)
+    # And: passing capsules that themselves refuse must still refuse
+    paths = _valid_capsule_paths(tmp_path, smoke_verdict="FAIL", smoke_failed=1)
+    with pytest.raises(PreflightLaunchRefused):
+        _run(tmp_path, capsules=paths, require_preflight=True)
+
+
+def test_run_sweep_with_valid_preflight_runs_reduced_grid(tmp_path: Path) -> None:
+    paths = _valid_capsule_paths(
+        tmp_path,
+        pos_excluded_combos=[["block_structured", "tau_onset"]],
+    )
+    result = _run(tmp_path, capsules=paths)
+    # 9-cell grid; POS exclusion removes (block_structured, tau_onset) ⇒ 1 cell
+    # at N=50, λ=0.40 → 8 runnable, 1 skipped
+    assert result.completed_cells == 8
+    assert len(result.skipped_cells) == 1
+    assert result.skipped_cells[0].substrate_id == "block_structured"
+    assert result.skipped_cells[0].metric_id == "tau_onset"
+    assert result.skipped_cells[0].reason == "POS_EXCLUDED_COMBO"
+
+
+def test_run_sweep_records_skipped_cells_in_checkpoint(tmp_path: Path) -> None:
+    paths = _valid_capsule_paths(
+        tmp_path,
+        pos_excluded_combos=[["block_structured", "tau_onset"]],
+    )
+    result = _run(tmp_path, capsules=paths)
+    assert len(result.skipped_cells) == 1
+    # Re-load checkpoint and confirm SKIPPED_BY_PREFLIGHT entry persists
+    prereg = _mini_prereg()
+    cfg = _well_formed_config(prereg)
+    mgr = CheckpointManager(tmp_path / "ckpt.json", sweep_config=cfg)
+    ckpt = mgr.load_or_create()
+    skipped_keys = [
+        k for k, v in ckpt.results.items() if v.payload.get("status") == "SKIPPED_BY_PREFLIGHT"
+    ]
+    assert len(skipped_keys) == 1
+    expected_key = cell_key((50, 0.40, "block_structured", "tau_onset"))
+    assert skipped_keys[0] == expected_key
+
+
+def test_run_sweep_does_not_compute_skipped_cells(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A SKIPPED_BY_PREFLIGHT cell must NOT trigger ``run_one_cell``.
+
+    We instrument :func:`run_one_cell` at the science-layer entry
+    point. Instrumenting ``substrate.realize`` would be ambiguous
+    because :class:`TemporalKtSubstrate.realize` internally calls
+    :class:`BlockStructuredSubstrate.realize` — so the call count at
+    the substrate layer is fan-in-amplified. The contract we enforce
+    is cell-level: no preflight-skipped cell is ever passed to
+    ``run_one_cell``.
+    """
+    from research.systemic_risk import d002c_sweep_runner as srm
+
+    call_log: list[tuple[str, str, int, float]] = []
+    orig_run_one_cell = srm.run_one_cell
+
+    def spy_run_one_cell(*args: Any, **kwargs: Any) -> Any:
+        sid = kwargs["substrate"].id
+        mid = kwargs["metric"].id
+        n = int(kwargs["N"])
+        lam = float(kwargs["lambda_"])
+        call_log.append((sid, mid, n, lam))
+        return orig_run_one_cell(*args, **kwargs)
+
+    monkeypatch.setattr(srm, "run_one_cell", spy_run_one_cell)
+
+    paths = _valid_capsule_paths(
+        tmp_path,
+        pos_excluded_combos=[["block_structured", "tau_onset"]],
+    )
+    result = _run(tmp_path, capsules=paths)
+    skipped_ids = {(s.substrate_id, s.metric_id) for s in result.skipped_cells}
+    computed_ids = {(c[0], c[1]) for c in call_log}
+    # The skipped cell was actually skipped
+    assert ("block_structured", "tau_onset") in skipped_ids
+    # No computed (substrate, metric) cell is in the skipped set
+    assert computed_ids.isdisjoint(skipped_ids)
+    # 9-cell mini grid − 1 skipped = 8 computed cells
+    assert len(call_log) == 8
+
+
+def test_run_sweep_resume_preserves_skipped_cells(tmp_path: Path) -> None:
+    paths = _valid_capsule_paths(
+        tmp_path,
+        pos_excluded_combos=[["block_structured", "tau_onset"]],
+    )
+    first = _run(tmp_path, capsules=paths, checkpoint_name="ckpt.json")
+    # Resume on the same checkpoint — no recompute, same skipped tuple
+    resumed = _run(tmp_path, capsules=paths, checkpoint_name="ckpt.json")
+    assert first.completed_cells == resumed.completed_cells
+    assert len(first.skipped_cells) == len(resumed.skipped_cells)
+    assert first.sha256 == resumed.sha256
+    assert first.preflight_decision_sha == resumed.preflight_decision_sha
+
+
+def test_aggregate_sha_includes_preflight_decision_sha(tmp_path: Path) -> None:
+    paths_a = _valid_capsule_paths(tmp_path / "a")
+    paths_b = _valid_capsule_paths(
+        tmp_path / "b",
+        pos_excluded_combos=[["block_structured", "tau_onset"]],
+    )
+    a = _run(tmp_path / "a", capsules=paths_a)
+    b = _run(tmp_path / "b", capsules=paths_b)
+    # Different preflight decision ⇒ different decision sha ⇒ different
+    # aggregate sweep sha
+    assert a.preflight_decision_sha != b.preflight_decision_sha
+    assert a.sha256 != b.sha256
+
+
+def test_preflight_capsule_sha_change_changes_sweep_sha(tmp_path: Path) -> None:
+    """Tampering with any capsule changes the decision sha, which folds
+    into the sweep aggregate sha. We assert this end-to-end."""
+    paths = _valid_capsule_paths(tmp_path / "x")
+    a = _run(tmp_path / "x", capsules=paths)
+
+    # Build a *different* but *valid* capsule set (different POS exclusion)
+    paths2 = _valid_capsule_paths(
+        tmp_path / "y",
+        pos_excluded_combos=[["ricci_flow", "phase_lag"]],
+    )
+    b = _run(tmp_path / "y", capsules=paths2)
+    assert a.preflight_decision_sha != b.preflight_decision_sha
+    assert a.sha256 != b.sha256
+
+
+def test_tampered_pos_capsule_sha_refuses(tmp_path: Path) -> None:
+    paths = _valid_capsule_paths(tmp_path)
+    # Forge the POS sha — without recomputing the canonical-JSON sha
+    raw = json.loads(paths.pos_control.read_text(encoding="utf-8"))
+    raw["sha256"] = "0" * 64
+    _write_json(paths.pos_control, raw)
+    with pytest.raises(PreflightLaunchRefused) as excinfo:
+        _run(tmp_path, capsules=paths)
+    assert "capsule_sha256_mismatch" in str(excinfo.value)
+
+
+def test_tampered_neg_capsule_sha_refuses(tmp_path: Path) -> None:
+    paths = _valid_capsule_paths(tmp_path)
+    raw = json.loads(paths.neg_control.read_text(encoding="utf-8"))
+    raw["sha256"] = "0" * 64
+    _write_json(paths.neg_control, raw)
+    with pytest.raises(PreflightLaunchRefused) as excinfo:
+        _run(tmp_path, capsules=paths)
+    assert "capsule_sha256_mismatch" in str(excinfo.value)
+
+
+def test_smoke_pass_but_null_fail_refuses(tmp_path: Path) -> None:
+    paths = _valid_capsule_paths(tmp_path, null_verdicts=["PASS", "FAIL"])
+    with pytest.raises(PreflightLaunchRefused) as excinfo:
+        _run(tmp_path, capsules=paths)
+    assert "null_audit_verdict_not_pass" in str(excinfo.value)
+
+
+def test_all_capsules_pass_but_unknown_cell_refuses(tmp_path: Path) -> None:
+    paths = _valid_capsule_paths(
+        tmp_path,
+        neg_excluded_cells=[["block_structured", "tau_onset", 99999]],
+    )
+    with pytest.raises(PreflightLaunchRefused) as excinfo:
+        _run(tmp_path, capsules=paths)
+    assert "capsule_unknown_N" in str(excinfo.value)
+
+
+def test_excluded_cell_cannot_reappear_as_computed(tmp_path: Path) -> None:
+    """A SKIPPED_BY_PREFLIGHT cell on disk must NOT be turned into a
+    computed SweepCellOutput by the second run."""
+    paths = _valid_capsule_paths(
+        tmp_path,
+        pos_excluded_combos=[["block_structured", "tau_onset"]],
+    )
+    first = _run(tmp_path, capsules=paths, checkpoint_name="ckpt.json")
+    second = _run(tmp_path, capsules=paths, checkpoint_name="ckpt.json")
+    expected_key = cell_key((50, 0.40, "block_structured", "tau_onset"))
+    runnable_keys_first = {r.cell_key for r in first.results}
+    runnable_keys_second = {r.cell_key for r in second.results}
+    assert expected_key not in runnable_keys_first
+    assert expected_key not in runnable_keys_second
+    # And the skipped cell carries the source capsule sha
+    assert all(s.source_capsule_sha256 for s in second.skipped_cells)
+
+
+# ---------------------------------------------------------------------------
+# Determinism + frozen-result invariants under preflight
+# ---------------------------------------------------------------------------
+
+
+def test_run_sweep_with_preflight_is_deterministic(tmp_path: Path) -> None:
+    paths_a = _valid_capsule_paths(tmp_path / "a")
+    paths_b = _valid_capsule_paths(tmp_path / "b")
+    a = _run(tmp_path / "a", capsules=paths_a, checkpoint_name="a.json")
+    b = _run(tmp_path / "b", capsules=paths_b, checkpoint_name="b.json")
+    assert a.sha256 == b.sha256
+    assert a.preflight_decision_sha == b.preflight_decision_sha
+
+
+def test_run_sweep_skipped_cells_count_matches_expectation(tmp_path: Path) -> None:
+    """Cross-check: POS excludes 1 combo ⇒ removes 1 cell (1 N × 1 λ).
+    NEG excludes 1 different cell ⇒ removes 1 more cell.
+    Total runnable = 9 − 2 = 7."""
+    paths = _valid_capsule_paths(
+        tmp_path,
+        pos_excluded_combos=[["block_structured", "tau_onset"]],
+        neg_excluded_cells=[["ricci_flow", "sync_auc", 50]],
+    )
+    result = _run(tmp_path, capsules=paths)
+    assert result.completed_cells == 7
+    assert len(result.skipped_cells) == 2
+    reasons = sorted(s.reason for s in result.skipped_cells)
+    assert reasons == ["NEG_EXCLUDED_CELL", "POS_EXCLUDED_COMBO"]

--- a/tests/research/systemic_risk/test_d002c_sweep_runner_preflight_integration.py
+++ b/tests/research/systemic_risk/test_d002c_sweep_runner_preflight_integration.py
@@ -479,3 +479,141 @@ def test_run_sweep_skipped_cells_count_matches_expectation(tmp_path: Path) -> No
     assert len(result.skipped_cells) == 2
     reasons = sorted(s.reason for s in result.skipped_cells)
     assert reasons == ["NEG_EXCLUDED_CELL", "POS_EXCLUDED_COMBO"]
+
+
+# ---------------------------------------------------------------------------
+# Codex P1 regression (2026-05-12) — checkpoint drift under capsule rotation
+#
+# Three drift modes are fail-closed: if the persisted checkpoint state
+# contradicts the CURRENT preflight decision, the runner must refuse
+# launch rather than silently return an incomplete / stale grid.
+# ---------------------------------------------------------------------------
+
+
+def test_checkpoint_drift_persisted_skipped_now_runnable_refuses(
+    tmp_path: Path,
+) -> None:
+    """Run 1: POS excludes (block_structured, tau_onset) → cell saved as
+    SKIPPED. Run 2: POS exclusion lifted (no excluded combos) → cell is
+    now runnable. The runner MUST refuse, because resuming would treat
+    the previously-skipped cell as already completed and never compute it,
+    silently emitting an incomplete sweep under a fresh aggregate sha."""
+    paths_strict = _valid_capsule_paths(
+        tmp_path,
+        pos_excluded_combos=[["block_structured", "tau_onset"]],
+    )
+    _run(tmp_path, capsules=paths_strict, checkpoint_name="ckpt.json")
+    # New capsules — exclusion removed — written to the same dir; the
+    # checkpoint still carries the SKIPPED row from run 1.
+    paths_relaxed = _valid_capsule_paths(tmp_path)
+    with pytest.raises(PreflightLaunchRefused) as excinfo:
+        _run(tmp_path, capsules=paths_relaxed, checkpoint_name="ckpt.json")
+    msg = str(excinfo.value)
+    assert "persisted_skipped_cell_no_longer_excluded" in msg
+    assert "block_structured" in msg
+    assert "tau_onset" in msg
+
+
+def test_checkpoint_drift_persisted_computed_now_excluded_refuses(
+    tmp_path: Path,
+) -> None:
+    """Run 1: no exclusions → all 9 cells computed. Run 2: POS now
+    excludes (block_structured, tau_onset) → that cell is in the
+    skipped tuple. The on-disk record is a computed result; the new
+    decision contradicts it. Refuse rather than rewrite the audit row."""
+    paths_open = _valid_capsule_paths(tmp_path)
+    _run(tmp_path, capsules=paths_open, checkpoint_name="ckpt.json")
+    paths_strict = _valid_capsule_paths(
+        tmp_path,
+        pos_excluded_combos=[["block_structured", "tau_onset"]],
+    )
+    with pytest.raises(PreflightLaunchRefused) as excinfo:
+        _run(tmp_path, capsules=paths_strict, checkpoint_name="ckpt.json")
+    msg = str(excinfo.value)
+    assert "persisted_computed_cell_now_excluded" in msg
+
+
+def test_checkpoint_drift_source_capsule_sha_change_refuses(
+    tmp_path: Path,
+) -> None:
+    """Run 1: POS capsule excludes (block_structured, tau_onset) → cell
+    skipped with source_capsule_sha256 = sha_A. Run 2: POS capsule
+    rotated to a structurally equivalent capsule with a different sha
+    (e.g. additional metadata field) but the SAME exclusion → still
+    excluded but the audit provenance changed. The runner must refuse
+    rather than silently rewrite the source_capsule_sha256 row."""
+    paths_run1 = _valid_capsule_paths(
+        tmp_path / "run1",
+        pos_excluded_combos=[["block_structured", "tau_onset"]],
+    )
+    # Copy the four capsules to a fresh run2 directory but rewrite the
+    # POS capsule with a different generated_at (so its sha shifts)
+    # while preserving the same excluded_combos.
+    import json
+    import shutil
+
+    run2_dir = tmp_path / "run2"
+    run2_dir.mkdir()
+    for name in ("pos", "neg", "null", "smoke"):
+        src = tmp_path / "run1" / f"{name}.json"
+        dst = run2_dir / f"{name}.json"
+        if name == "pos":
+            payload = json.loads(src.read_text(encoding="utf-8"))
+            # Recompute sha-bearing canonical form with a new generated_at
+            payload["generated_at"] = "2026-05-12T12:00:00Z"
+            payload.pop("sha256", None)
+            import hashlib
+
+            from research.systemic_risk.d002c_preflight import (
+                canonical_preflight_json,
+            )
+
+            payload["sha256"] = hashlib.sha256(
+                canonical_preflight_json(payload).encode("utf-8")
+            ).hexdigest()
+            dst.write_text(json.dumps(payload, sort_keys=True, indent=2), encoding="utf-8")
+        else:
+            shutil.copy(src, dst)
+    paths_run2 = PreflightCapsulePaths(
+        pos_control=run2_dir / "pos.json",
+        neg_control=run2_dir / "neg.json",
+        null_audit=run2_dir / "null.json",
+        smoke_test=run2_dir / "smoke.json",
+    )
+    # First run — populate the checkpoint with the original POS sha
+    ckpt = run2_dir / "ckpt.json"
+    prereg = _mini_prereg()
+    cfg = _well_formed_config(prereg)
+    run_sweep(
+        preregistration=prereg,
+        sweep_config=cfg,
+        checkpoint_path=ckpt,
+        steps_per_quarter=4,
+        preflight_capsules=paths_run1,
+        require_preflight=True,
+    )
+    # Resume against the rotated POS capsule — refuse
+    with pytest.raises(PreflightLaunchRefused) as excinfo:
+        run_sweep(
+            preregistration=prereg,
+            sweep_config=cfg,
+            checkpoint_path=ckpt,
+            steps_per_quarter=4,
+            preflight_capsules=paths_run2,
+            require_preflight=True,
+        )
+    msg = str(excinfo.value)
+    assert "persisted_skipped_cell_source_capsule_sha_drifted" in msg
+
+
+def test_checkpoint_drift_clean_resume_passes(tmp_path: Path) -> None:
+    """The drift check must NOT false-positive on a clean resume where
+    the capsules are byte-identical between run 1 and run 2."""
+    paths = _valid_capsule_paths(
+        tmp_path,
+        pos_excluded_combos=[["block_structured", "tau_onset"]],
+    )
+    first = _run(tmp_path, capsules=paths, checkpoint_name="ckpt.json")
+    second = _run(tmp_path, capsules=paths, checkpoint_name="ckpt.json")
+    assert first.sha256 == second.sha256
+    assert len(first.skipped_cells) == len(second.skipped_cells)


### PR DESCRIPTION
## Summary

C2.4-D closes the architectural gap left by sessions A/B/C: the runner now **refuses launch or reduces the execution grid based on the four preflight capsules** (`pos_control`, `neg_control`, `null_audit`, `smoke_test`) before any sweep cell is computed.

- New `research/systemic_risk/d002c_preflight.py`: frozen-dataclass enforcement layer (`PreflightCapsulePaths`, `PreflightDecision`, `SkippedCell`, `RunnableCell`) with deterministic canonical-JSON sha contract and accumulating refusal (never short-circuits).
- `run_sweep` gains `preflight_capsules` + `require_preflight` (default `True`); strict mode refuses on any preflight failure, reduces the grid by POS `excluded_combos` / NEG `excluded_cells`, persists `SKIPPED_BY_PREFLIGHT` entries to the D-002D checkpoint, and folds the preflight decision sha into the aggregate sweep sha.
- 33 + 15 = 48 new tests; 37 legacy `test_d002c_sweep_runner.py` tests still pass under `require_preflight=False` legacy-shim mode (no assertion relaxed).

## Files changed

- `research/systemic_risk/d002c_preflight.py` (NEW)
- `research/systemic_risk/d002c_sweep_runner.py` (EDIT — preflight wiring)
- `tests/research/systemic_risk/test_d002c_preflight.py` (NEW — 33 tests)
- `tests/research/systemic_risk/test_d002c_sweep_runner_preflight_integration.py` (NEW — 15 tests)
- `tests/research/systemic_risk/test_d002c_sweep_runner.py` (EDIT — legacy-shim: each `run_sweep` call site grew a single `require_preflight=False` kwarg; NO existing assertion was relaxed)
- `.claude/commit_acceptors/x10r-d002c-preflight-enforcement.yaml` (NEW)
- `docs/governance/D002C_PREFLIGHT_CONTRACT.md` (NEW)

## Contract closed (which integration gap C2.4-D closes)

Pre-C2.4-D, `run_sweep` only validated `sweep_config` against the pre-registration; the four preflight capsules were emitted by sessions A/B/C but never consulted. C2.4-D is the **launch-gating layer**: capsule SHA tampering, missing capsules, smoke FAIL, null FAIL, or unknown substrate/metric/N identities all refuse launch.

## Preflight refusal matrix

| Condition                                                                | launch_allowed |
| ------------------------------------------------------------------------ | -------------- |
| Any capsule file missing                                                 | False          |
| Any capsule non-JSON / root not an object                                | False          |
| Any capsule `kind` mismatch                                              | False          |
| Any capsule sha256 recomputation disagreement                            | False          |
| Any capsule missing `generated_at`                                       | False          |
| Smoke `verdict != PASS` or `n_cells_failed > 0`                          | False          |
| Null-audit `results` empty (no `aggregate_only` opt-in)                  | False          |
| Any null-audit cell `verdict != PASS`                                    | False          |
| Any capsule references unknown substrate / metric / N                    | False          |
| Any load-bearing numeric field is non-finite (NaN / Inf)                 | False          |
| POS `excluded_combos` non-empty                                          | **True**       |
| NEG `excluded_cells` non-empty                                           | **True**       |

POS / NEG exclusions are grid reducers by design, not launch blockers.

## Grid exclusion semantics

- **POS** `excluded_combos: list[(substrate_id, metric_id)]` — removes every sweep cell matching the `(substrate_id, metric_id)` pair, across ALL `(N, λ)`.
- **NEG** `excluded_cells: list[(substrate_id, metric_id, N)]` — removes the exact `(substrate_id, metric_id, N)` triple ONLY; siblings at different `N` survive.

## Skipped-cell checkpoint semantics

Skipped cells are persisted to the D-002D checkpoint as `CellResult` payloads with `status="SKIPPED_BY_PREFLIGHT"`, carrying `source_capsule` (`"pos_control"` or `"neg_control"`) and `source_capsule_sha256`. A resumed sweep restores SKIPPED entries identically to the original run; `IDEMPOTENT_ONLY` policy prevents a SKIPPED cell from being silently turned into a computed cell on resume.

The aggregate sweep `sha256` folds in:
- `preflight_decision_sha`
- `skipped_cell_keys` (sorted)
- `skipped_cell_source_shas`

So **capsule tampering between runs changes the sweep sha by construction**.

## Evidence commands

```bash
# Quality gates (all green)
ruff check research/systemic_risk/d002c_preflight.py \
           research/systemic_risk/d002c_sweep_runner.py \
           tests/research/systemic_risk/test_d002c_preflight.py \
           tests/research/systemic_risk/test_d002c_sweep_runner_preflight_integration.py
black --check research/systemic_risk/d002c_preflight.py \
              research/systemic_risk/d002c_sweep_runner.py \
              tests/research/systemic_risk/test_d002c_preflight.py \
              tests/research/systemic_risk/test_d002c_sweep_runner_preflight_integration.py
mypy --strict --follow-imports=silent \
     research/systemic_risk/d002c_preflight.py \
     research/systemic_risk/d002c_sweep_runner.py \
     tests/research/systemic_risk/test_d002c_preflight.py \
     tests/research/systemic_risk/test_d002c_sweep_runner_preflight_integration.py
pytest tests/research/systemic_risk/test_d002c_preflight.py \
       tests/research/systemic_risk/test_d002c_sweep_runner_preflight_integration.py \
       tests/research/systemic_risk/test_d002c_sweep_runner.py -q
```

## Falsifier result

All 6 probes PASS:

```
(1) missing capsule refuses        PASS
(2) smoke FAIL refuses             PASS
(3) null FAIL refuses              PASS
(4) POS excludes cell from grid    PASS
(5) NEG excludes exact cell only   PASS
(6) sha tampering refuses          PASS
```

## Known limitations

1. **Null-audit capsule schema is C2.4-D-defined.** The null-audit module emits per-cell `NullAuditResult` payloads but does not currently write an aggregate capsule. The preflight requires a wrapper of `kind: d002c_null_audit_capsule_v1` containing a `results: list[...]` field. An orchestrator (or future C2.4-C addendum) is responsible for producing this wrapper.
2. **Smoke capsule kind is structural.** The smoke-test writer emits no `kind` field; the preflight identifies it by the canonical field set the writer emits.
3. **POS/NEG exclusions are non-veto.** Non-empty `excluded_combos` / `excluded_cells` reduces the grid but does not refuse launch — gating on "any exclusion = refuse" would void the purpose of the controls.

## Claim boundary

This module is **claim-neutral**. Its only outputs are a `PreflightDecision` consumed by `run_sweep` and `SkippedCell` records persisted to the checkpoint. The sweep result reader (C2.5, pending) is the layer that may interpret these outputs for claim purposes; the preflight enforcement layer never does.

## Rollback command

```bash
git revert <commit-sha>
```

## DO NOT auto-merge — chain hold pattern

This PR is part of the C2.4 chain. Hold for review before merge.

## Test plan

- [x] `pytest tests/research/systemic_risk/test_d002c_preflight.py` — 33 passed
- [x] `pytest tests/research/systemic_risk/test_d002c_sweep_runner_preflight_integration.py` — 15 passed
- [x] `pytest tests/research/systemic_risk/test_d002c_sweep_runner.py` — 37 passed (legacy, no regression)
- [x] `ruff check` + `black --check` + `mypy --strict` clean on all 4 new/edited Python files
- [x] Falsifier probe — 6/6 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)