### PR TITLE
fix(physics): correct Ott-Antonsen RHS — linear coupling gain is z, not z̄

### DIFF
--- a/.claude/commit_acceptors/ott-antonsen-rhs-fix.yaml
+++ b/.claude/commit_acceptors/ott-antonsen-rhs-fix.yaml
@@ -1,0 +1,86 @@
+# Diff-bound commit acceptor: Ott-Antonsen RHS conjugate-defect fix.
+#
+# Before: core/kuramoto/ott_antonsen.py::_dz_dt used the conjugate on
+# the linear coupling gain — `(K/2)·(z̄ − z·|z|²)` instead of the
+# Ott&Antonsen 2008 Eq.2.13 form `(K/2)·(z − z·|z|²)`. For any ω₀≠0
+# the z̄ driving counter-rotates against z and the system collapses to
+# z=0; independent RK4 at K=4·K_c, ω₀=2.0 returned |z|→0.000000 where
+# physics requires √(1−2Δ/K)=0.866025. The defect was invisible to
+# every prior INV-OA2/OA3 test because they all fixed ω₀=0 and probed
+# only the real axis, where z̄≡z makes the forms bit-identical.
+#
+# After: the linear coupling term is `z`; the cubic is unchanged
+# (already correct: z·|z|² ≡ z̄·z²). The blind manifold is closed by
+# two added ω₀≠0 falsifiers in test_T23_ott_antonsen_algebraic.py
+# (rotating-fixed-point rigid-rotation invariant + ω₀≠0 integration
+# lock), which FALSIFY the old z̄ RHS (residual ~1.58) and PASS the
+# fix (≤2.2e-16).
+#
+# Locally verified: physics validator 6/6 grounding; mypy --strict /
+# black / ruff clean; 122 tests pass (OA algebraic incl new ω₀≠0 +
+# chimera + all core/kuramoto).
+
+id: ott-antonsen-rhs-fix
+status: ACTIVE
+claim_type: correctness
+promise: >-
+  core/kuramoto/ott_antonsen.py::_dz_dt implements the Ott&Antonsen
+  2008 Eq.2.13 order-parameter ODE with the linear coupling gain
+  +(K/2)·z (NOT the conjugate z̄) and the saturating cubic
+  −(K/2)·z·|z|². tests/unit/physics/test_T23_ott_antonsen_algebraic.py
+  asserts, for ω₀≠0 and arbitrary phase φ, that
+  _dz_dt(R_∞·e^{iφ}) == −iω₀·z to machine precision (rigid rotation,
+  zero radial drift) and that RK4 integration with ω₀≠0 locks to
+  √(1−2Δ/K) rather than collapsing to 0.
+diff_scope:
+  changed_files:
+    - path: ".claude/commit_acceptors/ott-antonsen-rhs-fix.yaml"
+    - path: "core/kuramoto/ott_antonsen.py"
+    - path: "tests/unit/physics/test_T23_ott_antonsen_algebraic.py"
+  forbidden_paths:
+    - "trading/"
+    - "execution/"
+    - "forecast/"
+    - "policy/"
+    - "application/api/"
+    - "schemas/openapi/"
+required_python_symbols:
+  - "core/kuramoto/ott_antonsen.py::OttAntonsenEngine"
+  - "tests/unit/physics/test_T23_ott_antonsen_algebraic.py::test_inv_oa2_rotating_fixed_point_is_rigid_rotation"
+  - "tests/unit/physics/test_T23_ott_antonsen_algebraic.py::test_inv_oa2_omega0_integration_locks_at_R_inf"
+expected_signal: >-
+  Local: `python .claude/physics/validate_tests.py
+  tests/unit/physics/test_T23_ott_antonsen_algebraic.py` reports 6/6
+  physics grounding; `mypy --strict --follow-imports=silent
+  core/kuramoto/ott_antonsen.py` reports "Success: no issues found";
+  `black --check` and `ruff check` clean; `pytest
+  tests/unit/physics/test_T23_ott_antonsen_algebraic.py
+  tests/unit/physics/test_T23_ott_antonsen_chimera.py core/kuramoto/
+  -q` reports 122 passed.
+measurement_command: >-
+  bash -c 'mypy --strict --follow-imports=silent core/kuramoto/ott_antonsen.py
+  && black --check core/kuramoto/ott_antonsen.py tests/unit/physics/test_T23_ott_antonsen_algebraic.py
+  && ruff check core/kuramoto/ott_antonsen.py tests/unit/physics/test_T23_ott_antonsen_algebraic.py
+  && python -m pytest tests/unit/physics/test_T23_ott_antonsen_algebraic.py -q'
+signal_artifact: "tmp/ott_antonsen_rhs_fix.log"
+falsifier:
+  command: >-
+    bash -c 'python -c "import re,sys; src=open(\"core/kuramoto/ott_antonsen.py\").read(); m=re.search(r\"def _dz_dt.*?return[^\\n]*\", src, re.S); body=m.group(0) if m else \"\"; sys.exit(0 if (\"z_conj\" not in body and \"conjugate\" not in body) else 1)"'
+  description: >-
+    Asserts the conjugate defect cannot reappear: the `_dz_dt` method
+    body must not reference `z_conj` / `conjugate()`. The OA linear
+    coupling gain is linear in z; any reintroduction of the conjugate
+    on the RHS (the original bug) flips this falsifier non-zero,
+    blocking the regression that was invisible to the ω₀=0 test
+    battery for its entire prior history.
+rollback_command: >-
+  git checkout HEAD~1 --
+  .claude/commit_acceptors/ott-antonsen-rhs-fix.yaml
+  core/kuramoto/ott_antonsen.py
+  tests/unit/physics/test_T23_ott_antonsen_algebraic.py
+rollback_verification_command: >-
+  git diff --exit-code core/kuramoto/ott_antonsen.py
+memory_update_type: append
+ledger_path: ".claude/commit_acceptors/ott-antonsen-rhs-fix.yaml"
+report_path: "tmp/ott_antonsen_rhs_fix.log"
+evidence: []

--- a/core/kuramoto/ott_antonsen.py
+++ b/core/kuramoto/ott_antonsen.py
@@ -6,7 +6,12 @@ Kuramoto (1975). Ott & Antonsen (2008) showed that for Lorentzian-
 distributed natural frequencies, the infinite-N Kuramoto model reduces
 to a SINGLE complex ODE for the order parameter z(t) = R(t)·exp(iΨ(t)):
 
-    dz/dt = -(Δ + iω₀)·z + (K/2)·(z̄ − z·|z|²)
+    dz/dt = -(Δ + iω₀)·z + (K/2)·(z − z·|z|²)
+
+The synchronising coupling gain is linear in z (NOT z̄). On the real
+axis with ω₀ = 0 the conjugate form is numerically identical, which is
+exactly why an ω₀ = 0 / real-z test cannot see a z↔z̄ swap — the OA
+falsification battery must probe ω₀ ≠ 0 (see test_T23_*).
 
 where:
     Δ = half-width of the Lorentzian frequency distribution
@@ -133,11 +138,14 @@ class OttAntonsenEngine:
     def _dz_dt(self, z: complex) -> complex:
         """Ott-Antonsen ODE right-hand side.
 
-        dz/dt = -(Δ + iω₀)·z + (K/2)·(z̄ − z·|z|²)
+        dz/dt = -(Δ + iω₀)·z + (K/2)·(z − z·|z|²)
+
+        The coupling contributes the synchronising gain +(K/2)·z
+        (linear in z, NOT z̄) and the saturating cubic −(K/2)·|z|²·z.
+        Ott & Antonsen, Chaos 18, 037113 (2008), Eq. 2.13.
         """
-        z_conj = z.conjugate()
         z_abs_sq = z.real**2 + z.imag**2
-        return -(self.delta + 1j * self.omega0) * z + (self.K / 2.0) * (z_conj - z * z_abs_sq)
+        return -(self.delta + 1j * self.omega0) * z + (self.K / 2.0) * (z - z * z_abs_sq)
 
     def integrate(
         self,

--- a/tests/unit/physics/test_T23_ott_antonsen_algebraic.py
+++ b/tests/unit/physics/test_T23_ott_antonsen_algebraic.py
@@ -160,3 +160,83 @@ def test_inv_oa2_residual_grows_with_perturbation_size() -> None:
         "fixed point, the algebraic test cannot catch implementation "
         "drift and INV-OA2 would be vacuously satisfied."
     )
+
+
+# ---------------------------------------------------------------------------
+# INV-OA2 — ω₀ ≠ 0 / off-real-axis falsifiers.
+#
+# Every test above fixes ω₀ = 0 and probes z on the real axis. On that
+# measure-zero slice the conjugate-vs-direct coupling form is bit-
+# identical, so a z↔z̄ swap in the linear coupling gain is INVISIBLE
+# there (the original defect: ``(K/2)·z̄`` instead of ``(K/2)·z``). The
+# tests below permanently close that blind manifold: they exercise the
+# rotating fixed point ``z = R_∞·e^{iφ}`` with ω₀ ≠ 0, where the OA
+# normal form requires *rigid rotation*::
+#
+#     dz/dt = -(Δ+iω₀)·z + (K/2)·(z − |z|²·z)
+#           = z·[-(Δ+iω₀) + (K/2)·(1 − R_∞²)]
+#           = z·[-(Δ+iω₀) + Δ]              (R_∞² = 1 − 2Δ/K)
+#           = -iω₀·z
+#
+# i.e. zero radial drift, pure rotation at the mean frequency, for
+# ANY phase φ. The buggy z̄ form does not satisfy this for ω₀ ≠ 0 (it
+# counter-rotates and collapses to z = 0), so these are genuine
+# falsifiers, not vacuous probes.
+# ---------------------------------------------------------------------------
+
+_OMEGA0_CASES: list[float] = [0.3, 1.0, 2.0, -1.7, 5.0]
+_PHASE_CASES: list[float] = [0.0, 0.7, math.pi / 2, math.pi, -2.1]
+
+
+@pytest.mark.parametrize("K", [1.5, 3.0, 5.0, 20.0])
+@pytest.mark.parametrize("omega0", _OMEGA0_CASES)
+@pytest.mark.parametrize("phi", _PHASE_CASES)
+def test_inv_oa2_rotating_fixed_point_is_rigid_rotation(
+    K: float, omega0: float, phi: float
+) -> None:
+    """INV-OA2 (ω₀≠0 algebraic): _dz_dt(R_∞·e^{iφ}) == -iω₀·z to machine ε.
+
+    Strongest non-integrator falsifier of the z↔z̄ coupling-gain
+    defect: at the supercritical amplitude the radial drift must
+    vanish and the order parameter must rotate rigidly at ω₀ for
+    every phase φ. A conjugate on the linear term breaks this for any
+    ω₀ ≠ 0 or φ ≠ 0.
+    """
+    delta = 0.5
+    engine = OttAntonsenEngine(K=K, delta=delta, omega0=omega0)
+    R_inf = math.sqrt(1.0 - 2.0 * delta / K)
+    z = complex(R_inf * math.cos(phi), R_inf * math.sin(phi))
+    dz = engine._dz_dt(z)  # noqa: SLF001 — algebraic invariant probe
+    expected = -1j * omega0 * z  # pure rigid rotation, zero radial drift
+    residual = abs(dz - expected)
+    assert residual < _ALGEBRAIC_TOL, (
+        f"INV-OA2 ROTATING-FIXED-POINT VIOLATED: at z = R_∞·e^(iφ) the "
+        f"OA RHS must equal -iω₀·z (rigid rotation, zero radial drift); "
+        f"|dz/dt − (−iω₀·z)| = {residual:.3e} > {_ALGEBRAIC_TOL:.0e}. "
+        f"K={K}, Δ={delta}, ω₀={omega0}, φ={phi}, R_∞={R_inf:.12f}, "
+        f"dz/dt={dz!r}, expected={expected!r}. A residual here is the "
+        f"signature of a conjugate on the linear coupling gain "
+        f"(z̄ instead of z) — invisible on the ω₀=0 real axis."
+    )
+
+
+@pytest.mark.parametrize("omega0", [0.0, 1.0, -2.5, 4.0])
+def test_inv_oa2_omega0_integration_locks_at_R_inf(omega0: float) -> None:
+    """INV-OA2 (ω₀≠0 dynamical): RK4 from a perturbation locks to R_∞.
+
+    Closes the integrator-path blind spot (integrate() also defaulted
+    ω₀=0). For supercritical K the magnitude must converge to
+    √(1−2Δ/K) regardless of ω₀; with the conjugate defect it instead
+    collapses to 0 for ω₀≠0.
+    """
+    K, delta = 4.0, 0.5
+    engine = OttAntonsenEngine(K=K, delta=delta, omega0=omega0)
+    result = engine.integrate(T=80.0, dt=0.005, R0=0.05, psi0=0.3)
+    R_final = result.R[-1]
+    R_expected = math.sqrt(1.0 - 2.0 * delta / K)
+    assert abs(R_final - R_expected) < 1e-3, (
+        f"INV-OA2 DYNAMICAL VIOLATED: integrated R_∞ = {R_final:.6f} at "
+        f"ω₀={omega0}, expected √(1−2Δ/K) = {R_expected:.6f} "
+        f"(K={K}, Δ={delta}). A collapse to ~0 for ω₀≠0 is the "
+        f"conjugate-coupling defect; the magnitude must be ω₀-invariant."
+    )


### PR DESCRIPTION
## The bug

`core/kuramoto/ott_antonsen.py:_dz_dt` put the **conjugate on the linear coupling term**:

```
CODE:    dz/dt = -(Δ+iω₀)·z + (K/2)·( z̄ − z·|z|² )      WRONG
PHYSICS: dz/dt = -(Δ+iω₀)·z + (K/2)·( z  − z·|z|² )      Ott&Antonsen 2008, Eq.2.13
```

The OA reduction is the Stuart–Landau normal form `ż = [−Δ−iω₀+K/2]·z − (K/2)|z|²·z`. The synchronising gain is **linear in z, not z̄**. The cubic term was already correct (`z·|z|² ≡ z̄·z²`); the only defect is `z_conj → z` on the linear term.

## Why it is the deepest physics bug, not a nit

- **Wrong governing equation** of the module the codebase calls "the most important theoretical advance since Kuramoto 1975" — not a tolerance/bound issue.
- With the conjugate, the driving counter-rotates (∝e^{+iω₀t}) against z (∝e^{−iω₀t}); for **any ω₀≠0** the only stable state is z=0. Real market data has ω₀ (mean drift) essentially never exactly 0.
- **Independent RK4 falsification** (K=4, Δ=0.5 ⇒ 4·K_c, ω₀=2.0): buggy → `|z|→0.000000` (asserts total desync at 4× critical coupling); correct → `0.866025 = √(1−2Δ/K)`. Maximum-magnitude error in a [0,1] quantity, pointing the wrong way.

## Truth-masking (closed)

Every prior INV-OA2/OA3 test fixed `ω₀=0` and probed only the real axis — the measure-zero slice where `z̄≡z` makes the wrong and correct RHS **bit-identical**. The test self-described as "the strongest possible test for INV-OA2" was structurally blind. Added permanent ω₀≠0 falsifiers:

- `test_inv_oa2_rotating_fixed_point_is_rigid_rotation` — 80 params (K×ω₀×φ): `_dz_dt(R_∞·e^{iφ}) == −iω₀·z` to 1e-13 (the rigid-rotation algebraic invariant the z̄ form violates by ~1.58).
- `test_inv_oa2_omega0_integration_locks_at_R_inf` — RK4 with ω₀≠0 must lock to `√(1−2Δ/K)`, not collapse to 0.

## Verification

```
physics validator                 6/6 grounding (100%)
mypy --strict / black / ruff      clean
pytest OA algebraic + chimera + core/kuramoto   122 passed
new test vs OLD z̄ RHS            residual 1.578 → FALSIFIED (genuine falsifier)
new test vs FIXED z RHS          residual 2.2e-16 → PASS
```

Found via an adversarial physics audit (hypothesis-destruction), independently re-derived from first principles and numerically falsified before the fix. Diagnosis: green tests ≠ correct physics — the invariant battery had a blind manifold that coincided exactly with the defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)