### PR TITLE
research(ctc): CTC-FALSIFY-001 L2 residual layer — estimator self-kills (fail-closed)

### DIFF
--- a/.claude/commit_acceptors/ctc-falsify-l2.yaml
+++ b/.claude/commit_acceptors/ctc-falsify-l2.yaml
@@ -1,0 +1,43 @@
+# Diff-bound commit acceptor for CTC-FALSIFY-001 L2.
+id: ctc-falsify-l2
+status: ACTIVE
+claim_type: governance
+promise: "CTC-FALSIFY-001 L2 is fail-closed pre-data: the v1 residual estimator is reported INADMISSIBLE_NPLUS_INSITU_BLIND by its own pre-registered positive-control gate; KILLED_SCOPED/SURVIVED_INITIAL are unreachable without a bound dataset and a non-blind estimator."
+diff_scope:
+  changed_files:
+    - path: "research/ctc_falsify/l2/__init__.py"
+    - path: "research/ctc_falsify/l2/config_l2.py"
+    - path: "research/ctc_falsify/l2/surrogate.py"
+    - path: "research/ctc_falsify/l2/residual.py"
+    - path: "research/ctc_falsify/l2/gates_l2.py"
+    - path: "research/ctc_falsify/l2/run.py"
+    - path: "research/ctc_falsify/l2/schema/ctc_falsify_l2_result.schema.json"
+    - path: "research/ctc_falsify/l2/evidence/ctc_falsify_l2_result.json"
+    - path: "tests/research/ctc_falsify/test_ctc_falsify_l2.py"
+    - path: ".github/detect-secrets.baseline"
+    - path: ".claude/commit_acceptors/ctc-falsify-l2.yaml"
+    - path: "docs/research/CTC_FALSIFY_001_L2_PREREGISTRATION.md"
+  forbidden_paths:
+    - "trading/"
+    - "execution/"
+    - "forecast/"
+    - "policy/"
+required_python_symbols:
+  - "run"
+  - "run_self_validation"
+  - "decide_l2"
+  - "standardized_residual"
+  - "build_joint_surrogate"
+  - "config_hash"
+expected_signal: "all L2 construct-validity tests pass; reference verdict is the fail-closed INADMISSIBLE_NPLUS_INSITU_BLIND"
+measurement_command: "python -m pytest tests/research/ctc_falsify/test_ctc_falsify_l2.py -q"
+signal_artifact: "tmp/ctc_falsify_l2_pytest.log"
+falsifier:
+  command: "python -c \"from research.ctc_falsify.l2.gates_l2 import decide_l2, L2SelfValidation; from research.ctc_falsify.l2 import config_l2 as c; decide_l2(L2SelfValidation(surrogate_all_matched=True, mean_nplus_residual_z=c.NPLUS_RESIDUAL_MIN_Z+1, max_confound_residual_z=0.0, nplus_recovered=True, confounds_not_flagged=True, n_validation_seeds=c.N_VALIDATION_SEEDS, worst_rate_rel_err=0.0, worst_power_rel_err=0.0), real_dataset_bound=True)\""
+  description: "With an admissible synthetic self-validation, the C3 real-data branch MUST raise NotImplementedError — proving terminal verdicts are gated behind a bound dataset and the promise is falsifiable."
+rollback_command: "git checkout -- research/ctc_falsify/l2 tests/research/ctc_falsify/test_ctc_falsify_l2.py .github/detect-secrets.baseline"
+rollback_verification_command: "git diff --exit-code research/ctc_falsify/l2 tests/research/ctc_falsify/test_ctc_falsify_l2.py"
+memory_update_type: append
+ledger_path: ".claude/commit_acceptors/ctc-falsify-l2.yaml"
+report_path: "docs/research/CTC_FALSIFY_001_L2_PREREGISTRATION.md"
+evidence: []

--- a/.github/detect-secrets.baseline
+++ b/.github/detect-secrets.baseline
@@ -3706,6 +3706,22 @@
         "line_number": 30
       }
     ],
+    "research/ctc_falsify/l2/evidence/ctc_falsify_l2_result.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "research/ctc_falsify/l2/evidence/ctc_falsify_l2_result.json",
+        "hashed_secret": "22c78e042ba9a2f485c52b7bbd7b7a4aa635551d",
+        "is_verified": false,
+        "line_number": 4
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "research/ctc_falsify/l2/evidence/ctc_falsify_l2_result.json",
+        "hashed_secret": "4e81202853677de25f49ec03d1cad72801d91adf",
+        "is_verified": false,
+        "line_number": 10
+      }
+    ],
     "results/FINAL_REPORT.json": [
       {
         "type": "Hex High Entropy String",
@@ -5395,5 +5411,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-16T21:15:54Z"
+  "generated_at": "2026-05-16T22:04:48Z"
 }

--- a/docs/research/CTC_FALSIFY_001_L2_PREREGISTRATION.md
+++ b/docs/research/CTC_FALSIFY_001_L2_PREREGISTRATION.md
@@ -1,0 +1,71 @@
+# CTC-FALSIFY-001 · L2 Pre-Registration (frozen, pre-data)
+
+L2 adds the real-data residual machinery to CTC-FALSIFY-001 (L1 merged in
+PR #748). It is **not** a test of the CTC theory; it is the fail-closed
+instrument that, only after a dataset is bound (C3), can reach
+`KILLED_SCOPED` / `SURVIVED_INITIAL`. Constants live only in
+`research/ctc_falsify/l2/config_l2.py` (SSOT; `config_hash` pins L1+L2).
+
+## The eight self-audit fixes (wired as gates, not prose)
+
+1. **Standardized residual estimand.** `residual_z = (SFC_obs −
+   mean(SFC_surr)) / std(SFC_surr)`; single primary endpoint = fraction of
+   pair-directions with `residual_z > Z_GATE`.
+2. **Jointly-matched surrogate.** One surrogate matched on rate ∧ power ∧
+   common-drive (A fixed, B phase-randomized, B-envelope re-imposed); marginal
+   matching forbidden. Mismatch ⇒ `INADMISSIBLE_SURROGATE_MISMATCH`.
+3. **Operational positive control.** Known-routing N⁺ must clear
+   `NPLUS_RESIDUAL_MIN_Z` while confound-only stays under
+   `CONFOUND_RESIDUAL_MAX_Z`; else `INADMISSIBLE_NPLUS_INSITU_BLIND`.
+4. **Pre-committed dataset rule / no data pre-bind** ⇒
+   `INADMISSIBLE_NO_PAIRED_DATA`.
+5. **P-replication gate.** Descriptive coherence↔behavior must replicate on
+   the bound dataset, else `INADMISSIBLE_DATASET_UNSUITABLE` (C3).
+6. **Multiplicity.** One primary endpoint + Holm for secondaries.
+7. **Power.** Pre-registered `MDE_RESIDUAL_Z` + `MIN_SESSIONS`; undershoot ⇒
+   `INADMISSIBLE_UNDERPOWERED` (C3).
+8. **Symmetric terminal thresholds.** KILLED and SURVIVED use the *same*
+   alpha and delta; identical reporting template.
+
+## Reference run (in-silico self-validation, pre-data) — honest outcome
+
+`verdict = INADMISSIBLE_NPLUS_INSITU_BLIND`.
+
+The jointly-matched surrogate matches rate/power to <0.1 % error, **but** the
+v1 phase-randomization PLV-residual estimator does **not** clear its own
+pre-registered positive-control gate (N⁺ `residual_z ≈ 1.6 < 3.0`;
+worst confound `residual_z ≈ 2.7 > 1.96`). Phase randomization destroys the
+legitimate channel phase along with the confound, and envelope re-imposition
+lets shared-drive structure leak — so the *standard residual-subtraction
+approach is itself blind* on the generative ground truth.
+
+This is the designed fail-closed behaviour, **not** a defect to tune away.
+Per the contract, thresholds are pre-committed; the estimator is reported
+inadmissible. The machine kills its own instrument (cf. L1 amendment A2).
+
+## What this licenses / forbids
+
+- **Forbidden:** lowering `NPLUS_RESIDUAL_MIN_Z`, widening
+  `CONFOUND_RESIDUAL_MAX_Z`, or changing the surrogate to make N⁺ "pass" —
+  that is post-hoc rescue (#199 class).
+- **Required before C3:** a *demonstrably non-blind* residual estimator
+  (e.g., a phase-preserving / time-reversed / trial-shuffled surrogate that
+  retains channel phase while killing confounds), re-pre-registered, that
+  clears self-validation. No real dataset is touched until then.
+
+## Honesty invariant
+
+If, at C3, the CTC residual survives the jointly-matched null with the
+estimator non-blind, we report **survival**, not spin — symmetric thresholds,
+identical template. The machine is indifferent to the audience.
+
+## Verification tags
+
+- FACT: phase-randomization surrogates degrade legitimate phase structure
+  (well known; here measured: N⁺ z≈1.6). confidence=high.
+- FACT: L1 generative + L2 surrogate/residual are executable, deterministic,
+  mypy-strict clean. confidence=high.
+- UNKNOWN: a non-blind estimator design — open problem, not yet pre-registered.
+- UNKNOWN: real dataset/licence — not checked, no data touched (C3).
+
+Research line: `ctc_falsify_001` (status OPEN; L2 continues same line).

--- a/research/ctc_falsify/l2/__init__.py
+++ b/research/ctc_falsify/l2/__init__.py
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: MIT
+"""CTC-FALSIFY-001 L2 — real-data residual layer (pre-data, fail-closed).
+
+L1 proved in-silico that the naive PLV+coherence pipeline confuses confounds
+with a channel. L2 adds the machinery that can finally reach
+``KILLED_SCOPED`` / ``SURVIVED_INITIAL`` on real electrophysiology — but only
+after a dataset is bound (C3). Pre-data, the reference verdict is the designed
+``INADMISSIBLE_NO_PAIRED_DATA``.
+
+All eight self-audit fixes (see docs/research/CTC_FALSIFY_001_L2_PREREGISTRATION.md)
+are wired as gates here, not as prose.
+"""
+
+from research.ctc_falsify.l2.config_l2 import L2_ID
+
+__all__ = ["L2_ID"]

--- a/research/ctc_falsify/l2/config_l2.py
+++ b/research/ctc_falsify/l2/config_l2.py
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: MIT
+"""L2 single source of truth. Constants live ONLY here (SSOT)."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from typing import Final
+
+from research.ctc_falsify import config as l1
+
+L2_ID: Final[str] = "CTC-FALSIFY-001-L2"
+
+CLAIM: Final[str] = (
+    "On real paired LFP+spike data, the CTC causal claim (the gamma phase "
+    "relation carries inter-areal routing) survives subtraction of a "
+    "jointly-matched confound surrogate."
+)
+BOUNDARY: Final[str] = (
+    "Scoped to the pre-committed dataset and the rate/waveform/SNR/common-drive "
+    "jointly-matched surrogate defined here. Pre-data: KILLED_SCOPED/"
+    "SURVIVED_INITIAL are unreachable until a dataset is bound (C3)."
+)
+
+# --- Fix #1: standardized residual estimand + single primary endpoint -----
+# residual_z = (SFC_obs - mean(SFC_surr)) / std(SFC_surr) per pair-direction.
+# Primary endpoint = fraction of pair-directions with residual_z > Z_GATE.
+Z_GATE: Final[float] = 1.96
+PRIMARY_ENDPOINT_DELTA: Final[float] = 0.10  # min fraction over surrogate share
+# --- Fix #2: joint surrogate matching tolerances --------------------------
+RATE_MATCH_TOL: Final[float] = 0.05  # |Δ mean-rate proxy| relative
+SNR_MATCH_TOL: Final[float] = 0.05  # |Δ power| relative
+N_SURROGATE: Final[int] = 200
+# --- Fix #3: positive control (known-routing) recovery --------------------
+NPLUS_RESIDUAL_MIN_Z: Final[float] = 3.0  # estimator must see a true channel
+CONFOUND_RESIDUAL_MAX_Z: Final[float] = 1.96  # must NOT flag confound-only
+# --- Fix #6: multiplicity -------------------------------------------------
+HOLM_ALPHA: Final[float] = 0.01
+# --- Fix #7: power --------------------------------------------------------
+MDE_RESIDUAL_Z: Final[float] = 0.5  # min detectable standardized residual
+MIN_SESSIONS: Final[int] = 8
+# --- Fix #8: symmetric terminal thresholds --------------------------------
+# KILLED and SURVIVED use the SAME endpoint magnitude and the SAME alpha.
+SYMMETRIC_ALPHA: Final[float] = HOLM_ALPHA
+SYMMETRIC_DELTA: Final[float] = PRIMARY_ENDPOINT_DELTA
+
+# In-silico self-validation reuses the L1 generative ground truth.
+N_VALIDATION_SEEDS: Final[int] = l1.N_NULL_SEEDS
+
+VERDICT_INADMISSIBLE_NO_PAIRED_DATA: Final[str] = "INADMISSIBLE_NO_PAIRED_DATA"
+VERDICT_INADMISSIBLE_DATASET_UNSUITABLE: Final[str] = "INADMISSIBLE_DATASET_UNSUITABLE"
+VERDICT_INADMISSIBLE_SURROGATE_MISMATCH: Final[str] = "INADMISSIBLE_SURROGATE_MISMATCH"
+VERDICT_INADMISSIBLE_NPLUS_INSITU_BLIND: Final[str] = "INADMISSIBLE_NPLUS_INSITU_BLIND"
+VERDICT_INADMISSIBLE_UNDERPOWERED: Final[str] = "INADMISSIBLE_UNDERPOWERED"
+VERDICT_KILLED_SCOPED: Final[str] = "KILLED_SCOPED"
+VERDICT_SURVIVED_INITIAL: Final[str] = "SURVIVED_INITIAL"
+
+ALL_VERDICTS: Final[tuple[str, ...]] = (
+    VERDICT_INADMISSIBLE_NO_PAIRED_DATA,
+    VERDICT_INADMISSIBLE_DATASET_UNSUITABLE,
+    VERDICT_INADMISSIBLE_SURROGATE_MISMATCH,
+    VERDICT_INADMISSIBLE_NPLUS_INSITU_BLIND,
+    VERDICT_INADMISSIBLE_UNDERPOWERED,
+    VERDICT_KILLED_SCOPED,
+    VERDICT_SURVIVED_INITIAL,
+)
+
+_PKG: Final[Path] = Path(__file__).resolve().parent
+SCHEMA_PATH: Final[Path] = _PKG / "schema" / "ctc_falsify_l2_result.schema.json"
+EVIDENCE_DIR: Final[Path] = _PKG / "evidence"
+RESULT_PATH: Final[Path] = EVIDENCE_DIR / "ctc_falsify_l2_result.json"
+
+
+def config_hash() -> str:
+    """Hash of BOTH SSOT files — L2 inherits L1 constants, so both pin."""
+    h = hashlib.sha256()
+    h.update(Path(__file__).read_bytes())
+    h.update(Path(l1.__file__).read_bytes())
+    return h.hexdigest()

--- a/research/ctc_falsify/l2/evidence/ctc_falsify_l2_result.json
+++ b/research/ctc_falsify/l2/evidence/ctc_falsify_l2_result.json
@@ -1,0 +1,31 @@
+{
+  "boundary": "Scoped to the pre-committed dataset and the rate/waveform/SNR/common-drive jointly-matched surrogate defined here. Pre-data: KILLED_SCOPED/SURVIVED_INITIAL are unreachable until a dataset is bound (C3).",
+  "claim": "On real paired LFP+spike data, the CTC causal claim (the gamma phase relation carries inter-areal routing) survives subtraction of a jointly-matched confound surrogate.",
+  "config_hash": "941455bb8dd06cb97c1aef75e79cd3392e4f1ca729052cb0cfd8bd842a1485b3",
+  "estimand": "standardized_residual_z = (SFC_obs - mean(SFC_surr)) / std(SFC_surr)",
+  "experiment_id": "CTC-FALSIFY-001-L2",
+  "joint_surrogate": "phase-randomized B, envelope-reimposed, A fixed (rate+power+common-drive matched)",
+  "primary_endpoint": "fraction of pair-directions with residual_z > Z_GATE",
+  "real_dataset_bound": false,
+  "repro_hash": "5cab499147b744454e106b39f39b1f3dee07ccb613c1f8a03c52165d5350177d",
+  "self_validation": {
+    "confounds_not_flagged": false,
+    "max_confound_residual_z": 2.6877233182064924,
+    "mean_nplus_residual_z": 1.5977325988836046,
+    "n_validation_seeds": 24,
+    "nplus_recovered": false,
+    "surrogate_all_matched": true,
+    "worst_power_rel_err": 0.00043979651298552114,
+    "worst_rate_rel_err": 2.6454102944415545e-10
+  },
+  "thresholds": {
+    "confound_residual_max_z": 1.96,
+    "mde_residual_z": 0.5,
+    "min_sessions": 8,
+    "nplus_residual_min_z": 3.0,
+    "symmetric_alpha": 0.01,
+    "symmetric_delta": 0.1,
+    "z_gate": 1.96
+  },
+  "verdict": "INADMISSIBLE_NPLUS_INSITU_BLIND"
+}

--- a/research/ctc_falsify/l2/gates_l2.py
+++ b/research/ctc_falsify/l2/gates_l2.py
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: MIT
+"""L2 fail-closed verdict logic.
+
+Pre-data decision order:
+
+  V1  Surrogate must jointly match rate AND power on every validation draw,
+      else INADMISSIBLE_SURROGATE_MISMATCH  (fix #2).
+  V2  Positive control (known-routing N+) standardized residual must exceed
+      NPLUS_RESIDUAL_MIN_Z AND confound-only residual must stay below
+      CONFOUND_RESIDUAL_MAX_Z, else INADMISSIBLE_NPLUS_INSITU_BLIND
+      (fix #3 — a blind estimator may never license a kill).
+  V3  No real paired dataset is bound → INADMISSIBLE_NO_PAIRED_DATA
+      (the designed pre-data success).
+
+KILLED_SCOPED / SURVIVED_INITIAL are reachable only with a bound dataset
+(C3): symmetric thresholds (fix #8), P-replication gate (fix #5),
+power/MDE gate (fix #7), Holm multiplicity (fix #6).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from research.ctc_falsify import config as l1
+from research.ctc_falsify.generative import draw_n_plus, draw_null
+from research.ctc_falsify.l2 import config_l2 as cfg
+from research.ctc_falsify.l2.residual import standardized_residual
+
+
+@dataclass(frozen=True)
+class L2SelfValidation:
+    surrogate_all_matched: bool
+    mean_nplus_residual_z: float
+    max_confound_residual_z: float
+    nplus_recovered: bool
+    confounds_not_flagged: bool
+    n_validation_seeds: int
+    worst_rate_rel_err: float
+    worst_power_rel_err: float
+
+
+def run_self_validation() -> L2SelfValidation:
+    """In-silico proof that the L2 estimator is not blind, BEFORE any data."""
+    seeds = [l1.SEED + i for i in range(cfg.N_VALIDATION_SEEDS)]
+
+    nplus_z: list[float] = []
+    rate_err: list[float] = []
+    power_err: list[float] = []
+    all_matched = True
+    for s in seeds:
+        r = standardized_residual(draw_n_plus(s), s)
+        nplus_z.append(r.residual_z)
+        rate_err.append(r.rate_rel_err)
+        power_err.append(r.power_rel_err)
+        all_matched = all_matched and r.matched
+
+    confound_z: list[float] = []
+    for fam in l1.NULL_FAMILIES:
+        for s in seeds:
+            r = standardized_residual(draw_null(s, fam), s)
+            confound_z.append(r.residual_z)
+            rate_err.append(r.rate_rel_err)
+            power_err.append(r.power_rel_err)
+            all_matched = all_matched and r.matched
+
+    mean_nplus = float(sum(nplus_z) / len(nplus_z))
+    max_conf = max(confound_z)
+    return L2SelfValidation(
+        surrogate_all_matched=all_matched,
+        mean_nplus_residual_z=mean_nplus,
+        max_confound_residual_z=max_conf,
+        nplus_recovered=mean_nplus >= cfg.NPLUS_RESIDUAL_MIN_Z,
+        confounds_not_flagged=max_conf <= cfg.CONFOUND_RESIDUAL_MAX_Z,
+        n_validation_seeds=len(seeds),
+        worst_rate_rel_err=max(rate_err),
+        worst_power_rel_err=max(power_err),
+    )
+
+
+def decide_l2(v: L2SelfValidation, *, real_dataset_bound: bool = False) -> str:
+    if not v.surrogate_all_matched:
+        return cfg.VERDICT_INADMISSIBLE_SURROGATE_MISMATCH
+    if not (v.nplus_recovered and v.confounds_not_flagged):
+        return cfg.VERDICT_INADMISSIBLE_NPLUS_INSITU_BLIND
+    if not real_dataset_bound:
+        return cfg.VERDICT_INADMISSIBLE_NO_PAIRED_DATA
+    raise NotImplementedError("real-data residual test is C3; no dataset is bound")

--- a/research/ctc_falsify/l2/residual.py
+++ b/research/ctc_falsify/l2/residual.py
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: MIT
+"""Fix #1: standardized residual estimand (not a difference of point estimates).
+
+residual_z = (SFC_obs - mean(SFC_surrogate)) / std(SFC_surrogate)
+
+SFC = the same gamma PLV the standard CTC pipeline uses (L1 pipeline), so the
+residual asks exactly: what is left after the jointly-matched confound null is
+subtracted, in surrogate-standardized units.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+from scipy.signal import hilbert
+
+from research.ctc_falsify.generative import TwoPopSignals
+from research.ctc_falsify.l2.surrogate import build_joint_surrogate
+from research.ctc_falsify.pipeline import _bandpass
+
+
+@dataclass(frozen=True)
+class ResidualResult:
+    residual_z: float
+    sfc_observed: float
+    surrogate_mean: float
+    surrogate_std: float
+    matched: bool
+    rate_rel_err: float
+    power_rel_err: float
+
+
+def _plv_pair(a: np.ndarray, b: np.ndarray) -> float:
+    pa = np.angle(hilbert(_bandpass(np.asarray(a, dtype=np.float64))))
+    pb = np.angle(hilbert(_bandpass(np.asarray(b, dtype=np.float64))))
+    return float(np.abs(np.exp(1j * (pa - pb)).mean()))
+
+
+def standardized_residual(sig: TwoPopSignals, seed: int) -> ResidualResult:
+    batch = build_joint_surrogate(sig, seed)
+    sfc_obs = _plv_pair(sig.sig_a, sig.sig_b)
+    surr_sfc = np.array(
+        [_plv_pair(batch.sig_a, batch.surrogate_b[i]) for i in range(batch.surrogate_b.shape[0])],
+        dtype=np.float64,
+    )
+    mu = float(surr_sfc.mean())
+    sd = float(surr_sfc.std(ddof=1))
+    z = (sfc_obs - mu) / sd if sd > 1e-12 else 0.0
+    return ResidualResult(
+        residual_z=float(z),
+        sfc_observed=sfc_obs,
+        surrogate_mean=mu,
+        surrogate_std=sd,
+        matched=batch.matched,
+        rate_rel_err=batch.rate_rel_err,
+        power_rel_err=batch.power_rel_err,
+    )

--- a/research/ctc_falsify/l2/run.py
+++ b/research/ctc_falsify/l2/run.py
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: MIT
+"""CTC-FALSIFY-001 L2 orchestrator — schema-valid, hash-bound, fail-closed.
+
+Pre-data reference verdict: INADMISSIBLE_NO_PAIRED_DATA (designed success)
+after the L2 estimator passes its in-silico self-validation.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+from research.ctc_falsify.l2 import config_l2 as cfg
+from research.ctc_falsify.l2.gates_l2 import decide_l2, run_self_validation
+
+
+def _repro_hash(payload: dict[str, Any]) -> str:
+    return hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+
+
+def run() -> dict[str, Any]:
+    v = run_self_validation()
+    verdict = decide_l2(v, real_dataset_bound=False)
+    cfg_hash = cfg.config_hash()
+
+    self_validation = {
+        "surrogate_all_matched": v.surrogate_all_matched,
+        "mean_nplus_residual_z": v.mean_nplus_residual_z,
+        "max_confound_residual_z": v.max_confound_residual_z,
+        "nplus_recovered": v.nplus_recovered,
+        "confounds_not_flagged": v.confounds_not_flagged,
+        "n_validation_seeds": v.n_validation_seeds,
+        "worst_rate_rel_err": v.worst_rate_rel_err,
+        "worst_power_rel_err": v.worst_power_rel_err,
+    }
+    result: dict[str, Any] = {
+        "experiment_id": cfg.L2_ID,
+        "verdict": verdict,
+        "claim": cfg.CLAIM,
+        "boundary": cfg.BOUNDARY,
+        "estimand": "standardized_residual_z = (SFC_obs - mean(SFC_surr)) / std(SFC_surr)",
+        "primary_endpoint": "fraction of pair-directions with residual_z > Z_GATE",
+        "joint_surrogate": "phase-randomized B, envelope-reimposed, A fixed (rate+power+common-drive matched)",
+        "self_validation": self_validation,
+        "thresholds": {
+            "z_gate": cfg.Z_GATE,
+            "nplus_residual_min_z": cfg.NPLUS_RESIDUAL_MIN_Z,
+            "confound_residual_max_z": cfg.CONFOUND_RESIDUAL_MAX_Z,
+            "symmetric_alpha": cfg.SYMMETRIC_ALPHA,
+            "symmetric_delta": cfg.SYMMETRIC_DELTA,
+            "mde_residual_z": cfg.MDE_RESIDUAL_Z,
+            "min_sessions": cfg.MIN_SESSIONS,
+        },
+        "real_dataset_bound": False,
+        "config_hash": cfg_hash,
+    }
+    result["repro_hash"] = _repro_hash(
+        {
+            "verdict": verdict,
+            "config_hash": cfg_hash,
+            "self_validation": self_validation,
+        }
+    )
+    return result
+
+
+def write_evidence(result: dict[str, Any]) -> str:
+    cfg.EVIDENCE_DIR.mkdir(parents=True, exist_ok=True)
+    cfg.RESULT_PATH.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n")
+    return str(cfg.RESULT_PATH)
+
+
+def main() -> None:
+    result = run()
+    path = write_evidence(result)
+    sv = result["self_validation"]
+    print(f"EXPERIMENT: {result['experiment_id']}")
+    print(f"VERDICT: {result['verdict']}")
+    print(
+        "SELF-VALIDATION: surrogate_matched="
+        f"{sv['surrogate_all_matched']} nplus_z={sv['mean_nplus_residual_z']:.3f} "
+        f"(min {cfg.NPLUS_RESIDUAL_MIN_Z}) max_confound_z={sv['max_confound_residual_z']:.3f} "
+        f"(max {cfg.CONFOUND_RESIDUAL_MAX_Z})"
+    )
+    print(
+        "SURROGATE MATCH worst rel-err: rate="
+        f"{sv['worst_rate_rel_err']:.4f} power={sv['worst_power_rel_err']:.4f}"
+    )
+    print(f"REPRO HASH: {result['repro_hash']}")
+    print(f"ARTIFACT: {path}")
+    print(f"BOUNDARY: {result['boundary']}")
+    print(
+        "NEXT: C3 — bind a pre-committed real LFP+spike dataset; only then are "
+        "KILLED_SCOPED/SURVIVED_INITIAL reachable. Clean INADMISSIBLE here is "
+        "the designed pre-data success."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/research/ctc_falsify/l2/schema/ctc_falsify_l2_result.schema.json
+++ b/research/ctc_falsify/l2/schema/ctc_falsify_l2_result.schema.json
@@ -1,0 +1,90 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "research/ctc_falsify/l2/schema/ctc_falsify_l2_result.schema.json",
+  "title": "CTC-FALSIFY-001-L2 result",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "experiment_id",
+    "verdict",
+    "claim",
+    "boundary",
+    "estimand",
+    "primary_endpoint",
+    "joint_surrogate",
+    "self_validation",
+    "thresholds",
+    "real_dataset_bound",
+    "config_hash",
+    "repro_hash"
+  ],
+  "properties": {
+    "experiment_id": { "const": "CTC-FALSIFY-001-L2" },
+    "verdict": {
+      "type": "string",
+      "enum": [
+        "INADMISSIBLE_NO_PAIRED_DATA",
+        "INADMISSIBLE_DATASET_UNSUITABLE",
+        "INADMISSIBLE_SURROGATE_MISMATCH",
+        "INADMISSIBLE_NPLUS_INSITU_BLIND",
+        "INADMISSIBLE_UNDERPOWERED",
+        "KILLED_SCOPED",
+        "SURVIVED_INITIAL"
+      ]
+    },
+    "claim": { "type": "string", "minLength": 1 },
+    "boundary": { "type": "string", "minLength": 1 },
+    "estimand": { "type": "string", "minLength": 1 },
+    "primary_endpoint": { "type": "string", "minLength": 1 },
+    "joint_surrogate": { "type": "string", "minLength": 1 },
+    "self_validation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "surrogate_all_matched",
+        "mean_nplus_residual_z",
+        "max_confound_residual_z",
+        "nplus_recovered",
+        "confounds_not_flagged",
+        "n_validation_seeds",
+        "worst_rate_rel_err",
+        "worst_power_rel_err"
+      ],
+      "properties": {
+        "surrogate_all_matched": { "type": "boolean" },
+        "mean_nplus_residual_z": { "type": "number" },
+        "max_confound_residual_z": { "type": "number" },
+        "nplus_recovered": { "type": "boolean" },
+        "confounds_not_flagged": { "type": "boolean" },
+        "n_validation_seeds": { "type": "integer", "minimum": 0 },
+        "worst_rate_rel_err": { "type": "number" },
+        "worst_power_rel_err": { "type": "number" }
+      }
+    },
+    "thresholds": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "z_gate",
+        "nplus_residual_min_z",
+        "confound_residual_max_z",
+        "symmetric_alpha",
+        "symmetric_delta",
+        "mde_residual_z",
+        "min_sessions"
+      ],
+      "properties": {
+        "z_gate": { "type": "number" },
+        "nplus_residual_min_z": { "type": "number" },
+        "confound_residual_max_z": { "type": "number" },
+        "symmetric_alpha": { "type": "number" },
+        "symmetric_delta": { "type": "number" },
+        "mde_residual_z": { "type": "number" },
+        "min_sessions": { "type": "integer" }
+      }
+    },
+    "real_dataset_bound": { "type": "boolean" },
+    "config_hash": { "type": "string", "pattern": "^[a-f0-9]{64}$" },
+    "repro_hash": { "type": "string", "pattern": "^[a-f0-9]{64}$" }
+  }
+}

--- a/research/ctc_falsify/l2/surrogate.py
+++ b/research/ctc_falsify/l2/surrogate.py
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: MIT
+"""Fix #2: a single JOINTLY-matched confound surrogate.
+
+Marginal (match-one-confound) surrogates leak — the Vinck/Schneider critique.
+This destroys any true A->B phase coupling while preserving, jointly:
+  * the power spectrum of B  (=> SNR / power matched by construction)
+  * the amplitude envelope of B  (=> rate proxy matched)
+  * signal A unchanged  (=> stimulus-locked common drive preserved)
+Match quality is measured and gated (INADMISSIBLE_SURROGATE_MISMATCH).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+from numpy.typing import NDArray
+
+from research.ctc_falsify.generative import TwoPopSignals
+from research.ctc_falsify.l2 import config_l2 as cfg
+
+FloatArray = NDArray[np.float64]
+
+
+@dataclass(frozen=True)
+class SurrogateBatch:
+    sig_a: FloatArray
+    surrogate_b: FloatArray  # shape (n_surrogate, T)
+    rate_rel_err: float
+    power_rel_err: float
+    matched: bool
+
+
+def _phase_randomize(x: FloatArray, rng: np.random.Generator) -> FloatArray:
+    """FFT phase randomization: preserves |X(f)| (power), destroys phase."""
+    spec = np.fft.rfft(x)
+    mag = np.abs(spec)
+    rand_phase = np.exp(1j * rng.uniform(0.0, 2.0 * np.pi, size=mag.shape))
+    rand_phase[0] = 1.0  # keep DC real
+    surr = np.fft.irfft(mag * rand_phase, n=x.shape[0])
+    return np.asarray(surr, dtype=np.float64)
+
+
+def build_joint_surrogate(sig: TwoPopSignals, seed: int) -> SurrogateBatch:
+    rng = np.random.default_rng(seed)
+    b = sig.sig_b
+    env_b = np.abs(b)
+    surr = np.empty((cfg.N_SURROGATE, b.shape[0]), dtype=np.float64)
+    for i in range(cfg.N_SURROGATE):
+        s = _phase_randomize(b, rng)
+        # Re-impose B's amplitude envelope (rate proxy) on the phase-killed signal.
+        s_env = np.abs(s)
+        s = s * (env_b / (s_env + 1e-12))
+        surr[i] = s
+
+    rate_obs = float(np.mean(env_b))
+    rate_surr = float(np.mean(np.abs(surr)))
+    power_obs = float(np.var(b))
+    power_surr = float(np.mean(np.var(surr, axis=1)))
+    rate_err = abs(rate_surr - rate_obs) / (abs(rate_obs) + 1e-12)
+    power_err = abs(power_surr - power_obs) / (abs(power_obs) + 1e-12)
+    matched = rate_err <= cfg.RATE_MATCH_TOL and power_err <= cfg.SNR_MATCH_TOL
+    return SurrogateBatch(
+        sig_a=sig.sig_a,
+        surrogate_b=surr,
+        rate_rel_err=rate_err,
+        power_rel_err=power_err,
+        matched=matched,
+    )

--- a/tests/research/ctc_falsify/test_ctc_falsify_l2.py
+++ b/tests/research/ctc_falsify/test_ctc_falsify_l2.py
@@ -1,0 +1,169 @@
+# SPDX-License-Identifier: MIT
+"""Construct-validity guards for CTC-FALSIFY-001 L2.
+
+The eight self-audit fixes are enforced here as executable invariants, not
+prose: standardized residual estimand, jointly-matched surrogate, in-situ
+positive control, no kill pre-data, symmetric terminal thresholds, SSOT.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from jsonschema import Draft202012Validator
+
+from research.ctc_falsify import config as l1
+from research.ctc_falsify.generative import draw_n_plus
+from research.ctc_falsify.l2 import config_l2 as cfg
+from research.ctc_falsify.l2.gates_l2 import L2SelfValidation, decide_l2, run_self_validation
+from research.ctc_falsify.l2.residual import standardized_residual
+from research.ctc_falsify.l2.run import run
+from research.ctc_falsify.l2.surrogate import build_joint_surrogate
+
+# Heavy: 24 seeds x 4 conditions x 200 surrogates x PLV. Runs in the
+# python-heavy-tests gate, NOT the 20-min python-fast-tests cap
+# (pre-registered constants are NOT reduced — that would be a #199 rescue).
+pytestmark = pytest.mark.slow
+
+
+@pytest.fixture(scope="module")
+def selfval() -> L2SelfValidation:
+    return run_self_validation()
+
+
+@pytest.fixture(scope="module")
+def result() -> dict[str, object]:
+    return run()
+
+
+def test_result_validates_against_schema(result: dict[str, object]) -> None:
+    schema = json.loads(cfg.SCHEMA_PATH.read_text())
+    Draft202012Validator.check_schema(schema)
+    Draft202012Validator(schema).validate(result)
+
+
+def test_schema_enum_is_single_source() -> None:
+    schema = json.loads(cfg.SCHEMA_PATH.read_text())
+    assert tuple(schema["properties"]["verdict"]["enum"]) == cfg.ALL_VERDICTS
+
+
+def test_pre_data_verdict_is_fail_closed_inadmissible(result: dict[str, object]) -> None:
+    assert str(result["verdict"]).startswith("INADMISSIBLE")
+    assert result["real_dataset_bound"] is False
+    assert result["verdict"] in cfg.ALL_VERDICTS
+
+
+def test_no_kill_or_survival_reachable_pre_data(selfval: L2SelfValidation) -> None:
+    """No KILLED/SURVIVED while pre-data — even if the data flag is forced."""
+    for flag in (False, True):
+        v = decide_l2(selfval, real_dataset_bound=flag)
+        assert v not in (cfg.VERDICT_KILLED_SCOPED, cfg.VERDICT_SURVIVED_INITIAL)
+        assert v.startswith("INADMISSIBLE")
+
+
+def test_c3_path_unreachable_only_when_estimator_admissible() -> None:
+    """The C3 (real-data) branch raises NotImplemented ONLY after the
+    estimator passes self-validation — it is gated behind admissibility."""
+    passing = L2SelfValidation(
+        surrogate_all_matched=True,
+        mean_nplus_residual_z=cfg.NPLUS_RESIDUAL_MIN_Z + 1.0,
+        max_confound_residual_z=0.0,
+        nplus_recovered=True,
+        confounds_not_flagged=True,
+        n_validation_seeds=cfg.N_VALIDATION_SEEDS,
+        worst_rate_rel_err=0.0,
+        worst_power_rel_err=0.0,
+    )
+    assert decide_l2(passing, real_dataset_bound=False) == cfg.VERDICT_INADMISSIBLE_NO_PAIRED_DATA
+    with pytest.raises(NotImplementedError):
+        decide_l2(passing, real_dataset_bound=True)
+
+
+def test_joint_surrogate_matches_rate_and_power() -> None:
+    """Fix #2: surrogate must match BOTH rate and power within tolerance,
+    and must destroy the true phase channel (residual collapses on its own
+    surrogate)."""
+    sig = draw_n_plus(l1.SEED)
+    batch = build_joint_surrogate(sig, l1.SEED)
+    assert batch.rate_rel_err <= cfg.RATE_MATCH_TOL
+    assert batch.power_rel_err <= cfg.SNR_MATCH_TOL
+    assert batch.surrogate_b.shape == (cfg.N_SURROGATE, sig.sig_b.shape[0])
+
+
+def test_reference_estimator_is_blind_and_fails_closed(
+    selfval: L2SelfValidation, result: dict[str, object]
+) -> None:
+    """Honest reference state (no post-hoc tuning to escape it): the v1
+    phase-randomization residual estimator does NOT clear its own
+    pre-registered positive-control gate, so the verdict is the fail-closed
+    INADMISSIBLE_NPLUS_INSITU_BLIND. A non-blind estimator is the open
+    problem that must be solved BEFORE C3 binds any real data."""
+    assert selfval.surrogate_all_matched is True
+    blind = (
+        selfval.mean_nplus_residual_z < cfg.NPLUS_RESIDUAL_MIN_Z
+        or selfval.max_confound_residual_z > cfg.CONFOUND_RESIDUAL_MAX_Z
+    )
+    assert blind, "estimator unexpectedly admissible — re-pre-register before claiming recovery"
+    assert result["verdict"] == cfg.VERDICT_INADMISSIBLE_NPLUS_INSITU_BLIND
+    # standardized residual is finite and well-formed regardless
+    r = standardized_residual(draw_n_plus(l1.SEED), l1.SEED)
+    assert r.matched is True
+    assert r.surrogate_std > 0.0
+
+
+def test_blind_estimator_gate_precedes_data(selfval: L2SelfValidation) -> None:
+    blind = L2SelfValidation(
+        surrogate_all_matched=True,
+        mean_nplus_residual_z=0.0,
+        max_confound_residual_z=0.0,
+        nplus_recovered=False,
+        confounds_not_flagged=True,
+        n_validation_seeds=selfval.n_validation_seeds,
+        worst_rate_rel_err=0.0,
+        worst_power_rel_err=0.0,
+    )
+    assert decide_l2(blind) == cfg.VERDICT_INADMISSIBLE_NPLUS_INSITU_BLIND
+
+
+def test_surrogate_mismatch_gate_is_first(selfval: L2SelfValidation) -> None:
+    mismatch = L2SelfValidation(
+        surrogate_all_matched=False,
+        mean_nplus_residual_z=99.0,
+        max_confound_residual_z=0.0,
+        nplus_recovered=True,
+        confounds_not_flagged=True,
+        n_validation_seeds=selfval.n_validation_seeds,
+        worst_rate_rel_err=1.0,
+        worst_power_rel_err=1.0,
+    )
+    assert decide_l2(mismatch) == cfg.VERDICT_INADMISSIBLE_SURROGATE_MISMATCH
+
+
+def test_symmetric_terminal_thresholds() -> None:
+    """Fix #8: KILLED and SURVIVED use the SAME alpha and the SAME delta."""
+    assert cfg.SYMMETRIC_ALPHA == cfg.HOLM_ALPHA
+    assert cfg.SYMMETRIC_DELTA == cfg.PRIMARY_ENDPOINT_DELTA
+
+
+def test_repro_hash_binds_verdict(result: dict[str, object]) -> None:
+    import hashlib
+
+    payload = {
+        "verdict": "SURVIVED_INITIAL",
+        "config_hash": result["config_hash"],
+        "self_validation": result["self_validation"],
+    }
+    mutated = hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    ).hexdigest()
+    assert mutated != result["repro_hash"]
+
+
+def test_config_is_single_source() -> None:
+    import research.ctc_falsify.l2.config_l2 as ssot
+    import research.ctc_falsify.l2.run as run_mod
+
+    for name in ("Z_GATE", "N_SURROGATE", "NPLUS_RESIDUAL_MIN_Z", "MIN_SESSIONS"):
+        assert not hasattr(run_mod, name), f"{name} duplicated outside config_l2"
+    assert ssot is cfg


### PR DESCRIPTION
## What this is

L2 of CTC-FALSIFY-001 (L1 = #748, merged). Adds the real-data residual
machinery with all **8 self-audit fixes wired as gates** (not prose):
standardized residual estimand · jointly-matched surrogate (rate∧power∧
common-drive) · operational positive control · pre-committed dataset rule ·
P-replication gate · Holm multiplicity · pre-registered MDE/power · symmetric
KILLED/SURVIVED thresholds.

## Honest reference outcome — no post-hoc tuning

`verdict = INADMISSIBLE_NPLUS_INSITU_BLIND`.

The jointly-matched surrogate matches rate/power to <0.1 % error, **but** the
v1 phase-randomization PLV-residual estimator fails its own pre-registered
positive-control gate (N⁺ residual z≈1.6 < 3.0; worst confound z≈2.7 > 1.96).
Phase randomization destroys the legitimate channel phase along with the
confound — so the *standard residual-subtraction approach is itself blind*.

This is the designed fail-closed behaviour. Thresholds are pre-committed;
lowering them to make N⁺ "pass" is a forbidden #199-class rescue. **The
machine kills its own instrument** (cf. L1 amendment A2). A demonstrably
non-blind estimator is the open problem that must be re-pre-registered
**before** C3 binds any real data. No real data touched.

## Provenance / gates

- SSOT `config_l2.py` (pins L1+L2 via `config_hash`); JSON schema; `repro_hash` binds verdict.
- Research line `ctc_falsify_001` continues (status OPEN, same line_id).
- Diff-bound commit acceptor `ctc-falsify-l2`; detect-secrets baseline updated (provenance hashes, audited false-positive).
- Local: ruff + black + mypy `--strict` clean; 12 construct-validity tests pass; schema validates. Isolated worktree off merged `main`.

## Honesty invariant

If at C3 the CTC residual survives the jointly-matched null with a non-blind
estimator, we report **survival**, not spin — symmetric thresholds, identical
template.

claim_status: hypothesized (pre-data; estimator inadmissible by its own gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)