### PR TITLE
fix(x10r,D-002C,C2.6): align writer capsule sha with preflight validator's canonical form (#654)

### DIFF
--- a/.claude/commit_acceptors/x10r-d002c-writer-sha-alignment.yaml
+++ b/.claude/commit_acceptors/x10r-d002c-writer-sha-alignment.yaml
@@ -1,0 +1,171 @@
+# Diff-bound commit acceptor for X-10R-1 D-002C C2.6 — capsule writer
+# sha alignment with the preflight validator (GH PR #654 chain hold).
+#
+# What lands:
+#   * research/systemic_risk/d002c_pos_control.py   — sha over FULL capsule
+#   * research/systemic_risk/d002c_neg_control.py   — sha over FULL capsule
+#   * research/systemic_risk/d002c_smoke_test.py    — sha over FULL capsule
+#   * tests/research/systemic_risk/test_d002c_writer_sha_alignment.py (NEW)
+#   * tests/research/systemic_risk/test_d002c_smoke_test.py — round-trip
+#   * .claude/commit_acceptors/x10r-d002c-writer-sha-alignment.yaml
+#
+# Bug
+# ===
+# C2.4-A/B/C writers hashed a small surrogate dict (3-7 fields) and
+# stored that sha in a FULL capsule (~16 fields). The C2.4-D preflight
+# validator recomputes sha over the FULL capsule body via
+# canonical_preflight_json — so the recomputed sha never matched and
+# the validator refused launch with capsule_sha256_mismatch on every
+# freshly-written capsule.
+#
+# Fix
+# ===
+# Writers now build the full capsule body FIRST, sha it via the
+# validator's exact canonical form (canonical_preflight_json), and
+# store the matching sha in both the dataclass and on-disk capsule.
+# The _sha256 / _canonical_json helpers were deleted in favour of a
+# single _capsule_sha256 helper that defers to canonical_preflight_json.
+
+id: x10r-d002c-writer-sha-alignment
+status: ACTIVE
+claim_type: correctness
+promise: >-
+  After this PR lands, the d002c_pos_control / d002c_neg_control /
+  d002c_smoke_test writers emit capsules whose sha256 round-trips
+  cleanly through the d002c_preflight validator's
+  canonical_preflight_json recompute. The preflight validator can
+  load every freshly-written capsule without triggering
+  capsule_sha256_mismatch refusal. Per-cell shas also use the same
+  canonical form, so any future non-finite per-cell field
+  (e.g. signal_ci_ratio=inf in degenerate-variance branches) is
+  hashed consistently on both sides via the validator's stable
+  string-sentinel substitution.
+diff_scope:
+  changed_files:
+    - path: ".claude/commit_acceptors/x10r-d002c-writer-sha-alignment.yaml"
+    - path: "research/systemic_risk/d002c_pos_control.py"
+    - path: "research/systemic_risk/d002c_neg_control.py"
+    - path: "research/systemic_risk/d002c_smoke_test.py"
+    - path: "tests/research/systemic_risk/test_d002c_smoke_test.py"
+    - path: "tests/research/systemic_risk/test_d002c_writer_sha_alignment.py"
+  forbidden_paths:
+    - "research/systemic_risk/d002c_preflight.py"
+    - "research/systemic_risk/d002c_null_audit.py"
+    - "research/systemic_risk/d002c_sweep_runner.py"
+    - "research/systemic_risk/d002c_verdict.py"
+    - "research/systemic_risk/d002c_preregistration.py"
+    - "docs/governance/D002C_PREREGISTRATION.yaml"
+    - "trading/"
+    - "execution/"
+    - "forecast/"
+    - "policy/"
+    - "core/physics/"
+    - "core/kuramoto/"
+    - "application/governance/claim_ledger.py"
+    - "application/governance/commit_acceptor.py"
+required_python_symbols:
+  - "research/systemic_risk/d002c_pos_control.py::run_pos_control_all"
+  - "research/systemic_risk/d002c_pos_control.py::run_pos_control_cell"
+  - "research/systemic_risk/d002c_pos_control.py::PosControlVerdict"
+  - "research/systemic_risk/d002c_pos_control.py::PosControlCellResult"
+  - "research/systemic_risk/d002c_neg_control.py::run_neg_control_all"
+  - "research/systemic_risk/d002c_neg_control.py::run_neg_control_cell"
+  - "research/systemic_risk/d002c_neg_control.py::NegControlVerdict"
+  - "research/systemic_risk/d002c_neg_control.py::NegControlCellResult"
+  - "research/systemic_risk/d002c_smoke_test.py::run_smoke_test"
+  - "research/systemic_risk/d002c_smoke_test.py::SmokeTestResult"
+  - "research/systemic_risk/d002c_smoke_test.py::SmokeCellResult"
+expected_signal: >-
+  Local: `pytest tests/research/systemic_risk/test_d002c_pos_control.py
+  tests/research/systemic_risk/test_d002c_neg_control.py
+  tests/research/systemic_risk/test_d002c_smoke_test.py
+  tests/research/systemic_risk/test_d002c_writer_sha_alignment.py
+  tests/research/systemic_risk/test_d002c_preflight.py
+  tests/research/systemic_risk/test_d002c_sweep_runner_preflight_integration.py
+  -q` reports all passed. `mypy --strict`, `ruff check`, and
+  `black --check` all clean on the three writers + the new
+  alignment test.
+measurement_command: >-
+  bash -c 'mypy --strict --follow-imports=silent
+  research/systemic_risk/d002c_pos_control.py
+  research/systemic_risk/d002c_neg_control.py
+  research/systemic_risk/d002c_smoke_test.py
+  tests/research/systemic_risk/test_d002c_writer_sha_alignment.py
+  && ruff check
+  research/systemic_risk/d002c_pos_control.py
+  research/systemic_risk/d002c_neg_control.py
+  research/systemic_risk/d002c_smoke_test.py
+  tests/research/systemic_risk/test_d002c_writer_sha_alignment.py
+  && black --check
+  research/systemic_risk/d002c_pos_control.py
+  research/systemic_risk/d002c_neg_control.py
+  research/systemic_risk/d002c_smoke_test.py
+  tests/research/systemic_risk/test_d002c_writer_sha_alignment.py
+  && pytest
+  tests/research/systemic_risk/test_d002c_pos_control.py
+  tests/research/systemic_risk/test_d002c_neg_control.py
+  tests/research/systemic_risk/test_d002c_smoke_test.py
+  tests/research/systemic_risk/test_d002c_writer_sha_alignment.py
+  tests/research/systemic_risk/test_d002c_preflight.py
+  tests/research/systemic_risk/test_d002c_sweep_runner_preflight_integration.py
+  -q'
+signal_artifact: "tmp/x10r_d002c_writer_sha_alignment.log"
+falsifier:
+  command: >-
+    bash -c 'python -c "
+    from pathlib import Path
+    import hashlib, json, tempfile
+    from research.systemic_risk.d002c_pos_control import run_pos_control_all
+    from research.systemic_risk.d002c_neg_control import run_neg_control_all
+    from research.systemic_risk.d002c_smoke_test import run_smoke_test
+    from research.systemic_risk.d002c_substrates import BlockStructuredSubstrate
+    from research.systemic_risk.d002c_metrics import AucPreEventMetric
+    from research.systemic_risk.d002c_preflight import (
+        NULL_AUDIT_KIND, PreflightCapsulePaths, canonical_preflight_json,
+        load_and_validate_preflight_capsules,
+    )
+    tmp = Path(tempfile.mkdtemp())
+    pos = tmp / \"pos.json\"; neg = tmp / \"neg.json\"
+    smoke = tmp / \"smoke.json\"; null_ = tmp / \"null.json\"
+    run_pos_control_all((BlockStructuredSubstrate(),), (AucPreEventMetric(),),
+        N=20, lambda_=1.0, n_seeds=4, threshold=0.01, steps_per_quarter=3,
+        output_path=pos)
+    run_neg_control_all((BlockStructuredSubstrate(),), (AucPreEventMetric(),),
+        N_grid=(50,), n_seeds=4, steps_per_quarter=3, output_path=neg)
+    run_smoke_test(substrates=(BlockStructuredSubstrate(),),
+        metrics=(AucPreEventMetric(),), N_grid=(20,), lambda_grid=(0.0,),
+        n_seeds=2, steps_per_quarter=3, max_wallclock_seconds=120.0,
+        output_path=smoke)
+    body = {\"kind\": NULL_AUDIT_KIND, \"aggregate_only\": True,
+            \"results\": [], \"generated_at\": \"2026-05-11T12:00:00Z\"}
+    body[\"sha256\"] = hashlib.sha256(
+        canonical_preflight_json(body).encode(\"utf-8\")).hexdigest()
+    null_.write_text(json.dumps(body, sort_keys=True, indent=2))
+    decision = load_and_validate_preflight_capsules(
+        PreflightCapsulePaths(pos_control=pos, neg_control=neg,
+                              null_audit=null_, smoke_test=smoke))
+    assert decision.launch_allowed, \
+        f\"falsifier FAILED: refusal_reasons={list(decision.refusal_reasons)}\"
+    "'
+  description: >-
+    Emits pos+neg+smoke capsules via the actual writers and a stub
+    aggregate-only null-audit capsule, then runs
+    load_and_validate_preflight_capsules. Verifies
+    decision.launch_allowed is True — i.e. NO capsule_sha256_mismatch
+    refusal. This is the exact contract the C2.4-D preflight enforces;
+    if writers regress, this assertion fails immediately.
+rollback_command: >-
+  bash -c 'git checkout HEAD~1 --
+  research/systemic_risk/d002c_pos_control.py
+  research/systemic_risk/d002c_neg_control.py
+  research/systemic_risk/d002c_smoke_test.py
+  tests/research/systemic_risk/test_d002c_smoke_test.py
+  && rm -f tests/research/systemic_risk/test_d002c_writer_sha_alignment.py
+  .claude/commit_acceptors/x10r-d002c-writer-sha-alignment.yaml'
+rollback_verification_command: >-
+  bash -c 'test ! -f tests/research/systemic_risk/test_d002c_writer_sha_alignment.py
+  && test ! -f .claude/commit_acceptors/x10r-d002c-writer-sha-alignment.yaml'
+memory_update_type: append
+ledger_path: ".claude/commit_acceptors/x10r-d002c-writer-sha-alignment.yaml"
+report_path: "tmp/x10r_d002c_writer_sha_alignment.log"
+evidence: []

--- a/research/systemic_risk/d002c_neg_control.py
+++ b/research/systemic_risk/d002c_neg_control.py
@@ -145,12 +145,21 @@ class NegControlVerdict:
 # ---------------------------------------------------------------------------
 
 
-def _canonical_json(payload: dict[str, Any]) -> str:
-    return json.dumps(payload, sort_keys=True, separators=(",", ":"))
+def _capsule_sha256(payload: dict[str, Any]) -> str:
+    """SHA-256 over the validator's exact canonical form.
 
+    See :func:`research.systemic_risk.d002c_pos_control._capsule_sha256`
+    for the contract — both writers MUST use the same formula or the
+    preflight validator refuses launch with ``capsule_sha256_mismatch``.
 
-def _sha256(payload: dict[str, Any]) -> str:
-    return hashlib.sha256(_canonical_json(payload).encode("utf-8")).hexdigest()
+    The :func:`canonical_preflight_json` import is deferred to the
+    function body to break the circular import between
+    :mod:`d002c_preflight` (which imports
+    :data:`DEFAULT_NEG_N_GRID` from this module) and this module.
+    """
+    from .d002c_preflight import canonical_preflight_json
+
+    return hashlib.sha256(canonical_preflight_json(payload).encode("utf-8")).hexdigest()
 
 
 def _now_iso() -> str:
@@ -378,7 +387,10 @@ def run_neg_control_cell(
         "omega_gamma": omega_gamma,
         "independent_seed_stride": independent_seed_stride,
     }
-    sha = _sha256(payload)
+    # Per-cell sha uses the validator's canonical form for
+    # forward-safety (no non-finite fields at present, but the
+    # validator's _sanitize is the single source of truth).
+    sha = _capsule_sha256(payload)
     return NegControlCellResult(
         substrate_id=substrate.id,
         metric_id=metric.id,
@@ -473,40 +485,37 @@ def run_neg_control_all(
     )
     all_pass = n_exclude == 0
 
-    aggregate = {
-        "per_cell_shas": [r.sha256 for r in results],
-        "n_pass": n_pass,
-        "n_exclude": n_exclude,
-        "alpha_bonferroni": alpha_bonferroni,
-        "tolerance": tolerance,
-        "all_pass": all_pass,
-        "excluded_cells": [list(c) for c in excluded_cells],
-    }
-    sha = _sha256(aggregate)
     generated_at = _now_iso()
 
+    # Build the FULL capsule body (every field except ``sha256``)
+    # FIRST, then sha it via the validator's canonical form so the
+    # preflight round-trip succeeds. Hashing a smaller aggregate
+    # dict would drift from the validator's recompute and trigger
+    # ``capsule_sha256_mismatch`` refusal.
+    capsule_without_sha: dict[str, Any] = {
+        "kind": "d002c_neg_control_capsule_v1",
+        "all_pass": all_pass,
+        "n_pass": n_pass,
+        "n_exclude": n_exclude,
+        "excluded_cells": [list(c) for c in excluded_cells],
+        "n_seeds": n_seeds,
+        "N_grid": list(N_grid),
+        "alpha_bonferroni": alpha_bonferroni,
+        "tolerance": tolerance,
+        "steps_per_quarter": steps_per_quarter,
+        "omega_gamma": omega_gamma,
+        "rng_seed_base": rng_seed_base,
+        "independent_seed_stride": independent_seed_stride,
+        "wallclock_seconds": wall,
+        "results": [_result_to_dict(r) for r in results],
+        "generated_at": generated_at,
+        "substrate_ids": [s.id for s in substrates],
+        "metric_ids": [m.id for m in metrics],
+    }
+    sha = _capsule_sha256(capsule_without_sha)
+
     if output_path is not None:
-        capsule: dict[str, Any] = {
-            "kind": "d002c_neg_control_capsule_v1",
-            "all_pass": all_pass,
-            "n_pass": n_pass,
-            "n_exclude": n_exclude,
-            "excluded_cells": [list(c) for c in excluded_cells],
-            "n_seeds": n_seeds,
-            "N_grid": list(N_grid),
-            "alpha_bonferroni": alpha_bonferroni,
-            "tolerance": tolerance,
-            "steps_per_quarter": steps_per_quarter,
-            "omega_gamma": omega_gamma,
-            "rng_seed_base": rng_seed_base,
-            "independent_seed_stride": independent_seed_stride,
-            "wallclock_seconds": wall,
-            "results": [_result_to_dict(r) for r in results],
-            "sha256": sha,
-            "generated_at": generated_at,
-            "substrate_ids": [s.id for s in substrates],
-            "metric_ids": [m.id for m in metrics],
-        }
+        capsule = {**capsule_without_sha, "sha256": sha}
         _atomic_write(Path(output_path), capsule)
 
     return NegControlVerdict(

--- a/research/systemic_risk/d002c_pos_control.py
+++ b/research/systemic_risk/d002c_pos_control.py
@@ -70,6 +70,7 @@ from .d002c_metrics import (
     MetricEvaluation,
     signal_mean,
 )
+from .d002c_preflight import canonical_preflight_json
 from .d002c_substrates import (
     ALL_SUBSTRATES,
     EVENT_QUARTER,
@@ -139,13 +140,18 @@ class PosControlVerdict:
 # ---------------------------------------------------------------------------
 
 
-def _canonical_json(payload: dict[str, Any]) -> str:
-    """Canonical JSON: sorted keys, no whitespace."""
-    return json.dumps(payload, sort_keys=True, separators=(",", ":"))
+def _capsule_sha256(payload: dict[str, Any]) -> str:
+    """SHA-256 over the validator's exact canonical form.
 
-
-def _sha256(payload: dict[str, Any]) -> str:
-    return hashlib.sha256(_canonical_json(payload).encode("utf-8")).hexdigest()
+    The pre-flight validator (:mod:`d002c_preflight`) recomputes
+    each capsule's sha by re-encoding the capsule body (minus the
+    ``sha256`` field) via :func:`canonical_preflight_json`. To
+    survive validator round-trip, writers MUST use the SAME
+    function — anything else (bare ``json.dumps``, smaller
+    aggregate dicts, untouched non-finite floats) drifts and the
+    validator refuses launch with ``capsule_sha256_mismatch``.
+    """
+    return hashlib.sha256(canonical_preflight_json(payload).encode("utf-8")).hexdigest()
 
 
 def _now_iso() -> str:
@@ -374,7 +380,12 @@ def run_pos_control_cell(
         "steps_per_quarter": steps_per_quarter,
         "omega_gamma": omega_gamma,
     }
-    sha = _sha256(payload)
+    # Per-cell sha uses the validator's exact canonical form so
+    # downstream tooling can recompute it independently. In the
+    # degenerate-variance branch ``ratio`` is ``math.inf``;
+    # canonical_preflight_json substitutes a stable string sentinel
+    # so the sha is well-defined.
+    sha = _capsule_sha256(payload)
     return PosControlCellResult(
         substrate_id=substrate.id,
         metric_id=metric.id,
@@ -471,38 +482,36 @@ def run_pos_control_all(
     )
     all_pass = n_exclude == 0
 
-    aggregate = {
-        "per_cell_shas": [r.sha256 for r in results],
-        "n_pass": n_pass,
-        "n_exclude": n_exclude,
-        "threshold": threshold,
-        "all_pass": all_pass,
-        "excluded_combos": [list(c) for c in excluded_combos],
-    }
-    sha = _sha256(aggregate)
     generated_at = _now_iso()
 
+    # Build the FULL capsule body (every field except ``sha256``)
+    # FIRST, then sha it via the validator's canonical form. This
+    # is what makes the preflight round-trip succeed: the validator
+    # recomputes sha over capsule_without_sha and refuses launch on
+    # any drift.
+    capsule_without_sha: dict[str, Any] = {
+        "kind": "d002c_pos_control_capsule_v1",
+        "all_pass": all_pass,
+        "n_pass": n_pass,
+        "n_exclude": n_exclude,
+        "excluded_combos": [list(c) for c in excluded_combos],
+        "n_seeds": n_seeds,
+        "N": N,
+        "lambda_": lambda_,
+        "threshold": threshold,
+        "steps_per_quarter": steps_per_quarter,
+        "omega_gamma": omega_gamma,
+        "rng_seed_base": rng_seed_base,
+        "wallclock_seconds": wall,
+        "results": [_result_to_dict(r) for r in results],
+        "generated_at": generated_at,
+        "substrate_ids": [s.id for s in substrates],
+        "metric_ids": [m.id for m in metrics],
+    }
+    sha = _capsule_sha256(capsule_without_sha)
+
     if output_path is not None:
-        capsule: dict[str, Any] = {
-            "kind": "d002c_pos_control_capsule_v1",
-            "all_pass": all_pass,
-            "n_pass": n_pass,
-            "n_exclude": n_exclude,
-            "excluded_combos": [list(c) for c in excluded_combos],
-            "n_seeds": n_seeds,
-            "N": N,
-            "lambda_": lambda_,
-            "threshold": threshold,
-            "steps_per_quarter": steps_per_quarter,
-            "omega_gamma": omega_gamma,
-            "rng_seed_base": rng_seed_base,
-            "wallclock_seconds": wall,
-            "results": [_result_to_dict(r) for r in results],
-            "sha256": sha,
-            "generated_at": generated_at,
-            "substrate_ids": [s.id for s in substrates],
-            "metric_ids": [m.id for m in metrics],
-        }
+        capsule = {**capsule_without_sha, "sha256": sha}
         _atomic_write(Path(output_path), capsule)
 
     return PosControlVerdict(

--- a/research/systemic_risk/d002c_smoke_test.py
+++ b/research/systemic_risk/d002c_smoke_test.py
@@ -64,10 +64,27 @@ from .d002c_metrics import (
     ALL_METRICS,
     Metric,
 )
+from .d002c_preflight import canonical_preflight_json
 from .d002c_substrates import (
     ALL_SUBSTRATES,
     Substrate,
 )
+
+
+def _capsule_sha256(payload: dict[str, Any]) -> str:
+    """SHA-256 over the validator's exact canonical form.
+
+    The pre-flight validator (:mod:`d002c_preflight`) recomputes
+    a capsule's sha by re-encoding the capsule body (minus the
+    ``sha256`` field) via :func:`canonical_preflight_json`. To
+    survive validator round-trip, the smoke-test writer MUST use
+    the SAME function — anything else (bare ``json.dumps``, a
+    smaller surrogate dict, untouched non-finite floats) drifts
+    and the validator refuses launch with
+    ``capsule_sha256_mismatch``.
+    """
+    return hashlib.sha256(canonical_preflight_json(payload).encode("utf-8")).hexdigest()
+
 
 # ---------------------------------------------------------------------------
 # Locked defaults
@@ -126,14 +143,6 @@ class SmokeTestResult:
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-
-def _canonical_json(payload: dict[str, Any]) -> str:
-    return json.dumps(payload, sort_keys=True, separators=(",", ":"))
-
-
-def _sha256(payload: dict[str, Any]) -> str:
-    return hashlib.sha256(_canonical_json(payload).encode("utf-8")).hexdigest()
 
 
 def _now_iso() -> str:
@@ -373,25 +382,32 @@ def run_smoke_test(
     over_budget = total_wall > max_wallclock_seconds
     verdict = "PASS" if (n_failed == 0 and not over_budget) else "FAIL"
 
-    payload: dict[str, Any] = {
+    generated_at = _now_iso()
+
+    # Build the FULL capsule body (every field except ``sha256``)
+    # FIRST, then sha it via the validator's canonical form so the
+    # preflight round-trip succeeds. The previous implementation
+    # hashed a smaller payload dict; that drifted from the
+    # validator's recompute and triggered ``capsule_sha256_mismatch``
+    # refusal at launch time.
+    capsule_without_sha: dict[str, Any] = {
+        "verdict": verdict,
         "grid_N": list(N_grid),
         "grid_lambda": list(lambda_grid),
         "n_seeds": n_seeds,
         "n_cells_total": len(cells),
         "n_cells_ok": n_ok,
         "n_cells_failed": n_failed,
+        "total_wallclock_seconds": total_wall,
         "max_wallclock_seconds": max_wallclock_seconds,
+        "over_budget": over_budget,
         "steps_per_quarter": steps_per_quarter,
         "omega_gamma": omega_gamma,
         "rng_seed_base": rng_seed_base,
-        "over_budget": over_budget,
-        "verdict": verdict,
-        "cell_signatures": [
-            f"{c.substrate_id}×{c.metric_id}@N={c.N},λ={c.lambda_}:ok={c.ok}" for c in cells
-        ],
+        "cells": [_cell_to_dict(c) for c in cells],
+        "generated_at": generated_at,
     }
-    sha = _sha256(payload)
-    generated_at = _now_iso()
+    sha = _capsule_sha256(capsule_without_sha)
 
     result = SmokeTestResult(
         grid_N=tuple(int(x) for x in N_grid),
@@ -408,24 +424,7 @@ def run_smoke_test(
     )
 
     if output_path is not None:
-        capsule: dict[str, Any] = {
-            "verdict": verdict,
-            "grid_N": list(N_grid),
-            "grid_lambda": list(lambda_grid),
-            "n_seeds": n_seeds,
-            "n_cells_total": len(cells),
-            "n_cells_ok": n_ok,
-            "n_cells_failed": n_failed,
-            "total_wallclock_seconds": total_wall,
-            "max_wallclock_seconds": max_wallclock_seconds,
-            "over_budget": over_budget,
-            "steps_per_quarter": steps_per_quarter,
-            "omega_gamma": omega_gamma,
-            "rng_seed_base": rng_seed_base,
-            "cells": [_cell_to_dict(c) for c in cells],
-            "sha256": sha,
-            "generated_at": generated_at,
-        }
+        capsule = {**capsule_without_sha, "sha256": sha}
         _atomic_write(Path(output_path), capsule)
 
     return result

--- a/tests/research/systemic_risk/test_d002c_smoke_test.py
+++ b/tests/research/systemic_risk/test_d002c_smoke_test.py
@@ -242,10 +242,22 @@ def test_run_cell_returns_failure_record_not_exception() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_sha256_deterministic_across_calls() -> None:
-    """Same config → same sha (sha is over canonical fields, not over
-    wallclock — wallclock varies but is excluded from the sha payload)."""
-    a = run_smoke_test(
+def test_sha256_round_trips_with_preflight_canonical_form(tmp_path: Path) -> None:
+    """Round-trip contract: the writer's sha MUST equal the preflight
+    validator's recompute over (capsule - sha256). This is the contract
+    that C2.4-D enforces — any drift triggers ``capsule_sha256_mismatch``.
+
+    Wallclock fields are now part of the full-capsule body (so the
+    validator can recompute over the on-disk JSON without rebuilding a
+    surrogate dict). Two separate runs therefore produce DIFFERENT
+    shas, but each run's sha MUST round-trip cleanly.
+    """
+    import hashlib
+
+    from research.systemic_risk.d002c_preflight import canonical_preflight_json
+
+    out = tmp_path / "smoke.json"
+    res = run_smoke_test(
         substrates=(BlockStructuredSubstrate(),),
         metrics=(AucPreEventMetric(),),
         N_grid=(20,),
@@ -253,18 +265,13 @@ def test_sha256_deterministic_across_calls() -> None:
         n_seeds=2,
         steps_per_quarter=3,
         max_wallclock_seconds=120.0,
+        output_path=out,
     )
-    b = run_smoke_test(
-        substrates=(BlockStructuredSubstrate(),),
-        metrics=(AucPreEventMetric(),),
-        N_grid=(20,),
-        lambda_grid=(0.0, 0.5),
-        n_seeds=2,
-        steps_per_quarter=3,
-        max_wallclock_seconds=120.0,
-    )
-    assert a.sha256 == b.sha256
-    assert a.n_cells_total == b.n_cells_total
+    on_disk = json.loads(out.read_text(encoding="utf-8"))
+    body = {k: v for k, v in on_disk.items() if k != "sha256"}
+    recomputed = hashlib.sha256(canonical_preflight_json(body).encode("utf-8")).hexdigest()
+    assert on_disk["sha256"] == recomputed
+    assert res.sha256 == recomputed
 
 
 def test_sha256_changes_with_grid() -> None:

--- a/tests/research/systemic_risk/test_d002c_writer_sha_alignment.py
+++ b/tests/research/systemic_risk/test_d002c_writer_sha_alignment.py
@@ -1,0 +1,330 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""D-002C C2.6 — Writer sha alignment with the preflight validator.
+
+Bug
+===
+The C2.4-A/B/C writers (pos_control, neg_control, smoke_test) hashed a
+small surrogate dict (3-7 fields) and then wrote a FULL capsule (~16
+fields) carrying that mismatched sha. The C2.4-D preflight validator
+recomputes sha over the full capsule minus the ``sha256`` field via
+:func:`canonical_preflight_json` — so the recomputed sha never matched
+and launch was refused with ``capsule_sha256_mismatch`` on every
+freshly-written capsule.
+
+Contract
+========
+Writer emits capsule body B; writes ``capsule = B ∪ {"sha256": sha}``
+to disk where ``sha = sha256(canonical_preflight_json(B))``.  Reader
+recomputes ``sha256(canonical_preflight_json(capsule - {"sha256"}))``
+and refuses launch on mismatch.  The two computations MUST agree by
+construction, for every input the writers accept — including
+non-finite per-cell fields (``signal_ci_ratio == inf`` in
+degenerate-variance branches), which the validator's
+``_sanitize`` collapses to a stable string sentinel.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+from research.systemic_risk.d002c_metrics import ALL_METRICS, AucPreEventMetric, Metric
+from research.systemic_risk.d002c_neg_control import run_neg_control_all
+from research.systemic_risk.d002c_pos_control import run_pos_control_all
+from research.systemic_risk.d002c_preflight import (
+    NULL_AUDIT_KIND,
+    PreflightCapsulePaths,
+    canonical_preflight_json,
+    load_and_validate_preflight_capsules,
+)
+from research.systemic_risk.d002c_smoke_test import run_smoke_test
+from research.systemic_risk.d002c_substrates import (
+    ALL_SUBSTRATES,
+    BlockStructuredSubstrate,
+    Substrate,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_json_dict(path: Path) -> dict[str, Any]:
+    """Read a JSON object from disk; cast for mypy --strict.
+
+    The on-disk capsule format tolerates ``NaN`` / ``Infinity`` literals
+    (python-flavour JSON, not RFC 8259) because :func:`json.loads` accepts
+    them by default. The validator's :func:`canonical_preflight_json`
+    canonicalises those into stable string sentinels before hashing.
+    """
+    return cast(dict[str, Any], json.loads(path.read_text(encoding="utf-8")))
+
+
+def _recompute_sha(capsule: dict[str, Any]) -> str:
+    body = {k: v for k, v in capsule.items() if k != "sha256"}
+    return hashlib.sha256(canonical_preflight_json(body).encode("utf-8")).hexdigest()
+
+
+def _emit_pos(path: Path) -> dict[str, Any]:
+    """Emit a tiny POS capsule via the actual writer; return parsed JSON."""
+    run_pos_control_all(
+        (BlockStructuredSubstrate(),),
+        (AucPreEventMetric(),),
+        N=20,
+        lambda_=1.0,
+        n_seeds=4,
+        threshold=0.01,
+        steps_per_quarter=3,
+        output_path=path,
+    )
+    return _load_json_dict(path)
+
+
+def _emit_neg(path: Path) -> dict[str, Any]:
+    """Emit a tiny NEG capsule via the actual writer (uses a single N
+    inside the locked DEFAULT_NEG_N_GRID so the preflight accepts it
+    without ``capsule_unknown_N``)."""
+    run_neg_control_all(
+        (BlockStructuredSubstrate(),),
+        (AucPreEventMetric(),),
+        N_grid=(50,),
+        n_seeds=4,
+        steps_per_quarter=3,
+        output_path=path,
+    )
+    return _load_json_dict(path)
+
+
+def _emit_smoke(path: Path) -> dict[str, Any]:
+    run_smoke_test(
+        substrates=(BlockStructuredSubstrate(),),
+        metrics=(AucPreEventMetric(),),
+        N_grid=(20,),
+        lambda_grid=(0.0,),
+        n_seeds=2,
+        steps_per_quarter=3,
+        max_wallclock_seconds=120.0,
+        output_path=path,
+    )
+    return _load_json_dict(path)
+
+
+def _write_null_audit_stub(path: Path) -> dict[str, Any]:
+    """Write an aggregate-only null-audit stub via the same canonical form
+    the validator uses. The stub carries ``aggregate_only=True`` so the
+    validator does not require per-cell results — it only checks the
+    capsule sha + kind + generated_at."""
+    body: dict[str, Any] = {
+        "kind": NULL_AUDIT_KIND,
+        "aggregate_only": True,
+        "results": [],
+        "generated_at": "2026-05-11T12:00:00Z",
+    }
+    sha = hashlib.sha256(canonical_preflight_json(body).encode("utf-8")).hexdigest()
+    capsule = {**body, "sha256": sha}
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(capsule, sort_keys=True, indent=2), encoding="utf-8")
+    return capsule
+
+
+# ---------------------------------------------------------------------------
+# Per-writer round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_pos_control_capsule_sha_matches_preflight_recompute(tmp_path: Path) -> None:
+    """Round-trip: emit POS capsule, then have preflight validator recompute
+    its sha. They MUST match (otherwise the launch script refuses)."""
+    capsule = _emit_pos(tmp_path / "pos.json")
+    assert "sha256" in capsule
+    recomputed = _recompute_sha(capsule)
+    assert capsule["sha256"] == recomputed
+    # The fix is honest only if the capsule has the FULL load-bearing
+    # field set, not the buggy 3-field surrogate dict.
+    assert len(capsule) > 5
+
+
+def test_neg_control_capsule_sha_matches_preflight_recompute(tmp_path: Path) -> None:
+    """Same contract for NEG."""
+    capsule = _emit_neg(tmp_path / "neg.json")
+    assert "sha256" in capsule
+    recomputed = _recompute_sha(capsule)
+    assert capsule["sha256"] == recomputed
+    assert len(capsule) > 5
+
+
+def test_smoke_test_capsule_sha_matches_preflight_recompute(tmp_path: Path) -> None:
+    """Same contract for SMOKE."""
+    capsule = _emit_smoke(tmp_path / "smoke.json")
+    assert "sha256" in capsule
+    recomputed = _recompute_sha(capsule)
+    assert capsule["sha256"] == recomputed
+    assert len(capsule) > 5
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: load via the preflight validator
+# ---------------------------------------------------------------------------
+
+
+def test_pos_control_capsule_loads_via_preflight_validator(tmp_path: Path) -> None:
+    """End-to-end: emit POS+NEG+NULL+SMOKE capsules, run
+    load_and_validate_preflight_capsules — verify launch_allowed=True
+    (no sha mismatch refusal). This is THE falsifier for the writer-sha
+    alignment fix."""
+    pos_path = tmp_path / "pos.json"
+    neg_path = tmp_path / "neg.json"
+    null_path = tmp_path / "null.json"
+    smoke_path = tmp_path / "smoke.json"
+
+    _emit_pos(pos_path)
+    _emit_neg(neg_path)
+    _emit_smoke(smoke_path)
+    _write_null_audit_stub(null_path)
+
+    decision = load_and_validate_preflight_capsules(
+        PreflightCapsulePaths(
+            pos_control=pos_path,
+            neg_control=neg_path,
+            null_audit=null_path,
+            smoke_test=smoke_path,
+        )
+    )
+    # The contract under test: no capsule_sha256_mismatch in refusal_reasons.
+    sha_mismatches = [r for r in decision.refusal_reasons if "capsule_sha256_mismatch" in r]
+    assert sha_mismatches == [], (
+        f"Writer-sha alignment regression: {len(sha_mismatches)} sha mismatches; "
+        f"first={sha_mismatches[0]!r}"
+    )
+    # And the bigger contract: launch is allowed (no other refusal either,
+    # since the four capsules are well-formed at small N).
+    assert decision.launch_allowed, f"refusal_reasons={list(decision.refusal_reasons)}"
+
+
+# ---------------------------------------------------------------------------
+# Determinism
+# ---------------------------------------------------------------------------
+
+
+def test_writer_sha_deterministic_across_calls(tmp_path: Path) -> None:
+    """Same inputs → same per-cell sha (per-cell payloads are wallclock-free
+    and so deterministic). The aggregate capsule sha drifts across runs
+    because the body carries ``wallclock_seconds``; we therefore assert
+    determinism at the per-cell level and round-trip correctness at the
+    capsule level."""
+    a = _emit_pos(tmp_path / "a.json")
+    b = _emit_pos(tmp_path / "b.json")
+    assert a["results"][0]["sha256"] == b["results"][0]["sha256"]
+    # And each on-disk capsule must round-trip cleanly.
+    assert a["sha256"] == _recompute_sha(a)
+    assert b["sha256"] == _recompute_sha(b)
+
+
+# ---------------------------------------------------------------------------
+# Non-finite forward-safety
+# ---------------------------------------------------------------------------
+
+
+def test_capsule_with_non_finite_field_has_consistent_sha(tmp_path: Path) -> None:
+    """If a per-cell result carries ``inf`` (saturated metric), the writer's
+    sha MUST still match the validator's recompute. canonical_preflight_json
+    handles this via sentinel substitution.
+
+    We trigger the path by surgically injecting ``inf`` into a real
+    per-cell result, then re-sha via the writer-equivalent canonical
+    form and verify the validator's recompute agrees. The point of this
+    test is to lock the sentinel substitution path on BOTH sides of the
+    round-trip — if either side stopped using
+    :func:`canonical_preflight_json` the recomputed sha would diverge.
+    """
+    cap = tmp_path / "pos_inf.json"
+    capsule = _emit_pos(cap)
+    capsule["results"][0]["signal_ci_ratio"] = float("inf")
+    body = {k: v for k, v in capsule.items() if k != "sha256"}
+    new_sha = hashlib.sha256(canonical_preflight_json(body).encode("utf-8")).hexdigest()
+    capsule["sha256"] = new_sha
+    # Writer-equivalent disk format: tolerate NaN/Infinity literals.
+    cap.write_text(json.dumps(capsule, sort_keys=True, indent=2), encoding="utf-8")
+
+    reread = _load_json_dict(cap)
+    recomputed = _recompute_sha(reread)
+    assert reread["sha256"] == recomputed
+    # Verify the inf actually went through the sentinel substitution.
+    canon = canonical_preflight_json({k: v for k, v in reread.items() if k != "sha256"})
+    assert '"Infinity"' in canon
+
+
+# ---------------------------------------------------------------------------
+# Regression: refute the OLD (buggy) sha formula
+# ---------------------------------------------------------------------------
+
+
+def test_writer_does_not_emit_old_buggy_aggregate_sha(tmp_path: Path) -> None:
+    """The OLD writer hashed a small dict like
+    {n_pass, n_exclude, excluded_combos} and stored that sha as the
+    capsule's sha. This test verifies the writer no longer does that
+    — i.e. the surrogate-aggregate sha is NEVER equal to the emitted
+    capsule sha for any non-trivial capsule.
+
+    Falsifier: if someone reverts the fix to hash a smaller aggregate
+    dict, this test fails."""
+    capsule = _emit_pos(tmp_path / "pos.json")
+    old_aggregate: dict[str, Any] = {
+        "per_cell_shas": [r["sha256"] for r in capsule["results"]],
+        "n_pass": capsule["n_pass"],
+        "n_exclude": capsule["n_exclude"],
+        "threshold": capsule["threshold"],
+        "all_pass": capsule["all_pass"],
+        "excluded_combos": capsule["excluded_combos"],
+    }
+    old_sha = hashlib.sha256(
+        json.dumps(old_aggregate, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+    assert capsule["sha256"] != old_sha, (
+        "writer regressed to the buggy small-aggregate sha formula; "
+        "preflight will refuse launch with capsule_sha256_mismatch"
+    )
+    # Sanity: the NEW sha must equal the validator's recompute.
+    assert capsule["sha256"] == _recompute_sha(capsule)
+
+
+# ---------------------------------------------------------------------------
+# Canonical-form parity (writer vs validator)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "substrate, metric",
+    [(ALL_SUBSTRATES[0], ALL_METRICS[0])],
+)
+def test_full_capsule_canonical_form_is_validator_canonical_form(
+    tmp_path: Path,
+    substrate: Substrate,
+    metric: Metric,
+) -> None:
+    """The writer and the validator MUST share one canonical form.
+    Anything that bypasses :func:`canonical_preflight_json` (e.g. a
+    raw ``json.dumps(sort_keys=True)``) would silently drift. This test
+    locks the contract by forcing the recompute through the validator's
+    own function and comparing to the on-disk sha."""
+    cap = tmp_path / "pos.json"
+    run_pos_control_all(
+        (substrate,),
+        (metric,),
+        N=20,
+        lambda_=1.0,
+        n_seeds=4,
+        threshold=0.01,
+        steps_per_quarter=3,
+        output_path=cap,
+    )
+    data = _load_json_dict(cap)
+    body = {k: v for k, v in data.items() if k != "sha256"}
+    via_validator = hashlib.sha256(canonical_preflight_json(body).encode("utf-8")).hexdigest()
+    assert data["sha256"] == via_validator
+    assert isinstance(data["sha256"], str)


### PR DESCRIPTION
## Bug

The C2.4-A/B/C writers (`d002c_pos_control`, `d002c_neg_control`, `d002c_smoke_test`) hashed a small surrogate dict (3-7 fields) via a local `_canonical_json` / `_sha256` helper, then wrote a FULL capsule (~16 fields) carrying that mismatched sha. The C2.4-D preflight validator (`d002c_preflight.verify_capsule_sha256`) recomputes the sha over the FULL capsule minus the `sha256` field via `canonical_preflight_json` — so the recomputed sha never matched and the validator refused launch with `capsule_sha256_mismatch` on every freshly-written capsule.

Concretely, the buggy form in `run_pos_control_all` (and replicated in neg / smoke):

```python
aggregate = {"per_cell_shas": [...], "n_pass": ..., ...}  # 6 fields
sha = _sha256(aggregate)
capsule = {"kind": ..., "all_pass": ..., ..., "sha256": sha}  # 16 fields
_atomic_write(path, capsule)
```

## Fix

Each writer now:

1. Imports `canonical_preflight_json` from `d002c_preflight` (lazy in `d002c_neg_control` to break the circular import — the validator depends on `DEFAULT_NEG_N_GRID`).
2. Builds the FULL capsule body FIRST (every load-bearing field except `sha256`).
3. Computes `sha = sha256(canonical_preflight_json(body))` — the SAME formula the validator uses for its round-trip recompute.
4. Writes `{**body, "sha256": sha}` atomically and stores the same sha in the in-memory verdict / result dataclass.

Per-cell shas redirected through `canonical_preflight_json` too, so forward-safe paths (e.g. `signal_ci_ratio = math.inf` in the degenerate-variance branch) hash consistently via the validator's stable string-sentinel substitution. The obsolete `_canonical_json` / `_sha256` helpers were deleted.

## Round-trip contract

For every capsule the writers emit:

```
sha256(canonical_preflight_json(capsule - {"sha256"}))
    == capsule["sha256"]
    == verdict.sha256
```

## Test plan

- [x] `pytest tests/research/systemic_risk/test_d002c_writer_sha_alignment.py` — 8/8 pass (NEW)
- [x] `pytest tests/research/systemic_risk/test_d002c_pos_control.py` — 35/35 pass
- [x] `pytest tests/research/systemic_risk/test_d002c_neg_control.py` — 27/27 pass
- [x] `pytest tests/research/systemic_risk/test_d002c_smoke_test.py` — 19/19 pass (one rewritten to round-trip)
- [x] `pytest tests/research/systemic_risk/test_d002c_preflight.py` — pass
- [x] `pytest tests/research/systemic_risk/test_d002c_sweep_runner_preflight_integration.py` — pass
- [x] `pytest tests/audit/test_false_confidence_detector.py` — 28/28 pass
- [x] Total: 169 tests across 7 files, all green
- [x] `ruff check` + `black --check` + `mypy --strict --follow-imports=silent` clean

## Falsifier

Emits pos+neg+smoke capsules via the actual writers + a stub aggregate-only null-audit, then runs `load_and_validate_preflight_capsules` — verifies `launch_allowed=True` with NO `capsule_sha256_mismatch` refusal. Runs in the acceptor's `falsifier.command`.

```
FALSIFIER PASS: launch_allowed=True, decision.sha=935eea8d05ca8883
```

## Chain hold pattern

DO NOT auto-merge — this PR is part of the D-002C #654 chain (C2.6 follows C2.5 #669); merge order is controlled by the chain hold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)