### PR TITLE
feat(x10r,D-002C,C2.4-C2): null audit aggregator + capsule sha aligned with preflight validator (#654)

### DIFF
--- a/.claude/commit_acceptors/x10r-d002c-null-audit-aggregator.yaml
+++ b/.claude/commit_acceptors/x10r-d002c-null-audit-aggregator.yaml
@@ -1,0 +1,335 @@
+# Diff-bound commit acceptor for D-002C C2.4-C2 (issue #654) —
+# Null audit aggregator + capsule-sha alignment with the preflight
+# validator.
+#
+# What lands:
+#   * research/systemic_risk/d002c_null_audit.py
+#       ADDITIVE EDIT: introduces run_null_audit_all (per-cell
+#       aggregator) + NullAuditInputCell + NullAuditAggregateResult
+#       + NullAuditAggregateInvalid. The existing run_null_audit /
+#       run_null_audit_from_capsule contracts are NOT touched.
+#
+#       The aggregator emits a real d002c_null_audit_capsule_v1
+#       capsule whose sha256 is computed through
+#       d002c_preflight.canonical_preflight_json (function-scope
+#       import to avoid coupling the module load graph to the
+#       preflight). This closes the C2.6 sha-drift the validator
+#       previously caught when writers hashed with plain
+#       json.dumps(sort_keys=True, separators) only.
+#
+#       Aggregate verdict rules:
+#         - PASS iff every audited cell has verdict==PASS AND zero
+#           cells were skipped (no per-seed data) AND >=1 cell was
+#           audited.
+#         - any FAIL cell → aggregate=FAIL (fail-closed)
+#         - any SKIPPED_NO_PER_SEED_DATA cell → aggregate=FAIL
+#           (a missing audit is not evidence of a passing audit)
+#         - empty resolved cell list without aggregate_only_if_empty
+#           → raise NullAuditAggregateInvalid (refuse to silently
+#           regress to the C2.5 launch-hygiene compromise)
+#         - empty resolved cell list with aggregate_only_if_empty
+#           → emit the preflight escape capsule (results=[],
+#           aggregate_only=true)
+#
+#   * tests/research/systemic_risk/test_d002c_null_audit_aggregator.py
+#       13 tests pinning the contract:
+#         - capsule kind = d002c_null_audit_capsule_v1
+#         - capsule sha matches preflight validator's canonical
+#           recompute end-to-end (loads stub POS/NEG/SMOKE + the
+#           emitted null-audit capsule through the validator and
+#           asserts launch_allowed=True)
+#         - aggregate PASS iff every cell PASSes
+#         - any FAIL cell → aggregate=FAIL
+#         - empty results without aggregate_only_if_empty → raises
+#         - empty results with aggregate_only_if_empty → emits the
+#           escape capsule the preflight accepts
+#         - non-finite p_value_empirical → preflight refuses with
+#           capsule_non_finite_load_bearing_field
+#         - capsule sha deterministic across calls (same inputs +
+#           same generated_at + same seed)
+#         - capsule sha changes when one cell's verdict flips
+#         - NullAuditInputCell is frozen
+#         - NullAuditAggregateResult is frozen
+#         - skipped cells force aggregate=FAIL (fail-closed)
+#         - exactly one of sweep_results / sweep_capsule_path
+#           must be provided (both, or neither, raises)
+#
+#   * .claude/commit_acceptors/x10r-d002c-null-audit-aggregator.yaml
+#       This file.
+#
+# Strict scope:
+#   Aggregator + capsule emission ONLY. NO claim layer. NO tier
+#   promotion. NO modification of the per-pair primitive contract.
+#   NO touching pos/neg/smoke writers (C2.6 PR #671 owns those).
+#   NO modification of d002c_preflight (the validator is correct).
+#   NO modification of D002C_PREREGISTRATION.yaml.
+#
+# Claim boundary:
+#   This PR removes the aggregate_only null-audit compromise to
+#   unblock the canonical D-002C rerun. It introduces NO claim
+#   layer and NO certification — the D-002C verdict tier is
+#   still gated by the C2.5 acceptance evaluator. The
+#   aggregator's verdict is consumed by the preflight, which
+#   refuses launch on FAIL; downstream tier promotion is
+#   strictly out of scope.
+
+id: x10r-d002c-null-audit-aggregator
+status: ACTIVE
+claim_type: correctness
+promise: >-
+  After this PR lands,
+  research.systemic_risk.d002c_null_audit.run_null_audit_all
+  aggregates per-cell paired-difference permutation audits into a
+  d002c_null_audit_capsule_v1 capsule whose recomputed sha256
+  bit-exactly matches the preflight validator's canonical recompute
+  through d002c_preflight.canonical_preflight_json. The aggregate
+  verdict is PASS iff every audited cell PASSes AND zero cells were
+  skipped for missing per-seed data; any FAIL or SKIPPED cell flips
+  it to FAIL (fail-closed). An empty resolved cell list raises
+  NullAuditAggregateInvalid unless the caller opts in via
+  aggregate_only_if_empty=True, so the C2.5 launch-hygiene
+  compromise cannot silently regress.
+
+  This PR removes the aggregate_only null-audit compromise to unblock
+  canonical D-002C rerun. It introduces NO claim layer and NO
+  certification.
+diff_scope:
+  changed_files:
+    - path: ".claude/commit_acceptors/x10r-d002c-null-audit-aggregator.yaml"
+    - path: "research/systemic_risk/d002c_null_audit.py"
+    - path: "tests/research/systemic_risk/test_d002c_null_audit_aggregator.py"
+  forbidden_paths:
+    - "trading/"
+    - "execution/"
+    - "forecast/"
+    - "policy/"
+    - "core/physics/"
+    - "core/kuramoto/"
+    - "research/reconstruction/"
+    - "research/systemic_risk/D002C_PREREGISTRATION.yaml"
+    - "research/systemic_risk/d002c_preflight.py"
+    - "research/systemic_risk/d002c_pos_control.py"
+    - "research/systemic_risk/d002c_neg_control.py"
+    - "research/systemic_risk/d002c_smoke_test.py"
+    - "research/systemic_risk/d002c_crn_validator.py"
+    - "research/systemic_risk/d002c_kuramoto.py"
+    - "research/systemic_risk/d002c_metrics.py"
+    - "research/systemic_risk/d002c_substrates.py"
+    - "research/systemic_risk/d002c_preregistration.py"
+    - "research/systemic_risk/d002c_sweep_runner.py"
+    - "research/systemic_risk/d002c_verdict.py"
+    - "research/systemic_risk/sweep_checkpoint.py"
+    - "scripts/run_x10r_"
+    - "application/governance/claim_ledger.py"
+    - "application/governance/commit_acceptor.py"
+required_python_symbols:
+  - "research/systemic_risk/d002c_null_audit.py::run_null_audit_all"
+  - "research/systemic_risk/d002c_null_audit.py::NullAuditInputCell"
+  - "research/systemic_risk/d002c_null_audit.py::NullAuditAggregateResult"
+  - "research/systemic_risk/d002c_null_audit.py::NullAuditAggregateInvalid"
+  - "research/systemic_risk/d002c_null_audit.py::NULL_AUDIT_AGGREGATE_KIND"
+  - "research/systemic_risk/d002c_null_audit.py::SKIPPED_NO_PER_SEED_DATA"
+  - "tests/research/systemic_risk/test_d002c_null_audit_aggregator.py::test_run_null_audit_all_writes_capsule_with_correct_kind"
+  - "tests/research/systemic_risk/test_d002c_null_audit_aggregator.py::test_capsule_sha_matches_validator_recompute"
+  - "tests/research/systemic_risk/test_d002c_null_audit_aggregator.py::test_aggregate_pass_iff_all_cells_pass"
+  - "tests/research/systemic_risk/test_d002c_null_audit_aggregator.py::test_one_fail_cell_makes_aggregate_fail"
+  - "tests/research/systemic_risk/test_d002c_null_audit_aggregator.py::test_empty_results_without_aggregate_only_refuses"
+  - "tests/research/systemic_risk/test_d002c_null_audit_aggregator.py::test_non_finite_p_value_refuses_via_preflight"
+  - "tests/research/systemic_risk/test_d002c_null_audit_aggregator.py::test_capsule_sha_deterministic_across_calls"
+  - "tests/research/systemic_risk/test_d002c_null_audit_aggregator.py::test_capsule_sha_changes_when_one_cell_verdict_changes"
+  - "tests/research/systemic_risk/test_d002c_null_audit_aggregator.py::test_null_audit_input_cell_is_frozen"
+  - "tests/research/systemic_risk/test_d002c_null_audit_aggregator.py::test_null_audit_aggregate_result_is_frozen"
+  - "tests/research/systemic_risk/test_d002c_null_audit_aggregator.py::test_skipped_cells_force_aggregate_fail"
+  - "tests/research/systemic_risk/test_d002c_null_audit_aggregator.py::test_handles_capsule_path_or_sweep_results_but_not_both"
+expected_signal: >-
+  Local: `pytest tests/research/systemic_risk/test_d002c_null_audit_aggregator.py
+  tests/research/systemic_risk/test_d002c_null_audit.py
+  tests/research/systemic_risk/test_d002c_sweep_runner_preflight_integration.py
+  tests/audit/test_false_confidence_detector.py -q`
+  reports all green (13 new + 26 existing null-audit + 19 sweep-runner
+  preflight integration + 28 false-confidence detector). `mypy --strict
+  --follow-imports=silent` clean on the two edited Python files.
+  `ruff check` and `black --check` both pass.
+measurement_command: >-
+  bash -c 'mypy --strict --follow-imports=silent
+  research/systemic_risk/d002c_null_audit.py
+  tests/research/systemic_risk/test_d002c_null_audit_aggregator.py
+  && ruff check
+  research/systemic_risk/d002c_null_audit.py
+  tests/research/systemic_risk/test_d002c_null_audit_aggregator.py
+  && black --check
+  research/systemic_risk/d002c_null_audit.py
+  tests/research/systemic_risk/test_d002c_null_audit_aggregator.py
+  && pytest tests/research/systemic_risk/test_d002c_null_audit_aggregator.py
+  tests/research/systemic_risk/test_d002c_null_audit.py
+  tests/research/systemic_risk/test_d002c_sweep_runner_preflight_integration.py
+  tests/audit/test_false_confidence_detector.py -q'
+signal_artifact: "tests/research/systemic_risk/test_d002c_null_audit_aggregator.py"
+falsifier:
+  command: >-
+    bash -c 'PYTHONPATH=. python -c "
+    import hashlib, json, tempfile
+    from pathlib import Path
+    import numpy as np
+    from research.systemic_risk.d002c_null_audit import (
+        run_null_audit_all,
+        NullAuditInputCell,
+        NullAuditAggregateInvalid,
+        NULL_AUDIT_AGGREGATE_KIND,
+    )
+    from research.systemic_risk.d002c_preflight import (
+        canonical_preflight_json,
+        load_and_validate_preflight_capsules,
+        PreflightCapsulePaths,
+        POS_CONTROL_KIND,
+        NEG_CONTROL_KIND,
+    )
+
+    def _seal(body):
+        canon = canonical_preflight_json(body)
+        sha = hashlib.sha256(canon.encode('"'"'utf-8'"'"')).hexdigest()
+        out = dict(body)
+        out['"'"'sha256'"'"'] = sha
+        return out
+
+    def _strong(key, n=20):
+        rng = np.random.default_rng(hash(key) & 0xFFFFFFFF)
+        null = rng.normal(0.0, 0.05, size=n).astype(np.float64)
+        return NullAuditInputCell(key, null + 1.0, null)
+
+    def _noise(key, n=20):
+        rng = np.random.default_rng((hash(key) ^ 0xDEADBEEF) & 0xFFFFFFFF)
+        p = rng.normal(0, 1, size=n).astype(np.float64)
+        nl = rng.normal(0, 1, size=n).astype(np.float64)
+        p = p - float(p.mean()) + 0.5
+        nl = nl - float(nl.mean()) + 0.5
+        return NullAuditInputCell(key, p, nl)
+
+    with tempfile.TemporaryDirectory() as td:
+        td = Path(td)
+
+        # (a) all-PASS cells → aggregate=PASS
+        out_pass = td / '"'"'all_pass.json'"'"'
+        res_pass = run_null_audit_all(
+            output_path=out_pass,
+            sweep_results=(_strong('"'"'A'"'"'), _strong('"'"'B'"'"')),
+            n_shuffles=100,
+        )
+        assert res_pass.aggregate_verdict == '"'"'PASS'"'"', res_pass.aggregate_verdict
+        assert res_pass.n_pass == 2
+
+        # (b) one FAIL cell → aggregate=FAIL
+        out_fail = td / '"'"'mixed.json'"'"'
+        res_fail = run_null_audit_all(
+            output_path=out_fail,
+            sweep_results=(_strong('"'"'A'"'"'), _noise('"'"'B'"'"')),
+            n_shuffles=200,
+        )
+        assert res_fail.aggregate_verdict == '"'"'FAIL'"'"', res_fail.aggregate_verdict
+        assert res_fail.n_fail >= 1
+
+        # (c) emitted PASS capsule passes preflight (stub POS/NEG/SMOKE)
+        pos = td / '"'"'pos.json'"'"'
+        neg = td / '"'"'neg.json'"'"'
+        smoke = td / '"'"'smoke.json'"'"'
+        pos_body = _seal({
+            '"'"'kind'"'"': POS_CONTROL_KIND, '"'"'all_pass'"'"': True,
+            '"'"'n_pass'"'"': 9, '"'"'n_exclude'"'"': 0, '"'"'excluded_combos'"'"': [],
+            '"'"'n_seeds'"'"': 50, '"'"'N'"'"': 400, '"'"'lambda_'"'"': 1.0,
+            '"'"'threshold'"'"': 2.0, '"'"'steps_per_quarter'"'"': 10,
+            '"'"'omega_gamma'"'"': 0.5, '"'"'rng_seed_base'"'"': 42,
+            '"'"'wallclock_seconds'"'"': 0.0, '"'"'results'"'"': [],
+            '"'"'generated_at'"'"': '"'"'2026-05-12T12:00:00Z'"'"',
+            '"'"'substrate_ids'"'"': ['"'"'ricci_flow'"'"', '"'"'block_structured'"'"', '"'"'temporal_coupling'"'"'],
+            '"'"'metric_ids'"'"': ['"'"'tau_onset'"'"', '"'"'sync_auc'"'"', '"'"'phase_lag'"'"'],
+        })
+        neg_body = _seal({
+            '"'"'kind'"'"': NEG_CONTROL_KIND, '"'"'all_pass'"'"': True,
+            '"'"'n_pass'"'"': 27, '"'"'n_exclude'"'"': 0, '"'"'excluded_cells'"'"': [],
+            '"'"'n_seeds'"'"': 50, '"'"'N_grid'"'"': [50, 100, 200],
+            '"'"'alpha_bonferroni'"'"': 2.31e-4, '"'"'tolerance'"'"': 1e-3,
+            '"'"'steps_per_quarter'"'"': 10, '"'"'omega_gamma'"'"': 0.5,
+            '"'"'rng_seed_base'"'"': 42, '"'"'independent_seed_stride'"'"': 10000,
+            '"'"'wallclock_seconds'"'"': 0.0, '"'"'results'"'"': [],
+            '"'"'generated_at'"'"': '"'"'2026-05-12T12:01:00Z'"'"',
+            '"'"'substrate_ids'"'"': ['"'"'ricci_flow'"'"', '"'"'block_structured'"'"', '"'"'temporal_coupling'"'"'],
+            '"'"'metric_ids'"'"': ['"'"'tau_onset'"'"', '"'"'sync_auc'"'"', '"'"'phase_lag'"'"'],
+        })
+        smoke_body = _seal({
+            '"'"'verdict'"'"': '"'"'PASS'"'"', '"'"'grid_N'"'"': [50, 100],
+            '"'"'grid_lambda'"'"': [0.0, 0.5], '"'"'n_seeds'"'"': 5,
+            '"'"'n_cells_total'"'"': 36, '"'"'n_cells_ok'"'"': 36, '"'"'n_cells_failed'"'"': 0,
+            '"'"'total_wallclock_seconds'"'"': 1.0, '"'"'max_wallclock_seconds'"'"': 60.0,
+            '"'"'over_budget'"'"': False, '"'"'steps_per_quarter'"'"': 6,
+            '"'"'omega_gamma'"'"': 0.5, '"'"'rng_seed_base'"'"': 42,
+            '"'"'cells'"'"': [], '"'"'generated_at'"'"': '"'"'2026-05-12T12:03:00Z'"'"',
+        })
+        pos.write_text(json.dumps(pos_body), encoding='"'"'utf-8'"'"')
+        neg.write_text(json.dumps(neg_body), encoding='"'"'utf-8'"'"')
+        smoke.write_text(json.dumps(smoke_body), encoding='"'"'utf-8'"'"')
+
+        paths = PreflightCapsulePaths(
+            pos_control=pos, neg_control=neg,
+            null_audit=out_pass, smoke_test=smoke,
+        )
+        decision = load_and_validate_preflight_capsules(paths)
+        assert decision.launch_allowed, decision.refusal_reasons
+        assert decision.capsule_shas['"'"'null_audit'"'"'] == res_pass.sha256
+
+        # (d) capsule sha deterministic for same inputs + fixed ts
+        out_d1 = td / '"'"'d1.json'"'"'
+        out_d2 = td / '"'"'d2.json'"'"'
+        cells = (_strong('"'"'X'"'"'),)
+        r1 = run_null_audit_all(
+            output_path=out_d1, sweep_results=cells,
+            n_shuffles=50, rng_seed=7,
+            generated_at='"'"'2026-05-12T14:00:00Z'"'"',
+        )
+        r2 = run_null_audit_all(
+            output_path=out_d2, sweep_results=cells,
+            n_shuffles=50, rng_seed=7,
+            generated_at='"'"'2026-05-12T14:00:00Z'"'"',
+        )
+        assert r1.sha256 == r2.sha256
+
+        # (e) empty without aggregate_only → raises
+        out_e = td / '"'"'empty.json'"'"'
+        try:
+            run_null_audit_all(output_path=out_e, sweep_results=(), n_shuffles=20)
+            raise AssertionError('"'"'should have raised'"'"')
+        except NullAuditAggregateInvalid:
+            pass
+    print('"'"'falsifier_ok'"'"')
+    "'
+  description: >-
+    Probes the C2.4-C2 contract end-to-end:
+      (a) all-PASS sweep_results aggregate to aggregate_verdict=PASS;
+      (b) one FAIL cell flips the aggregate to FAIL (fail-closed);
+      (c) the emitted PASS capsule passes the preflight validator
+          end-to-end with stub POS/NEG/SMOKE (launch_allowed=True),
+          AND the validator's recomputed null_audit sha matches the
+          writer's sha — confirming the C2.6 canonical_preflight_json
+          alignment;
+      (d) the capsule sha is deterministic for the same inputs +
+          fixed generated_at;
+      (e) an empty resolved cell list without aggregate_only_if_empty
+          raises NullAuditAggregateInvalid (no silent regression to
+          the C2.5 launch-hygiene compromise).
+    If any of these regress, the canonical D-002C launch hygiene
+    breaks — either the preflight refuses a real PASS capsule, or
+    the system silently accepts a launch that did not exercise the
+    null-audit FAIL signal.
+rollback_command: >-
+  bash -c 'git checkout HEAD~1 --
+  research/systemic_risk/d002c_null_audit.py
+  && rm -f
+  tests/research/systemic_risk/test_d002c_null_audit_aggregator.py
+  .claude/commit_acceptors/x10r-d002c-null-audit-aggregator.yaml'
+rollback_verification_command: >-
+  bash -c 'test ! -f tests/research/systemic_risk/test_d002c_null_audit_aggregator.py
+  && test ! -f .claude/commit_acceptors/x10r-d002c-null-audit-aggregator.yaml
+  && ! grep -q "run_null_audit_all" research/systemic_risk/d002c_null_audit.py'
+memory_update_type: append
+ledger_path: ".claude/commit_acceptors/x10r-d002c-null-audit-aggregator.yaml"
+report_path: "tests/research/systemic_risk/test_d002c_null_audit_aggregator.py"
+evidence: []

--- a/research/systemic_risk/d002c_null_audit.py
+++ b/research/systemic_risk/d002c_null_audit.py
@@ -357,14 +357,382 @@ def run_null_audit_from_capsule(
     return tuple(out)
 
 
+# ---------------------------------------------------------------------------
+# C2.4-C2 — Aggregate null audit (D-002C launch-hygiene contract)
+#
+# The preflight validator at d002c_preflight._process_null_audit expects a
+# capsule of kind d002c_null_audit_capsule_v1 with per-cell NullAuditResult
+# payloads (each carrying verdict in {"PASS","FAIL"}) and a recomputed
+# sha256 that matches the validator's canonical_preflight_json discipline.
+#
+# Until C2.4-C2 lands, the runtime path emits an aggregate_only=true escape
+# capsule with results=[] — the validator accepts that as a launch-hygiene
+# compromise (no real null-audit FAIL signal is exercised). This block
+# closes that gap: run_null_audit_all aggregates per-cell audits across
+# the full sweep grid and emits a real capsule whose sha aligns with the
+# validator's recompute, so launch_allowed reflects the actual null-audit
+# result.
+#
+# Strict scope: aggregation + capsule emission ONLY. NO claim layer. NO
+# tier promotion. NO modification of the per-pair primitive contract.
+# ---------------------------------------------------------------------------
+
+NULL_AUDIT_AGGREGATE_KIND: Final[str] = "d002c_null_audit_capsule_v1"
+
+#: Verdict emitted for cells that the capsule path lacks per-seed data
+#: for. Treated as fail-closed by the aggregate verdict (NOT counted
+#: as PASS): a missing audit is not evidence of a passing audit.
+SKIPPED_NO_PER_SEED_DATA: Final[str] = "SKIPPED_NO_PER_SEED_DATA"
+
+
+class NullAuditAggregateInvalid(RuntimeError):
+    """Bad input to :func:`run_null_audit_all`.
+
+    Raised when caller-side preconditions fail (both/neither input source
+    supplied, empty results without ``aggregate_only=true``, etc.). Per-cell
+    audit failures DO NOT raise — they are recorded in the capsule and
+    flip ``aggregate_verdict`` to ``"FAIL"`` for the caller to handle.
+    """
+
+
+@dataclass(frozen=True)
+class NullAuditInputCell:
+    """Per-cell input payload for the aggregate audit.
+
+    Carries the paired (precursor, null) per-seed samples for one
+    (substrate × metric × N × λ) sweep cell. The ``cell_key`` is the
+    canonical identity string (any stable encoding of the cell tuple
+    — the aggregator does not parse it, only carries it through to the
+    emitted capsule).
+    """
+
+    cell_key: str
+    precursor_values: NDArray[np.float64]
+    null_values: NDArray[np.float64]
+
+
+@dataclass(frozen=True)
+class NullAuditAggregateResult:
+    """Frozen aggregate verdict across all audited sweep cells.
+
+    Fields
+    ------
+    aggregate_verdict
+        ``"PASS"`` iff EVERY audited cell has ``verdict == "PASS"`` AND
+        zero cells were skipped for missing per-seed data. Any FAIL or
+        SKIPPED cell flips it to ``"FAIL"`` (fail-closed).
+    n_audited_cells
+        Number of cells with a real audit verdict (PASS or FAIL).
+        Does NOT include SKIPPED_NO_PER_SEED_DATA cells.
+    n_pass, n_fail
+        Counts within ``n_audited_cells``.
+    results
+        Tuple of per-cell :class:`NullAuditResult` (one per
+        audited-or-skipped cell, in input traversal order). Skipped
+        cells carry verdict=``SKIPPED_NO_PER_SEED_DATA``.
+    sha256
+        Canonical sha256 of the emitted capsule body (recomputed
+        through :func:`d002c_preflight.canonical_preflight_json` so it
+        matches the preflight validator's recompute bit-exactly).
+    generated_at
+        ISO-8601 UTC timestamp written into the capsule.
+    """
+
+    aggregate_verdict: str  # "PASS" | "FAIL"
+    n_audited_cells: int
+    n_pass: int
+    n_fail: int
+    results: tuple[NullAuditResult, ...]
+    sha256: str
+    generated_at: str
+
+
+def _result_to_payload(res: NullAuditResult, cell_key: str) -> dict[str, Any]:
+    """Convert a :class:`NullAuditResult` into the dict layout the
+    preflight validator iterates over in ``_process_null_audit``.
+
+    Keeps the canonical NullAuditResult sha (a different sha — over the
+    per-cell payload — than the aggregate capsule sha) and adds the
+    aggregator-only ``cell_key`` field. Skipped cells get a synthetic
+    payload with verdict=SKIPPED_NO_PER_SEED_DATA and a deterministic
+    sha over the cell_key alone, so the aggregate capsule is content-
+    addressed even when some cells are unaudited.
+    """
+    return {
+        "cell_key": cell_key,
+        "n_seeds": int(res.n_seeds),
+        "n_shuffles": int(res.n_shuffles),
+        "unshuffled_abs_signal": float(res.unshuffled_abs_signal),
+        "shuffled_abs_signal_median": float(res.shuffled_abs_signal_median),
+        "shuffled_abs_signal_p95": float(res.shuffled_abs_signal_p95),
+        "p_value_empirical": float(res.p_value_empirical),
+        "verdict": str(res.verdict),
+        "sha256": str(res.sha256),
+    }
+
+
+def _skipped_result(cell_key: str) -> NullAuditResult:
+    """Build a synthetic NullAuditResult for a cell lacking per-seed
+    data. The aggregate verdict treats it as FAIL (fail-closed). The
+    per-cell sha is deterministic in ``cell_key`` so two runs over the
+    same skipped cell produce the same aggregate capsule sha."""
+    payload: dict[str, Any] = {
+        "cell_key": cell_key,
+        "verdict": SKIPPED_NO_PER_SEED_DATA,
+    }
+    sha = _sha256(payload)
+    return NullAuditResult(
+        n_seeds=0,
+        n_shuffles=0,
+        unshuffled_abs_signal=0.0,
+        shuffled_abs_signal_median=0.0,
+        shuffled_abs_signal_p95=0.0,
+        unshuffled_greater_than_median=False,
+        p_value_empirical=1.0,
+        verdict=SKIPPED_NO_PER_SEED_DATA,
+        sha256=sha,
+    )
+
+
+def _iter_cells_from_capsule(
+    capsule_path: Path,
+) -> tuple[tuple[str, tuple[NDArray[np.float64], NDArray[np.float64]] | None], ...]:
+    """Walk a sweep capsule and yield (cell_key, arrays_or_None) pairs.
+
+    Cells lacking per-seed data are yielded with ``None`` so the
+    aggregator can record them as SKIPPED — they MUST NOT be silently
+    dropped (a dropped cell would falsely raise aggregate=PASS).
+    """
+    capsule_path = Path(capsule_path)
+    if not capsule_path.exists():
+        raise NullAuditInvalid(f"capsule does not exist: {capsule_path}")
+    try:
+        raw = capsule_path.read_text(encoding="utf-8")
+        data = json.loads(raw)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise NullAuditInvalid(f"could not parse capsule {capsule_path}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise NullAuditInvalid(f"capsule root must be a JSON object; got {type(data).__name__}")
+    results_list = data.get("results")
+    if not isinstance(results_list, list):
+        return ()
+    out: list[tuple[str, tuple[NDArray[np.float64], NDArray[np.float64]] | None]] = []
+    for cell in results_list:
+        if not isinstance(cell, dict):
+            continue
+        cell_id = (
+            f"[N={cell.get('N', '?')},"
+            f"lambda={cell.get('lambda_', '?')},"
+            f"sub={cell.get('substrate_id', '?')},"
+            f"metric={cell.get('metric_id', '?')}]"
+        )
+        arrays = _extract_per_seed_arrays(cell)
+        out.append((cell_id, arrays))
+    return tuple(out)
+
+
+def run_null_audit_all(
+    *,
+    output_path: Path,
+    sweep_results: tuple[NullAuditInputCell, ...] | None = None,
+    sweep_capsule_path: Path | None = None,
+    n_shuffles: int = DEFAULT_N_SHUFFLES,
+    rng_seed: int = DEFAULT_RNG_SEED,
+    p_value_threshold: float = DEFAULT_P_VALUE_THRESHOLD,
+    aggregate_only_if_empty: bool = False,
+    generated_at: str | None = None,
+) -> NullAuditAggregateResult:
+    """Aggregate null audit across all sweep cells.
+
+    Runs :func:`run_null_audit` on every (precursor, null) pair the
+    caller supplies (or that the capsule path carries), records each
+    per-cell verdict, and emits a ``d002c_null_audit_capsule_v1``
+    capsule whose sha256 matches the preflight validator's canonical
+    recompute (so ``launch_allowed=True`` is reachable for the canonical
+    D-002C launch hygiene path).
+
+    Exactly one of ``sweep_results`` or ``sweep_capsule_path`` must be
+    provided.
+
+    Parameters
+    ----------
+    output_path
+        Where to write the emitted capsule (atomic tmp + fsync +
+        os.replace; on-disk JSON is content-addressed).
+    sweep_results
+        Tuple of :class:`NullAuditInputCell` carrying per-cell
+        paired-seed precursor/null samples.
+    sweep_capsule_path
+        Path to a sweep result capsule from which per-cell pair samples
+        are loaded. Cells lacking per-seed data are recorded with
+        ``verdict=SKIPPED_NO_PER_SEED_DATA`` — NEVER silently dropped.
+    n_shuffles, rng_seed, p_value_threshold
+        Forwarded per-cell to :func:`run_null_audit`.
+    aggregate_only_if_empty
+        Genuine-empty-grid escape hatch. If True AND the resolved cell
+        list is empty, emit ``aggregate_only=true, results=[]`` (which
+        the preflight accepts) instead of raising. Required for, e.g.,
+        a sweep that has POS/NEG-excluded the entire grid.
+    generated_at
+        Optional ISO-8601 UTC timestamp. Defaults to ``_now_iso()``.
+        Override only when test-pinning determinism of the sha.
+
+    Returns
+    -------
+    NullAuditAggregateResult
+        Frozen aggregate carrying the per-cell results, capsule sha,
+        and ``aggregate_verdict`` (PASS iff every audited cell PASSes
+        AND no cell was skipped).
+
+    Raises
+    ------
+    NullAuditAggregateInvalid
+        Both inputs missing, both inputs supplied, or empty resolved
+        cell list without ``aggregate_only_if_empty=True``.
+    """
+    if (sweep_results is None) == (sweep_capsule_path is None):
+        raise NullAuditAggregateInvalid(
+            "exactly one of sweep_results or sweep_capsule_path must be provided"
+        )
+
+    # Resolve the (cell_key, arrays_or_None) sequence.
+    resolved: list[tuple[str, tuple[NDArray[np.float64], NDArray[np.float64]] | None]] = []
+    if sweep_results is not None:
+        for cell in sweep_results:
+            if not isinstance(cell, NullAuditInputCell):
+                raise NullAuditAggregateInvalid(
+                    f"sweep_results must contain NullAuditInputCell; got {type(cell).__name__}"
+                )
+            resolved.append((cell.cell_key, (cell.precursor_values, cell.null_values)))
+    else:
+        assert sweep_capsule_path is not None  # mypy guard
+        resolved.extend(_iter_cells_from_capsule(sweep_capsule_path))
+
+    # Empty path: aggregate_only escape hatch, or fail-closed refuse.
+    if not resolved:
+        if not aggregate_only_if_empty:
+            raise NullAuditAggregateInvalid(
+                "resolved cell list is empty and aggregate_only_if_empty=False — refuse "
+                "to emit an empty real-results capsule (the preflight escape hatch must "
+                "be opt-in)"
+            )
+        ts = generated_at if generated_at is not None else _now_iso()
+        body: dict[str, Any] = {
+            "kind": NULL_AUDIT_AGGREGATE_KIND,
+            "generated_at": ts,
+            "n_audited_cells": 0,
+            "n_pass": 0,
+            "n_fail": 0,
+            "n_shuffles_per_cell": int(n_shuffles),
+            "aggregate_verdict": "PASS",
+            "aggregate_only": True,
+            "results": [],
+        }
+        sha = _canonical_capsule_sha(body)
+        body["sha256"] = sha
+        _atomic_write(output_path, body)
+        return NullAuditAggregateResult(
+            aggregate_verdict="PASS",
+            n_audited_cells=0,
+            n_pass=0,
+            n_fail=0,
+            results=(),
+            sha256=sha,
+            generated_at=ts,
+        )
+
+    # Per-cell audits (or SKIPPED records).
+    per_cell_results: list[NullAuditResult] = []
+    per_cell_payloads: list[dict[str, Any]] = []
+    n_audited = 0
+    n_pass = 0
+    n_fail = 0
+    n_skipped = 0
+    for cell_key, arrays in resolved:
+        if arrays is None:
+            res = _skipped_result(cell_key)
+            per_cell_results.append(res)
+            per_cell_payloads.append(_result_to_payload(res, cell_key))
+            n_skipped += 1
+            continue
+        precursor_arr, null_arr = arrays
+        res = run_null_audit(
+            precursor_arr,
+            null_arr,
+            n_shuffles=n_shuffles,
+            rng_seed=rng_seed,
+            p_value_threshold=p_value_threshold,
+        )
+        per_cell_results.append(res)
+        per_cell_payloads.append(_result_to_payload(res, cell_key))
+        n_audited += 1
+        if res.verdict == "PASS":
+            n_pass += 1
+        else:
+            n_fail += 1
+
+    # Aggregate verdict: fail-closed on any FAIL or any SKIPPED cell.
+    aggregate_verdict = "PASS" if (n_fail == 0 and n_skipped == 0 and n_audited > 0) else "FAIL"
+    ts = generated_at if generated_at is not None else _now_iso()
+
+    body = {
+        "kind": NULL_AUDIT_AGGREGATE_KIND,
+        "generated_at": ts,
+        "n_audited_cells": int(n_audited),
+        "n_pass": int(n_pass),
+        "n_fail": int(n_fail),
+        "n_skipped_cells": int(n_skipped),
+        "n_shuffles_per_cell": int(n_shuffles),
+        "aggregate_verdict": aggregate_verdict,
+        "aggregate_only": False,
+        "results": per_cell_payloads,
+    }
+    sha = _canonical_capsule_sha(body)
+    body["sha256"] = sha
+    _atomic_write(output_path, body)
+
+    return NullAuditAggregateResult(
+        aggregate_verdict=aggregate_verdict,
+        n_audited_cells=int(n_audited),
+        n_pass=int(n_pass),
+        n_fail=int(n_fail),
+        results=tuple(per_cell_results),
+        sha256=sha,
+        generated_at=ts,
+    )
+
+
+def _canonical_capsule_sha(body: dict[str, Any]) -> str:
+    """Compute the capsule sha using the preflight validator's canonical
+    JSON discipline. Lazy import: ``d002c_preflight`` already imports
+    several sibling modules (substrates, metrics, neg_control); a top-
+    level import here is safe today but would couple this module to the
+    preflight's import graph for all callers. We follow the C2.6
+    function-scope import pattern (used for ``d002c_neg_control`` from
+    ``d002c_preflight``) so any future import-graph change in
+    ``d002c_preflight`` does not break ``d002c_null_audit`` at module
+    load time."""
+    from .d002c_preflight import canonical_preflight_json  # noqa: PLC0415
+
+    body_for_sha = {k: v for k, v in body.items() if k != "sha256"}
+    canon = canonical_preflight_json(body_for_sha)
+    return hashlib.sha256(canon.encode("utf-8")).hexdigest()
+
+
 __all__ = [
     "DEFAULT_N_SHUFFLES",
     "DEFAULT_RNG_SEED",
     "DEFAULT_P_VALUE_THRESHOLD",
     "MIN_N_SHUFFLES",
     "MIN_N_SEEDS",
+    "NULL_AUDIT_AGGREGATE_KIND",
+    "SKIPPED_NO_PER_SEED_DATA",
     "NullAuditInvalid",
+    "NullAuditAggregateInvalid",
+    "NullAuditInputCell",
     "NullAuditResult",
+    "NullAuditAggregateResult",
     "run_null_audit",
     "run_null_audit_from_capsule",
+    "run_null_audit_all",
 ]

--- a/tests/research/systemic_risk/test_d002c_null_audit_aggregator.py
+++ b/tests/research/systemic_risk/test_d002c_null_audit_aggregator.py
@@ -1,0 +1,527 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""D-002C C2.4-C2 — Tests for the null-audit aggregator.
+
+The aggregator removes the ``aggregate_only=true, results=[]`` launch-
+hygiene compromise documented in C2.5: it emits a real per-cell
+``d002c_null_audit_capsule_v1`` whose recomputed sha matches the
+preflight validator's canonical recompute, so ``launch_allowed=True``
+is reachable for a launch that genuinely exercises the null-audit
+FAIL signal.
+
+Each test carries >=2 assertions OR ``pytest.raises`` to satisfy the
+false-confidence detector heuristic — every assertion drives an
+observable contract bit.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+
+from research.systemic_risk.d002c_null_audit import (
+    NULL_AUDIT_AGGREGATE_KIND,
+    SKIPPED_NO_PER_SEED_DATA,
+    NullAuditAggregateInvalid,
+    NullAuditAggregateResult,
+    NullAuditInputCell,
+    run_null_audit_all,
+)
+from research.systemic_risk.d002c_preflight import (
+    NEG_CONTROL_KIND,
+    POS_CONTROL_KIND,
+    PreflightCapsulePaths,
+    canonical_preflight_json,
+    load_and_validate_preflight_capsules,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers — stub capsule writers for POS / NEG / SMOKE
+#
+# These mirror the canonical sealing pattern from
+# tests/research/systemic_risk/test_d002c_preflight.py:
+#   sha256 over canonical_preflight_json(body without sha) hashed with
+#   sha256. Any deviation here re-introduces the C2.6 sha drift this
+#   patch exists to close.
+# ---------------------------------------------------------------------------
+
+
+def _sha(payload: dict[str, Any]) -> str:
+    canon = canonical_preflight_json(payload)
+    return hashlib.sha256(canon.encode("utf-8")).hexdigest()
+
+
+def _seal(body: dict[str, Any]) -> dict[str, Any]:
+    sha = _sha(body)
+    out = dict(body)
+    out["sha256"] = sha
+    return out
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, sort_keys=True, indent=2), encoding="utf-8")
+
+
+def _pos_capsule_stub() -> dict[str, Any]:
+    body: dict[str, Any] = {
+        "kind": POS_CONTROL_KIND,
+        "all_pass": True,
+        "n_pass": 9,
+        "n_exclude": 0,
+        "excluded_combos": [],
+        "n_seeds": 50,
+        "N": 400,
+        "lambda_": 1.0,
+        "threshold": 2.0,
+        "steps_per_quarter": 10,
+        "omega_gamma": 0.5,
+        "rng_seed_base": 42,
+        "wallclock_seconds": 0.0,
+        "results": [],
+        "generated_at": "2026-05-12T12:00:00Z",
+        "substrate_ids": ["ricci_flow", "block_structured", "temporal_coupling"],
+        "metric_ids": ["tau_onset", "sync_auc", "phase_lag"],
+    }
+    return _seal(body)
+
+
+def _neg_capsule_stub() -> dict[str, Any]:
+    body: dict[str, Any] = {
+        "kind": NEG_CONTROL_KIND,
+        "all_pass": True,
+        "n_pass": 27,
+        "n_exclude": 0,
+        "excluded_cells": [],
+        "n_seeds": 50,
+        "N_grid": [50, 100, 200],
+        "alpha_bonferroni": 2.31e-4,
+        "tolerance": 1e-3,
+        "steps_per_quarter": 10,
+        "omega_gamma": 0.5,
+        "rng_seed_base": 42,
+        "independent_seed_stride": 10000,
+        "wallclock_seconds": 0.0,
+        "results": [],
+        "generated_at": "2026-05-12T12:01:00Z",
+        "substrate_ids": ["ricci_flow", "block_structured", "temporal_coupling"],
+        "metric_ids": ["tau_onset", "sync_auc", "phase_lag"],
+    }
+    return _seal(body)
+
+
+def _smoke_capsule_stub() -> dict[str, Any]:
+    body: dict[str, Any] = {
+        "verdict": "PASS",
+        "grid_N": [50, 100],
+        "grid_lambda": [0.0, 0.5],
+        "n_seeds": 5,
+        "n_cells_total": 36,
+        "n_cells_ok": 36,
+        "n_cells_failed": 0,
+        "total_wallclock_seconds": 1.0,
+        "max_wallclock_seconds": 60.0,
+        "over_budget": False,
+        "steps_per_quarter": 6,
+        "omega_gamma": 0.5,
+        "rng_seed_base": 42,
+        "cells": [],
+        "generated_at": "2026-05-12T12:03:00Z",
+    }
+    return _seal(body)
+
+
+def _write_all_stubs(tmp_path: Path, null_path: Path) -> PreflightCapsulePaths:
+    pos = tmp_path / "pos.json"
+    neg = tmp_path / "neg.json"
+    smoke = tmp_path / "smoke.json"
+    _write_json(pos, _pos_capsule_stub())
+    _write_json(neg, _neg_capsule_stub())
+    _write_json(smoke, _smoke_capsule_stub())
+    return PreflightCapsulePaths(
+        pos_control=pos, neg_control=neg, null_audit=null_path, smoke_test=smoke
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers — sweep_results fixtures
+# ---------------------------------------------------------------------------
+
+
+def _strong_signal_cell(cell_key: str, n_seeds: int = 20) -> NullAuditInputCell:
+    """Strong-signal cell: precursor = null + 1.0 ⇒ verdict PASS."""
+    rng = np.random.default_rng(hash(cell_key) & 0xFFFFFFFF)
+    null = rng.normal(0.0, 0.05, size=n_seeds).astype(np.float64)
+    precursor = null + 1.0
+    return NullAuditInputCell(
+        cell_key=cell_key,
+        precursor_values=precursor,
+        null_values=null,
+    )
+
+
+def _noise_only_cell(cell_key: str, n_seeds: int = 20) -> NullAuditInputCell:
+    """Centred pure-noise cell: unshuffled |signal| ≈ 0 ⇒ verdict FAIL."""
+    rng = np.random.default_rng((hash(cell_key) ^ 0xDEADBEEF) & 0xFFFFFFFF)
+    precursor = rng.normal(0.0, 1.0, size=n_seeds).astype(np.float64)
+    null = rng.normal(0.0, 1.0, size=n_seeds).astype(np.float64)
+    precursor = precursor - float(precursor.mean()) + 0.5
+    null = null - float(null.mean()) + 0.5
+    return NullAuditInputCell(
+        cell_key=cell_key,
+        precursor_values=precursor,
+        null_values=null,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Capsule emission
+# ---------------------------------------------------------------------------
+
+
+def test_run_null_audit_all_writes_capsule_with_correct_kind(tmp_path: Path) -> None:
+    """Emitted capsule must declare kind=d002c_null_audit_capsule_v1 and
+    carry the load-bearing fields the preflight validator inspects."""
+    out = tmp_path / "null_audit.json"
+    cells = (_strong_signal_cell("cellA"), _strong_signal_cell("cellB"))
+    res = run_null_audit_all(
+        output_path=out,
+        sweep_results=cells,
+        n_shuffles=50,
+        rng_seed=0,
+    )
+    assert out.exists()
+    body = json.loads(out.read_text(encoding="utf-8"))
+    assert body["kind"] == NULL_AUDIT_AGGREGATE_KIND
+    assert isinstance(body["generated_at"], str) and body["generated_at"]
+    assert isinstance(body["results"], list)
+    assert len(body["results"]) == 2
+    assert body["aggregate_only"] is False
+    assert res.aggregate_verdict == "PASS"
+
+
+# ---------------------------------------------------------------------------
+# Capsule sha must match the preflight validator's canonical recompute
+# (the C2.6 alignment guarantee)
+# ---------------------------------------------------------------------------
+
+
+def test_capsule_sha_matches_validator_recompute(tmp_path: Path) -> None:
+    """The emitted capsule's sha256 must match the preflight validator's
+    recompute exactly. This is THE C2.6 alignment invariant: the writer
+    must hash through canonical_preflight_json, not plain
+    json.dumps(sort_keys=True). Verified end-to-end by feeding the
+    capsule into load_and_validate_preflight_capsules with stub POS /
+    NEG / SMOKE capsules — launch_allowed must be True with zero
+    refusal reasons."""
+    null_path = tmp_path / "null_audit.json"
+    cells = (_strong_signal_cell("cellA"), _strong_signal_cell("cellB"))
+    res = run_null_audit_all(
+        output_path=null_path,
+        sweep_results=cells,
+        n_shuffles=100,
+        rng_seed=0,
+    )
+    assert res.aggregate_verdict == "PASS"
+
+    paths = _write_all_stubs(tmp_path, null_path)
+    decision = load_and_validate_preflight_capsules(paths)
+    assert (
+        decision.launch_allowed is True
+    ), f"preflight refused; reasons={list(decision.refusal_reasons)}"
+    assert decision.refusal_reasons == ()
+    # The validator's recomputed null_audit sha must match what
+    # run_null_audit_all wrote on disk.
+    assert decision.capsule_shas["null_audit"] == res.sha256
+
+
+# ---------------------------------------------------------------------------
+# Aggregate verdict rules
+# ---------------------------------------------------------------------------
+
+
+def test_aggregate_pass_iff_all_cells_pass(tmp_path: Path) -> None:
+    """PASS iff EVERY audited cell has verdict==PASS AND zero skipped."""
+    out = tmp_path / "all_pass.json"
+    cells = (
+        _strong_signal_cell("cellA"),
+        _strong_signal_cell("cellB"),
+        _strong_signal_cell("cellC"),
+    )
+    res = run_null_audit_all(output_path=out, sweep_results=cells, n_shuffles=100)
+    assert res.aggregate_verdict == "PASS"
+    assert res.n_audited_cells == 3
+    assert res.n_pass == 3
+    assert res.n_fail == 0
+
+
+def test_one_fail_cell_makes_aggregate_fail(tmp_path: Path) -> None:
+    """ANY FAIL cell ⇒ aggregate FAIL (fail-closed). The preflight reads
+    per-cell verdicts, so the aggregator MUST surface FAIL to it."""
+    out = tmp_path / "one_fail.json"
+    cells = (
+        _strong_signal_cell("cellA"),
+        _noise_only_cell("cellB_noise"),
+        _strong_signal_cell("cellC"),
+    )
+    res = run_null_audit_all(output_path=out, sweep_results=cells, n_shuffles=200)
+    assert res.aggregate_verdict == "FAIL"
+    assert res.n_fail >= 1
+    assert res.n_pass == res.n_audited_cells - res.n_fail
+
+
+# ---------------------------------------------------------------------------
+# Empty-input handling (fail-closed without escape hatch)
+# ---------------------------------------------------------------------------
+
+
+def test_empty_results_without_aggregate_only_refuses(tmp_path: Path) -> None:
+    """Empty resolved cell list MUST raise unless aggregate_only_if_empty=True.
+    This blocks the C2.5 launch-hygiene compromise from regressing into
+    a silent default."""
+    out = tmp_path / "empty.json"
+    with pytest.raises(NullAuditAggregateInvalid):
+        run_null_audit_all(
+            output_path=out,
+            sweep_results=(),
+            n_shuffles=20,
+        )
+    assert not out.exists()
+
+
+def test_empty_with_aggregate_only_emits_escape_capsule(tmp_path: Path) -> None:
+    """Genuinely-empty-grid escape hatch: aggregate_only_if_empty=True
+    emits the escape capsule the preflight accepts."""
+    out = tmp_path / "empty_escape.json"
+    res = run_null_audit_all(
+        output_path=out,
+        sweep_results=(),
+        n_shuffles=20,
+        aggregate_only_if_empty=True,
+    )
+    assert out.exists()
+    assert res.aggregate_verdict == "PASS"
+    body = json.loads(out.read_text(encoding="utf-8"))
+    assert body["aggregate_only"] is True
+    assert body["results"] == []
+
+
+# ---------------------------------------------------------------------------
+# Non-finite p-value path through the preflight validator
+# ---------------------------------------------------------------------------
+
+
+def test_non_finite_p_value_refuses_via_preflight(tmp_path: Path) -> None:
+    """If a capsule is forged with a non-finite p_value_empirical, the
+    preflight validator must refuse launch with _R_NON_FINITE_FIELD.
+    Verifies that the canonical sha encoding correctly stringifies
+    non-finite floats AND that the validator inspects p_value_empirical."""
+    forged_body: dict[str, Any] = {
+        "kind": NULL_AUDIT_AGGREGATE_KIND,
+        "generated_at": "2026-05-12T13:00:00Z",
+        "n_audited_cells": 1,
+        "n_pass": 1,
+        "n_fail": 0,
+        "n_shuffles_per_cell": 100,
+        "aggregate_verdict": "PASS",
+        "aggregate_only": False,
+        "results": [
+            {
+                "cell_key": "forged_cell",
+                "n_seeds": 20,
+                "n_shuffles": 100,
+                "unshuffled_abs_signal": 0.5,
+                "shuffled_abs_signal_median": 0.05,
+                "shuffled_abs_signal_p95": 0.1,
+                "p_value_empirical": float("nan"),
+                "verdict": "PASS",
+                "sha256": "00" * 32,
+            }
+        ],
+    }
+    sealed = _seal(forged_body)
+    null_path = tmp_path / "forged.json"
+    # plain json.dumps refuses NaN by default; canonical_preflight_json
+    # replaces it with "NaN" so we round-trip through the canonical
+    # encoder for the on-disk artifact too.
+    canon = canonical_preflight_json(sealed)
+    null_path.write_text(canon, encoding="utf-8")
+
+    paths = _write_all_stubs(tmp_path, null_path)
+    decision = load_and_validate_preflight_capsules(paths)
+    assert decision.launch_allowed is False
+    joined = "\n".join(decision.refusal_reasons)
+    assert "capsule_non_finite_load_bearing_field" in joined
+
+
+# ---------------------------------------------------------------------------
+# Determinism
+# ---------------------------------------------------------------------------
+
+
+def test_capsule_sha_deterministic_across_calls(tmp_path: Path) -> None:
+    """Same inputs + same generated_at + same seed ⇒ identical capsule
+    sha. Guards against accidental non-determinism in the writer (e.g.
+    a hidden timestamp drift)."""
+    cells = (_strong_signal_cell("cellX"),)
+    fixed_ts = "2026-05-12T14:00:00Z"
+    out_a = tmp_path / "a.json"
+    out_b = tmp_path / "b.json"
+    res_a = run_null_audit_all(
+        output_path=out_a,
+        sweep_results=cells,
+        n_shuffles=50,
+        rng_seed=7,
+        generated_at=fixed_ts,
+    )
+    res_b = run_null_audit_all(
+        output_path=out_b,
+        sweep_results=cells,
+        n_shuffles=50,
+        rng_seed=7,
+        generated_at=fixed_ts,
+    )
+    assert res_a.sha256 == res_b.sha256
+    body_a = json.loads(out_a.read_text(encoding="utf-8"))
+    body_b = json.loads(out_b.read_text(encoding="utf-8"))
+    assert body_a["sha256"] == body_b["sha256"]
+
+
+def test_capsule_sha_changes_when_one_cell_verdict_changes(tmp_path: Path) -> None:
+    """sha must distinguish capsules whose per-cell content differs in
+    the verdict bit, otherwise tampering with a single cell would slip
+    past the chain-of-custody check."""
+    fixed_ts = "2026-05-12T14:30:00Z"
+    cells_pass = (_strong_signal_cell("cellY"), _strong_signal_cell("cellZ"))
+    cells_mixed = (_strong_signal_cell("cellY"), _noise_only_cell("cellZ_noise"))
+    res_pass = run_null_audit_all(
+        output_path=tmp_path / "pass.json",
+        sweep_results=cells_pass,
+        n_shuffles=100,
+        rng_seed=3,
+        generated_at=fixed_ts,
+    )
+    res_mixed = run_null_audit_all(
+        output_path=tmp_path / "mixed.json",
+        sweep_results=cells_mixed,
+        n_shuffles=100,
+        rng_seed=3,
+        generated_at=fixed_ts,
+    )
+    assert res_pass.sha256 != res_mixed.sha256
+    assert res_pass.aggregate_verdict != res_mixed.aggregate_verdict
+
+
+# ---------------------------------------------------------------------------
+# Frozen dataclass contracts
+# ---------------------------------------------------------------------------
+
+
+def test_null_audit_input_cell_is_frozen() -> None:
+    """Frozen contract: mutating an instance must raise — input pair
+    samples are load-bearing inputs to the audit sha."""
+    cell = _strong_signal_cell("frozen_in")
+    assert isinstance(cell, NullAuditInputCell)
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        cell.cell_key = "MUTATED"  # type: ignore[misc]
+
+
+def test_null_audit_aggregate_result_is_frozen(tmp_path: Path) -> None:
+    """Frozen contract: aggregate verdict / sha are immutable once
+    emitted — otherwise the chain-of-custody guarantee breaks."""
+    out = tmp_path / "frozen.json"
+    res = run_null_audit_all(
+        output_path=out,
+        sweep_results=(_strong_signal_cell("frozen_out"),),
+        n_shuffles=20,
+    )
+    assert isinstance(res, NullAuditAggregateResult)
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        res.aggregate_verdict = "MUTATED"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Skipped cells must force aggregate FAIL (fail-closed)
+# ---------------------------------------------------------------------------
+
+
+def test_skipped_cells_force_aggregate_fail(tmp_path: Path) -> None:
+    """A sweep capsule cell lacking per-seed data MUST be recorded with
+    verdict=SKIPPED_NO_PER_SEED_DATA AND the aggregate verdict MUST be
+    FAIL (a missing audit is not evidence of a passing audit)."""
+    sweep_cap = tmp_path / "sweep.json"
+    rng = np.random.default_rng(0)
+    p_arr = rng.normal(1.0, 0.05, size=15).tolist()
+    n_arr = rng.normal(0.0, 0.05, size=15).tolist()
+    sweep_cap.write_text(
+        json.dumps(
+            {
+                "results": [
+                    {
+                        "substrate_id": "ricci_flow",
+                        "metric_id": "sync_auc",
+                        "N": 100,
+                        "lambda_": 0.5,
+                        "precursor_per_seed": p_arr,
+                        "null_per_seed": n_arr,
+                    },
+                    # Cell with NO per-seed arrays — must be SKIPPED.
+                    {
+                        "substrate_id": "block_structured",
+                        "metric_id": "tau_onset",
+                        "N": 100,
+                        "lambda_": 0.5,
+                        "variance_ratio": 0.4,
+                    },
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    out = tmp_path / "skipped.json"
+    res = run_null_audit_all(
+        output_path=out,
+        sweep_capsule_path=sweep_cap,
+        n_shuffles=50,
+        rng_seed=0,
+    )
+    assert res.aggregate_verdict == "FAIL"
+    # Exactly one cell is auditable (and PASSes); one is skipped.
+    skipped_verdicts = [r.verdict for r in res.results if r.verdict == SKIPPED_NO_PER_SEED_DATA]
+    assert len(skipped_verdicts) == 1
+    assert res.n_audited_cells == 1
+
+
+# ---------------------------------------------------------------------------
+# Input-source mutual exclusion
+# ---------------------------------------------------------------------------
+
+
+def test_handles_capsule_path_or_sweep_results_but_not_both(tmp_path: Path) -> None:
+    """Exactly one input source MUST be supplied. Both, or neither, MUST
+    raise NullAuditAggregateInvalid — the contract is not negotiable
+    (passing both would silently ignore one)."""
+    out = tmp_path / "rejected.json"
+    sweep_cap = tmp_path / "sweep.json"
+    sweep_cap.write_text(json.dumps({"results": []}), encoding="utf-8")
+    cells = (_strong_signal_cell("X"),)
+
+    with pytest.raises(NullAuditAggregateInvalid):
+        run_null_audit_all(
+            output_path=out,
+            sweep_results=cells,
+            sweep_capsule_path=sweep_cap,
+            n_shuffles=20,
+        )
+
+    with pytest.raises(NullAuditAggregateInvalid):
+        run_null_audit_all(
+            output_path=out,
+            n_shuffles=20,
+        )


### PR DESCRIPTION
## Summary

- Adds `research.systemic_risk.d002c_null_audit.run_null_audit_all` — per-cell aggregator that emits a real `d002c_null_audit_capsule_v1` capsule with per-cell `NullAuditResult` payloads + an aggregate verdict.
- Removes the `aggregate_only=true, results=[]` launch-hygiene compromise documented in C2.5 so the canonical D-002C launch genuinely exercises the null-audit FAIL signal.
- Capsule sha computed through `d002c_preflight.canonical_preflight_json` (function-scope import) so the writer's sha bit-exactly matches the preflight validator's recompute — the C2.6 alignment guarantee, applied locally without touching the pos/neg/smoke writers or the validator.

## Aggregate verdict (fail-closed)

- PASS iff every audited cell has `verdict==PASS` AND zero cells were skipped (missing per-seed data) AND `n_audited >= 1`
- any FAIL or `SKIPPED_NO_PER_SEED_DATA` cell → `aggregate=FAIL`
- empty resolved cell list without `aggregate_only_if_empty=True` raises `NullAuditAggregateInvalid` (no silent regression to the C2.5 compromise)
- empty + `aggregate_only_if_empty=True` → emits the preflight escape capsule for the genuinely-empty-grid case only

## Claim boundary

This PR removes the `aggregate_only` null-audit compromise to unblock the canonical D-002C rerun. It introduces **NO** claim layer and **NO** certification — the D-002C verdict tier is still gated by the C2.5 acceptance evaluator.

## Strict scope

- Aggregator + capsule emission **ONLY**
- No modification of the per-pair `run_null_audit` / `run_null_audit_from_capsule` contracts
- No modification of `d002c_preflight.py`, the pos/neg/smoke writers, or `D002C_PREREGISTRATION.yaml`
- No claim layer; no tier promotion

## Quality gates (all green, serial under thermal envelope)

- `ruff check` clean
- `black --check` clean
- `mypy --strict --follow-imports=silent` clean
- `pytest tests/research/systemic_risk/test_d002c_null_audit_aggregator.py` → **13/13 PASS**
- `pytest tests/research/systemic_risk/test_d002c_null_audit.py` (regression) → **26/26 PASS**
- `pytest tests/research/systemic_risk/test_d002c_sweep_runner_preflight_integration.py` → **19/19 PASS**
- `pytest tests/audit/test_false_confidence_detector.py` → **28/28 PASS, zero new findings**

## Test plan

- [x] `pytest` 13 new tests cover: capsule kind, sha matches validator recompute end-to-end, aggregate PASS iff all cells PASS, one FAIL → aggregate FAIL, empty without aggregate_only raises, non-finite p-value rejected via preflight, sha deterministic, sha changes when one verdict flips, frozen dataclasses, skipped cells force FAIL, mutual exclusion of inputs
- [x] Falsifier probe executes end-to-end: stub POS/NEG/SMOKE + emitted PASS null-audit capsule → `launch_allowed=True`, validator's recomputed null_audit sha matches writer's sha
- [x] All existing test suites still pass (regression bands explicitly checked)
- [ ] CI green on push

## Sibling PR coordination

A sibling PR #671 (C2.6 — writer capsule sha alignment for pos/neg/smoke writers) is in flight. This PR is **independent**: branched fresh from `main` (sha `98ef559`), touches only `d002c_null_audit.py`, applies the canonical-JSON pattern locally via `function-scope import` — does not depend on #671 landing first.

Chain-hold: do not auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)