### PR TITLE
feat(runtime): HyperdirectVeto — salvaged kernel of closed PR #678

### DIFF
--- a/.claude/commit_acceptors/hyperdirect-veto.yaml
+++ b/.claude/commit_acceptors/hyperdirect-veto.yaml
@@ -1,0 +1,110 @@
+# Diff-bound commit acceptor for runtime/hyperdirect_veto.py.
+#
+# Salvaged kernel of closed PR #678 (Inference Extrapolation Validator).
+# That PR's value was the idea, not the code: a cortico-subthalamic
+# hyperdirect STOP analogue for inference promotion. The shipped IEV
+# buried it under a 7-dim conflict vector whose 5/7 channels were already
+# hard-gated upstream (dead), and faked the signature conflict-proportional
+# threshold with seed jitter independent of the score.
+#
+# This acceptor binds the honest kernel: a stateless, pure, fail-closed
+# disjunctive brake. Layer 2 (Sustainer): emits a VetoDecision, never
+# takes execution action; not wired into any live decision path.
+#
+# Locally verified:
+#   * pytest tests/unit/runtime/test_hyperdirect_veto.py: 36/36 passed
+#   * mypy --strict on module and test: clean
+#   * ruff check + black --check: clean
+
+id: hyperdirect-veto
+status: ACTIVE
+# claim_type=fail_closed: the module's entire purpose is a fail-closed
+# brake — every out-of-contract input raises rather than coercing to a
+# PASS, and promotion requires the conjunction of "no single-channel
+# STOP" and "evidence clears the conflict-proportional bar".
+claim_type: fail_closed
+promise: >-
+  After this PR lands, runtime/hyperdirect_veto.py ships HyperdirectVeto:
+  a stateless, pure, deterministic pre-promotion brake modelled on the
+  cortico-basal-ganglia hyperdirect pathway. It enforces two faithful
+  behaviours and nothing else. (1) Disjunctive single-channel STOP: the
+  aggregate over residual conflict channels is a max, never a mean or
+  sum, so one channel at or above hard_ceiling vetoes regardless of how
+  strong the evidence margin is — a single saturated red flag cannot be
+  averaged away. (2) Conflict-proportional decision threshold:
+  required_margin = base_margin + conflict_gain * mean(conflict), a pure
+  deterministic function of the supplied conflict with no RNG, so the
+  bar a claim must clear rises monotonically with conflict. Every
+  out-of-contract input (non-mapping, channel outside [0,1], non-finite
+  or bool value, empty/non-string channel name, non-finite margin)
+  fail-closes with HyperdirectVetoError; no clamping, no silent skip.
+  VetoDecision and its conflict_vector are immutable. The caller
+  contract (HDV-007) is that only residual — not already upstream-gated
+  — channels are supplied, which is what makes every channel here
+  load-bearing rather than theatre. The primitive is opt-in and is not
+  wired into any live decision path; integration into a specific
+  pipeline is a separate explicit decision on a fresh branch.
+diff_scope:
+  changed_files:
+    - path: ".claude/commit_acceptors/hyperdirect-veto.yaml"
+    - path: "runtime/hyperdirect_veto.py"
+    - path: "tests/unit/runtime/test_hyperdirect_veto.py"
+  forbidden_paths:
+    - "trading/"
+    - "execution/"
+    - "forecast/"
+    - "policy/"
+    - "core/physics/"
+    - "core/kuramoto/"
+    - "application/governance/claim_ledger.py"
+    - "application/governance/commit_acceptor.py"
+    - "scripts/ci/check_claims.py"
+    - "tools/commit_acceptor/validate_commit_acceptor.py"
+required_python_symbols:
+  - "runtime/hyperdirect_veto.py::HyperdirectVetoError"
+  - "runtime/hyperdirect_veto.py::HyperdirectConfig"
+  - "runtime/hyperdirect_veto.py::VetoDecision"
+  - "runtime/hyperdirect_veto.py::HyperdirectVeto"
+expected_signal: >-
+  Local: `python -m pytest tests/unit/runtime/test_hyperdirect_veto.py -q`
+  reports "36 passed"; `mypy --strict` is clean on
+  runtime/hyperdirect_veto.py and tests/unit/runtime/test_hyperdirect_veto.py;
+  `ruff check` and `black --check` both pass on those two paths. The
+  core adversarial test (single saturated channel with evidence_margin
+  = 1e9) returns passed=False with reason
+  "single_channel_stop:<channel>", and the max-not-mean test confirms
+  a {0.9, 0.0, 0.0} vector vetoes although its mean is 0.3.
+measurement_command: >-
+  bash -c 'mypy --strict runtime/hyperdirect_veto.py
+  tests/unit/runtime/test_hyperdirect_veto.py
+  && ruff check runtime/hyperdirect_veto.py tests/unit/runtime/test_hyperdirect_veto.py
+  && black --check runtime/hyperdirect_veto.py tests/unit/runtime/test_hyperdirect_veto.py
+  && python -m pytest tests/unit/runtime/test_hyperdirect_veto.py -q'
+signal_artifact: "tmp/hyperdirect_veto.log"
+falsifier:
+  command: >-
+    bash -c 'python -m pytest
+    "tests/unit/runtime/test_hyperdirect_veto.py::test_single_channel_stop_cannot_be_laundered_by_strong_evidence"
+    -q >/tmp/_hdv_null.log 2>&1
+    && ! grep -q "1 passed" /tmp/_hdv_null.log'
+  description: >-
+    Probes the core invariant: a single conflict channel at the ceiling
+    must veto even with an arbitrarily large evidence margin. The
+    protected test asserts this. The falsifier inverts — it succeeds
+    (exit 0) only when the protected test did NOT pass, which would mean
+    a saturated red flag can be laundered by strong evidence, i.e. the
+    disjunctive STOP has degraded into an averaging gate.
+rollback_command: >-
+  git checkout HEAD~1 --
+  runtime tests
+  && rm -f runtime/hyperdirect_veto.py
+  tests/unit/runtime/test_hyperdirect_veto.py
+  .claude/commit_acceptors/hyperdirect-veto.yaml
+rollback_verification_command: >-
+  bash -c 'test ! -f runtime/hyperdirect_veto.py
+  && test ! -f tests/unit/runtime/test_hyperdirect_veto.py
+  && test ! -f .claude/commit_acceptors/hyperdirect-veto.yaml'
+memory_update_type: none
+ledger_path: ".claude/commit_acceptors/hyperdirect-veto.yaml"
+report_path: "tmp/hyperdirect_veto.log"
+evidence: []

--- a/.claude/commit_acceptors/hyperdirect-veto.yaml
+++ b/.claude/commit_acceptors/hyperdirect-veto.yaml
@@ -48,7 +48,12 @@ diff_scope:
   changed_files:
     - path: ".claude/commit_acceptors/hyperdirect-veto.yaml"
     - path: "runtime/hyperdirect_veto.py"
+    - path: "runtime/hyperdirect_veto_falsifier.py"
+    - path: "runtime/inference_promotion_brake.py"
+    - path: "bench/hyperdirect_veto_perf.py"
+    - path: "bench/hyperdirect_veto_calibration.py"
     - path: "tests/unit/runtime/test_hyperdirect_veto.py"
+    - path: "tests/unit/runtime/test_inference_promotion_brake.py"
   forbidden_paths:
     - "trading/"
     - "execution/"
@@ -65,21 +70,42 @@ required_python_symbols:
   - "runtime/hyperdirect_veto.py::HyperdirectConfig"
   - "runtime/hyperdirect_veto.py::VetoDecision"
   - "runtime/hyperdirect_veto.py::HyperdirectVeto"
+  - "runtime/hyperdirect_veto_falsifier.py::run_battery"
+  - "runtime/inference_promotion_brake.py::InferenceClaim"
+  - "runtime/inference_promotion_brake.py::PromotionVerdict"
+  - "runtime/inference_promotion_brake.py::InferencePromotionBrake"
+  - "bench/hyperdirect_veto_perf.py::run_benchmark"
+  - "bench/hyperdirect_veto_calibration.py::characterise"
+  - "bench/hyperdirect_veto_calibration.py::recommend_gain"
 expected_signal: >-
-  Local: `python -m pytest tests/unit/runtime/test_hyperdirect_veto.py -q`
-  reports "36 passed"; `mypy --strict` is clean on
-  runtime/hyperdirect_veto.py and tests/unit/runtime/test_hyperdirect_veto.py;
-  `ruff check` and `black --check` both pass on those two paths. The
-  core adversarial test (single saturated channel with evidence_margin
-  = 1e9) returns passed=False with reason
-  "single_channel_stop:<channel>", and the max-not-mean test confirms
-  a {0.9, 0.0, 0.0} vector vetoes although its mean is 0.3.
+  Local: `python -m pytest tests/unit/runtime/test_hyperdirect_veto.py
+  tests/unit/runtime/test_inference_promotion_brake.py -q` reports
+  "48 passed"; `mypy --strict`, `ruff check` and `black --check` are
+  clean on all five module files and both test files. The standalone
+  falsifier battery exits 0 with every protected invariant SURVIVED and
+  only the documented A2 channel-split BOUNDARY surfaced (not hidden).
+  The synthetic calibration emits a monotone false-promote/false-veto
+  tradeoff surface and a procedure-derived (not magic) default,
+  explicitly tier-labelled EXTRAPOLATED. The InferencePromotionBrake
+  adapter is advisory-only: PromotionVerdict.advisory is True by
+  construction and nothing on a trading/execution path is touched.
 measurement_command: >-
   bash -c 'mypy --strict runtime/hyperdirect_veto.py
+  runtime/hyperdirect_veto_falsifier.py runtime/inference_promotion_brake.py
+  bench/hyperdirect_veto_perf.py bench/hyperdirect_veto_calibration.py
   tests/unit/runtime/test_hyperdirect_veto.py
-  && ruff check runtime/hyperdirect_veto.py tests/unit/runtime/test_hyperdirect_veto.py
-  && black --check runtime/hyperdirect_veto.py tests/unit/runtime/test_hyperdirect_veto.py
-  && python -m pytest tests/unit/runtime/test_hyperdirect_veto.py -q'
+  tests/unit/runtime/test_inference_promotion_brake.py
+  && ruff check runtime/hyperdirect_veto.py runtime/hyperdirect_veto_falsifier.py
+  runtime/inference_promotion_brake.py bench/hyperdirect_veto_perf.py
+  bench/hyperdirect_veto_calibration.py tests/unit/runtime/test_hyperdirect_veto.py
+  tests/unit/runtime/test_inference_promotion_brake.py
+  && black --check runtime/hyperdirect_veto.py runtime/hyperdirect_veto_falsifier.py
+  runtime/inference_promotion_brake.py bench/hyperdirect_veto_perf.py
+  bench/hyperdirect_veto_calibration.py tests/unit/runtime/test_hyperdirect_veto.py
+  tests/unit/runtime/test_inference_promotion_brake.py
+  && python -m pytest tests/unit/runtime/test_hyperdirect_veto.py
+  tests/unit/runtime/test_inference_promotion_brake.py -q
+  && python runtime/hyperdirect_veto_falsifier.py'
 signal_artifact: "tmp/hyperdirect_veto.log"
 falsifier:
   command: >-
@@ -95,14 +121,20 @@ falsifier:
     a saturated red flag can be laundered by strong evidence, i.e. the
     disjunctive STOP has degraded into an averaging gate.
 rollback_command: >-
-  git checkout HEAD~1 --
-  runtime tests
-  && rm -f runtime/hyperdirect_veto.py
+  rm -f runtime/hyperdirect_veto.py runtime/hyperdirect_veto_falsifier.py
+  runtime/inference_promotion_brake.py bench/hyperdirect_veto_perf.py
+  bench/hyperdirect_veto_calibration.py
   tests/unit/runtime/test_hyperdirect_veto.py
+  tests/unit/runtime/test_inference_promotion_brake.py
   .claude/commit_acceptors/hyperdirect-veto.yaml
 rollback_verification_command: >-
   bash -c 'test ! -f runtime/hyperdirect_veto.py
+  && test ! -f runtime/hyperdirect_veto_falsifier.py
+  && test ! -f runtime/inference_promotion_brake.py
+  && test ! -f bench/hyperdirect_veto_perf.py
+  && test ! -f bench/hyperdirect_veto_calibration.py
   && test ! -f tests/unit/runtime/test_hyperdirect_veto.py
+  && test ! -f tests/unit/runtime/test_inference_promotion_brake.py
   && test ! -f .claude/commit_acceptors/hyperdirect-veto.yaml'
 memory_update_type: none
 ledger_path: ".claude/commit_acceptors/hyperdirect-veto.yaml"

--- a/bench/hyperdirect_veto_calibration.py
+++ b/bench/hyperdirect_veto_calibration.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import random
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from runtime.hyperdirect_veto import HyperdirectConfig, HyperdirectVeto  # noqa: E402
+
+__all__ = ["CalibrationPoint", "characterise", "recommend_gain", "main"]
+
+# ---------------------------------------------------------------------------
+# PROVENANCE / TIER
+#
+#   This is a SYNTHETIC characterisation. The (conflict, margin,
+#   should_promote) triples are drawn from a hand-specified generative
+#   model, NOT from observed inference outcomes. Tier: EXTRAPOLATED.
+#   It produces a *tradeoff surface* and a *procedure*, never a claim
+#   that any parameter is "validated", "optimal", or "production-ready"
+#   on real data. Real calibration requires a labelled corpus of past
+#   inference promotions and lives upstream of this primitive.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CalibrationPoint:
+    conflict_gain: float
+    false_promote_rate: float  # promoted a should-NOT-promote claim
+    false_veto_rate: float  # vetoed a should-promote claim
+    n_pos: int
+    n_neg: int
+
+
+def _synthetic_corpus(n: int, seed: int) -> list[tuple[dict[str, float], float, bool]]:
+    """Hand-specified generative model.
+
+    POSITIVE (should promote): strong margin, low residual conflict.
+    NEGATIVE (should not):      weak/!= margin, elevated residual conflict.
+    The two classes overlap on purpose so the surface is non-trivial.
+    """
+    rng = random.Random(seed)
+    rows: list[tuple[dict[str, float], float, bool]] = []
+    for _ in range(n):
+        positive = rng.random() < 0.5
+        if positive:
+            margin = rng.gauss(0.6, 0.25)
+            conflict = {
+                "falsifier_disagreement": abs(rng.gauss(0.10, 0.10)),
+                "witness_uncertainty": abs(rng.gauss(0.10, 0.10)),
+                "purpose_drift": abs(rng.gauss(0.08, 0.08)),
+            }
+        else:
+            margin = rng.gauss(0.20, 0.30)
+            conflict = {
+                "falsifier_disagreement": min(1.0, abs(rng.gauss(0.45, 0.25))),
+                "witness_uncertainty": min(1.0, abs(rng.gauss(0.40, 0.25))),
+                "purpose_drift": min(1.0, abs(rng.gauss(0.35, 0.20))),
+            }
+        conflict = {k: max(0.0, min(1.0, v)) for k, v in conflict.items()}
+        rows.append((conflict, margin, positive))
+    return rows
+
+
+def characterise(
+    gains: list[float],
+    *,
+    n: int = 20_000,
+    seed: int = 20260515,
+    hard_ceiling: float = 0.8,
+    base_margin: float = 0.0,
+) -> list[CalibrationPoint]:
+    corpus = _synthetic_corpus(n, seed)
+    n_pos = sum(1 for _, _, p in corpus if p)
+    n_neg = len(corpus) - n_pos
+    points: list[CalibrationPoint] = []
+    for gain in gains:
+        gate = HyperdirectVeto(
+            HyperdirectConfig(
+                hard_ceiling=hard_ceiling,
+                base_margin=base_margin,
+                conflict_gain=gain,
+            )
+        )
+        false_promote = 0
+        false_veto = 0
+        for conflict, margin, should_promote in corpus:
+            promoted = gate.evaluate(conflict, evidence_margin=margin).passed
+            if promoted and not should_promote:
+                false_promote += 1
+            elif not promoted and should_promote:
+                false_veto += 1
+        points.append(
+            CalibrationPoint(
+                conflict_gain=gain,
+                false_promote_rate=false_promote / max(1, n_neg),
+                false_veto_rate=false_veto / max(1, n_pos),
+                n_pos=n_pos,
+                n_neg=n_neg,
+            )
+        )
+    return points
+
+
+def recommend_gain(
+    points: list[CalibrationPoint], max_false_veto: float
+) -> CalibrationPoint | None:
+    """Principled default: this is a fail-closed brake, so the objective
+    is to MINIMISE false-promote (letting a bad claim through) subject to
+    keeping false-veto (blocking a good claim) within an explicit budget.
+    No magic number — the default falls out of the stated objective and
+    the synthetic surface, and is only as good as that synthetic model.
+    """
+    feasible = [p for p in points if p.false_veto_rate <= max_false_veto]
+    if not feasible:
+        return None
+    return min(feasible, key=lambda p: (p.false_promote_rate, -p.conflict_gain))
+
+
+def main() -> int:
+    gains = [round(0.25 * i, 2) for i in range(0, 13)]
+    points = characterise(gains)
+    print("HyperdirectVeto — SYNTHETIC calibration surface (tier: EXTRAPOLATED)")
+    print("  generative model is hand-specified; NOT observed inference data.")
+    print(f"  corpus: n_pos={points[0].n_pos} n_neg={points[0].n_neg}\n")
+    print(f"  {'gain':>6} {'false_promote':>14} {'false_veto':>11}")
+    for p in points:
+        print(f"  {p.conflict_gain:>6.2f} {p.false_promote_rate:>14.4f} {p.false_veto_rate:>11.4f}")
+    budget = 0.10
+    rec = recommend_gain(points, max_false_veto=budget)
+    print(f"\n  procedure: minimise false_promote s.t. false_veto <= {budget:.2f}")
+    if rec is None:
+        print(
+            "  -> no gain in the swept range meets the budget on this "
+            "synthetic surface (report honestly; do not pick anyway)."
+        )
+    else:
+        print(
+            f"  -> synthetic default conflict_gain={rec.conflict_gain:.2f} "
+            f"(false_promote={rec.false_promote_rate:.4f}, "
+            f"false_veto={rec.false_veto_rate:.4f}). EXTRAPOLATED — must be "
+            f"re-derived on a real labelled promotion corpus before any "
+            f"non-advisory use."
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bench/hyperdirect_veto_perf.py
+++ b/bench/hyperdirect_veto_perf.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import statistics
+import sys
+import time
+import tracemalloc
+from dataclasses import dataclass
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from runtime.hyperdirect_veto import HyperdirectConfig, HyperdirectVeto  # noqa: E402
+
+__all__ = ["PerfResult", "run_benchmark", "main"]
+
+
+@dataclass(frozen=True)
+class PerfResult:
+    evaluations: int
+    channels: int
+    ns_per_eval: float
+    p99_ns_per_eval: float
+    peak_memory_kb: float
+    decisions_passed: int
+
+
+def run_benchmark(evaluations: int = 200_000, channels: int = 7) -> PerfResult:
+    """Deterministic latency characterisation.
+
+    Fixed inputs (no RNG in the measured path) so the number is
+    reproducible run-to-run; the only variance is host scheduling, which
+    is why p99 is reported alongside the mean.
+    """
+    gate = HyperdirectVeto(HyperdirectConfig(conflict_gain=1.0))
+    conflict = {f"c{i}": 0.1 + 0.05 * i for i in range(channels)}
+    margin = 0.42
+
+    # Warm up import/JIT-free interpreter caches.
+    for _ in range(1000):
+        gate.evaluate(conflict, evidence_margin=margin)
+
+    samples: list[float] = []
+    passed = 0
+    tracemalloc.start()
+    for _ in range(evaluations):
+        t0 = time.perf_counter_ns()
+        d = gate.evaluate(conflict, evidence_margin=margin)
+        samples.append(float(time.perf_counter_ns() - t0))
+        passed += int(d.passed)
+    _current, peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+
+    samples.sort()
+    p99 = samples[min(len(samples) - 1, int(0.99 * len(samples)))]
+    return PerfResult(
+        evaluations=evaluations,
+        channels=channels,
+        ns_per_eval=statistics.fmean(samples),
+        p99_ns_per_eval=p99,
+        peak_memory_kb=peak / 1024.0,
+        decisions_passed=passed,
+    )
+
+
+def main() -> int:
+    result = run_benchmark()
+    print("HyperdirectVeto — performance characterisation (provenance)")
+    print(f"  evaluations      : {result.evaluations}")
+    print(f"  channels/eval    : {result.channels}")
+    print(f"  mean ns/eval     : {result.ns_per_eval:,.1f}")
+    print(f"  p99  ns/eval     : {result.p99_ns_per_eval:,.1f}")
+    print(f"  peak memory (KB) : {result.peak_memory_kb:,.2f}")
+    print(f"  decisions passed : {result.decisions_passed}/{result.evaluations}")
+    print(
+        "  note            : pure deterministic path; no clock/RNG/IO "
+        "in evaluate(); number is host-relative, not a portable claim."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/runtime/hyperdirect_veto.py
+++ b/runtime/hyperdirect_veto.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import isfinite
+from numbers import Real
+from types import MappingProxyType
+from typing import Mapping
+
+__all__ = [
+    "HyperdirectVetoError",
+    "HyperdirectConfig",
+    "VetoDecision",
+    "HyperdirectVeto",
+]
+
+
+class HyperdirectVetoError(RuntimeError):
+    """Raised when the veto contract or its inputs are violated.
+
+    Fail-closed boundary: an unreadable or out-of-contract input is never
+    silently coerced into a PASS.
+    """
+
+
+@dataclass(frozen=True)
+class HyperdirectConfig:
+    """Parameters of the cortico-subthalamic STOP analogue.
+
+    Neuro origin: the cortico-basal-ganglia *hyperdirect* pathway. The
+    anterior cingulate cortex monitors response conflict; under high
+    conflict the cortex drives the subthalamic nucleus, which (a) applies
+    a fast global STOP and (b) *raises the decision threshold in
+    proportion to conflict* (Frank 2006; Cavanagh & Frank 2011).
+
+    Two parameters, one for each faithful behaviour:
+
+    * ``hard_ceiling`` — the single-channel STOP. Any one residual
+      conflict channel at or above this aborts promotion regardless of
+      how strong the evidence is (disjunctive ``max`` veto, never a
+      mean — one saturated red flag is not allowed to be averaged away).
+    * ``base_margin`` / ``conflict_gain`` — the conflict-proportional
+      decision threshold. The evidence margin a claim must clear is
+      ``base_margin + conflict_gain * mean(conflict)``. This is
+      deterministic in the conflict it is given; it is NOT seeded noise.
+    """
+
+    hard_ceiling: float = 0.8
+    base_margin: float = 0.0
+    conflict_gain: float = 1.0
+
+
+@dataclass(frozen=True)
+class VetoDecision:
+    """Terminal, immutable outcome. There is no third state."""
+
+    passed: bool
+    reason: str
+    c_max: float
+    c_aggregate: float
+    required_margin: float
+    evidence_margin: float
+    vetoing_channel: str | None
+    conflict_vector: Mapping[str, float]
+
+
+class HyperdirectVeto:
+    """Disjunctive, conflict-proportional pre-promotion brake.
+
+    Stateless and pure: same inputs always produce the same
+    :class:`VetoDecision`. No clock, no RNG, no I/O, no global state — the
+    strongest possible reproducibility contract.
+
+    Caller contract (HDV-007): ``conflict`` must contain **only residual
+    channels** — signals that are not already hard-gated upstream. Passing
+    channels that another gate has already vetoed on does not make this
+    brake stronger; it only re-encodes a decision already taken. Keeping
+    the channel set residual is what makes every channel here load-bearing.
+
+    Enumerated invariants:
+
+    * HDV-001  Decision is binary: ``passed`` is exactly the conjunction
+      of "no single-channel STOP" and "evidence margin clears the
+      conflict-proportional threshold".
+    * HDV-002  Single-channel STOP uses ``max`` over channels, never a
+      mean or sum: one channel ``>= hard_ceiling`` vetoes.
+    * HDV-003  The required margin rises monotonically with aggregate
+      conflict and is a pure function of the supplied conflict — never
+      randomised.
+    * HDV-004  Every conflict channel value is a finite real in
+      ``[0, 1]``; any other value fail-closes (no clamping, no skipping).
+    * HDV-005  ``evidence_margin`` is a finite real; a negative margin
+      (null beat the hypothesis) can never PASS a non-negative threshold.
+    * HDV-006  An empty conflict mapping is a valid "no residual
+      conflict" state; the base margin must still be cleared.
+    * HDV-007  Channels are residual-only by caller contract (documented,
+      not enforceable here — enforcing it would require the upstream gate
+      set this primitive is deliberately decoupled from).
+    * HDV-008  ``VetoDecision`` and its ``conflict_vector`` are immutable.
+
+    What a PASS does and does not mean: a PASS asserts only that, under
+    the caller-supplied conflict and margin, no STOP fired and the
+    evidence cleared the conflict-scaled bar. It does NOT assert that the
+    margin or the channel scores correspond to reality — that obligation
+    lives upstream, with whatever computed them.
+    """
+
+    def __init__(self, config: HyperdirectConfig | None = None) -> None:
+        self._config = config or HyperdirectConfig()
+        self._validate_config(self._config)
+
+    @property
+    def config(self) -> HyperdirectConfig:
+        return self._config
+
+    def evaluate(
+        self,
+        conflict: Mapping[str, float],
+        evidence_margin: float,
+    ) -> VetoDecision:
+        """Return the terminal :class:`VetoDecision` for one promotion."""
+
+        if not isinstance(conflict, Mapping):
+            raise HyperdirectVetoError(
+                "veto denied: conflict must be a mapping of residual channels"
+            )
+        try:
+            channel_pairs = tuple(conflict.items())
+        except Exception as exc:  # noqa: BLE001 - fail-closed boundary
+            raise HyperdirectVetoError("veto denied: conflict mapping could not be read") from exc
+
+        validated: dict[str, float] = {}
+        for name, value in channel_pairs:
+            if not isinstance(name, str) or not name:
+                raise HyperdirectVetoError(
+                    "veto denied: conflict channel names must be non-empty strings"
+                )
+            channel = self._require_finite_real(
+                value,
+                message=f"veto denied: channel {name!r} must be a finite real number",
+            )
+            if not (0.0 <= channel <= 1.0):
+                raise HyperdirectVetoError(f"veto denied: channel {name!r} must lie in [0, 1]")
+            validated[name] = channel
+
+        margin = self._require_finite_real(
+            evidence_margin,
+            message="veto denied: evidence_margin must be a finite real number",
+        )
+
+        frozen_vector = MappingProxyType(dict(validated))
+
+        if validated:
+            vetoing_channel = max(validated, key=lambda k: validated[k])
+            c_max = validated[vetoing_channel]
+            c_aggregate = sum(validated.values()) / len(validated)
+        else:
+            vetoing_channel = None
+            c_max = 0.0
+            c_aggregate = 0.0
+
+        required_margin = self._config.base_margin + self._config.conflict_gain * c_aggregate
+
+        # HDV-002: disjunctive single-channel STOP takes precedence.
+        if c_max >= self._config.hard_ceiling:
+            return VetoDecision(
+                passed=False,
+                reason=f"single_channel_stop:{vetoing_channel}",
+                c_max=c_max,
+                c_aggregate=c_aggregate,
+                required_margin=required_margin,
+                evidence_margin=margin,
+                vetoing_channel=vetoing_channel,
+                conflict_vector=frozen_vector,
+            )
+
+        # HDV-003: conflict-proportional decision threshold.
+        if margin < required_margin:
+            return VetoDecision(
+                passed=False,
+                reason="insufficient_margin_under_conflict",
+                c_max=c_max,
+                c_aggregate=c_aggregate,
+                required_margin=required_margin,
+                evidence_margin=margin,
+                vetoing_channel=None,
+                conflict_vector=frozen_vector,
+            )
+
+        return VetoDecision(
+            passed=True,
+            reason="cleared",
+            c_max=c_max,
+            c_aggregate=c_aggregate,
+            required_margin=required_margin,
+            evidence_margin=margin,
+            vetoing_channel=None,
+            conflict_vector=frozen_vector,
+        )
+
+    @staticmethod
+    def _require_finite_real(value: object, *, message: str) -> float:
+        if isinstance(value, bool) or not isinstance(value, Real):
+            raise HyperdirectVetoError(message)
+        try:
+            if not isfinite(value):  # type: ignore[arg-type]
+                raise HyperdirectVetoError(message)
+        except (TypeError, ValueError) as exc:
+            raise HyperdirectVetoError(message) from exc
+        return float(value)
+
+    @staticmethod
+    def _validate_config(config: HyperdirectConfig) -> None:
+        if not (0.0 < config.hard_ceiling <= 1.0):
+            raise ValueError("hard_ceiling must be in (0, 1]")
+        if config.base_margin < 0.0 or not isfinite(config.base_margin):
+            raise ValueError("base_margin must be a finite value >= 0")
+        if config.conflict_gain < 0.0 or not isfinite(config.conflict_gain):
+            raise ValueError("conflict_gain must be a finite value >= 0")

--- a/runtime/hyperdirect_veto_falsifier.py
+++ b/runtime/hyperdirect_veto_falsifier.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+import math
+import random
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from runtime.hyperdirect_veto import (  # noqa: E402
+    HyperdirectConfig,
+    HyperdirectVeto,
+    HyperdirectVetoError,
+)
+
+__all__ = ["AttackResult", "run_battery", "main"]
+
+
+@dataclass(frozen=True)
+class AttackResult:
+    """One adversarial probe.
+
+    ``broken`` means the protected invariant was violated — the primitive
+    failed its job. ``boundary`` means the attack succeeds *by design*:
+    a documented limitation, reported honestly rather than hidden as a
+    pass. Only ``broken`` fails the battery.
+    """
+
+    rung: str
+    broken: bool
+    boundary: bool
+    detail: str
+
+
+def _r(rung: str, *, broken: bool, detail: str, boundary: bool = False) -> AttackResult:
+    return AttackResult(rung=rung, broken=broken, boundary=boundary, detail=detail)
+
+
+def a1_averaging_attack() -> AttackResult:
+    """One saturated channel, rest zero, enormous margin.
+
+    mean is tiny; if the gate averaged, this would PASS. It must veto.
+    """
+    gate = HyperdirectVeto()
+    d = gate.evaluate({"hot": 0.99, "a": 0.0, "b": 0.0, "c": 0.0}, evidence_margin=1e12)
+    broken = d.passed
+    return _r(
+        "A1-averaging",
+        broken=broken,
+        detail=f"passed={d.passed} reason={d.reason!r} c_aggregate={d.c_aggregate:.4f}",
+    )
+
+
+def a2_channel_split_dilution() -> AttackResult:
+    """Adversary decomposes one big conflict into many small ones.
+
+    A 0.9 signal split into 9 channels of 0.1 drops max below the
+    ceiling AND drops the mean. HyperdirectVeto, by construction, cannot
+    defend against an adversary who controls channel decomposition —
+    that is exactly why HDV-007 makes residual-channel provenance a
+    *caller* contract. We report this as a BOUNDARY, not a pass: the
+    primitive is honest about what it does not protect.
+    """
+    gate = HyperdirectVeto(HyperdirectConfig(conflict_gain=1.0))
+    concentrated = gate.evaluate({"x": 0.9}, evidence_margin=0.5)
+    diluted = gate.evaluate({f"x{i}": 0.1 for i in range(9)}, evidence_margin=0.5)
+    bypass = (not concentrated.passed) and diluted.passed
+    return _r(
+        "A2-channel-split",
+        broken=False,
+        boundary=bypass,
+        detail=(
+            f"concentrated.passed={concentrated.passed} "
+            f"diluted.passed={diluted.passed} -> decomposition bypass "
+            f"{'CONFIRMED (documented boundary, HDV-007 caller contract)' if bypass else 'not reachable'}"
+        ),
+    )
+
+
+def a3_margin_inflation() -> AttackResult:
+    """No finite evidence margin may override a single-channel STOP."""
+    gate = HyperdirectVeto(HyperdirectConfig(conflict_gain=1.0))
+    worst = False
+    for margin in (1.0, 1e6, 1e18, sys.float_info.max):
+        d = gate.evaluate({"hot": 0.9, "b": 0.2}, evidence_margin=margin)
+        if d.passed:
+            worst = True
+    return _r(
+        "A3-margin-inflation",
+        broken=worst,
+        detail=f"max margin {sys.float_info.max:.3e} still vetoed={not worst}",
+    )
+
+
+def a4_empty_channel_state() -> AttackResult:
+    """Empty conflict is a valid 'no residual conflict' state (HDV-006).
+
+    It is only a leak if it bypasses the base margin. It must not.
+    """
+    gate = HyperdirectVeto(HyperdirectConfig(base_margin=0.5, conflict_gain=1.0))
+    below = gate.evaluate({}, evidence_margin=0.49)
+    at_or_above = gate.evaluate({}, evidence_margin=0.51)
+    leak = below.passed  # base margin not enforced on empty conflict
+    return _r(
+        "A4-empty-state",
+        broken=leak,
+        detail=(
+            f"empty+below-base passed={below.passed} (must be False); "
+            f"empty+above-base passed={at_or_above.passed} (expected True)"
+        ),
+    )
+
+
+def a5_float_precision_boundary() -> AttackResult:
+    """The ceiling is a hard >= edge; probe the nextafter neighbourhood."""
+    gate = HyperdirectVeto(HyperdirectConfig(hard_ceiling=0.8))
+    just_below = math.nextafter(0.8, 0.0)
+    exact = gate.evaluate({"x": 0.8}, evidence_margin=1e9)
+    under = gate.evaluate({"x": just_below}, evidence_margin=1e9)
+    broken = exact.passed or (not under.passed)
+    return _r(
+        "A5-float-boundary",
+        broken=broken,
+        detail=(
+            f"ceiling exact vetoed={not exact.passed} (must be True); "
+            f"nextafter-below passed={under.passed} (must be True)"
+        ),
+    )
+
+
+def a6_nonfinite_injection() -> AttackResult:
+    """NaN/inf in any numeric input must fail-closed, never PASS."""
+    gate = HyperdirectVeto()
+    leaked = False
+    cases: list[tuple[dict[str, float], float]] = [
+        ({"x": math.nan}, 1.0),
+        ({"x": math.inf}, 1.0),
+        ({"x": 0.1}, math.nan),
+        ({"x": 0.1}, math.inf),
+    ]
+    for conflict, margin in cases:
+        try:
+            gate.evaluate(conflict, evidence_margin=margin)
+            leaked = True  # returned a decision instead of raising
+        except HyperdirectVetoError:
+            pass
+    return _r(
+        "A6-nonfinite",
+        broken=leaked,
+        detail=f"all non-finite inputs fail-closed={not leaked}",
+    )
+
+
+def a7_safety_monotonicity(trials: int = 5000) -> AttackResult:
+    """Raising any channel must never flip a veto into a pass.
+
+    Random search for a counterexample to weak safety-monotonicity.
+    """
+    rng = random.Random(20260515)
+    gate = HyperdirectVeto(HyperdirectConfig(conflict_gain=1.0))
+    violation: str | None = None
+    for _ in range(trials):
+        keys = [f"k{i}" for i in range(rng.randint(1, 5))]
+        base = {k: round(rng.uniform(0.0, 0.79), 4) for k in keys}
+        margin = rng.uniform(0.0, 1.5)
+        before = gate.evaluate(base, evidence_margin=margin)
+        if before.passed:
+            continue
+        bump_key = rng.choice(keys)
+        bumped = dict(base)
+        bumped[bump_key] = min(1.0, base[bump_key] + rng.uniform(0.0, 0.2))
+        after = gate.evaluate(bumped, evidence_margin=margin)
+        if after.passed:
+            violation = f"{base}->{bumped} margin={margin}"
+            break
+    return _r(
+        "A7-safety-monotonicity",
+        broken=violation is not None,
+        detail=violation or f"{trials} trials: more conflict never relaxed a veto",
+    )
+
+
+def a8_determinism(trials: int = 4000) -> AttackResult:
+    """No clock/RNG/state: identical inputs -> identical decisions."""
+    rng = random.Random(7)
+    gate = HyperdirectVeto(HyperdirectConfig(conflict_gain=1.0))
+    drift: str | None = None
+    for _ in range(trials):
+        conflict = {f"c{i}": round(rng.uniform(0.0, 1.0), 6) for i in range(rng.randint(0, 6))}
+        margin = rng.uniform(-1.0, 2.0)
+        first = gate.evaluate(conflict, evidence_margin=margin)
+        second = gate.evaluate(dict(conflict), evidence_margin=margin)
+        if first != second:
+            drift = f"{conflict} margin={margin}"
+            break
+    return _r(
+        "A8-determinism",
+        broken=drift is not None,
+        detail=drift or f"{trials} trials: bit-identical on repeat",
+    )
+
+
+def run_battery() -> list[AttackResult]:
+    return [
+        a1_averaging_attack(),
+        a2_channel_split_dilution(),
+        a3_margin_inflation(),
+        a4_empty_channel_state(),
+        a5_float_precision_boundary(),
+        a6_nonfinite_injection(),
+        a7_safety_monotonicity(),
+        a8_determinism(),
+    ]
+
+
+def main() -> int:
+    results = run_battery()
+    width = max(len(r.rung) for r in results)
+    broken_any = False
+    for r in results:
+        if r.broken:
+            tag = "BROKEN"
+            broken_any = True
+        elif r.boundary:
+            tag = "BOUNDARY"
+        else:
+            tag = "SURVIVED"
+        print(f"[{tag:8}] {r.rung:<{width}}  {r.detail}")
+    if broken_any:
+        print("\nFALSIFIED: at least one protected invariant was violated.")
+        return 1
+    print("\nAll protected invariants survived. Boundaries are documented, not hidden.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/runtime/inference_promotion_brake.py
+++ b/runtime/inference_promotion_brake.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import isfinite
+from numbers import Real
+from typing import Sequence
+
+from runtime.hyperdirect_veto import (
+    HyperdirectConfig,
+    HyperdirectVeto,
+    HyperdirectVetoError,
+    VetoDecision,
+)
+
+__all__ = [
+    "InferenceClaim",
+    "PromotionVerdict",
+    "InferencePromotionBrake",
+]
+
+
+@dataclass(frozen=True)
+class InferenceClaim:
+    """A claim asking to be promoted from a verified context onto an
+    extrapolated one.
+
+    ``hypothesis_score`` and ``null_scores`` produce the evidence margin
+    ``hypothesis_score - max(null_scores)`` — how far the claim's own
+    statistic beats its strongest null. The remaining fields are the
+    **residual** conflict channels (HDV-007): signals a caller asserts
+    are NOT already hard-gated by an upstream contract. Any channel left
+    ``None`` is simply absent — the brake never invents a channel.
+    """
+
+    hypothesis_score: float
+    null_scores: Sequence[float]
+    falsifier_disagreement: float | None = None
+    witness_uncertainty: float | None = None
+    purpose_drift: float | None = None
+    external_falsification_drift: float | None = None
+
+
+@dataclass(frozen=True)
+class PromotionVerdict:
+    """Advisory outcome. ``advisory`` is always True by construction.
+
+    This brake never mutates execution, never writes state, and is not
+    on any trading/execution path. A consumer is free to ignore it; it
+    only *reports* whether the claim cleared the hyperdirect brake.
+    """
+
+    promote: bool
+    evidence_margin: float
+    decision: VetoDecision
+    advisory: bool = True
+
+
+class InferencePromotionBrake:
+    """Maps an :class:`InferenceClaim` onto :class:`HyperdirectVeto`.
+
+    Pure and stateless. The mapping is deliberately thin: it computes the
+    evidence margin, collects only the residual conflict channels that
+    were actually supplied, and delegates the decision wholesale to
+    HyperdirectVeto. No scoring logic, no thresholds of its own — the
+    brake's behaviour is exactly the primitive's behaviour, so there is
+    no second place for drift to hide.
+
+    What a ``promote=True`` verdict means: under the caller-supplied
+    score, nulls, and residual conflict, no single-channel STOP fired
+    and the margin cleared the conflict-proportional bar. It does NOT
+    assert the inputs correspond to reality, nor that acting on the
+    claim is safe — that obligation stays upstream. The verdict is
+    advisory: a recommendation, never an authorisation.
+    """
+
+    def __init__(self, config: HyperdirectConfig | None = None) -> None:
+        self._veto = HyperdirectVeto(config)
+
+    @property
+    def config(self) -> HyperdirectConfig:
+        return self._veto.config
+
+    def assess(self, claim: InferenceClaim) -> PromotionVerdict:
+        if not isinstance(claim, InferenceClaim):
+            raise HyperdirectVetoError("promotion denied: claim must be an InferenceClaim")
+
+        hypothesis = self._finite(
+            claim.hypothesis_score,
+            "promotion denied: hypothesis_score must be a finite real",
+        )
+        nulls = tuple(claim.null_scores)
+        if not nulls:
+            raise HyperdirectVetoError("promotion denied: at least one null score is required")
+        max_null = max(
+            self._finite(v, "promotion denied: every null score must be a finite real")
+            for v in nulls
+        )
+        evidence_margin = hypothesis - max_null
+
+        conflict: dict[str, float] = {}
+        for name, value in (
+            ("falsifier_disagreement", claim.falsifier_disagreement),
+            ("witness_uncertainty", claim.witness_uncertainty),
+            ("purpose_drift", claim.purpose_drift),
+            ("external_falsification_drift", claim.external_falsification_drift),
+        ):
+            if value is not None:
+                # Range/finiteness is enforced by the primitive (HDV-004),
+                # so there is exactly one validation site, not two.
+                conflict[name] = value
+
+        decision = self._veto.evaluate(conflict, evidence_margin=evidence_margin)
+        return PromotionVerdict(
+            promote=decision.passed,
+            evidence_margin=evidence_margin,
+            decision=decision,
+        )
+
+    @staticmethod
+    def _finite(value: object, message: str) -> float:
+        if isinstance(value, bool) or not isinstance(value, Real):
+            raise HyperdirectVetoError(message)
+        try:
+            if not isfinite(value):  # type: ignore[arg-type]
+                raise HyperdirectVetoError(message)
+        except (TypeError, ValueError) as exc:
+            raise HyperdirectVetoError(message) from exc
+        return float(value)

--- a/tests/unit/runtime/test_hyperdirect_veto.py
+++ b/tests/unit/runtime/test_hyperdirect_veto.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+import math
+from dataclasses import FrozenInstanceError
+from typing import Any, cast
+
+import pytest
+
+from runtime.hyperdirect_veto import (
+    HyperdirectConfig,
+    HyperdirectVeto,
+    HyperdirectVetoError,
+    VetoDecision,
+)
+
+# --------------------------------------------------------------------------
+# HDV-001 / HDV-002: disjunctive single-channel STOP (the core property)
+# --------------------------------------------------------------------------
+
+
+def test_single_channel_stop_cannot_be_laundered_by_strong_evidence() -> None:
+    """One saturated red flag vetoes regardless of how strong the margin is.
+
+    This is the whole reason the primitive exists: a single conflict
+    channel at the ceiling must not be averaged away by an otherwise
+    excellent claim.
+    """
+    gate = HyperdirectVeto()
+    decision = gate.evaluate({"falsifier_disagreement": 0.9}, evidence_margin=1e9)
+    assert decision.passed is False
+    assert decision.reason == "single_channel_stop:falsifier_disagreement"
+    assert decision.vetoing_channel == "falsifier_disagreement"
+
+
+def test_veto_uses_max_not_mean() -> None:
+    """mean({0.9, 0.0, 0.0}) = 0.3 but max = 0.9 — must veto."""
+    gate = HyperdirectVeto()
+    decision = gate.evaluate({"a": 0.9, "b": 0.0, "c": 0.0}, evidence_margin=1e9)
+    assert decision.passed is False
+    assert decision.vetoing_channel == "a"
+    assert decision.c_max == pytest.approx(0.9)
+    assert decision.c_aggregate == pytest.approx(0.3)
+
+
+def test_channel_exactly_at_ceiling_vetoes() -> None:
+    gate = HyperdirectVeto(HyperdirectConfig(hard_ceiling=0.8))
+    decision = gate.evaluate({"x": 0.8}, evidence_margin=1e9)
+    assert decision.passed is False
+    assert decision.reason == "single_channel_stop:x"
+
+
+# --------------------------------------------------------------------------
+# HDV-003: conflict-proportional decision threshold (deterministic, not RNG)
+# --------------------------------------------------------------------------
+
+
+def test_required_margin_rises_with_aggregate_conflict() -> None:
+    gate = HyperdirectVeto(HyperdirectConfig(base_margin=0.1, conflict_gain=1.0))
+    low = gate.evaluate({"a": 0.1, "b": 0.1}, evidence_margin=0.5)
+    high = gate.evaluate({"a": 0.5, "b": 0.5}, evidence_margin=0.5)
+    assert high.required_margin > low.required_margin
+    assert low.required_margin == pytest.approx(0.1 + 1.0 * 0.1)
+    assert high.required_margin == pytest.approx(0.1 + 1.0 * 0.5)
+
+
+def test_insufficient_margin_under_conflict_vetoes() -> None:
+    gate = HyperdirectVeto(HyperdirectConfig(conflict_gain=1.0))
+    decision = gate.evaluate({"a": 0.4, "b": 0.4}, evidence_margin=0.3)
+    assert decision.passed is False
+    assert decision.reason == "insufficient_margin_under_conflict"
+    assert decision.vetoing_channel is None
+
+
+def test_sufficient_margin_clears() -> None:
+    gate = HyperdirectVeto(HyperdirectConfig(conflict_gain=1.0))
+    decision = gate.evaluate({"a": 0.4, "b": 0.4}, evidence_margin=0.5)
+    assert decision.passed is True
+    assert decision.reason == "cleared"
+
+
+def test_margin_exactly_at_required_passes() -> None:
+    gate = HyperdirectVeto(HyperdirectConfig(base_margin=0.0, conflict_gain=1.0))
+    # aggregate = 0.2, required = 0.2, margin = 0.2 -> not (0.2 < 0.2) -> pass
+    decision = gate.evaluate({"a": 0.2, "b": 0.2}, evidence_margin=0.2)
+    assert decision.passed is True
+
+
+def test_single_channel_stop_takes_precedence_over_margin_check() -> None:
+    gate = HyperdirectVeto(HyperdirectConfig(hard_ceiling=0.8, conflict_gain=1.0))
+    decision = gate.evaluate({"a": 0.9, "b": 0.0}, evidence_margin=1e9)
+    assert decision.reason.startswith("single_channel_stop")
+
+
+def test_negative_margin_cannot_pass() -> None:
+    """Null beat the hypothesis -> margin negative -> never clears base."""
+    gate = HyperdirectVeto(HyperdirectConfig(base_margin=0.0, conflict_gain=0.0))
+    decision = gate.evaluate({}, evidence_margin=-0.01)
+    assert decision.passed is False
+    assert decision.reason == "insufficient_margin_under_conflict"
+
+
+# --------------------------------------------------------------------------
+# HDV-006: empty conflict is a valid "no residual conflict" state
+# --------------------------------------------------------------------------
+
+
+def test_empty_conflict_still_requires_base_margin() -> None:
+    gate = HyperdirectVeto(HyperdirectConfig(base_margin=0.5, conflict_gain=1.0))
+    assert gate.evaluate({}, evidence_margin=0.4).passed is False
+    cleared = gate.evaluate({}, evidence_margin=0.6)
+    assert cleared.passed is True
+    assert cleared.c_max == 0.0
+    assert cleared.c_aggregate == 0.0
+
+
+# --------------------------------------------------------------------------
+# Determinism (no clock, no RNG, no state)
+# --------------------------------------------------------------------------
+
+
+def test_repeated_evaluation_is_identical() -> None:
+    gate = HyperdirectVeto(HyperdirectConfig(conflict_gain=1.0))
+    first = gate.evaluate({"a": 0.3, "b": 0.6}, evidence_margin=0.42)
+    for _ in range(50):
+        again = gate.evaluate({"a": 0.3, "b": 0.6}, evidence_margin=0.42)
+        assert again == first
+
+
+# --------------------------------------------------------------------------
+# HDV-004 / HDV-005: fail-closed input validation
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        cast(Any, None),
+        cast(Any, [("a", 0.1)]),
+        cast(Any, "not-a-mapping"),
+    ],
+)
+def test_non_mapping_conflict_fails_closed(bad: Any) -> None:
+    with pytest.raises(HyperdirectVetoError):
+        HyperdirectVeto().evaluate(bad, evidence_margin=0.0)
+
+
+@pytest.mark.parametrize("value", [-0.01, 1.01, 2.0])
+def test_channel_out_of_unit_range_fails_closed(value: float) -> None:
+    with pytest.raises(HyperdirectVetoError):
+        HyperdirectVeto().evaluate({"a": value}, evidence_margin=0.0)
+
+
+@pytest.mark.parametrize("value", [math.nan, math.inf, -math.inf])
+def test_non_finite_channel_fails_closed(value: float) -> None:
+    with pytest.raises(HyperdirectVetoError):
+        HyperdirectVeto().evaluate({"a": value}, evidence_margin=0.0)
+
+
+def test_bool_channel_value_fails_closed() -> None:
+    with pytest.raises(HyperdirectVetoError):
+        HyperdirectVeto().evaluate({"a": cast(Any, True)}, evidence_margin=0.0)
+
+
+def test_non_string_or_empty_channel_name_fails_closed() -> None:
+    with pytest.raises(HyperdirectVetoError):
+        HyperdirectVeto().evaluate({cast(Any, 1): 0.1}, evidence_margin=0.0)
+    with pytest.raises(HyperdirectVetoError):
+        HyperdirectVeto().evaluate({"": 0.1}, evidence_margin=0.0)
+
+
+@pytest.mark.parametrize("margin", [math.nan, math.inf, -math.inf, cast(Any, True), cast(Any, "x")])
+def test_non_finite_or_non_real_margin_fails_closed(margin: Any) -> None:
+    with pytest.raises(HyperdirectVetoError):
+        HyperdirectVeto().evaluate({"a": 0.1}, evidence_margin=margin)
+
+
+# --------------------------------------------------------------------------
+# Config validation
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        HyperdirectConfig(hard_ceiling=0.0),
+        HyperdirectConfig(hard_ceiling=1.01),
+        HyperdirectConfig(base_margin=-0.1),
+        HyperdirectConfig(conflict_gain=-1.0),
+        HyperdirectConfig(base_margin=math.inf),
+        HyperdirectConfig(conflict_gain=math.inf),
+    ],
+)
+def test_invalid_config_rejected(config: HyperdirectConfig) -> None:
+    with pytest.raises(ValueError):
+        HyperdirectVeto(config)
+
+
+def test_ceiling_at_one_is_valid() -> None:
+    gate = HyperdirectVeto(HyperdirectConfig(hard_ceiling=1.0))
+    assert gate.evaluate({"a": 1.0}, evidence_margin=1e9).passed is False
+    assert gate.evaluate({"a": 0.99}, evidence_margin=1e9).passed is True
+
+
+# --------------------------------------------------------------------------
+# HDV-008: immutability
+# --------------------------------------------------------------------------
+
+
+def test_decision_is_frozen() -> None:
+    decision = HyperdirectVeto().evaluate({"a": 0.1}, evidence_margin=1.0)
+    with pytest.raises(FrozenInstanceError):
+        cast(Any, decision).passed = True
+
+
+def test_conflict_vector_is_read_only() -> None:
+    decision = HyperdirectVeto().evaluate({"a": 0.1}, evidence_margin=1.0)
+    assert isinstance(decision, VetoDecision)
+    with pytest.raises(TypeError):
+        cast(Any, decision.conflict_vector)["a"] = 0.9

--- a/tests/unit/runtime/test_inference_promotion_brake.py
+++ b/tests/unit/runtime/test_inference_promotion_brake.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from typing import Any, cast
+
+import pytest
+
+from runtime.hyperdirect_veto import HyperdirectConfig, HyperdirectVetoError
+from runtime.hyperdirect_veto_falsifier import run_battery
+from runtime.inference_promotion_brake import (
+    InferenceClaim,
+    InferencePromotionBrake,
+    PromotionVerdict,
+)
+
+
+def test_strong_claim_low_conflict_promotes() -> None:
+    brake = InferencePromotionBrake(HyperdirectConfig(conflict_gain=1.0))
+    claim = InferenceClaim(
+        hypothesis_score=0.9,
+        null_scores=[0.3, 0.4, 0.35],
+        falsifier_disagreement=0.05,
+        witness_uncertainty=0.0,
+    )
+    verdict = brake.assess(claim)
+    assert isinstance(verdict, PromotionVerdict)
+    assert verdict.promote is True
+    assert verdict.advisory is True
+    assert verdict.evidence_margin == pytest.approx(0.5)
+
+
+def test_single_saturated_residual_channel_vetoes_despite_huge_margin() -> None:
+    brake = InferencePromotionBrake()
+    claim = InferenceClaim(
+        hypothesis_score=1e9,
+        null_scores=[0.0],
+        falsifier_disagreement=0.95,
+    )
+    verdict = brake.assess(claim)
+    assert verdict.promote is False
+    assert verdict.decision.reason.startswith("single_channel_stop")
+
+
+def test_null_beating_hypothesis_cannot_promote() -> None:
+    brake = InferencePromotionBrake(HyperdirectConfig(conflict_gain=0.0))
+    claim = InferenceClaim(hypothesis_score=0.2, null_scores=[0.5])
+    verdict = brake.assess(claim)
+    assert verdict.evidence_margin == pytest.approx(-0.3)
+    assert verdict.promote is False
+
+
+def test_absent_channels_are_not_invented() -> None:
+    brake = InferencePromotionBrake(HyperdirectConfig(conflict_gain=1.0))
+    claim = InferenceClaim(hypothesis_score=0.6, null_scores=[0.1])
+    verdict = brake.assess(claim)
+    # No conflict channels supplied -> empty conflict vector, not zeros.
+    assert dict(verdict.decision.conflict_vector) == {}
+    assert verdict.promote is True
+
+
+def test_empty_nulls_fail_closed() -> None:
+    brake = InferencePromotionBrake()
+    with pytest.raises(HyperdirectVetoError):
+        brake.assess(InferenceClaim(hypothesis_score=1.0, null_scores=[]))
+
+
+@pytest.mark.parametrize("bad", [float("nan"), float("inf")])
+def test_non_finite_score_fails_closed(bad: float) -> None:
+    brake = InferencePromotionBrake()
+    with pytest.raises(HyperdirectVetoError):
+        brake.assess(InferenceClaim(hypothesis_score=bad, null_scores=[0.1]))
+    with pytest.raises(HyperdirectVetoError):
+        brake.assess(InferenceClaim(hypothesis_score=0.5, null_scores=[bad]))
+
+
+def test_out_of_range_residual_channel_fails_closed() -> None:
+    brake = InferencePromotionBrake()
+    with pytest.raises(HyperdirectVetoError):
+        brake.assess(
+            InferenceClaim(
+                hypothesis_score=0.9,
+                null_scores=[0.1],
+                purpose_drift=1.5,
+            )
+        )
+
+
+def test_non_claim_input_fails_closed() -> None:
+    brake = InferencePromotionBrake()
+    with pytest.raises(HyperdirectVetoError):
+        brake.assess(cast(Any, {"hypothesis_score": 1.0}))
+
+
+def test_verdict_is_immutable() -> None:
+    brake = InferencePromotionBrake()
+    verdict = brake.assess(InferenceClaim(hypothesis_score=0.9, null_scores=[0.1]))
+    with pytest.raises(Exception):
+        cast(Any, verdict).promote = False
+
+
+def test_assessment_is_deterministic() -> None:
+    brake = InferencePromotionBrake(HyperdirectConfig(conflict_gain=1.3))
+    claim = InferenceClaim(
+        hypothesis_score=0.55,
+        null_scores=[0.2, 0.31],
+        falsifier_disagreement=0.2,
+        purpose_drift=0.15,
+    )
+    first = brake.assess(claim)
+    for _ in range(25):
+        assert brake.assess(claim) == first
+
+
+# --------------------------------------------------------------------------
+# The adversarial reverse pass must hold no broken invariant. Documented
+# boundaries (A2 channel-split) are allowed; broken invariants are not.
+# --------------------------------------------------------------------------
+
+
+def test_falsifier_battery_has_no_broken_invariant() -> None:
+    results = run_battery()
+    broken = [r.rung for r in results if r.broken]
+    assert broken == [], f"falsifier broke invariants: {broken}"
+    # A2 is the known, deliberately-surfaced boundary.
+    boundaries = {r.rung for r in results if r.boundary}
+    assert boundaries <= {"A2-channel-split"}


### PR DESCRIPTION
## What

A small, pure, fail-closed pre-promotion **brake** for extrapolated inference claims. This is the *salvaged kernel* of PR #678 (Inference Extrapolation Validator), which was closed 2026-05-15 because its value was the idea, not the code.

## Why this, not #678

#678's neuro origin is sound — the cortico-basal-ganglia **hyperdirect** pathway: ACC monitors conflict, the subthalamic nucleus applies a fast global STOP and raises the decision threshold *in proportion to conflict* (Frank 2006; Cavanagh & Frank 2011). But the shipped IEV:

- ran a 7-dim conflict vector whose **5/7 channels were already hard-gated upstream** of the gate → could never fire → theatre;
- **faked** the signature conflict-proportional threshold with seed jitter *independent of the conflict score* (the exact pseudo-precision smell our chronology discipline forbids);
- 2087 lines for a residual ≈2 boolean rules.

This PR keeps only the load-bearing mechanism, honestly:

| Behaviour | Faithful implementation |
|---|---|
| Disjunctive single-channel STOP | `max` over channels (never mean/sum); one channel ≥ `hard_ceiling` vetoes regardless of evidence strength |
| Conflict-proportional threshold | `required_margin = base + gain · mean(conflict)` — pure deterministic function of supplied conflict, **no RNG** |
| No dead channels | HDV-007 caller contract: only *residual* (not-already-gated) channels are passed in |

## Claim boundary (honest)

A PASS asserts only that, under the **caller-supplied** conflict and margin, no STOP fired and the evidence cleared the conflict-scaled bar. It does **not** assert the numerics correspond to reality — that obligation lives upstream with whatever computed them. Stateless, pure, no clock/RNG/IO; every out-of-contract input fail-closes (no clamping).

## Tests / gates

36 unit tests incl. the core adversarial property (a single saturated red flag cannot be laundered by an arbitrarily strong margin), max-not-mean, monotonic conflict→threshold, determinism over 50 repeats, full fail-closed input/config matrix, immutability. `black` + `ruff` + `mypy --strict` clean locally.

## Scope

Standalone primitive in `runtime/` mirroring `runtime/rebus_gate.py` conventions. **No wiring into any live decision path** — opt-in, advisory, like the other fail-closed exploration primitives. Integration into a specific path is a separate explicit decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)