### PR TITLE
feat(api): IERD-Q5 Phase-4 ENTRY — UX state-coverage gate (UXRS §5)

### DIFF
--- a/.claude/commit_acceptors/ierd-q5-ux-state-coverage-gate.yaml
+++ b/.claude/commit_acceptors/ierd-q5-ux-state-coverage-gate.yaml
@@ -1,0 +1,117 @@
+# Diff-bound commit acceptor for IERD-Q5 Phase-4 ENTRY: UX
+# state-coverage gate.
+#
+# Before: claim `ux-readiness-state-coverage` declared that every
+# endpoint must surface the six IERD §5 UX states (success, empty,
+# partial, validation_error, server_error, timeout) with a standard
+# error envelope, but no CI gate scored the OpenAPI spec against the
+# UXRS ≥ 0.95 threshold. Reset-wave subsystem state set was the only
+# existing evidence.
+#
+# After: tests/api/test_ux_state_coverage.py reads the frozen
+# schemas/openapi/geosync-online-inference-v1.json, maps each declared
+# HTTP status code to a UX state via the HTTP-canonical mapping, and
+# asserts the aggregate UXRS over all public operations (the /graphql
+# carve-out is identical to the Q4 schemathesis gate) is ≥ 0.95. A
+# second test asserts every declared 4xx/5xx response $refs the
+# canonical ErrorResponse envelope. The UX State Coverage workflow
+# runs the same suite on every PR touching schemas/openapi/** or the
+# API surface and uploads junit.xml + run.log as artifacts (14-day
+# retention). Phase-4 ENTRY only: continue-on-error: true on the run
+# step so frontend renderers + the end-to-end matrix can land under
+# the same claim without flipping gate strictness mid-phase. Phase-4
+# EXIT removes it and the claim re-classifies ANCHORED.
+#
+# Locally verified (development laptop, native Python):
+#   test_spec_present_and_has_public_operations       PASS
+#   test_error_envelope_on_all_4xx_5xx                PASS
+#   test_uxrs_meets_threshold                         FAIL (informational)
+#     [uxrs] AGGREGATE declared=29/66 UXRS=0.4394
+#   The UXRS failure is the honest Phase-4 ENTRY gap: 9 of 11
+#   operations declare only success+validation_error+server_error;
+#   empty/partial/timeout declarations land in Phase-4 EXIT.
+
+id: ierd-q5-ux-state-coverage-gate
+status: ACTIVE
+claim_type: correctness
+promise: >-
+  `pytest tests/api/test_ux_state_coverage.py` reads the frozen
+  OpenAPI 3.1 spec at
+  schemas/openapi/geosync-online-inference-v1.json, maps each declared
+  status code to one of the six IERD §5 UX states (success → 200/201,
+  empty → 204, partial → 206, validation_error → 400/422, server_error
+  → 500/502/503, timeout → 504), and asserts the aggregate
+  UXRS = declared / (6 × endpoints) ≥ 0.95 over every public operation
+  (the /graphql carve-out matches the Q4 gate). A second test asserts
+  every declared 4xx/5xx response body $refs
+  #/components/schemas/ErrorResponse. Each case emits structured
+  `[uxrs] ...` lines consumed by the GitHub Step Summary. The UX
+  State Coverage workflow runs the same suite path-filtered to the
+  schema + API surface and uploads junit.xml + run.log as
+  `ux-state-coverage-results` (14-day retention). Phase-4 ENTRY
+  contract: continue-on-error is set on the run STEP so the GitHub
+  check resolves SUCCESS even though the UXRS sub-test currently
+  fails; Phase-4 EXIT removes it and the claim re-classifies ANCHORED.
+diff_scope:
+  changed_files:
+    - path: ".claude/commit_acceptors/ierd-q5-ux-state-coverage-gate.yaml"
+    - path: ".github/workflows/ux-state-coverage.yml"
+    - path: "docs/CLAIMS.yaml"
+    - path: "tests/api/test_ux_state_coverage.py"
+  forbidden_paths:
+    - "trading/"
+    - "execution/"
+    - "forecast/"
+    - "policy/"
+    - "core/physics/"
+    - "core/kuramoto/"
+    - "application/api/service.py"
+    - "application/api/errors.py"
+    - "schemas/openapi/"
+required_python_symbols:
+  - "tests/api/test_ux_state_coverage.py::test_uxrs_meets_threshold"
+  - "tests/api/test_ux_state_coverage.py::test_error_envelope_on_all_4xx_5xx"
+  - "tests/api/test_ux_state_coverage.py::test_spec_present_and_has_public_operations"
+  - "tests/api/test_ux_state_coverage.py::UXRS_THRESHOLD"
+  - "tests/api/test_ux_state_coverage.py::REQUIRED_STATES"
+expected_signal: >-
+  Local: `mypy --strict --follow-imports=silent
+  tests/api/test_ux_state_coverage.py` reports "Success: no issues
+  found in 1 source file"; `black --check` and `ruff check` both
+  report clean; `pytest tests/api/test_ux_state_coverage.py -q -s`
+  prints per-operation `[uxrs] ...` lines plus an `[uxrs] AGGREGATE`
+  line, with test_spec_present and test_error_envelope passing and
+  test_uxrs_meets_threshold failing informationally at
+  UXRS=0.4394 (29/66); `python scripts/ci/check_claims.py` reports
+  schema v3 with `ux-readiness-state-coverage` extended evidence_paths
+  (test file, workflow) all present.
+measurement_command: >-
+  bash -c 'mypy --strict --follow-imports=silent tests/api/test_ux_state_coverage.py
+  && black --check tests/api/test_ux_state_coverage.py
+  && ruff check tests/api/test_ux_state_coverage.py
+  && python scripts/ci/check_claims.py'
+signal_artifact: "tmp/ierd_q5_ux_state_coverage_gate.log"
+falsifier:
+  command: >-
+    bash -c 'python -c "import yaml,sys; spec=yaml.safe_load(open(\".github/workflows/ux-state-coverage.yml\")); steps=spec[\"jobs\"][\"ux-state-coverage\"][\"steps\"]; run_step=next(s for s in steps if s.get(\"id\")==\"run\"); sys.exit(0 if run_step.get(\"continue-on-error\") is True else 1)"'
+  description: >-
+    Probes the workflow YAML for the Phase-4 ENTRY contract
+    `continue-on-error: true` on the ux-state-coverage run step. If a
+    future change flips the gate to fail-closed without re-classifying
+    the claim ANCHORED in docs/CLAIMS.yaml, the falsifier exits
+    non-zero, signalling that Phase-4 EXIT promotion must be
+    co-shipped with the strictness flip — preventing silent
+    strictness drift identical to the Q4 and Q6 guarantees.
+rollback_command: >-
+  git checkout HEAD~1 --
+  .claude/commit_acceptors/ierd-q5-ux-state-coverage-gate.yaml
+  .github/workflows/ux-state-coverage.yml
+  tests/api/test_ux_state_coverage.py
+  docs/CLAIMS.yaml
+rollback_verification_command: >-
+  git diff --exit-code tests/api/test_ux_state_coverage.py
+  .github/workflows/ux-state-coverage.yml
+memory_update_type: append
+ledger_path: ".claude/commit_acceptors/ierd-q5-ux-state-coverage-gate.yaml"
+report_path: "tmp/ierd_q5_ux_state_coverage_gate.log"
+evidence: []

--- a/.claude/commit_acceptors/ierd-q5-ux-state-coverage-gate.yaml
+++ b/.claude/commit_acceptors/ierd-q5-ux-state-coverage-gate.yaml
@@ -22,6 +22,14 @@
 # the same claim without flipping gate strictness mid-phase. Phase-4
 # EXIT removes it and the claim re-classifies ANCHORED.
 #
+# Isolation: test_uxrs_meets_threshold is red by design until Phase-4
+# EXIT, so it is guarded by GEOSYNC_UX_STATE_GATE=1 (set only on the
+# dedicated workflow job). In the global python-fast-tests /
+# python-heavy-tests lanes the flag is absent and the sub-test SKIPs;
+# the two genuinely-green tests (spec present, error envelope) run
+# unguarded there. Same posture as the Q4 schemathesis gate, which
+# runs only in its own workflow via an optional-dependency skip.
+#
 # Locally verified (development laptop, native Python):
 #   test_spec_present_and_has_public_operations       PASS
 #   test_error_envelope_on_all_4xx_5xx                PASS
@@ -82,7 +90,9 @@ expected_signal: >-
   prints per-operation `[uxrs] ...` lines plus an `[uxrs] AGGREGATE`
   line, with test_spec_present and test_error_envelope passing and
   test_uxrs_meets_threshold failing informationally at
-  UXRS=0.4394 (29/66); `python scripts/ci/check_claims.py` reports
+  UXRS=0.4394 (29/66); the same suite WITHOUT
+  GEOSYNC_UX_STATE_GATE=1 reports 2 passed + 1 skipped (global-lane
+  posture); `python scripts/ci/check_claims.py` reports
   schema v3 with `ux-readiness-state-coverage` extended evidence_paths
   (test file, workflow) all present.
 measurement_command: >-

--- a/.github/workflows/ux-state-coverage.yml
+++ b/.github/workflows/ux-state-coverage.yml
@@ -51,6 +51,15 @@ jobs:
     name: ux-state-coverage
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    env:
+      # Activates the Phase-4 ENTRY informational UXRS sub-test. The
+      # global python-fast-tests / python-heavy-tests lanes do NOT set
+      # this, so test_uxrs_meets_threshold SKIPs there (it is red by
+      # design until Phase-4 EXIT lands the missing state
+      # declarations); it runs and fails informationally only here,
+      # where continue-on-error: true on the run step keeps the check
+      # green. Same isolation posture as the Q4 schemathesis gate.
+      GEOSYNC_UX_STATE_GATE: "1"
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/ux-state-coverage.yml
+++ b/.github/workflows/ux-state-coverage.yml
@@ -1,0 +1,106 @@
+# SPDX-License-Identifier: MIT
+#
+# UX State-Coverage Gate (IERD-Q5 Phase-4 ENTRY).
+#
+# Asserts that the frozen OpenAPI 3.1 spec at
+# schemas/openapi/geosync-online-inference-v1.json declares the six
+# IERD §5 UX states per public endpoint:
+#
+#     success  empty  partial  validation_error  server_error  timeout
+#
+# Readiness score UXRS = (declared states) / (6 × endpoints) must be
+# ≥ 0.95. The same suite also asserts every declared 4xx/5xx response
+# $refs the canonical ErrorResponse envelope.
+#
+# Phase status (per ADR 0020):
+#   * Phase-4 ENTRY (this workflow lands) — the OpenAPI state-coverage
+#     contract is gated informationally; frontend rendering for every
+#     state and the end-to-end matrix test land as follow-ups under
+#     the same claim.
+#   * Phase-4 EXIT (follow-up PRs) — missing empty/partial/timeout
+#     declarations remediated, frontend renderers + matrix test
+#     shipped; the run step flips fail-closed and the claim
+#     re-classifies ANCHORED.
+#
+# Tracked by GitHub issue IERD-Q5 (#530) and claim
+# `ux-readiness-state-coverage` in `docs/CLAIMS.yaml`.
+name: UX State Coverage — IERD-Q5
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'schemas/openapi/**'
+      - 'application/api/**'
+      - 'tests/api/test_ux_state_coverage.py'
+      - 'pyproject.toml'
+      - '.github/workflows/ux-state-coverage.yml'
+  merge_group:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ux-state-coverage-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  ux-state-coverage:
+    name: ux-state-coverage
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+
+      - name: Install runtime + test dependencies
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade pip
+          pip install -e .
+          pip install pytest
+
+      - name: Run UX state-coverage gate
+        id: run
+        # Phase-4 ENTRY: the OpenAPI state-coverage contract is gated
+        # informationally so the remaining acceptance criteria
+        # (frontend rendering per state, end-to-end matrix test) can
+        # land under the same claim without flipping gate strictness
+        # mid-phase. Phase-4 EXIT removes this and makes the gate
+        # fail-closed, at which point the claim re-classifies ANCHORED.
+        continue-on-error: true
+        run: |
+          set -o pipefail
+          mkdir -p artifacts/ux-state-coverage
+          pytest tests/api/test_ux_state_coverage.py \
+            -q -s --tb=short \
+            --junitxml=artifacts/ux-state-coverage/junit.xml \
+            2>&1 | tee artifacts/ux-state-coverage/run.log
+
+      - name: Upload ux-state-coverage artifact
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ux-state-coverage-results
+          path: artifacts/ux-state-coverage/
+          retention-days: 14
+
+      - name: Summarise UX state coverage
+        if: always()
+        run: |
+          set -euo pipefail
+          echo "## UX state coverage — IERD-Q5 §5" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          if [ -f artifacts/ux-state-coverage/run.log ]; then
+            grep -E "^\[uxrs\]" artifacts/ux-state-coverage/run.log >> "$GITHUB_STEP_SUMMARY" || true
+          fi
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Phase status: **Phase-4 ENTRY** — OpenAPI state-coverage contract gated informationally. Frontend renderers + end-to-end matrix land in Phase-4 EXIT." >> "$GITHUB_STEP_SUMMARY"

--- a/docs/CLAIMS.yaml
+++ b/docs/CLAIMS.yaml
@@ -750,22 +750,42 @@ claims:
       Every endpoint declares the six required UX states (success,
       empty, partial, validation_error, server_error, timeout) with
       a standard error envelope and a frontend rendering for each.
-      Status (Wave 6): EXTRAPOLATED — the reset-wave subsystem
-      already returns a finite supported state set via
+      Status (Phase-4 ENTRY 2026-05-16): EXTRAPOLATED — the OpenAPI
+      state-coverage contract is now gated on every PR via
+      tests/api/test_ux_state_coverage.py +
+      .github/workflows/ux-state-coverage.yml. The gate reads the
+      frozen schemas/openapi/geosync-online-inference-v1.json, maps
+      each declared status code to a UX state (success → 200/201,
+      empty → 204, partial → 206, validation_error → 400/422,
+      server_error → 500/502/503, timeout → 504), and scores
+      UXRS = declared / (6 × endpoints) over every public operation
+      (the /graphql carve-out matches the Q4 schemathesis gate). The
+      standard error envelope is already ANCHORED-level: every
+      declared 4xx/5xx response $refs #/components/schemas/
+      ErrorResponse ({error: {code, message, path, meta}}) — verified
+      by test_error_envelope_on_all_4xx_5xx (PASS). The reset-wave
+      subsystem still returns a finite supported state set via
       latent_interpretive_forecast_layer (LOCKED / CONVERGING /
       DIVERGING / OSCILLATORY / UNSTABLE / UNKNOWN, bounded
-      confidence ∈ [0, 1]); ResetWaveResult is a typed envelope with
-      explicit converged + locked + final_potential fields suitable
-      for UX rendering. Missing evidence: full per-endpoint state
-      enumeration in OpenAPI responses; standard {error_code,
-      message, details, trace_id, recoverable} envelope on all
-      4xx/5xx; frontend contract test verifying the matrix.
-      Re-classify ANCHORED on Phase-4 entry. Tracked by issue IERD-Q5.
+      confidence ∈ [0, 1]). Current UXRS = 0.4394 (29/66): 9 of 11
+      operations declare only success + validation_error +
+      server_error. Missing evidence: empty/partial/timeout
+      declarations across the OpenAPI responses; frontend rendering
+      for every declared state; an end-to-end matrix test. Phase-4
+      ENTRY runs the gate informationally (continue-on-error: true on
+      the run step). Re-classify ANCHORED on Phase-4 EXIT, when the
+      missing declarations + frontend renderers + matrix test land
+      and the gate flips fail-closed. Tracked by issue IERD-Q5 (#530).
     evidence_paths:
       - docs/yana-response.md
       - geosync/neuroeconomics/reset_wave_engine.py
       - tests/test_reset_wave_engine.py
+      - tests/api/test_ux_state_coverage.py
+      - .github/workflows/ux-state-coverage.yml
+      - schemas/openapi/geosync-online-inference-v1.json
+      - application/api/errors.py
     added_utc: "2026-05-03"
+    last_updated_utc: "2026-05-16"
 
   - id: e2e-latency-budget-compliance
     priority: P1

--- a/tests/api/test_ux_state_coverage.py
+++ b/tests/api/test_ux_state_coverage.py
@@ -48,9 +48,12 @@ and GitHub issue IERD-Q5 (#530).
 from __future__ import annotations
 
 import json
+import os
 import re
 from pathlib import Path
 from typing import Any, Final
+
+import pytest
 
 # Frozen, versioned OpenAPI 3.1 spec — the same artifact the Q4
 # schemathesis gate fuzzes the live app against. Reading the persisted
@@ -145,6 +148,30 @@ def test_spec_present_and_has_public_operations() -> None:
     )
 
 
+# The UXRS sub-test is red by design at Phase-4 ENTRY (the spec is
+# missing empty/partial/timeout declarations — that is precisely what
+# the gate surfaces). It must therefore run ONLY in the dedicated
+# ux-state-coverage workflow, which sets GEOSYNC_UX_STATE_GATE=1 and
+# carries continue-on-error: true on its run step. In the global
+# python-fast-tests / python-heavy-tests lanes the flag is absent so
+# the test SKIPs — identical posture to the Q4 schemathesis gate,
+# which likewise runs only in its own workflow (there via an optional
+# dependency skip). The two genuinely-green tests stay unguarded and
+# provide real coverage in the global lanes. Phase-4 EXIT removes
+# this guard together with the fail-closed flip.
+_UX_STATE_GATE_ENV: Final[str] = "GEOSYNC_UX_STATE_GATE"
+_uxrs_gate_only = pytest.mark.skipif(
+    os.environ.get(_UX_STATE_GATE_ENV) != "1",
+    reason=(
+        "IERD-Q5 Phase-4 ENTRY informational UXRS gate; runs only in the "
+        "dedicated ux-state-coverage workflow "
+        f"({_UX_STATE_GATE_ENV}=1, continue-on-error). Phase-4 EXIT lifts "
+        "this guard when the missing state declarations land."
+    ),
+)
+
+
+@_uxrs_gate_only
 def test_uxrs_meets_threshold() -> None:
     """Aggregate UXRS over public operations is ≥ the §5 threshold."""
     operations = _public_operations(_load_spec())

--- a/tests/api/test_ux_state_coverage.py
+++ b/tests/api/test_ux_state_coverage.py
@@ -1,0 +1,213 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""UX state-coverage gate (IERD-Q5 Phase-4 ENTRY).
+
+IERD-PAI-FPS-UX-001 §5 requires every public endpoint to declare the
+six UX states the frontend must be able to render:
+
+    success  empty  partial  validation_error  server_error  timeout
+
+The readiness score is
+
+    UXRS = (declared states across endpoints) / (6 × endpoints)
+
+and §5 demands UXRS ≥ 0.95.
+
+This module asserts the contract at the OpenAPI layer. It reads the
+frozen, versioned spec at
+``schemas/openapi/geosync-online-inference-v1.json`` (the same
+single-source-of-truth the Q4 schemathesis gate validates the running
+app against) and maps each declared HTTP status code to a UX state via
+the HTTP-canonical mapping below. An endpoint "declares" a state when
+its ``responses:`` block carries at least one status code mapped to
+that state.
+
+Two independent contracts are checked:
+
+* ``test_uxrs_meets_threshold`` — the aggregate UXRS over all public
+  operations is ≥ ``UXRS_THRESHOLD``.
+* ``test_error_envelope_on_all_4xx_5xx`` — every declared 4xx/5xx
+  response body ``$ref``\\s the standard ``ErrorResponse`` envelope
+  (``{error: {code, message, path, meta}}``), never an ad-hoc shape.
+
+``/graphql`` is excluded by design, identical to the Q4 gate: GraphQL
+carries its own typed Strawberry schema and is tracked under a separate
+contract suite.
+
+Phase-4 ENTRY: the workflow runs this suite with
+``continue-on-error: true`` so the remaining acceptance criteria
+(frontend rendering for every state, end-to-end matrix test) can land
+under the same claim without flipping gate strictness mid-phase.
+Phase-4 EXIT removes that and makes the gate fail-closed, at which
+point the claim re-classifies ANCHORED.
+
+Tracks claim ``ux-readiness-state-coverage`` in ``docs/CLAIMS.yaml``
+and GitHub issue IERD-Q5 (#530).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any, Final
+
+# Frozen, versioned OpenAPI 3.1 spec — the same artifact the Q4
+# schemathesis gate fuzzes the live app against. Reading the persisted
+# file (rather than building the app) keeps this a pure contract gate:
+# deterministic, env-free, and decoupled from runtime wiring.
+_SPEC_PATH: Final[Path] = (
+    Path(__file__).resolve().parents[2] / "schemas" / "openapi" / "geosync-online-inference-v1.json"
+)
+
+# §5 readiness threshold. Override via env only for shadow runs; the
+# IERD number is verbatim here.
+UXRS_THRESHOLD: Final[float] = 0.95
+
+# The six required UX states, in §5 order.
+REQUIRED_STATES: Final[tuple[str, ...]] = (
+    "success",
+    "empty",
+    "partial",
+    "validation_error",
+    "server_error",
+    "timeout",
+)
+
+# HTTP-canonical state → status-code mapping. A state counts as
+# declared for an operation if any of its codes appears in the
+# operation's ``responses:`` keys. The mapping is intentionally
+# standards-aligned (RFC 9110) rather than bespoke so the contract is
+# auditable without reading handler code:
+#
+#   success           200 Created/OK family
+#   empty             204 No Content
+#   partial           206 Partial Content
+#   validation_error  400 Bad Request / 422 Unprocessable Entity
+#   server_error      500 / 502 / 503 server-side failure
+#   timeout           504 Gateway Timeout
+_STATE_CODES: Final[dict[str, frozenset[str]]] = {
+    "success": frozenset({"200", "201"}),
+    "empty": frozenset({"204"}),
+    "partial": frozenset({"206"}),
+    "validation_error": frozenset({"400", "422"}),
+    "server_error": frozenset({"500", "502", "503"}),
+    "timeout": frozenset({"504"}),
+}
+
+# Excluded by design — GraphQL has its own typed schema (Strawberry);
+# identical carve-out to tests/api/test_schemathesis_contract.py.
+_EXCLUDE_PATH_RE: Final[re.Pattern[str]] = re.compile(r"^/graphql")
+
+_HTTP_METHODS: Final[frozenset[str]] = frozenset(
+    {"get", "post", "put", "delete", "patch", "options", "head"}
+)
+
+
+def _load_spec() -> dict[str, Any]:
+    """Load the frozen OpenAPI document."""
+    with _SPEC_PATH.open(encoding="utf-8") as handle:
+        spec: dict[str, Any] = json.load(handle)
+    return spec
+
+
+def _public_operations(spec: dict[str, Any]) -> list[tuple[str, str, dict[str, Any]]]:
+    """Return [(method, path, operation)] for every gated public operation."""
+    operations: list[tuple[str, str, dict[str, Any]]] = []
+    for path, path_item in (spec.get("paths") or {}).items():
+        if _EXCLUDE_PATH_RE.match(path):
+            continue
+        for method, operation in path_item.items():
+            if method.lower() in _HTTP_METHODS:
+                operations.append((method.upper(), path, operation))
+    return operations
+
+
+def _declared_states(operation: dict[str, Any]) -> set[str]:
+    """The subset of REQUIRED_STATES this operation declares in responses."""
+    codes = {str(code) for code in (operation.get("responses") or {})}
+    return {state for state, state_codes in _STATE_CODES.items() if codes & state_codes}
+
+
+def test_spec_present_and_has_public_operations() -> None:
+    """The frozen spec exists and exposes at least one gated operation."""
+    assert _SPEC_PATH.is_file(), (
+        f"IERD-Q5 §5 gate cannot run: OpenAPI spec missing at {_SPEC_PATH}. "
+        f"The UXRS contract is defined against the frozen versioned spec, "
+        f"not the live app — restore schemas/openapi/ before this gate can "
+        f"score state coverage."
+    )
+    operations = _public_operations(_load_spec())
+    assert operations, (
+        "IERD-Q5 §5 gate found zero public operations after the /graphql "
+        "carve-out — the spec is empty or every path was excluded; UXRS is "
+        "undefined with a zero denominator."
+    )
+
+
+def test_uxrs_meets_threshold() -> None:
+    """Aggregate UXRS over public operations is ≥ the §5 threshold."""
+    operations = _public_operations(_load_spec())
+    denominator = len(REQUIRED_STATES) * len(operations)
+    declared_total = 0
+    for method, path, operation in operations:
+        declared = _declared_states(operation)
+        declared_total += len(declared)
+        missing = sorted(set(REQUIRED_STATES) - declared)
+        print(  # surfaced via pytest -s / Step Summary
+            f"\n[uxrs] {method:6s} {path:30s} "
+            f"declared={len(declared)}/{len(REQUIRED_STATES)} "
+            f"missing={','.join(missing) if missing else '-'}"
+        )
+
+    uxrs = declared_total / denominator if denominator else 0.0
+    print(  # aggregate line consumed by the Step Summary
+        f"\n[uxrs] AGGREGATE "
+        f"declared={declared_total}/{denominator} "
+        f"UXRS={uxrs:.4f} threshold={UXRS_THRESHOLD:.2f} "
+        f"endpoints={len(operations)}"
+    )
+
+    assert uxrs >= UXRS_THRESHOLD, (
+        f"IERD-Q5 §5 UXRS violated: observed UXRS={uxrs:.4f} below "
+        f"threshold {UXRS_THRESHOLD:.2f} "
+        f"(declared {declared_total} of {denominator} state cells across "
+        f"{len(operations)} public operations). Each operation must declare "
+        f"all six UX states {REQUIRED_STATES} via responses: keys mapped by "
+        f"{_STATE_CODES}. Phase-4 EXIT remediation adds the missing "
+        f"empty/partial/timeout declarations and flips this gate fail-closed."
+    )
+
+
+def test_error_envelope_on_all_4xx_5xx() -> None:
+    """Every declared 4xx/5xx response body $refs the standard envelope.
+
+    The §5 contract demands a single canonical error envelope
+    (``{error: {code, message, path, meta}}``) on all failure
+    responses. We assert structurally that each 4xx/5xx response's
+    ``application/json`` body resolves to ``#/components/schemas/
+    ErrorResponse`` — never an ad-hoc inline shape — so the frontend
+    can render every failure state through one renderer.
+    """
+    spec = _load_spec()
+    expected_ref = "#/components/schemas/ErrorResponse"
+    offenders: list[str] = []
+
+    for method, path, operation in _public_operations(spec):
+        for code, response in (operation.get("responses") or {}).items():
+            if not re.fullmatch(r"[45]\d\d", str(code)):
+                continue
+            schema = (response.get("content") or {}).get("application/json", {}).get("schema", {})
+            if schema.get("$ref") != expected_ref:
+                offenders.append(
+                    f"{method} {path} [{code}] -> {schema or 'no application/json body'}"
+                )
+
+    assert not offenders, (
+        f"IERD-Q5 §5 error-envelope contract violated: "
+        f"{len(offenders)} declared 4xx/5xx response(s) do not $ref the "
+        f"canonical {expected_ref} envelope. Every failure response must "
+        f"resolve to the standard {{error: {{code, message, path, meta}}}} "
+        f"shape so the frontend renders all failure states through one "
+        f"path. Offenders: " + "; ".join(sorted(offenders))
+    )


### PR DESCRIPTION
Closes the Phase-4 ENTRY scope of **IERD-Q5 (#530)** following the exact Phase-N precedent set by **#529 (Q4 schemathesis)** and **#531 (Q6 latency)**.

## What lands in `main`

| File | Role |
|---|---|
| `tests/api/test_ux_state_coverage.py` | Reads frozen `schemas/openapi/geosync-online-inference-v1.json`; maps each declared status code → one of the six §5 UX states; asserts `UXRS = declared/(6×endpoints) ≥ 0.95`; second test asserts every 4xx/5xx `$ref`s the canonical `ErrorResponse` envelope. `/graphql` carved out (identical to Q4). |
| `.github/workflows/ux-state-coverage.yml` | Path-filtered gate; `continue-on-error: true` on the run step (Phase-4 ENTRY contract); junit + run.log artifact (14d); `[uxrs]` Step Summary. |
| `.claude/commit_acceptors/ierd-q5-ux-state-coverage-gate.yaml` | Diff-bound acceptor; falsifier asserts `continue-on-error is True` so a future fail-closed flip must co-ship the ANCHORED re-classification (same guarantee as Q4/Q6). |
| `docs/CLAIMS.yaml` | `ux-readiness-state-coverage` stays **EXTRAPOLATED**; evidence_paths extended; Phase-4 EXIT enumeration written. |

## State → status-code mapping (RFC 9110-canonical)

`success → 200/201` · `empty → 204` · `partial → 206` · `validation_error → 400/422` · `server_error → 500/502/503` · `timeout → 504`

## Honest Phase-4 ENTRY state

- `test_spec_present_and_has_public_operations` — **PASS**
- `test_error_envelope_on_all_4xx_5xx` — **PASS** (every declared 4xx/5xx already `$ref`s `#/components/schemas/ErrorResponse`)
- `test_uxrs_meets_threshold` — **FAIL, informational** — `UXRS=0.4394 (29/66)`; 9 of 11 operations declare only `success + validation_error + server_error`. The gate runs informationally so the missing `empty/partial/timeout` declarations + frontend renderers + end-to-end matrix land under the same claim without flipping strictness mid-phase.

## Phase-4 EXIT (follow-up)

Add `empty/partial/timeout` declarations to the OpenAPI responses, ship frontend rendering per state + the end-to-end matrix test, flip the run step fail-closed, and re-classify the claim **ANCHORED**. Q5 EXIT unblocks **#532 (Q7)**, which is blocked by Q5.

## Local verification

```
mypy --strict --follow-imports=silent tests/api/test_ux_state_coverage.py   Success
black --check / ruff check                                                  clean
python scripts/ci/check_claims.py        PASS (schema v3, all evidence present)
falsifier (continue-on-error is True)    exit 0
validate_commit_acceptor.py              no ERROR for this acceptor
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)