### PR TITLE
docs(x10r,D-002G): add structural closure artifact for null admissibility path

### DIFF
--- a/.claude/commit_acceptors/x10r-d002g-structural-closure.yaml
+++ b/.claude/commit_acceptors/x10r-d002g-structural-closure.yaml
@@ -1,0 +1,210 @@
+# Diff-bound commit acceptor for the D-002G structural closure PR.
+#
+# Lands the negative-result retention artifact that pins the
+# structural impossibility of the locked 3-substrate
+# null-admissibility path under PRs #677 (M1) / #679 (M2 edge-weight)
+# / #680 (M2 node-payload + injection-sequence) / #681 (M3
+# topology-conditioned). The bottom-turtle fact is encoded in
+# research/systemic_risk/d002c_substrates.py:401 (BlockStructuredSubstrate
+# discards its seed by construction); TemporalKtSubstrate inherits the
+# discard via delegation at lines 481-483.
+#
+# Strict scope:
+#   * NO D-002G scientific PASS claim.
+#   * NO canonical D-002G run authorisation.
+#   * NO D-002C ledger update (sha pinned byte-exact).
+#   * NO substrate code edit.
+#   * NO prereg edit (D002G_PREREGISTRATION.yaml + D002G_P3_M3_PREREGISTRATION.md byte-exact).
+#   * NO M4 implementation. NO M4 pre-registration.
+#   * NO B2 closure.
+#   * NO removal / weakening of any P1 / P2 / P3 / M3 verdict / test / invariant.
+#   * NO edit to prior PR reports (sha-locked by their merge commits).
+#
+# The closure verdict is SCOPED to the conjunction
+# (D-002G prereg substrates x locked marginal set x M1/M2/M3
+# mechanism families). It does NOT claim D-002G globally falsified,
+# does NOT impugn ricci_flow, does NOT claim universal invalidity of
+# null mechanisms. Resolution requires a FRESH D-002H pre-registration
+# (scope narrowing OR substrate redesign OR negative-retention) in a
+# separate PR; the operator decides among the three legal paths.
+
+id: x10r-d002g-structural-closure
+status: ACTIVE
+claim_type: documentation
+promise: >-
+  After this PR lands, docs/governance/D002G_STRUCTURAL_CLOSURE_REPORT.md
+  carries the 7-section scoped-closure artifact;
+  docs/governance/D002G_NEGATIVE_SPACE_MAP.md enumerates the five
+  exhausted null-mechanism families (M1 / M2 edge-weight /
+  M2 node-payload / M2 injection-sequence / M3 topology-conditioned)
+  with rule-out lessons; artifacts/d002g/closure/d002g_structural_closure.json
+  carries the schema_version "D002G-STRUCTURAL-CLOSURE-v1" payload
+  with merge_chain of 4 PRs (#677 / #679 / #680 / #681), all four
+  boolean claim-boundary flags false (canonical_run_authorized,
+  scientific_pass_claimed, d002g_globally_falsified_claimed,
+  ricci_flow_invalid_claimed) plus d002c_ledger_touched false,
+  b1_status starting with OPEN_STRUCTURALLY_BLOCKED, and exactly 3
+  legal_next_paths (D002H_SCOPE_NARROWING, D002H_SUBSTRATE_REDESIGN,
+  D002G_NEGATIVE_ARTIFACT_RETENTION).
+
+  docs/governance/D002G_CANONICAL_RUN_BLOCKERS.md gains an append-only
+  B1.closure subsection inside the B1 block (before B2), citing the
+  PR #681 merge sha cced6e60 and the structural-closure report.
+
+  tests/systemic_risk/test_d002g_structural_closure.py adds 10 tests
+  pinning the closure invariants: closure_report_exists,
+  closure_json_schema_keys, closure_forbids_canonical_run,
+  closure_forbids_scientific_pass, closure_preserves_d002c_ledger,
+  negative_space_map_mentions_all_four_prs,
+  bottom_turtle_seed_ignored_fact_present, no_m4_implementation_claim,
+  legal_next_paths_are_fresh_prereg_only,
+  blocker_doc_appended_not_rewritten.
+
+  Strict scope: closure artifact + tests + acceptor + BLOCKERS append
+  only. This PR does NOT modify substrate code, does NOT touch the
+  D-002C ledger, does NOT touch any prior PR report, does NOT
+  pre-register M4, does NOT authorise a canonical run, does NOT
+  claim D-002G globally falsified, does NOT impugn ricci_flow.
+
+diff_scope:
+  changed_files:
+    - path: ".claude/commit_acceptors/x10r-d002g-structural-closure.yaml"
+    - path: "docs/governance/D002G_STRUCTURAL_CLOSURE_REPORT.md"
+    - path: "docs/governance/D002G_NEGATIVE_SPACE_MAP.md"
+    - path: "docs/governance/D002G_CANONICAL_RUN_BLOCKERS.md"
+    - path: "artifacts/d002g/closure/d002g_structural_closure.json"
+    - path: "tests/systemic_risk/test_d002g_structural_closure.py"
+  forbidden_paths:
+    # D-002G locked governance + prior PR reports
+    - "docs/governance/D002G_PREREGISTRATION.yaml"
+    - "docs/governance/D002G_NONDEGENERATE_NULL_DESIGN.md"
+    - "docs/governance/D002G_ACCEPTANCE_RULES.md"
+    - "docs/governance/D002G_P3_M3_PREREGISTRATION.md"
+    - "docs/governance/D002G_P1_IMPLEMENTATION_REPORT.md"
+    - "docs/governance/D002G_P1_DESIGN_ADVERSARIAL_AUDIT.md"
+    - "docs/governance/D002G_P2_M2_IMPLEMENTATION_REPORT.md"
+    - "docs/governance/D002G_M2_TOPOLOGY_PRESERVING_NULL.md"
+    - "docs/governance/D002G_P3_DISCOVERY_REPORT.md"
+    - "docs/governance/D002G_P3_NULL_DOMAIN_CONTRACTS.md"
+    - "docs/governance/D002G_P3_ELIGIBILITY_MATRIX.md"
+    - "docs/governance/D002G_P3_IMPLEMENTATION_REPORT.md"
+    - "docs/governance/D002G_M3_IMPLEMENTATION_REPORT.md"
+    - "docs/governance/D002G_M3_ELIGIBILITY_MATRIX.md"
+    # D-002C locked governance
+    - "docs/governance/D002C_PREREGISTRATION.yaml"
+    - "docs/governance/D002C_CLAIM_LEDGER.yaml"
+    - "docs/governance/D002C_CANONICAL_RUN_REPORT.md"
+    - "docs/governance/D002C_ATTEMPT_2_NULL_AUDIT_FALSIFICATION_REPORT.md"
+    # All prior commit acceptors
+    - ".claude/commit_acceptors/x10r-d002g-nondegenerate-null-redesign.yaml"
+    - ".claude/commit_acceptors/x10r-d002g-p1-implementation.yaml"
+    - ".claude/commit_acceptors/x10r-d002g-p1-strike-scaffolding.yaml"
+    - ".claude/commit_acceptors/x10r-d002g-p2-m2-topology-preserving-shuffle.yaml"
+    - ".claude/commit_acceptors/x10r-d002g-p3-constant-payload-null-recovery.yaml"
+    - ".claude/commit_acceptors/x10r-d002g-m3-topology-conditioned-null.yaml"
+    # Substrate code + null mechanism module
+    - "research/systemic_risk/d002c_substrates.py"
+    - "research/systemic_risk/d002g_null_mechanisms.py"
+    # Canonical-run artifact tree
+    - "artifacts/d002g/canonical/"
+required_python_symbols: []
+expected_signal: >-
+  `pytest tests/systemic_risk/test_d002g_structural_closure.py -q`
+  passes all 10 closure tests; `python -c "import json;
+  d=json.load(open('artifacts/d002g/closure/d002g_structural_closure.json'));
+  assert d['schema_version']=='D002G-STRUCTURAL-CLOSURE-v1'; assert
+  len(d['merge_chain'])==4; assert d['canonical_run_authorized'] is False;
+  assert d['scientific_pass_claimed'] is False; assert
+  d['d002c_ledger_touched'] is False"` succeeds; the closure report
+  contains the verbatim "STRUCTURAL CLOSURE" verdict block; the
+  D002C_CLAIM_LEDGER.yaml sha256 stays byte-exact at the locked pin
+  (f96ba9b5a2057d2e0bff84afc28578ab316cff73f6dc6673fb0d6d543b8bd6dd);
+  D002G_P3_M3_PREREGISTRATION.md sha256 stays byte-exact at the #680
+  merge-anchor pin (0f11a0c890374c35e4dedecc66caec52ae867f49a8f8b3be2374f1464712c1f8);
+  the BLOCKERS.md gains a B1.closure subsection citing cced6e60 and
+  the structural closure report; the negative-space map enumerates
+  all five mechanism rows.
+measurement_command: >-
+  bash -c 'set -e;
+  PYTHONPATH=. python -m pytest tests/systemic_risk/test_d002g_structural_closure.py -q;
+  python -c "import json;
+  d=json.load(open(\"artifacts/d002g/closure/d002g_structural_closure.json\"));
+  assert d[\"schema_version\"]==\"D002G-STRUCTURAL-CLOSURE-v1\";
+  assert len(d[\"merge_chain\"])==4;
+  assert d[\"canonical_run_authorized\"] is False;
+  assert d[\"scientific_pass_claimed\"] is False;
+  assert d[\"d002c_ledger_touched\"] is False;
+  assert d[\"d002g_globally_falsified_claimed\"] is False;
+  assert d[\"ricci_flow_invalid_claimed\"] is False;
+  assert len(d[\"legal_next_paths\"])==3";
+  grep -q "STRUCTURAL CLOSURE" docs/governance/D002G_STRUCTURAL_CLOSURE_REPORT.md;
+  grep -q "STRUCTURALLY BLOCKED" docs/governance/D002G_STRUCTURAL_CLOSURE_REPORT.md;
+  grep -q "Canonical run remains BLOCKED" docs/governance/D002G_STRUCTURAL_CLOSURE_REPORT.md;
+  grep -q "B1.closure" docs/governance/D002G_CANONICAL_RUN_BLOCKERS.md;
+  grep -q "cced6e60" docs/governance/D002G_CANONICAL_RUN_BLOCKERS.md;
+  grep -q "M3 topology-conditioned independent realisation" docs/governance/D002G_NEGATIVE_SPACE_MAP.md;
+  test "$(sha256sum docs/governance/D002C_CLAIM_LEDGER.yaml | cut -d\ -f1)" = "f96ba9b5a2057d2e0bff84afc28578ab316cff73f6dc6673fb0d6d543b8bd6dd";
+  test "$(sha256sum docs/governance/D002G_P3_M3_PREREGISTRATION.md | cut -d\ -f1)" = "0f11a0c890374c35e4dedecc66caec52ae867f49a8f8b3be2374f1464712c1f8"'
+signal_artifact: "docs/governance/D002G_STRUCTURAL_CLOSURE_REPORT.md"
+falsifier:
+  command: >-
+    bash -c 'set -e;
+    PYTHONPATH=. python -m pytest tests/systemic_risk/test_d002g_structural_closure.py -q || exit 1;
+    test -f docs/governance/D002G_STRUCTURAL_CLOSURE_REPORT.md || exit 2;
+    test -f docs/governance/D002G_NEGATIVE_SPACE_MAP.md || exit 3;
+    test -f artifacts/d002g/closure/d002g_structural_closure.json || exit 4;
+    python -c "import json;
+    d=json.load(open(\"artifacts/d002g/closure/d002g_structural_closure.json\"));
+    assert d[\"schema_version\"]==\"D002G-STRUCTURAL-CLOSURE-v1\";
+    assert len(d[\"merge_chain\"])==4;
+    assert d[\"canonical_run_authorized\"] is False;
+    assert d[\"scientific_pass_claimed\"] is False;
+    assert d[\"d002c_ledger_touched\"] is False;
+    ids=[p[\"id\"] for p in d[\"legal_next_paths\"]];
+    assert set(ids)=={\"D002H_SCOPE_NARROWING\",\"D002H_SUBSTRATE_REDESIGN\",\"D002G_NEGATIVE_ARTIFACT_RETENTION\"}" || exit 5;
+    grep -q "B1.closure" docs/governance/D002G_CANONICAL_RUN_BLOCKERS.md || exit 6;
+    grep -q "cced6e60" docs/governance/D002G_CANONICAL_RUN_BLOCKERS.md || exit 7;
+    grep -q "_ = seed" docs/governance/D002G_STRUCTURAL_CLOSURE_REPORT.md || exit 8;
+    grep -q "research/systemic_risk/d002c_substrates.py" docs/governance/D002G_STRUCTURAL_CLOSURE_REPORT.md || exit 9;
+    test "$(sha256sum docs/governance/D002C_CLAIM_LEDGER.yaml | cut -d\ -f1)" = "f96ba9b5a2057d2e0bff84afc28578ab316cff73f6dc6673fb0d6d543b8bd6dd" || exit 10;
+    test "$(sha256sum docs/governance/D002G_P3_M3_PREREGISTRATION.md | cut -d\ -f1)" = "0f11a0c890374c35e4dedecc66caec52ae867f49a8f8b3be2374f1464712c1f8" || exit 11;
+    if grep -E "D-002G validated|canonical run authoriz|canonical run authorised|D-002C rescued|M4 implementation in this PR|M4 will fix this" docs/governance/D002G_STRUCTURAL_CLOSURE_REPORT.md docs/governance/D002G_NEGATIVE_SPACE_MAP.md | grep -vE "forbidden|NOT|never|cannot|does not|do not|out of scope|out-of-scope"; then
+      echo "forbidden promotional phrase leaked outside denial context"; exit 12;
+    fi'
+  description: >-
+    Probes the D-002G structural closure artifact:
+    (a) the 10 closure tests all pass;
+    (b) all 3 new artifact files exist on disk;
+    (c) the closure JSON carries schema v1 + 4-entry merge_chain
+        + 5 false claim-boundary flags + 3 legal_next_paths with
+        the exact expected id set;
+    (d) BLOCKERS.md carries the new B1.closure subsection citing
+        the PR #681 merge sha cced6e60;
+    (e) the closure report carries the bottom-turtle ``_ = seed``
+        quote AND the substrate file-path citation;
+    (f) D002C_CLAIM_LEDGER.yaml is byte-exact unchanged;
+    (g) D002G_P3_M3_PREREGISTRATION.md is byte-exact unchanged at
+        the #680 merge-anchor sha;
+    (h) no forbidden D-002G PASS / D-002C rescue / canonical-run
+        authorisation / M4-in-D002G string leaks outside denial
+        context.
+    If any of these regress, the closure contract is broken.
+rollback_command: >-
+  bash -c 'rm -f
+  docs/governance/D002G_STRUCTURAL_CLOSURE_REPORT.md
+  docs/governance/D002G_NEGATIVE_SPACE_MAP.md
+  artifacts/d002g/closure/d002g_structural_closure.json
+  tests/systemic_risk/test_d002g_structural_closure.py
+  .claude/commit_acceptors/x10r-d002g-structural-closure.yaml
+  && git checkout HEAD~1 -- docs/governance/D002G_CANONICAL_RUN_BLOCKERS.md'
+rollback_verification_command: >-
+  bash -c 'test ! -f docs/governance/D002G_STRUCTURAL_CLOSURE_REPORT.md
+  && test ! -f docs/governance/D002G_NEGATIVE_SPACE_MAP.md
+  && test ! -f artifacts/d002g/closure/d002g_structural_closure.json
+  && test ! -f tests/systemic_risk/test_d002g_structural_closure.py
+  && test ! -f .claude/commit_acceptors/x10r-d002g-structural-closure.yaml
+  && ! grep -q "B1.closure" docs/governance/D002G_CANONICAL_RUN_BLOCKERS.md'
+memory_update_type: append
+ledger_path: ".claude/commit_acceptors/x10r-d002g-structural-closure.yaml"
+report_path: "docs/governance/D002G_STRUCTURAL_CLOSURE_REPORT.md"
+evidence: []

--- a/.github/detect-secrets.baseline
+++ b/.github/detect-secrets.baseline
@@ -4568,6 +4568,36 @@
         "line_number": 21
       }
     ],
+    "artifacts/d002g/closure/d002g_structural_closure.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "artifacts/d002g/closure/d002g_structural_closure.json",
+        "hashed_secret": "e15c9a57f4f96fb8a1172ac1c0dda1fa08914a03",
+        "is_verified": false,
+        "line_number": 13
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "artifacts/d002g/closure/d002g_structural_closure.json",
+        "hashed_secret": "951fe3d4e52dde365236d85ed4503c99a4a86c70",
+        "is_verified": false,
+        "line_number": 14
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "artifacts/d002g/closure/d002g_structural_closure.json",
+        "hashed_secret": "50bd18de7210b2986280a0b266783922d7c7da0a",
+        "is_verified": false,
+        "line_number": 15
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "artifacts/d002g/closure/d002g_structural_closure.json",
+        "hashed_secret": "436b7ba8a83f8323b3d4c5d60fd3734863ccd2c8",
+        "is_verified": false,
+        "line_number": 16
+      }
+    ],
     "artifacts/d002g/m3/m3_null_domain_verdicts.json": [
       {
         "type": "Hex High Entropy String",
@@ -7584,5 +7614,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-13T07:29:01Z"
+  "generated_at": "2026-05-13T09:04:57Z"
 }

--- a/artifacts/d002g/closure/d002g_structural_closure.json
+++ b/artifacts/d002g/closure/d002g_structural_closure.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": "D002G-STRUCTURAL-CLOSURE-v1",
+  "status": "STRUCTURALLY_BLOCKED",
+  "scope": "D-002G locked substrate grid × locked marginal set × M1/M2/M3 mechanism families",
+  "canonical_run_authorized": false,
+  "scientific_pass_claimed": false,
+  "d002g_globally_falsified_claimed": false,
+  "d002c_ledger_touched": false,
+  "ricci_flow_invalid_claimed": false,
+  "b1_status": "OPEN_STRUCTURALLY_BLOCKED_UNDER_D002G",
+  "b2_status": "OPEN_UNTOUCHED",
+  "merge_chain": [
+    {"pr": 677, "merge_sha": "d3400c2e981d947449c7457fd163c71e7abc0dab", "mechanism": "M1 independent-seed", "verdict_blocked_substrates": "INELIGIBLE_M1_BIT_IDENTICAL"},
+    {"pr": 679, "merge_sha": "7b386ef3e95311c93147d97ebb23ec2d085a3650", "mechanism": "M2 edge-weight permutation", "verdict_blocked_substrates": "INELIGIBLE_M2_DEGENERATE_SHUFFLE_POOL"},
+    {"pr": 680, "merge_sha": "0f4433e04c7a594fc80c964eeec337a8b1128038", "mechanism": "M2 node-payload + injection-sequence", "verdict_blocked_substrates": "INELIGIBLE_M2_NODE_PAYLOAD_TOPOLOGY_COUPLED + INELIGIBLE_M2_INJECTION_SEQUENCE_DEGENERATE/CONTRACT_VIOLATION"},
+    {"pr": 681, "merge_sha": "cced6e60f3b448878d51cb9848c990ab5133da28", "mechanism": "M3 topology-conditioned independent realisation", "verdict_blocked_substrates": "INELIGIBLE_M3_NON_PRECURSOR_SPECIFIC"}
+  ],
+  "bottom_turtle": {
+    "file": "research/systemic_risk/d002c_substrates.py",
+    "line": 401,
+    "fact": "BlockStructuredSubstrate.realize() explicitly discards its seed parameter",
+    "evidence_quote": "_ = seed  # block substrate is fully deterministic in N, lambda_",
+    "downstream": "TemporalKtSubstrate.realize() inherits the discard via delegation at line 481-483"
+  },
+  "legal_next_paths": [
+    {"id": "D002H_SCOPE_NARROWING", "description": "Fresh pre-registration restricting canonical grid to ricci_flow only"},
+    {"id": "D002H_SUBSTRATE_REDESIGN", "description": "Fresh pre-registration replacing block_structured + temporal_coupling spec with seed-dependent variants"},
+    {"id": "D002G_NEGATIVE_ARTIFACT_RETENTION", "description": "Retain D-002G as structurally-blocked; do NOT attempt B1 closure"}
+  ],
+  "decision_among_legal_paths": "DEFERRED_TO_FRESH_PRE_REGISTRATION"
+}

--- a/docs/governance/D002G_CANONICAL_RUN_BLOCKERS.md
+++ b/docs/governance/D002G_CANONICAL_RUN_BLOCKERS.md
@@ -76,6 +76,10 @@ Full machine-readable matrix is at `artifacts/d002g/m3/m3_null_domain_verdicts.j
 
 **Canonical-run status (verbatim):** even though M3 lands ELIGIBLE on `ricci_flow`, canonical run authorisation requires B1 closure (all three substrates ELIGIBLE) AND B2 closure / acceptance AND an explicit canonical-run authorisation artefact. NONE of these conjuncts are satisfied by this PR. Canonical D-002G remains BLOCKED.
 
+#### B1.closure — Structural closure under current locked grid
+
+> After PR #681 (M3 topology-conditioned, merge `cced6e60`) returned `INELIGIBLE_M3_NON_PRECURSOR_SPECIFIC` for both `block_structured` and `temporal_coupling`, the M1/M2/M3 mechanism family is exhausted on the locked substrate grid. The bottom-turtle code fact (`research/systemic_risk/d002c_substrates.py:401`) confirms the substrates discard seed by construction. B1 closure under D-002G is therefore STRUCTURALLY BLOCKED; canonical D-002G run remains BLOCKED. See `D002G_STRUCTURAL_CLOSURE_REPORT.md` for the full closure artifact. Resolution requires fresh D-002H pre-registration (scope narrowing OR substrate redesign), NOT an M4 mechanism inside the current D-002G prereg.
+
 ### B2 — Phase 0b CI is percentile bootstrap, not BCa — OPEN (limitation)
 
 The Phase 0b verdict-grade CI on the per-seed paired-difference mean is a percentile bootstrap CI (P1-3 Codex review, Path 2 downgrade). True BCa (bias-corrected accelerated) bootstrap CI was advertised in the original implementation docstring + adversarial audit narrative; the implementation always was percentile.

--- a/docs/governance/D002G_NEGATIVE_SPACE_MAP.md
+++ b/docs/governance/D002G_NEGATIVE_SPACE_MAP.md
@@ -1,0 +1,79 @@
+# D-002G — Negative Space Map
+
+## Excluded null-mechanism families under D-002G locked substrate grid
+
+Companion artifact to `D002G_STRUCTURAL_CLOSURE_REPORT.md`. This
+document enumerates the five null-mechanism families empirically
+exhausted by PRs #677 / #679 / #680 / #681 against the two
+M1-INELIGIBLE substrates (`block_structured`, `temporal_coupling`)
+under the locked D-002G pre-registration.
+
+Each row records (i) what was tried, (ii) what the mechanism preserves
+by construction, (iii) the empirical failure mode, and (iv) the
+generalisable rule-out lesson for downstream pre-registrations.
+
+| Mechanism | Tried | Preserved | Failure mode | Rule-out lesson |
+|---|---|---|---|---|
+| M1 independent seed | drawing K_null from substrate at λ=0 with offset null_seed | substrate API | bit-identical K_p == K_null when substrate discards seed | independent-seed null requires substrate stochasticity in K_p |
+| M2 edge-weight permutation | permuting ΔK support values | topology hash + support count | constant ΔK payload → no-op permutation | edge-weight permutation requires ΔK with ≥ 2 distinct support values |
+| M2 node-payload permutation | permuting node labels under fixed topology | topology + node count | node identity IS the topology (block label = node label space) | node-payload permutation requires substrate where node identity is decoupled from topology semantics |
+| M2 injection-sequence permutation | permuting injection event order under fixed topology | event multiset | injection IS the precursor (sequence is the causal hypothesis) OR sequence length < 2 | injection-sequence permutation requires non-trivial event sequence outside causal hypothesis |
+| M3 topology-conditioned independent realisation | matched-marginal generator at locked marginal set | degree + block + spectral/N + density | marginals seed-invariant by substrate construction | mechanisms conditioned on marginal set X cannot identify precursor-specificity if substrate signal lies OUTSIDE X |
+
+The five rows above span the full closed null-mechanism design space
+that conditions only on quantities derivable from `(N, λ)` for a
+seed-deterministic substrate. There is no sixth mechanism in this
+family — any further mechanism that conditions only on `(N, λ)`-driven
+quantities is structurally equivalent to one of the five rows.
+
+## Design rule for future mechanism families
+
+> Any future null-mechanism family proposed under a fresh
+> pre-registration MUST first demonstrate that the substrate's
+> `realize(seed)` produces seed-dependent variation in a quantity the
+> mechanism CONDITIONS on. If the substrate is seed-deterministic and
+> the proposed null conditions on quantities that depend ONLY on
+> (N, λ), the mechanism is structurally INVALID a priori.
+
+The rule is intentionally substrate-first: it is a *prerequisite check
+on the substrate*, not a property of the mechanism. A mechanism that
+would be valid on a different substrate is not therefore valid on the
+locked D-002G substrate; the mechanism's admissibility is conditional
+on the substrate's stochastic content along the axis the mechanism
+conditions on.
+
+Concretely:
+
+- A mechanism conditioning on **edge-weight distributions** requires
+  the substrate to produce seed-dependent edge weights at λ > 0.
+- A mechanism conditioning on **node identity** requires the substrate
+  to expose a node-label space decoupled from topology semantics.
+- A mechanism conditioning on **injection event timing/order**
+  requires injection events that are NOT themselves the causal
+  hypothesis under test.
+- A mechanism conditioning on **graph marginals** (degree, density,
+  spectral radius, block histogram) requires substrate stochasticity
+  in at least one marginal axis.
+
+For the locked D-002G `block_structured` and `temporal_coupling`
+substrates, none of these prerequisites hold, by substrate-class
+design. The five rows in the table above record the exhaustive
+empirical demonstration of that fact.
+
+## Scope
+
+This document does NOT impugn `ricci_flow`, which carries
+seed-dependent stochastic content and admits ELIGIBLE_M1 / ELIGIBLE_M2
+(edge-weight) / ELIGIBLE_M3 verdicts on the same grid. It does NOT
+universally invalidate the listed mechanism families on substrate
+designs outside the D-002G locked grid. It does NOT authorise a
+canonical run on the partial `ricci_flow`-only coverage.
+
+The negative space mapped here is bounded by:
+
+1. The locked D-002G pre-registration substrate set (3 substrates).
+2. The locked marginal set (degree + block + spectral/N + density).
+3. The M1 / M2 / M3 mechanism family pursued in PRs #677 / #679 /
+   #680 / #681.
+
+Outside that conjunction the map is silent.

--- a/docs/governance/D002G_STRUCTURAL_CLOSURE_REPORT.md
+++ b/docs/governance/D002G_STRUCTURAL_CLOSURE_REPORT.md
@@ -1,0 +1,215 @@
+# D-002G — Structural Closure Report
+
+Anchor: PR #681 (M3 topology-conditioned independent realisation),
+squash-merge commit `cced6e60f3b448878d51cb9848c990ab5133da28`.
+
+This document is an append-only **negative-result retention artifact**.
+It pins the structural impossibility of the locked 3-substrate
+null-admissibility path into governance, so that a future M4 PR cannot
+pretend to escape via cosmetic mechanism choice inside the current
+D-002G pre-registration.
+
+---
+
+## 1. Executive verdict
+
+> **D-002G STRUCTURAL CLOSURE.** The current locked 3-substrate
+> null-admissibility path under PRs #677 / #679 / #680 / #681 is
+> STRUCTURALLY BLOCKED. Canonical run remains BLOCKED. No scientific
+> PASS claimed. No D-002C ledger mutation. Closure is scoped to the
+> conjunction (D-002G prereg substrates × locked marginal set ×
+> M1/M2/M3 mechanism families).
+
+This is a **scoped** verdict. It does NOT claim D-002G globally
+falsified; it does NOT claim `ricci_flow` invalid; it does NOT claim
+universal invalidity of null mechanisms. The verdict is bounded by the
+exact conjunction stated above and no further.
+
+---
+
+## 2. Evidence chain
+
+The four prior PRs exhaust the M1/M2/M3 null-mechanism family against
+the two M1-INELIGIBLE substrates (`block_structured`,
+`temporal_coupling`) on the locked D-002G pre-registration grid:
+
+| PR | merge sha | mechanism | result for blocked substrates | retained lesson |
+|---|---|---|---|---|
+| #677 | d3400c2e | M1 independent-seed | INELIGIBLE_M1_BIT_IDENTICAL | substrate discards seed by construction → independent-seed null collapses to bit-identity |
+| #679 | 7b386ef3 | M2 edge-weight permutation | INELIGIBLE_M2_DEGENERATE_SHUFFLE_POOL | constant ΔK payload → edge-weight permutation is a no-op |
+| #680 | 0f4433e0 | M2 node-payload + injection-sequence | INELIGIBLE_M2_NODE_PAYLOAD_TOPOLOGY_COUPLED / INELIGIBLE_M2_INJECTION_SEQUENCE_DEGENERATE / CONTRACT_VIOLATION | node identity == topology; injection-sequence either degenerate or violates substrate contract |
+| #681 | cced6e60 | M3 topology-conditioned independent realisation | INELIGIBLE_M3_NON_PRECURSOR_SPECIFIC | locked marginals (degree + block + spectral/N + density) carry zero seed-dependent precursor signal |
+
+Each row above is sha-pinned to a merged origin/main commit. Each
+report (`D002G_P1_IMPLEMENTATION_REPORT.md`,
+`D002G_P2_M2_IMPLEMENTATION_REPORT.md`,
+`D002G_P3_IMPLEMENTATION_REPORT.md`,
+`D002G_M3_IMPLEMENTATION_REPORT.md`) is retained read-only in
+`docs/governance/`. This closure report does not edit them.
+
+---
+
+## 3. Bottom-turtle fact
+
+The structural cause of every verdict in §2 is one line of substrate
+code:
+
+```
+research/systemic_risk/d002c_substrates.py:
+    _ = seed  # block substrate is fully deterministic in N, lambda_
+```
+
+Located at `research/systemic_risk/d002c_substrates.py:401`, inside
+`BlockStructuredSubstrate.realize()`. This line is not a bug — it is
+the locked **substrate API contract** for `block_structured` under the
+D-002G pre-registration. It encodes the deliberate design choice that
+the block substrate has *no stochastic content* in its realisation.
+
+Downstream consequences, by code:
+
+- `BlockStructuredSubstrate.realize()` line 401 explicitly discards
+  the `seed` parameter via the `_ = seed` idiom.
+- `TemporalKtSubstrate.realize()` (line 481-483) constructs its
+  baseline by calling `BlockStructuredSubstrate(...).realize(N=N,
+  lambda_=0.0, seed=seed)` — inheriting the seed-discard via
+  delegation. The `temporal_coupling` substrate carries the same
+  structural property as the block substrate plus a deterministic
+  sinusoidal envelope.
+- The sinusoidal envelope (line 485-486) is deterministic in
+  `period_quarters` + `amplitude` — no seed.
+- The precursor lift (line 493-497) is deterministic in `λ` and `K_c`
+  — no seed.
+
+**Result: for both substrates, no quantity in `K_p` depends on
+`base_seed`.** The locked marginal set used by the M3 verifier
+(degree sequence, block-label histogram, spectral radius / N, density)
+is therefore seed-INVARIANT by substrate construction. The M3
+admissibility criterion 3 (`Identifiable from precursor`) requires
+that different precursor seeds yield different marginals with
+probability ≥ 0.5 over 100 paired seeds. A seed-invariant marginal
+set produces 0 / 99 distinct adjacent-seed pairs against the required
+≥ 50 / 99. The criterion fails by construction, not by parameter
+choice or numerical accident. **The fact is encoded in the substrate
+class itself.**
+
+The same line is the root cause of every prior verdict in §2:
+
+- M1 independent-seed (PR #677): null is bit-identical to precursor
+  because both share the seed-invariant K(N, λ).
+- M2 edge-weight permutation (PR #679): the precursor ΔK contains a
+  single constant payload value driven by `0.25 · λ · K_c`, with no
+  seed-dependent perturbation; permuting a constant multiset is a
+  no-op.
+- M2 node-payload (PR #680): the block label IS the node label space
+  — there is no decoupled "node identity" to permute.
+- M2 injection-sequence (PR #680): injection events are either the
+  precursor itself (and so the sequence IS the causal hypothesis) or
+  the sequence length is below the non-degeneracy threshold.
+- M3 topology-conditioned (PR #681): explained above — seed-invariant
+  marginals.
+
+---
+
+## 4. Formal conclusion
+
+B1 (substrate eligibility) cannot be closed under the current D-002G
+locked grid without **one** of the following:
+
+- **A. Scope narrowing** — fresh pre-registration restricting the
+  canonical grid to `ricci_flow` only. The M1 / M2 (edge-weight) / M3
+  surface already lands ELIGIBLE for `ricci_flow`; a scope-narrowed
+  prereg would acknowledge the two blocked substrates as
+  out-of-scope.
+- **B. Substrate redesign** — fresh pre-registration replacing the
+  `block_structured` and `temporal_coupling` substrate specifications
+  with seed-dependent variants. This is a substrate-API surgery, not
+  a null-mechanism PR.
+- **C. Closure as negative artifact** — retain D-002G as
+  structurally-blocked and do NOT attempt B1 closure. The negative
+  result IS the scientific result; it is preserved by this artifact.
+
+Each path requires a **FRESH** pre-registration document (D-002H or
+later). Editing the D-002G pre-registration in any of these paths is
+forbidden by its own anchor lock, by the M3 pre-reg §9.1 forbidden
+refinement scope, and by the cross-PR test
+`tests/systemic_risk/test_d002g_m3_no_promotion.py::test_m3_p3_m3_prereg_unchanged`.
+
+This closure report does **not** make the decision between A / B / C.
+The decision is reserved for the next pre-registration cycle.
+
+---
+
+## 5. Forbidden interpretations
+
+The following readings of this artifact are explicitly disallowed:
+
+- ❌ "This PR proves D-002G scientifically falsehood." It proves the
+  locked path is structurally blocked for the conjunction described;
+  the scientific question is not adjudicated.
+- ❌ "This PR proves ricci_flow invalid." `ricci_flow` is M1-eligible
+  and M3-eligible; the closure scope excludes it.
+- ❌ "This PR proves all null mechanisms invalid." The M1/M2/M3
+  family is exhausted for THESE substrates; other substrate designs
+  are untested.
+- ❌ "This PR authorises canonical run." Canonical run remains
+  BLOCKED.
+- ❌ "This PR updates D002C_CLAIM_LEDGER.yaml." It does NOT. The
+  ledger sha256 is byte-exact preserved.
+- ❌ "This PR permits post-hoc M4 inside D-002G." M4 mechanism inside
+  the locked grid is structurally meaningless; M4 requires fresh
+  pre-registration.
+
+---
+
+## 6. Next legal paths
+
+Three legal paths are available; each requires a fresh
+pre-registration document.
+
+- **A — `D002H_SCOPE_NARROWING`.** Fresh pre-registration restricting
+  the canonical D-002G grid to `ricci_flow` only.
+- **B — `D002H_SUBSTRATE_REDESIGN`.** Fresh pre-registration
+  replacing `block_structured` + `temporal_coupling` specs with
+  seed-dependent variants.
+- **C — `D002G_NEGATIVE_ARTIFACT_RETENTION`.** Retain D-002G as
+  structurally-blocked; do NOT attempt B1 closure.
+
+> Decision among A/B/C is deferred to the next pre-registration
+> cycle. This artifact does NOT make the decision.
+
+---
+
+## 7. Decision recommendation
+
+Recommendation (non-binding):
+
+> Recommendation (non-binding): merge this structural closure artifact
+> FIRST. Then open a fresh D-002H pre-registration PR that explicitly
+> declares which path among A/B/C is chosen. Do NOT amend D-002G
+> post-hoc with an "M4 inside D-002G" — that conflates a fresh
+> pre-registration with a patch.
+
+The asymmetry between "fresh pre-reg PR" and "post-hoc patch" is the
+core of the pre-registration discipline; it is what gives the
+scoped-closure verdict any value at all. Collapsing the asymmetry
+would retroactively invalidate every prior D-002G verdict the
+discipline produced.
+
+---
+
+## Appendix — Allowed claim (verbatim)
+
+The only claim this artifact makes is the following:
+
+> The current D-002G locked substrate/null-admissibility path is
+> STRUCTURALLY BLOCKED for the canonical 3-substrate grid because
+> `block_structured` and `temporal_coupling` do not carry
+> precursor-specific stochastic content required by M1/M2/M3
+> admissible null mechanisms. Closure is SCOPED to the conjunction
+> (D-002G prereg substrates × locked marginal set × M1/M2/M3
+> mechanism families). It does NOT prove D-002G globally falsified;
+> it does NOT prove ricci_flow invalid; it does NOT prove universal
+> invalidity of null mechanisms.
+
+Anything beyond this allowed claim is out of scope for this PR and
+forbidden by §5.

--- a/tests/systemic_risk/test_d002g_structural_closure.py
+++ b/tests/systemic_risk/test_d002g_structural_closure.py
@@ -1,0 +1,402 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""D-002G — Structural-closure artifact invariants.
+
+These tests pin the negative-result retention artifact landed in this
+PR. They fail-closed on:
+
+* the closure report being missing or stripped of its verdict block;
+* the JSON closure record drifting from schema_version v1, losing any
+  of the four merge-chain entries, or flipping any of the boolean
+  claim-boundary flags;
+* a forbidden D-002G PASS / canonical-run authorisation phrase
+  appearing in the closure docs or JSON outside an explicit denial
+  context;
+* a byte-level mutation of ``docs/governance/D002C_CLAIM_LEDGER.yaml``
+  (sha256 pin verified against the cross-PR locked anchor);
+* the negative-space map dropping any of the five mechanism rows;
+* the closure documents losing the bottom-turtle ``_ = seed`` quote
+  or the ``research/systemic_risk/d002c_substrates.py`` line-401
+  citation;
+* any "M4 implementation" / "M4 will fix" / "M4 inside D-002G"
+  string outside an explicit forbidden-list / denial context;
+* the ``legal_next_paths`` JSON list growing an M4-themed id or
+  losing any of the three fresh-pre-registration ids;
+* the ``D002G_CANONICAL_RUN_BLOCKERS.md`` losing any of its
+  pre-existing section headings, or the new B1.closure subsection
+  appearing before them in source order.
+
+Closure scope: STRUCTURAL_CLOSURE on the conjunction (D-002G prereg
+substrates x locked marginal set x M1/M2/M3 mechanism families).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GOV = REPO_ROOT / "docs" / "governance"
+
+CLOSURE_REPORT = GOV / "D002G_STRUCTURAL_CLOSURE_REPORT.md"
+NEGATIVE_SPACE_MAP = GOV / "D002G_NEGATIVE_SPACE_MAP.md"
+CLOSURE_JSON = REPO_ROOT / "artifacts" / "d002g" / "closure" / "d002g_structural_closure.json"
+BLOCKERS_DOC = GOV / "D002G_CANONICAL_RUN_BLOCKERS.md"
+CLAIM_LEDGER = GOV / "D002C_CLAIM_LEDGER.yaml"
+SUBSTRATES_PY = REPO_ROOT / "research" / "systemic_risk" / "d002c_substrates.py"
+
+# fmt: off
+_LEDGER_SHA256_PIN: str = "f96ba9b5a2057d2e0bff84afc28578ab316cff73f6dc6673fb0d6d543b8bd6dd"  # noqa: E501  # pragma: allowlist secret
+# fmt: on
+
+_MERGE_SHA_PREFIXES: tuple[str, ...] = (
+    "d3400c2e",
+    "7b386ef3",
+    "0f4433e0",
+    "cced6e60",
+)
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _load_json() -> dict[str, Any]:
+    raw = _read(CLOSURE_JSON)
+    payload = json.loads(raw)
+    if not isinstance(payload, dict):
+        raise AssertionError("closure JSON payload must be a dict")
+    return payload
+
+
+def _require(cond: bool, msg: str) -> None:
+    """Assert helper that survives black + ruff format without re-flow."""
+    if not cond:
+        raise AssertionError(msg)
+
+
+_DENIAL_MARKERS: tuple[str, ...] = (
+    "forbidden",
+    " not ",
+    " no ",
+    " never",
+    "cannot",
+    "does not",
+    "do not",
+    "is not",
+    "are not",
+    "out of scope",
+    "out-of-scope",
+    "rejected",
+    "claimed: false",
+    '_claimed": false',
+    "remains blocked",
+    "remain blocked",
+    "is blocked",
+    "is_blocked",
+    "conflates",
+    "deferred",
+    "untested",
+    "must not",
+    "would have demanded",
+)
+
+
+def _is_denial_context(lines: list[str], lineno: int) -> bool:
+    """Return True if the line at ``lineno`` sits inside a denial paragraph.
+
+    The protocol allows forbidden phrases inside denial bullets, denial
+    sentences ("does NOT", "do NOT", "is not", "no scientific PASS"),
+    forbidden-list blocks, and quoted-blockquote denials. Because
+    markdown soft-wraps a denial sentence across multiple physical
+    lines, the check inspects a small symmetric paragraph window
+    around the candidate line (3 lines before, 3 lines after) and
+    treats the candidate as denial-context if any window line carries
+    a denial marker.
+    """
+    start = max(0, lineno - 4)
+    end = min(len(lines), lineno + 3)
+    window = "\n".join(lines[start:end]).lower()
+    # The cross-mark character is added explicitly (kept out of the
+    # ASCII marker list to keep the file safe under formatter pipelines).
+    if "❌" in window:
+        return True
+    return any(marker in window for marker in _DENIAL_MARKERS)
+
+
+# ---------------------------------------------------------------------------
+# 1. closure report exists + verdict present
+# ---------------------------------------------------------------------------
+
+
+def test_closure_report_exists() -> None:
+    """The closure report file exists and carries the verbatim verdict block."""
+    _require(CLOSURE_REPORT.is_file(), f"closure report missing: {CLOSURE_REPORT}")
+    body = _read(CLOSURE_REPORT)
+    _require("STRUCTURAL CLOSURE" in body, "verdict block 'STRUCTURAL CLOSURE' missing")
+    _require("STRUCTURALLY BLOCKED" in body, "verdict 'STRUCTURALLY BLOCKED' missing")
+    _require("Canonical run remains BLOCKED" in body, "'Canonical run remains BLOCKED' missing")
+
+
+# ---------------------------------------------------------------------------
+# 2. JSON schema keys + boolean claim-boundary flags
+# ---------------------------------------------------------------------------
+
+
+def test_closure_json_schema_keys() -> None:
+    """Closure JSON conforms to schema v1 with required boolean flags."""
+    payload = _load_json()
+
+    schema_v = payload["schema_version"]
+    _require(schema_v == "D002G-STRUCTURAL-CLOSURE-v1", f"schema_version drift: {schema_v!r}")
+
+    merge_chain = payload["merge_chain"]
+    _require(isinstance(merge_chain, list), "merge_chain must be a list")
+    assert isinstance(merge_chain, list)  # mypy narrow
+    _require(len(merge_chain) == 4, f"merge_chain must have 4 entries, got {len(merge_chain)}")
+
+    for entry in merge_chain:
+        _require(isinstance(entry, dict), "merge_chain entry must be dict")
+        assert isinstance(entry, dict)  # mypy narrow
+        sha_val = entry["merge_sha"]
+        _require(isinstance(sha_val, str), "merge_sha must be str")
+        assert isinstance(sha_val, str)  # mypy narrow
+        sha_prefix = sha_val[:8]
+        _require(sha_prefix in _MERGE_SHA_PREFIXES, f"bad sha prefix {sha_prefix!r}")
+
+    _require(payload["canonical_run_authorized"] is False, "canonical_run_authorized flipped")
+    _require(payload["scientific_pass_claimed"] is False, "scientific_pass_claimed flipped")
+    _require(payload["d002c_ledger_touched"] is False, "d002c_ledger_touched flipped")
+    _require(
+        payload["d002g_globally_falsified_claimed"] is False,
+        "d002g_globally_falsified_claimed flipped",
+    )
+    _require(payload["ricci_flow_invalid_claimed"] is False, "ricci_flow_invalid_claimed flipped")
+
+    b1_status = payload["b1_status"]
+    _require(isinstance(b1_status, str), "b1_status must be str")
+    assert isinstance(b1_status, str)  # mypy narrow
+    _require(b1_status.startswith("OPEN_STRUCTURALLY_BLOCKED"), f"bad b1_status: {b1_status!r}")
+    _require(payload["b2_status"] == "OPEN_UNTOUCHED", f"bad b2_status: {payload['b2_status']!r}")
+
+
+# ---------------------------------------------------------------------------
+# 3. forbidden canonical-run authorisation phrases
+# ---------------------------------------------------------------------------
+
+
+def _scan_forbidden(needles: tuple[str, ...], label: str) -> None:
+    targets = (CLOSURE_REPORT, NEGATIVE_SPACE_MAP, CLOSURE_JSON)
+    violations: list[str] = []
+    for target in targets:
+        lines = _read(target).splitlines()
+        for idx, raw_line in enumerate(lines):
+            lower = raw_line.lower()
+            if not any(n in lower for n in needles):
+                continue
+            if _is_denial_context(lines, idx):
+                continue
+            violations.append(f"{target.name}:{idx + 1}: {raw_line.strip()}")
+    if violations:
+        msg = f"forbidden {label} phrase outside denial context:\n" + "\n".join(violations)
+        raise AssertionError(msg)
+
+
+def test_closure_forbids_canonical_run() -> None:
+    """No 'canonical run authorized/authorised' assertion outside denial context."""
+    needles = (
+        "canonical run authorized",
+        "canonical run authorised",
+        "canonical-run authorized",
+        "canonical-run authorised",
+    )
+    _scan_forbidden(needles, "canonical-run-authorisation")
+
+
+# ---------------------------------------------------------------------------
+# 4. forbidden D-002G scientific PASS phrases
+# ---------------------------------------------------------------------------
+
+
+def test_closure_forbids_scientific_pass() -> None:
+    """No D-002G PASS / scientific-PASS assertion outside denial context."""
+    needles = (
+        "d-002g pass",
+        "d002g pass",
+        "d-002g validated",
+        "d002g validated",
+        "scientific pass achieved",
+        "validated_real_bank_level_result",
+        "tested_positive_real",
+        "bank_level_precursor_confirmed",
+        "gamma universality",
+        "bank-level confirmed",
+        "real-data validated",
+    )
+    _scan_forbidden(needles, "scientific-PASS")
+
+
+# ---------------------------------------------------------------------------
+# 5. D002C ledger byte-exact pin
+# ---------------------------------------------------------------------------
+
+
+def test_closure_preserves_d002c_ledger() -> None:
+    """D002C_CLAIM_LEDGER.yaml sha256 byte-exact against locked pin."""
+    _require(CLAIM_LEDGER.is_file(), f"locked ledger missing: {CLAIM_LEDGER}")
+    digest = hashlib.sha256(CLAIM_LEDGER.read_bytes()).hexdigest()
+    _require(digest == _LEDGER_SHA256_PIN, f"ledger sha256 mutated: {digest}")
+
+
+# ---------------------------------------------------------------------------
+# 6. negative-space map enumerates all five mechanism rows
+# ---------------------------------------------------------------------------
+
+
+def test_negative_space_map_mentions_all_four_prs() -> None:
+    """Negative-space map enumerates all five exhausted mechanism families."""
+    _require(NEGATIVE_SPACE_MAP.is_file(), f"negative-space map missing: {NEGATIVE_SPACE_MAP}")
+    body = _read(NEGATIVE_SPACE_MAP)
+    required_rows = (
+        "M1 independent seed",
+        "M2 edge-weight permutation",
+        "M2 node-payload permutation",
+        "M2 injection-sequence permutation",
+        "M3 topology-conditioned independent realisation",
+    )
+    for row in required_rows:
+        _require(row in body, f"negative-space map missing row: {row!r}")
+    required_lessons = (
+        "independent-seed null requires substrate stochasticity",
+        "edge-weight permutation requires",
+        "node-payload permutation requires",
+        "injection-sequence permutation requires",
+        "mechanisms conditioned on marginal set",
+    )
+    for lesson in required_lessons:
+        _require(lesson in body, f"negative-space map missing lesson: {lesson!r}")
+
+
+# ---------------------------------------------------------------------------
+# 7. bottom-turtle seed-ignored fact present
+# ---------------------------------------------------------------------------
+
+
+def test_bottom_turtle_seed_ignored_fact_present() -> None:
+    """Closure report quotes the substrate-line-401 ``_ = seed`` fact."""
+    body = _read(CLOSURE_REPORT)
+    _require("_ = seed" in body, "closure report missing ``_ = seed`` quote")
+    _require(
+        "research/systemic_risk/d002c_substrates.py" in body,
+        "closure report missing substrate file path citation",
+    )
+    _require("401" in body, "closure report missing line-401 citation")
+
+    # Verify the cited substrate line truly contains the quoted fact.
+    src_lines = _read(SUBSTRATES_PY).splitlines()
+    _require(len(src_lines) >= 401, "substrate source shorter than expected")
+    window = "\n".join(src_lines[395:405])
+    _require("_ = seed" in window, "substrate source missing ``_ = seed`` near line 401")
+
+    payload = _load_json()
+    bottom = payload["bottom_turtle"]
+    _require(isinstance(bottom, dict), "bottom_turtle must be dict")
+    assert isinstance(bottom, dict)  # mypy narrow
+    _require(bottom["line"] == 401, f"bottom_turtle.line must be 401, got {bottom['line']!r}")
+
+
+# ---------------------------------------------------------------------------
+# 8. no M4-implementation-in-D-002G claim
+# ---------------------------------------------------------------------------
+
+
+def test_no_m4_implementation_claim() -> None:
+    """No 'M4 implementation' / 'M4 will fix' assertion outside denial context."""
+    needles = (
+        "m4 implementation",
+        "m4 will fix",
+        "m4 inside d-002g",
+        "m4 inside d002g",
+        "m4 mechanism inside d-002g",
+        "m4 mechanism inside d002g",
+    )
+    _scan_forbidden(needles, "M4-implementation")
+
+
+# ---------------------------------------------------------------------------
+# 9. legal_next_paths are fresh-pre-registration ids only
+# ---------------------------------------------------------------------------
+
+
+def test_legal_next_paths_are_fresh_prereg_only() -> None:
+    """legal_next_paths == 3 fresh-pre-reg ids; no M4-themed entry."""
+    payload = _load_json()
+    paths = payload["legal_next_paths"]
+    _require(isinstance(paths, list), "legal_next_paths must be a list")
+    assert isinstance(paths, list)  # mypy narrow
+    _require(len(paths) == 3, f"legal_next_paths must have 3 entries, got {len(paths)}")
+
+    seen_ids: list[str] = []
+    for entry in paths:
+        _require(isinstance(entry, dict), "legal_next_paths entry must be dict")
+        assert isinstance(entry, dict)  # mypy narrow
+        path_id = entry["id"]
+        _require(isinstance(path_id, str), "legal_next_paths id must be str")
+        assert isinstance(path_id, str)  # mypy narrow
+        seen_ids.append(path_id)
+        is_d002h = path_id.startswith("D002H_")
+        is_retention = path_id == "D002G_NEGATIVE_ARTIFACT_RETENTION"
+        _require(is_d002h or is_retention, f"bad legal_next_paths id: {path_id!r}")
+        _require("M4" not in path_id, f"legal_next_paths id contains M4: {path_id!r}")
+
+    expected_ids = {
+        "D002H_SCOPE_NARROWING",
+        "D002H_SUBSTRATE_REDESIGN",
+        "D002G_NEGATIVE_ARTIFACT_RETENTION",
+    }
+    _require(set(seen_ids) == expected_ids, f"legal_next_paths ids drift: {sorted(seen_ids)}")
+
+
+# ---------------------------------------------------------------------------
+# 10. BLOCKERS.md appended, not rewritten
+# ---------------------------------------------------------------------------
+
+
+def test_blocker_doc_appended_not_rewritten() -> None:
+    """The new B1.closure subsection appends after all prior B1/B2 sections."""
+    body = _read(BLOCKERS_DOC)
+
+    pre_existing_headings = (
+        "### B1 — Substrate eligibility",
+        "#### B1.M2 — Mitigation status",
+        "#### B1.M3 — Topology-conditioned null mitigation status",
+        "### B2 — Phase 0b CI is percentile bootstrap",
+    )
+    indices: list[int] = []
+    for heading in pre_existing_headings:
+        idx = body.find(heading)
+        _require(idx >= 0, f"BLOCKERS.md missing pre-existing heading: {heading!r}")
+        indices.append(idx)
+
+    closure_marker = "#### B1.closure — Structural closure under current locked grid"
+    closure_idx = body.find(closure_marker)
+    _require(closure_idx >= 0, f"BLOCKERS.md missing closure subsection: {closure_marker!r}")
+
+    b1_main_idx, b1_m2_idx, b1_m3_idx, b2_idx = indices
+    _require(closure_idx > b1_main_idx, "B1.closure must come after B1 main")
+    _require(closure_idx > b1_m2_idx, "B1.closure must come after B1.M2")
+    _require(closure_idx > b1_m3_idx, "B1.closure must come after B1.M3")
+    _require(closure_idx < b2_idx, "B1.closure must remain inside the B1 block (before B2)")
+
+    closure_body_window = body[closure_idx : closure_idx + 1500]
+    _require(
+        "D002G_STRUCTURAL_CLOSURE_REPORT.md" in closure_body_window,
+        "B1.closure must cite D002G_STRUCTURAL_CLOSURE_REPORT.md",
+    )
+    _require(
+        re.search(r"cced6e60", closure_body_window) is not None,
+        "B1.closure must cite PR #681 merge sha (cced6e60)",
+    )


### PR DESCRIPTION
## Promise

After 4 merged PRs exhausting the M1/M2/M3 null-mechanism family on the locked D-002G 3-substrate grid, this PR lands a sha-pinned **negative-result retention artifact** that pins the structural impossibility into governance. The artifact is scoped, append-only, and explicitly disallows post-hoc "M4 inside D-002G" escape patches.

## Summary

- `docs/governance/D002G_STRUCTURAL_CLOSURE_REPORT.md` — 7-section scoped-closure report (executive verdict, evidence chain, bottom-turtle fact, formal conclusion, forbidden interpretations, next legal paths, decision recommendation).
- `docs/governance/D002G_NEGATIVE_SPACE_MAP.md` — enumerates the 5 exhausted null-mechanism families (M1 / M2 edge-weight / M2 node-payload / M2 injection-sequence / M3) with rule-out lessons + a design rule for future mechanism families.
- `artifacts/d002g/closure/d002g_structural_closure.json` — schema_version `D002G-STRUCTURAL-CLOSURE-v1`, merge_chain of 4 PRs (#677 / #679 / #680 / #681), 5 boolean claim-boundary flags all false, 3 legal_next_paths (D002H_SCOPE_NARROWING / D002H_SUBSTRATE_REDESIGN / D002G_NEGATIVE_ARTIFACT_RETENTION).
- `docs/governance/D002G_CANONICAL_RUN_BLOCKERS.md` — append-only B1.closure subsection citing PR #681 sha `cced6e60` and the structural closure report. No pre-existing section rewritten.
- `tests/systemic_risk/test_d002g_structural_closure.py` — 10 tests pinning structural-closure invariants (closure report present, JSON schema, forbidden-phrase scan, ledger sha pin, negative-space map row count, bottom-turtle fact, no-M4-claim, fresh-prereg-ids-only, blocker-doc append).
- `.claude/commit_acceptors/x10r-d002g-structural-closure.yaml` — diff-bound acceptor (`claim_type: documentation`, 6 changed files, 27 forbidden paths, falsifier shell command).

## Bottom-turtle code fact

```
research/systemic_risk/d002c_substrates.py:
    _ = seed  # block substrate is fully deterministic in N, lambda_
```

Located at `research/systemic_risk/d002c_substrates.py:401` inside `BlockStructuredSubstrate.realize()`. `TemporalKtSubstrate.realize()` inherits the seed-discard via delegation at lines 481-483. The locked marginal set (degree + block-label histogram + spectral radius/N + density) is therefore seed-invariant for both blocked substrates, which makes any M1/M2/M3-family null structurally unable to satisfy the M3 precursor-specificity criterion 3.

## Claim boundary (verbatim allowed claim)

> The current D-002G locked substrate/null-admissibility path is STRUCTURALLY BLOCKED for the canonical 3-substrate grid because `block_structured` and `temporal_coupling` do not carry precursor-specific stochastic content required by M1/M2/M3 admissible null mechanisms. Closure is SCOPED to the conjunction (D-002G prereg substrates × locked marginal set × M1/M2/M3 mechanism families). It does NOT prove D-002G globally falsified; it does NOT prove ricci_flow invalid; it does NOT prove universal invalidity of null mechanisms.

## Forbidden interpretations

- This PR does NOT claim D-002G scientific PASS.
- This PR does NOT authorise a canonical D-002G run.
- This PR does NOT claim D-002G globally falsified (only scoped-closed under the conjunction).
- This PR does NOT impugn `ricci_flow` (M1/M2-edge/M3 all ELIGIBLE on `ricci_flow`).
- This PR does NOT touch `D002C_CLAIM_LEDGER.yaml` (sha pin `f96ba9b5...d6dd` verified byte-exact).
- This PR does NOT pre-register or implement M4 inside D-002G — M4 requires a fresh pre-registration (D-002H or later).

## Tests

10 new tests, all PASS:

1. `test_closure_report_exists`
2. `test_closure_json_schema_keys`
3. `test_closure_forbids_canonical_run`
4. `test_closure_forbids_scientific_pass`
5. `test_closure_preserves_d002c_ledger`
6. `test_negative_space_map_mentions_all_four_prs`
7. `test_bottom_turtle_seed_ignored_fact_present`
8. `test_no_m4_implementation_claim`
9. `test_legal_next_paths_are_fresh_prereg_only`
10. `test_blocker_doc_appended_not_rewritten`

Regression sweep: 123 / 123 non-slow `tests/systemic_risk/` tests pass.

## Final decision

`D002G_STRUCTURAL_CLOSURE_ARTIFACT_LANDED`

## Next required PR (operator decision)

`docs(x10r,D-002H): pre-registration of <scope-narrowing | substrate-redesign | negative-retention> — operator decision`

The decision among the 3 legal paths (A `D002H_SCOPE_NARROWING`, B `D002H_SUBSTRATE_REDESIGN`, C `D002G_NEGATIVE_ARTIFACT_RETENTION`) is deferred to the next pre-registration cycle in a separate PR. Do NOT amend D-002G post-hoc with "M4 inside D-002G" — that conflates a fresh pre-registration with a patch.

## Test plan

- [x] `pytest tests/systemic_risk/test_d002g_structural_closure.py -q` — 10 / 10 PASS
- [x] `pytest tests/systemic_risk/ -k "d002g and not slow" -q` — 123 / 123 PASS, 32 deselected
- [x] `ruff format --check tests/systemic_risk/test_d002g_structural_closure.py` — clean
- [x] `ruff check tests/systemic_risk/test_d002g_structural_closure.py` — clean
- [x] `black --check tests/systemic_risk/test_d002g_structural_closure.py` — clean
- [x] `mypy --strict --follow-imports=silent tests/systemic_risk/test_d002g_structural_closure.py` — clean
- [x] D002C_CLAIM_LEDGER.yaml sha256 byte-exact `f96ba9b5a2057d2e0bff84afc28578ab316cff73f6dc6673fb0d6d543b8bd6dd`
- [x] D002G_P3_M3_PREREGISTRATION.md sha256 byte-exact `0f11a0c890374c35e4dedecc66caec52ae867f49a8f8b3be2374f1464712c1f8`
- [x] `research/systemic_risk/d002c_substrates.py` byte-exact unchanged

Generated with Claude Code.