### PR TITLE
fix(physics): register INV-SAK1 — close the Sakaguchi frustration-sign blind manifold

### DIFF
--- a/.claude/commit_acceptors/sakaguchi-frustration-invariant.yaml
+++ b/.claude/commit_acceptors/sakaguchi-frustration-invariant.yaml
@@ -1,0 +1,99 @@
+# Diff-bound commit acceptor: register INV-SAK1 + close the Sakaguchi
+# frustration-sign blind manifold.
+#
+# Before: the Sakaguchi phase-lag term sin(θ_j(t−τ) − θ_i − α) had NO
+# invariant in the registry and NO test exercising α≠0. Its sign is
+# canonical (verified on the real integrator), but a future −α→+α
+# regression would be invisible exactly like the Ott–Antonsen
+# conjugate defect (PR #745) was at ω₀=0 — the same blind-manifold
+# class. No invariant ⇒ no mandated coverage.
+#
+# After: INV-SAK1 (kuramoto/sakaguchi_frustration_sign) is registered
+# in .claude/physics/INVARIANTS.yaml; the registry count goes 96→97
+# and every documentation surface (README badge+prose, BASELINE.md,
+# CLAUDE.md header) is synced (invariant-count-sync gate OK).
+# tests/unit/physics/test_sakaguchi_frustration_alpha.py grounds
+# INV-SAK1 with a derivation-backed, maximally discriminative
+# falsifier on the REAL forward integrator
+# core.kuramoto.synthetic._simulate_sdde: identical all-to-all
+# oscillators must phase-lock and rotate at Ω = ω₀ − (N−1)·κ·sin(α);
+# the sign-flipped law differs by ~1.25 rad/s at the tested α. α=0 is
+# kept as the explicit blind-manifold control.
+#
+# Locally verified: count_invariants → 97; check_invariant_count_sync
+# → OK; physics validator grounding 1/1 (100%, L1/L2/L3 clean); pytest
+# 4/4; mypy --strict / black / ruff clean; registry has no duplicate
+# ids and INV-SAK1 present (97 total).
+
+id: sakaguchi-frustration-invariant
+status: ACTIVE
+claim_type: correctness
+promise: >-
+  .claude/physics/INVARIANTS.yaml declares INV-SAK1 (the Sakaguchi
+  phase-lag minus-α sign and the identical-oscillator collective
+  frequency Ω = ω₀ − (N−1)·κ·sin(α)).
+  tests/unit/physics/test_sakaguchi_frustration_alpha.py grounds it
+  (docstring cites INV-SAK1; physics validator L1/L2/L3 clean) and
+  falsifies the sign on the real _simulate_sdde integrator for α ≠ 0,
+  with α = 0 retained as the documented blind-manifold control. The
+  registry count is 97 and README/BASELINE/CLAUDE headline counts are
+  in sync (invariant-count-sync fail-closed gate).
+diff_scope:
+  changed_files:
+    - path: ".claude/commit_acceptors/sakaguchi-frustration-invariant.yaml"
+    - path: ".claude/physics/INVARIANTS.yaml"
+    - path: "tests/unit/physics/test_sakaguchi_frustration_alpha.py"
+    - path: "README.md"
+    - path: "BASELINE.md"
+    - path: "CLAUDE.md"
+  forbidden_paths:
+    - "trading/"
+    - "execution/"
+    - "forecast/"
+    - "policy/"
+    - "application/api/"
+    - "schemas/openapi/"
+    - "core/kuramoto/synthetic.py"
+required_python_symbols:
+  - "tests/unit/physics/test_sakaguchi_frustration_alpha.py::test_sakaguchi_collective_frequency_shift_sign"
+expected_signal: >-
+  Local: `python scripts/count_invariants.py` prints 97; `python
+  scripts/check_invariant_count_sync.py` reports "OK: 97 invariants,
+  all documentation surfaces in sync"; `python
+  .claude/physics/validate_tests.py
+  tests/unit/physics/test_sakaguchi_frustration_alpha.py` reports
+  "Physics grounding: 1/1 tests (100%)" with L1=L2=L3=0; `mypy
+  --strict --follow-imports=silent` + `ruff check` + `black --check`
+  clean; `pytest tests/unit/physics/test_sakaguchi_frustration_alpha.py
+  -q` reports 4 passed.
+measurement_command: >-
+  bash -c 'python scripts/count_invariants.py
+  && python scripts/check_invariant_count_sync.py
+  && python .claude/physics/validate_tests.py tests/unit/physics/test_sakaguchi_frustration_alpha.py
+  && mypy --strict --follow-imports=silent tests/unit/physics/test_sakaguchi_frustration_alpha.py
+  && ruff check tests/unit/physics/test_sakaguchi_frustration_alpha.py
+  && black --check tests/unit/physics/test_sakaguchi_frustration_alpha.py
+  && python -m pytest tests/unit/physics/test_sakaguchi_frustration_alpha.py -q'
+signal_artifact: "tmp/sakaguchi_frustration_invariant.log"
+falsifier:
+  command: >-
+    bash -c 'python -c "import re,sys; reg=open(\".claude/physics/INVARIANTS.yaml\").read(); tst=open(\"tests/unit/physics/test_sakaguchi_frustration_alpha.py\").read(); ok=(\"id: INV-SAK1\" in reg) and (\"INV-SAK1\" in tst) and (\"- α\" in reg or \"− α\" in reg or \"minus α\" in reg); sys.exit(0 if ok else 1)"'
+  description: >-
+    Asserts INV-SAK1 stays registered AND its grounding test keeps
+    citing it AND the registry statement keeps the minus-α form. If
+    the invariant is deleted, the test stops referencing it, or the
+    sign is silently changed in the registry, the falsifier exits
+    non-zero — the Sakaguchi blind manifold cannot silently reopen.
+rollback_command: >-
+  git checkout HEAD~1 --
+  .claude/commit_acceptors/sakaguchi-frustration-invariant.yaml
+  .claude/physics/INVARIANTS.yaml
+  tests/unit/physics/test_sakaguchi_frustration_alpha.py
+  README.md BASELINE.md CLAUDE.md
+rollback_verification_command: >-
+  git diff --exit-code .claude/physics/INVARIANTS.yaml
+  tests/unit/physics/test_sakaguchi_frustration_alpha.py
+memory_update_type: append
+ledger_path: ".claude/commit_acceptors/sakaguchi-frustration-invariant.yaml"
+report_path: "tmp/sakaguchi_frustration_invariant.log"
+evidence: []

--- a/.claude/physics/INVARIANTS.yaml
+++ b/.claude/physics/INVARIANTS.yaml
@@ -103,6 +103,17 @@ kuramoto:
     condition: "All ω_i = 0 (identical frequencies)"
     priority: P1
 
+  sakaguchi_frustration_sign:
+    id: INV-SAK1
+    type: qualitative
+    statement: "The Sakaguchi phase-lag enters the coupling as sin(θ_j(t−τ_ij) − θ_i(t) − α_ij) (minus α). For N identical all-to-all oscillators (ω_i ≡ ω₀, K_ij = κ for i≠j, τ = 0, σ = 0) the phase-locked state rotates at the collective frequency Ω = ω₀ − (N−1)·κ·sin(α)."
+    test_type: sweep_test
+    condition: "Identical oscillators, uniform frustration α, zero delay and noise; Ω measured from the least-squares slope of the unwrapped mean phase. α = 0 is the blind manifold (both sign conventions agree) — falsification requires α ≠ 0."
+    falsification: "Observed collective frequency matches the sign-flipped law ω₀ + (N−1)·κ·sin(α) instead of the canonical minus-α form, i.e. |Ω − (ω₀ − (N−1)·κ·sin(α))| above integrator tolerance for any α ≠ 0. Registered because the absence of any frustration-sign invariant is precisely why no test mandated α ≠ 0 coverage — the blind manifold that hid the analogous Ott–Antonsen conjugate defect (PR #745)."
+    priority: P0
+    source: core/kuramoto/synthetic.py
+    tests: tests/unit/physics/test_sakaguchi_frustration_alpha.py
+
 # ═══════════════════════════════════════════════════
 # EXPLOSIVE SYNCHRONIZATION
 # ═══════════════════════════════════════════════════

--- a/BASELINE.md
+++ b/BASELINE.md
@@ -10,7 +10,7 @@ preserved as historical context, not as the current count.
 ## 0. TL;DR (current state, 2026-04-30)
 
 - **Physics kernel is real.** `.claude/physics/` currently contains
-  **96 invariants** (per `python scripts/count_invariants.py`, single source of
+  **97 invariants** (per `python scripts/count_invariants.py`, single source of
   truth: `.claude/physics/INVARIANTS.yaml`), 5 theory files, a 780-line
   validator with 7 levels (L1–L5 + C1–C2), and a self-check that passes.
   CI gate `invariant-count-sync` fail-closes on any drift between this file,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ GeoSync is a quantitative trading platform with neuroscience-inspired risk manag
 
 ---
 
-## INVARIANT REGISTRY — 96 invariants loaded by kernel self-check
+## INVARIANT REGISTRY — 97 invariants loaded by kernel self-check
 
 > **Single source of truth:** `.claude/physics/INVARIANTS.yaml` (`python scripts/count_invariants.py`). The 2026-04-30 external audit corrected a four-way drift (`57 / 66 / 67 / 87`); CI gate `invariant-count-sync` now fail-closes on any future divergence between this header, README badges, BASELINE.md, and the registry.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <br><br>
 
 [![modules-15](https://img.shields.io/badge/modules-15-blueviolet?style=for-the-badge)](docs/ARCHITECTURE.md)
-[![invariants-96](https://img.shields.io/badge/invariants-96-critical?style=for-the-badge)](CLAUDE.md)
+[![invariants-97](https://img.shields.io/badge/invariants-97-critical?style=for-the-badge)](CLAUDE.md)
 [![tests-11446](https://img.shields.io/badge/tests-11%2C446-brightgreen?style=for-the-badge)](tests/)
 [![indicators-17](https://img.shields.io/badge/indicators-17-gold?style=for-the-badge)](core/indicators/)
 [![ADRs-16](https://img.shields.io/badge/ADRs-16-blue?style=for-the-badge)](docs/adr/)
@@ -21,7 +21,7 @@
 Kuramoto synchronization  ·  Ricci curvature flow  ·  Free-energy thermodynamics  ·  Cryptobiosis
 ```
 
-*Physics-inspired quantitative research platform with 96 machine-checkable invariants.*
+*Physics-inspired quantitative research platform with 97 machine-checkable invariants.*
 *Every signal traces back to peer-reviewed science. Every clamp traces back to a law.*
 
 <br>
@@ -145,13 +145,13 @@ dθᵢ/dt = ωᵢ + K · Σⱼ Aᵢⱼ sin(θⱼ − θᵢ)
 
 ## Physics Kernel
 
-GeoSync is a **physics-inspired quantitative research platform with a partially machine-checkable invariant layer**, not a "verified physical system" — that stronger claim was retracted on 2026-04-30 after an external audit ([CLAIMS.md](CLAIMS.md), [ALTERNATIVE_HYPOTHESES.md](.claude/physics/ALTERNATIVE_HYPOTHESES.md)). The physics kernel (`.claude/physics/`) declares **96 machine-checkable invariants** across the modules listed in [`INVARIANTS.yaml`](.claude/physics/INVARIANTS.yaml). Tests grounded in `INV-*` ids are *mathematical witnesses* of a specific invariant; the `BASELINE.md` ledger tracks how many of them currently exist (it is intentionally smaller than the registry — coverage growth is gated, not assumed).
+GeoSync is a **physics-inspired quantitative research platform with a partially machine-checkable invariant layer**, not a "verified physical system" — that stronger claim was retracted on 2026-04-30 after an external audit ([CLAIMS.md](CLAIMS.md), [ALTERNATIVE_HYPOTHESES.md](.claude/physics/ALTERNATIVE_HYPOTHESES.md)). The physics kernel (`.claude/physics/`) declares **97 machine-checkable invariants** across the modules listed in [`INVARIANTS.yaml`](.claude/physics/INVARIANTS.yaml). Tests grounded in `INV-*` ids are *mathematical witnesses* of a specific invariant; the `BASELINE.md` ledger tracks how many of them currently exist (it is intentionally smaller than the registry — coverage growth is gated, not assumed).
 
 Control-plane safety properties are additionally **model-checked in TLA⁺** — see [`formal/tla/AdmissionGate.tla`](formal/tla/AdmissionGate.tla) for the four-barrier admission gate with three TLC-checkable invariants (`TypeOK`, `SafeFirstRejectionWins`, `RejectCodeMatchesBarrier`). CI runs TLC on every PR via [`formal-verification.yml`](.github/workflows/formal-verification.yml).
 
 ```
                      ┌──────────────────────────────────────┐
-                     │   96 INVARIANTS  ·  registry-tracked  │
+                     │   97 INVARIANTS  ·  registry-tracked  │
                      │   Every assert derives its tolerance  │
                      │   from the law's formula, not from    │
                      │   a magic literal.                    │
@@ -172,7 +172,7 @@ Control-plane safety properties are additionally **model-checked in TLA⁺** —
 
 | Metric | Value | Source |
 |--------|-------|--------|
-| Physics invariants declared | **96 in `.claude/physics/INVARIANTS.yaml`** (single source of truth) | `python scripts/count_invariants.py` |
+| Physics invariants declared | **97 in `.claude/physics/INVARIANTS.yaml`** (single source of truth) | `python scripts/count_invariants.py` |
 | Physics invariants grounded by tests | tracked in [`BASELINE.md`](BASELINE.md) — **deliberately smaller than declared count**; coverage growth is gated, not assumed | `BASELINE.md` ledger |
 | C1/C2 code audit | **0** undocumented physics clamps in `core/` | `physics-kernel-gate.yml` |
 | CI gates | physics-kernel-gate · invariant-count-sync · formal-verification (TLA⁺) · claims-evidence-gate | `.github/workflows/` |
@@ -778,6 +778,6 @@ Trading financial instruments involves substantial risk of loss. GeoSync provide
 
 [![MIT](https://img.shields.io/badge/license-MIT-yellow?style=flat)](LICENSE)
 
-<sub>Built on peer-reviewed science. Physics-first, 96 invariants loaded from `.claude/physics/INVARIANTS.yaml`, every clamp documented.</sub>
+<sub>Built on peer-reviewed science. Physics-first, 97 invariants loaded from `.claude/physics/INVARIANTS.yaml`, every clamp documented.</sub>
 
 </div>

--- a/tests/unit/physics/test_sakaguchi_frustration_alpha.py
+++ b/tests/unit/physics/test_sakaguchi_frustration_alpha.py
@@ -1,0 +1,106 @@
+# SPDX-License-Identifier: MIT
+"""Sakaguchi frustration α≠0 falsifier — closes a test blind manifold.
+
+Grounds **INV-SAK1** (`.claude/physics/INVARIANTS.yaml`, kuramoto /
+sakaguchi_frustration_sign): the phase-lag enters as
+``sin(θ_j(t−τ) − θ_i − α)`` (minus α), and for identical all-to-all
+oscillators the phase-locked collective frequency is
+``Ω = ω₀ − (N−1)·κ·sin(α)``. This invariant was registered together
+with this test because its prior absence is exactly why no test
+mandated α ≠ 0 coverage.
+
+Motivation
+----------
+The Ott–Antonsen conjugate defect (PR #745) hid for the module's
+entire history because every INV-OA test fixed ω₀ = 0 on the real
+axis, the measure-zero slice where the bug is a no-op. An audit for
+the same *class* of blindness found that the Sakaguchi–Kuramoto
+phase-lag term ``sin(θ_j(t−τ) − θ_i(t) − α_{ij})`` — used by the real
+forward integrator ``core.kuramoto.synthetic._simulate_sdde`` and by
+``core/kuramoto/network_engine.py`` — had **no test exercising
+α ≠ 0**. The implemented sign is canonical (verified), but a future
+``−α → +α`` regression would be invisible exactly like the OA case.
+
+This test permanently closes that manifold with a derivation-backed,
+maximally discriminative invariant on the *real* integrator.
+
+Physics
+-------
+For ``N`` identical oscillators (ωᵢ ≡ ω₀), all-to-all coupling
+``K_{ij}=κ`` (i≠j), zero delay, uniform frustration α, zero noise, the
+in-phase synchronised state (all θᵢ equal) is a fixed point of the
+relative dynamics and rotates at the collective frequency::
+
+    Ω = ω₀ + Σ_j K_{ij}·sin(θ_j − θ_i − α)|_{θ_j=θ_i}
+      = ω₀ − (N−1)·κ·sin(α)              (canonical Sakaguchi −α sign)
+
+A sign error in the phase-lag term flips this to ω₀ + (N−1)κ·sin(α).
+At α = 0 both collapse to ω₀ — that is the blind manifold; the
+parametrisation below pins α ≠ 0 where the two hypotheses diverge by
+``2(N−1)κ·sin(α)`` (≈1.25 rad/s at the values used), far above any
+integrator tolerance.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from core.kuramoto.synthetic import _simulate_sdde
+
+
+def _collective_frequency(theta: np.ndarray, dt: float) -> float:
+    """Least-squares slope of the unwrapped mean phase over the tail."""
+    unwrapped = np.unwrap(theta, axis=0)
+    tail = unwrapped[int(0.6 * unwrapped.shape[0]) :]
+    t = np.arange(tail.shape[0], dtype=np.float64) * dt
+    slope: float = float(np.polyfit(t, tail.mean(axis=1), 1)[0])
+    return slope
+
+
+@pytest.mark.parametrize("alpha0", [0.0, 0.4, -0.7, 1.1])
+def test_sakaguchi_collective_frequency_shift_sign(alpha0: float) -> None:
+    """INV-SAK1 (qualitative): Ω = ω₀ − (N−1)·κ·sin(α) on the real integrator.
+
+    Sweeps the frustration α and checks the collective-frequency
+    direction against the canonical minus-α Sakaguchi law. α = 0 is
+    the explicit blind-manifold control (both sign conventions agree
+    there); α ≠ 0 is the genuine INV-SAK1 falsifier.
+    """
+    N, kappa, omega0, dt, steps = 3, 0.8, 0.5, 0.01, 20000
+    K = kappa * (np.ones((N, N)) - np.eye(N))
+    tau = np.zeros((N, N), dtype=np.int64)
+    alpha = alpha0 * np.ones((N, N))
+    omega = omega0 * np.ones(N)
+    rng = np.random.default_rng(0)
+
+    theta, _noise = _simulate_sdde(K, tau, alpha, omega, T=steps, dt=dt, sigma=0.0, rng=rng)
+
+    R_final = float(np.abs(np.exp(1j * theta[-1]).mean()))
+    assert R_final > 0.999, (
+        f"identical all-to-all oscillators must phase-lock (R→1); got "
+        f"R={R_final:.4f} at α={alpha0}. Without locking the collective "
+        f"frequency is undefined and the sign test is vacuous."
+    )
+
+    omega_obs = _collective_frequency(theta, dt)
+    canonical = omega0 - (N - 1) * kappa * np.sin(alpha0)
+    sign_flipped = omega0 + (N - 1) * kappa * np.sin(alpha0)
+
+    assert abs(omega_obs - canonical) < 1e-3, (
+        f"Sakaguchi −α SIGN VIOLATED: observed Ω={omega_obs:.6f} ≠ "
+        f"canonical ω₀−(N−1)κ·sin(α)={canonical:.6f} at α={alpha0} "
+        f"(N={N}, κ={kappa}, ω₀={omega0}). Sign-flipped hypothesis "
+        f"ω₀+(N−1)κ·sin(α)={sign_flipped:.6f}. A residual here is the "
+        f"signature of a +α phase-lag regression — invisible at α=0."
+    )
+
+    if abs(alpha0) > 1e-9:
+        # Discriminative-power guarantee: the canonical and sign-flipped
+        # predictions must be far apart, so the assertion above is a
+        # real falsifier, not a degenerate tautology.
+        assert abs(canonical - sign_flipped) > 1e-2, (
+            f"non-discriminative at α={alpha0}: canonical and "
+            f"sign-flipped predictions coincide — this α is itself a "
+            f"blind manifold and must not be used as a falsifier."
+        )


### PR DESCRIPTION
## Why

The Ott–Antonsen conjugate defect (#745) hid for the module's entire history because every INV-OA test sat at `ω₀=0` on the real axis — a degenerate slice where the bug is a no-op. Auditing for the **same class of blindness** found the Sakaguchi phase-lag term `sin(θ_j(t−τ) − θ_i − α)` (used by the real forward integrator `core.kuramoto.synthetic._simulate_sdde` and `network_engine.py`) had **no registered invariant and no α≠0 test**: a structurally identical blind manifold. No invariant ⇒ no mandated coverage ⇒ a future `−α→+α` regression would be invisible.

The implemented sign is **canonical** (independently verified on the real integrator) — this PR is **preventive registry + coverage closure of the class**, not an active-bug fix. Severity is honestly labelled: only a computed-wrong-number-asserted-as-truth is critical (the OA bug was; this is hardening).

## What

- **`.claude/physics/INVARIANTS.yaml`** — register **INV-SAK1** (`kuramoto/sakaguchi_frustration_sign`, P0): the minus-α phase-lag and the identical-oscillator collective frequency `Ω = ω₀ − (N−1)·κ·sin(α)`. Its prior absence is exactly why no test mandated α≠0.
- **`tests/unit/physics/test_sakaguchi_frustration_alpha.py`** — grounds INV-SAK1 with a derivation-backed, maximally discriminative falsifier on the **real** `_simulate_sdde`: identical all-to-all oscillators phase-lock (R→1) and rotate at `Ω=ω₀−(N−1)κ·sin α`; the sign-flipped law differs by **~1.25 rad/s** at the tested α. `α=0` retained as the explicit blind-manifold control.
- **README.md / BASELINE.md / CLAUDE.md** — registry count `96→97`; all headline surfaces synced (`invariant-count-sync` fail-closed gate OK).
- **acceptor** `sakaguchi-frustration-invariant` — falsifier keeps INV-SAK1 registered, cited, and minus-α; the manifold cannot silently reopen.

## Verification (local)

```
scripts/count_invariants.py                 97
scripts/check_invariant_count_sync.py       OK: 97 invariants, all surfaces in sync
.claude/physics/validate_tests.py <file>    Physics grounding: 1/1 (100%), L1/L2/L3 = 0
pytest <file> -q                            4 passed (α ∈ {0, 0.4, -0.7, 1.1})
mypy --strict / ruff / black                clean
registry integrity                          no duplicate ids, INV-SAK1 present, 97 total
```

Empirical anchor (real integrator, N=3 κ=0.8 ω₀=0.5 α=0.4): R_final=1.0000, Ω=−0.123069 = canonical `ω₀−(N−1)κ sin α` (−0.123069); sign-flipped hypothesis = +1.123069 — rejected by 1.25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)