### PR TITLE
research(ctc): C3 v2 time-reversed estimator — also blind, channel recoverable in principle (fail-closed)

### DIFF
--- a/.claude/commit_acceptors/ctc-falsify-c3.yaml
+++ b/.claude/commit_acceptors/ctc-falsify-c3.yaml
@@ -1,0 +1,38 @@
+# Diff-bound commit acceptor for CTC-FALSIFY-001 C3 (v2 estimator).
+id: ctc-falsify-c3
+status: ACTIVE
+claim_type: governance
+promise: "C3 swaps the L2 estimator to a time-reversed-surrogate directed PSI without relaxing the gate; the honest reference verdict is INADMISSIBLE_NPLUS_INSITU_BLIND (v2 also blind), and the boundary probe shows the channel is recoverable in principle."
+diff_scope:
+  changed_files:
+    - path: "research/ctc_falsify/l2/config_l2.py"
+    - path: "research/ctc_falsify/l2/estimator_v2.py"
+    - path: "research/ctc_falsify/l2/run_v2.py"
+    - path: "research/ctc_falsify/l2/schema/ctc_falsify_l2v2_result.schema.json"
+    - path: "research/ctc_falsify/l2/evidence/ctc_falsify_l2v2_result.json"
+    - path: "tests/research/ctc_falsify/test_ctc_falsify_l2v2.py"
+    - path: ".github/detect-secrets.baseline"
+    - path: ".claude/commit_acceptors/ctc-falsify-c3.yaml"
+    - path: "docs/research/CTC_FALSIFY_001_C3_PREREGISTRATION.md"
+  forbidden_paths:
+    - "trading/"
+    - "execution/"
+    - "forecast/"
+    - "policy/"
+required_python_symbols:
+  - "directed_residual_v2"
+  - "time_reversed_surrogates"
+  - "run_self_validation_v2"
+  - "run"
+expected_signal: "all C3 construct-validity tests pass; reference verdict is the fail-closed INADMISSIBLE_NPLUS_INSITU_BLIND"
+measurement_command: "python -m pytest tests/research/ctc_falsify/test_ctc_falsify_l2v2.py -q"
+signal_artifact: "tmp/ctc_falsify_c3_pytest.log"
+falsifier:
+  command: "python -c \"from research.ctc_falsify.l2.run_v2 import run_self_validation_v2; from research.ctc_falsify.l2 import config_l2 as c; v=run_self_validation_v2(); raise SystemExit(0 if (v.mean_nplus_residual_z < c.NPLUS_RESIDUAL_MIN_Z or v.max_confound_residual_z > c.CONFOUND_RESIDUAL_MAX_Z) else 1)\""
+  description: "Probe asserts v2 is blind by its own gate; it exits 0 (blind, as honestly reported) and would exit 1 if v2 silently became admissible — surfacing any post-hoc tuning."
+rollback_command: "git checkout -- research/ctc_falsify/l2 tests/research/ctc_falsify/test_ctc_falsify_l2v2.py .github/detect-secrets.baseline"
+rollback_verification_command: "git diff --exit-code research/ctc_falsify/l2 tests/research/ctc_falsify/test_ctc_falsify_l2v2.py"
+memory_update_type: append
+ledger_path: ".claude/commit_acceptors/ctc-falsify-c3.yaml"
+report_path: "docs/research/CTC_FALSIFY_001_C3_PREREGISTRATION.md"
+evidence: []

--- a/.github/detect-secrets.baseline
+++ b/.github/detect-secrets.baseline
@@ -3784,6 +3784,22 @@
         "line_number": 10
       }
     ],
+    "research/ctc_falsify/l2/evidence/ctc_falsify_l2v2_result.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "research/ctc_falsify/l2/evidence/ctc_falsify_l2v2_result.json",
+        "hashed_secret": "2dba7c1df3dbbac929f33daa3166feb2253ddf44",
+        "is_verified": false,
+        "line_number": 4
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "research/ctc_falsify/l2/evidence/ctc_falsify_l2v2_result.json",
+        "hashed_secret": "9ca1b4046e4467067c89a86b6a4fae1988437661",
+        "is_verified": false,
+        "line_number": 8
+      }
+    ],
     "results/FINAL_REPORT.json": [
       {
         "type": "Hex High Entropy String",
@@ -5473,5 +5489,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-16T23:37:32Z"
+  "generated_at": "2026-05-17T03:34:56Z"
 }

--- a/docs/research/CTC_FALSIFY_001_C3_PREREGISTRATION.md
+++ b/docs/research/CTC_FALSIFY_001_C3_PREREGISTRATION.md
@@ -1,0 +1,71 @@
+# CTC-FALSIFY-001 · C3 Pre-Registration + Honest Outcome (frozen, pre-data)
+
+C3 replaces the L2 v1 residual estimator (phase-randomization, blind) with a
+**time-reversed-surrogate directed Phase-Slope Index** (Nolte 2008;
+Schreiber-Schmitz surrogate). Same admissibility bar — only the estimator
+changes (no threshold relaxation; that would be a #199-class rescue). SSOT:
+`research/ctc_falsify/l2/config_l2.py` (`ESTIMATOR_VERSION = v2_time_reversed_psi`).
+
+## Rationale
+
+Time reversal preserves the power spectrum, autocorrelation, amplitude
+distribution and common-drive structure **exactly**, but flips the sign of a
+directed phase lag — so a true A→B channel should leave a directed-asymmetry
+residual while confound-only signals collapse to ~0.
+
+## Honest reference outcome (NO tuning)
+
+`verdict = INADMISSIBLE_NPLUS_INSITU_BLIND`.
+
+v2 self-validation: N⁺ `residual_z ≈ 0.15` (< 3.0); worst confound
+`residual_z ≈ 2.52` (> 1.96). **v2 is also blind by its own pre-registered
+gate.** Reported as-is; thresholds untouched.
+
+## Manifestation-vs-boundary elevation (the key C3 finding)
+
+Two **orthogonal** standard estimators now fail the same way:
+
+| estimator | N⁺ z | worst confound z | verdict |
+|---|---|---|---|
+| v1 phase-randomization PLV-residual | ≈1.6 | ≈2.7 | BLIND |
+| v2 time-reversed directed PSI | ≈0.15 | ≈2.52 | BLIND |
+
+Per the manifestation-vs-boundary discipline, before iterating further
+estimators we ran a **boundary probe**: a *privileged* mean-gamma-phase-offset
+estimator cleanly separates the populations —
+N⁺ mean phase offset ≈ −1.38 rad vs N1 common-drive ≈ +0.26 rad;
+cross-correlation lag ≈ −251 samples for N⁺.
+
+**Conclusion:** the generative channel is *recoverable in principle*; the
+blindness of v1 and v2 is a **manifestation property of the standard CTC
+estimands** (PLV-residual, PSI), not a ground-truth defect. This convergent
+in-silico blindness is exactly the instrument-level signal the whole
+CTC-FALSIFY line exists to surface — but it is in-silico and N=2, so it is
+recorded as a **hypothesis**, not a theory claim.
+
+## What this licenses / forbids
+
+- **Forbidden:** lowering the gate, tuning v3 by trial-and-error to "pass".
+- **C4 (pre-registered here, pre-data):** ONE principled estimator — the
+  mean-gamma-phase-offset *residual* the boundary probe identified — built and
+  self-validated. If it clears the gate → estimator admissible →
+  `INADMISSIBLE_NO_PAIRED_DATA` (real data still unbound; C5 = bind dataset).
+  If it too is blind → STOP estimator iteration (N≥3 convergent failures) and
+  elevate to a boundary-conditions writeup: "standard gamma-coherence CTC
+  estimands are structurally blind to a known directed channel."
+
+## Honesty invariant
+
+If a principled estimator recovers N⁺ and, on real data (C5), the CTC residual
+survives the jointly-matched null — we report **survival**, not spin.
+
+## Verification tags
+
+- FACT: v1 and v2 are blind by their own gates (measured here). confidence=high.
+- FACT: the channel is recoverable by a privileged phase-offset estimator
+  (boundary probe, asserted in tests). confidence=high.
+- INFERENCE: standard CTC estimands are structurally blind here — N=2
+  in-silico; hypothesis, not theory. confidence=medium.
+- UNKNOWN: real dataset/licence — not touched (C5).
+
+Research line: `ctc_falsify_001` (status OPEN; C3 continues same line).

--- a/research/ctc_falsify/l2/config_l2.py
+++ b/research/ctc_falsify/l2/config_l2.py
@@ -65,6 +65,20 @@ ALL_VERDICTS: Final[tuple[str, ...]] = (
     VERDICT_SURVIVED_INITIAL,
 )
 
+# --- C3: v2 time-reversed-surrogate directed estimator -------------------
+# v1 (phase-randomization) was blind by its own gate. v2 uses a directed
+# Phase-Slope Index with a time-reversed surrogate. SAME admissibility bar
+# (NPLUS_RESIDUAL_MIN_Z / CONFOUND_RESIDUAL_MAX_Z) — the gate is not relaxed
+# for v2; only the estimator changes.
+ESTIMATOR_VERSION: Final[str] = "v2_time_reversed_psi"
+PSI_NPERSEG: Final[int] = 512
+V2_SCHEMA_PATH: Final[Path] = (
+    Path(__file__).resolve().parent / "schema" / "ctc_falsify_l2v2_result.schema.json"
+)
+V2_RESULT_PATH: Final[Path] = (
+    Path(__file__).resolve().parent / "evidence" / "ctc_falsify_l2v2_result.json"
+)
+
 _PKG: Final[Path] = Path(__file__).resolve().parent
 SCHEMA_PATH: Final[Path] = _PKG / "schema" / "ctc_falsify_l2_result.schema.json"
 EVIDENCE_DIR: Final[Path] = _PKG / "evidence"

--- a/research/ctc_falsify/l2/estimator_v2.py
+++ b/research/ctc_falsify/l2/estimator_v2.py
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: MIT
+"""C3: time-reversed-surrogate directed residual estimator (v2).
+
+The v1 phase-randomization estimator was blind (it destroyed the legitimate
+channel phase along with the confound). v2 instead uses a TIME-REVERSED
+surrogate (Schreiber-Schmitz): time reversal preserves the power spectrum,
+autocorrelation, amplitude distribution and any shared (common-drive)
+structure EXACTLY, but flips the sign of a directed phase lag — so a true
+causal A->B channel survives as a directed-asymmetry residual while
+confound-only (zero-lag / symmetric) signals collapse to ~0.
+
+Directed statistic: the Phase-Slope Index (Nolte 2008) over the gamma band,
+which is antisymmetric under time reversal of one channel.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+from scipy.signal import csd
+
+from research.ctc_falsify import config as l1
+from research.ctc_falsify.generative import TwoPopSignals
+from research.ctc_falsify.l2 import config_l2 as cfg
+
+_FS: float = 1.0 / l1.DT
+_GAMMA_LO: float = l1.F0 - l1.GAMMA_BAND_HALFWIDTH
+_GAMMA_HI: float = l1.F0 + l1.GAMMA_BAND_HALFWIDTH
+
+
+@dataclass(frozen=True)
+class ResidualV2:
+    residual_z: float
+    psi_observed: float
+    surrogate_mean_abs: float
+    surrogate_std_abs: float
+
+
+def _phase_slope_index(a: np.ndarray, b: np.ndarray) -> float:
+    """PSI over the gamma band. Sign/magnitude is directional and flips
+    under time reversal of one channel."""
+    freqs, pxy = csd(a, b, fs=_FS, nperseg=cfg.PSI_NPERSEG)
+    coh = pxy / (np.abs(pxy) + 1e-18)  # unit complex coherency proxy
+    band = (freqs >= _GAMMA_LO) & (freqs <= _GAMMA_HI)
+    idx = np.where(band)[0]
+    if idx.size < 2:
+        return 0.0
+    val = 0.0
+    for j in range(idx.size - 1):
+        f0, f1 = idx[j], idx[j + 1]
+        val += float(np.imag(np.conj(coh[f0]) * coh[f1]))
+    return val
+
+
+def time_reversed_surrogates(sig: TwoPopSignals, seed: int) -> np.ndarray:
+    """Time-reversed B with random circular shift per surrogate.
+
+    Time reversal kills directed phase; the circular shift (spectrum- and
+    autocorrelation-preserving) provides an ensemble for standardization
+    without re-introducing a directed relationship.
+    """
+    rng = np.random.default_rng(seed)
+    b_rev = sig.sig_b[::-1].copy()
+    n = b_rev.shape[0]
+    out = np.empty((cfg.N_SURROGATE, n), dtype=np.float64)
+    for i in range(cfg.N_SURROGATE):
+        shift = int(rng.integers(1, n))
+        out[i] = np.roll(b_rev, shift)
+    return out
+
+
+def directed_residual_v2(sig: TwoPopSignals, seed: int) -> ResidualV2:
+    psi_obs = _phase_slope_index(sig.sig_a, sig.sig_b)
+    surr = time_reversed_surrogates(sig, seed)
+    psi_surr = np.array(
+        [abs(_phase_slope_index(sig.sig_a, surr[i])) for i in range(surr.shape[0])],
+        dtype=np.float64,
+    )
+    mu = float(psi_surr.mean())
+    sd = float(psi_surr.std(ddof=1))
+    z = (abs(psi_obs) - mu) / sd if sd > 1e-18 else 0.0
+    return ResidualV2(
+        residual_z=float(z),
+        psi_observed=float(psi_obs),
+        surrogate_mean_abs=mu,
+        surrogate_std_abs=sd,
+    )

--- a/research/ctc_falsify/l2/evidence/ctc_falsify_l2v2_result.json
+++ b/research/ctc_falsify/l2/evidence/ctc_falsify_l2v2_result.json
@@ -1,0 +1,22 @@
+{
+  "boundary": "Scoped to the pre-committed dataset and the rate/waveform/SNR/common-drive jointly-matched surrogate defined here. Pre-data: KILLED_SCOPED/SURVIVED_INITIAL are unreachable until a dataset is bound (C3).",
+  "claim": "On real paired LFP+spike data, the CTC causal claim (the gamma phase relation carries inter-areal routing) survives subtraction of a jointly-matched confound surrogate.",
+  "config_hash": "6f2021b840b9fcf523773f76f6fd3cccb285f8de577e28e0a8d700a0dbd9a527",
+  "estimator": "time-reversed-surrogate directed Phase-Slope Index (Nolte 2008)",
+  "experiment_id": "CTC-FALSIFY-001-L2V2",
+  "real_dataset_bound": false,
+  "repro_hash": "2e5c5aa99982a3ce33c2e279dba6d7fff862d0bd0f5585e1e43de922ad38222c",
+  "self_validation": {
+    "confounds_not_flagged": false,
+    "estimator_version": "v2_time_reversed_psi",
+    "max_confound_residual_z": 2.515518346084445,
+    "mean_nplus_residual_z": 0.14897414809154605,
+    "n_validation_seeds": 24,
+    "nplus_recovered": false
+  },
+  "thresholds": {
+    "confound_residual_max_z": 1.96,
+    "nplus_residual_min_z": 3.0
+  },
+  "verdict": "INADMISSIBLE_NPLUS_INSITU_BLIND"
+}

--- a/research/ctc_falsify/l2/run_v2.py
+++ b/research/ctc_falsify/l2/run_v2.py
@@ -1,0 +1,112 @@
+# SPDX-License-Identifier: MIT
+"""C3 orchestrator — v2 time-reversed-surrogate estimator self-validation.
+
+Reuses the L2 verdict logic (`decide_l2`) and the SAME admissibility bar.
+Only the estimator changed (v1 phase-randomization -> v2 directed PSI with a
+time-reversed surrogate). Honest outcome is reported with no threshold
+tuning: if v2 is still blind -> INADMISSIBLE_NPLUS_INSITU_BLIND; if it
+clears the bar -> INADMISSIBLE_NO_PAIRED_DATA (estimator admissible, real
+data still unbound — C3-data is the next cycle).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+from research.ctc_falsify import config as l1
+from research.ctc_falsify.generative import draw_n_plus, draw_null
+from research.ctc_falsify.l2 import config_l2 as cfg
+from research.ctc_falsify.l2.estimator_v2 import directed_residual_v2
+from research.ctc_falsify.l2.gates_l2 import L2SelfValidation, decide_l2
+
+
+def run_self_validation_v2() -> L2SelfValidation:
+    seeds = [l1.SEED + i for i in range(cfg.N_VALIDATION_SEEDS)]
+    nplus_z = [directed_residual_v2(draw_n_plus(s), s).residual_z for s in seeds]
+    confound_z: list[float] = []
+    for fam in l1.NULL_FAMILIES:
+        confound_z += [directed_residual_v2(draw_null(s, fam), s).residual_z for s in seeds]
+
+    mean_nplus = float(sum(nplus_z) / len(nplus_z))
+    max_conf = max(confound_z)
+    return L2SelfValidation(
+        surrogate_all_matched=True,  # time reversal preserves spectrum exactly
+        mean_nplus_residual_z=mean_nplus,
+        max_confound_residual_z=max_conf,
+        nplus_recovered=mean_nplus >= cfg.NPLUS_RESIDUAL_MIN_Z,
+        confounds_not_flagged=max_conf <= cfg.CONFOUND_RESIDUAL_MAX_Z,
+        n_validation_seeds=len(seeds),
+        worst_rate_rel_err=0.0,
+        worst_power_rel_err=0.0,
+    )
+
+
+def _repro_hash(payload: dict[str, Any]) -> str:
+    return hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+
+
+def run() -> dict[str, Any]:
+    v = run_self_validation_v2()
+    verdict = decide_l2(v, real_dataset_bound=False)
+    cfg_hash = cfg.config_hash()
+    sv = {
+        "estimator_version": cfg.ESTIMATOR_VERSION,
+        "mean_nplus_residual_z": v.mean_nplus_residual_z,
+        "max_confound_residual_z": v.max_confound_residual_z,
+        "nplus_recovered": v.nplus_recovered,
+        "confounds_not_flagged": v.confounds_not_flagged,
+        "n_validation_seeds": v.n_validation_seeds,
+    }
+    result: dict[str, Any] = {
+        "experiment_id": "CTC-FALSIFY-001-L2V2",
+        "verdict": verdict,
+        "estimator": "time-reversed-surrogate directed Phase-Slope Index (Nolte 2008)",
+        "claim": cfg.CLAIM,
+        "boundary": cfg.BOUNDARY,
+        "self_validation": sv,
+        "thresholds": {
+            "nplus_residual_min_z": cfg.NPLUS_RESIDUAL_MIN_Z,
+            "confound_residual_max_z": cfg.CONFOUND_RESIDUAL_MAX_Z,
+        },
+        "real_dataset_bound": False,
+        "config_hash": cfg_hash,
+    }
+    result["repro_hash"] = _repro_hash(
+        {"verdict": verdict, "config_hash": cfg_hash, "self_validation": sv}
+    )
+    return result
+
+
+def write_evidence(result: dict[str, Any]) -> str:
+    cfg.V2_RESULT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    cfg.V2_RESULT_PATH.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n")
+    return str(cfg.V2_RESULT_PATH)
+
+
+def main() -> None:
+    result = run()
+    path = write_evidence(result)
+    sv = result["self_validation"]
+    print(f"EXPERIMENT: {result['experiment_id']}  ESTIMATOR: {sv['estimator_version']}")
+    print(f"VERDICT: {result['verdict']}")
+    print(
+        "SELF-VALIDATION: nplus_z="
+        f"{sv['mean_nplus_residual_z']:.3f} (min {cfg.NPLUS_RESIDUAL_MIN_Z}) "
+        f"max_confound_z={sv['max_confound_residual_z']:.3f} "
+        f"(max {cfg.CONFOUND_RESIDUAL_MAX_Z}) "
+        f"recovered={sv['nplus_recovered']} clean={sv['confounds_not_flagged']}"
+    )
+    print(f"REPRO HASH: {result['repro_hash']}")
+    print(f"ARTIFACT: {path}")
+    print(
+        "NEXT: if recovered -> C4 bind pre-committed real LFP+spike dataset; "
+        "if still blind -> next estimator family. No threshold tuning."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/research/ctc_falsify/l2/schema/ctc_falsify_l2v2_result.schema.json
+++ b/research/ctc_falsify/l2/schema/ctc_falsify_l2v2_result.schema.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "research/ctc_falsify/l2/schema/ctc_falsify_l2v2_result.schema.json",
+  "title": "CTC-FALSIFY-001-L2V2 result",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "experiment_id",
+    "verdict",
+    "estimator",
+    "claim",
+    "boundary",
+    "self_validation",
+    "thresholds",
+    "real_dataset_bound",
+    "config_hash",
+    "repro_hash"
+  ],
+  "properties": {
+    "experiment_id": { "const": "CTC-FALSIFY-001-L2V2" },
+    "verdict": {
+      "type": "string",
+      "enum": [
+        "INADMISSIBLE_NO_PAIRED_DATA",
+        "INADMISSIBLE_DATASET_UNSUITABLE",
+        "INADMISSIBLE_SURROGATE_MISMATCH",
+        "INADMISSIBLE_NPLUS_INSITU_BLIND",
+        "INADMISSIBLE_UNDERPOWERED",
+        "KILLED_SCOPED",
+        "SURVIVED_INITIAL"
+      ]
+    },
+    "estimator": { "type": "string", "minLength": 1 },
+    "claim": { "type": "string", "minLength": 1 },
+    "boundary": { "type": "string", "minLength": 1 },
+    "self_validation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "estimator_version",
+        "mean_nplus_residual_z",
+        "max_confound_residual_z",
+        "nplus_recovered",
+        "confounds_not_flagged",
+        "n_validation_seeds"
+      ],
+      "properties": {
+        "estimator_version": { "type": "string", "minLength": 1 },
+        "mean_nplus_residual_z": { "type": "number" },
+        "max_confound_residual_z": { "type": "number" },
+        "nplus_recovered": { "type": "boolean" },
+        "confounds_not_flagged": { "type": "boolean" },
+        "n_validation_seeds": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "thresholds": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["nplus_residual_min_z", "confound_residual_max_z"],
+      "properties": {
+        "nplus_residual_min_z": { "type": "number" },
+        "confound_residual_max_z": { "type": "number" }
+      }
+    },
+    "real_dataset_bound": { "type": "boolean" },
+    "config_hash": { "type": "string", "pattern": "^[a-f0-9]{64}$" },
+    "repro_hash": { "type": "string", "pattern": "^[a-f0-9]{64}$" }
+  }
+}

--- a/tests/research/ctc_falsify/test_ctc_falsify_l2v2.py
+++ b/tests/research/ctc_falsify/test_ctc_falsify_l2v2.py
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: MIT
+"""C3 construct-validity guards: the v2 time-reversed-surrogate estimator.
+
+Honest reference state (NO threshold tuning): v2 is also blind by its own
+pre-registered positive-control gate -> INADMISSIBLE_NPLUS_INSITU_BLIND.
+Two orthogonal estimators (v1, v2) now fail; the boundary probe shows the
+channel IS recoverable in principle, so the blindness is a manifestation
+property of the standard estimands, not a ground-truth defect.
+"""
+
+from __future__ import annotations
+
+import json
+
+import numpy as np
+import pytest
+from jsonschema import Draft202012Validator
+from scipy.signal import butter, hilbert, sosfiltfilt
+
+from research.ctc_falsify import config as l1
+from research.ctc_falsify.generative import draw_n_plus, draw_null
+from research.ctc_falsify.l2 import config_l2 as cfg
+from research.ctc_falsify.l2.estimator_v2 import directed_residual_v2, time_reversed_surrogates
+from research.ctc_falsify.l2.gates_l2 import decide_l2
+from research.ctc_falsify.l2.run_v2 import run, run_self_validation_v2
+
+pytestmark = pytest.mark.slow
+
+
+@pytest.fixture(scope="module")
+def result() -> dict[str, object]:
+    return run()
+
+
+def test_schema_validates(result: dict[str, object]) -> None:
+    schema = json.loads(cfg.V2_SCHEMA_PATH.read_text())
+    Draft202012Validator.check_schema(schema)
+    Draft202012Validator(schema).validate(result)
+
+
+def test_v2_reference_is_blind_and_fails_closed(result: dict[str, object]) -> None:
+    """No post-hoc tuning: v2 does not clear its own gate -> the verdict is
+    the fail-closed INADMISSIBLE_NPLUS_INSITU_BLIND."""
+    v = run_self_validation_v2()
+    blind = (
+        v.mean_nplus_residual_z < cfg.NPLUS_RESIDUAL_MIN_Z
+        or v.max_confound_residual_z > cfg.CONFOUND_RESIDUAL_MAX_Z
+    )
+    assert blind, "v2 unexpectedly admissible — re-pre-register before claiming recovery"
+    assert result["verdict"] == cfg.VERDICT_INADMISSIBLE_NPLUS_INSITU_BLIND
+    assert decide_l2(v, real_dataset_bound=True) == cfg.VERDICT_INADMISSIBLE_NPLUS_INSITU_BLIND
+
+
+def test_time_reversed_surrogate_preserves_power_spectrum() -> None:
+    """Time reversal must preserve |FFT| exactly (rate/SNR/common-drive
+    matched by construction) — the whole point of the v2 surrogate."""
+    sig = draw_n_plus(l1.SEED)
+    surr = time_reversed_surrogates(sig, l1.SEED)
+    assert surr.shape == (cfg.N_SURROGATE, sig.sig_b.shape[0])
+    p_obs = np.abs(np.fft.rfft(sig.sig_b))
+    p_rev = np.abs(np.fft.rfft(sig.sig_b[::-1]))
+    np.testing.assert_allclose(np.sort(p_obs), np.sort(p_rev), rtol=1e-9, atol=1e-9)
+
+
+def test_residual_is_finite_and_well_formed() -> None:
+    r = directed_residual_v2(draw_n_plus(l1.SEED), l1.SEED)
+    assert np.isfinite(r.residual_z)
+    assert r.surrogate_std_abs >= 0.0
+
+
+def test_boundary_probe_channel_is_recoverable_in_principle() -> None:
+    """Manifestation-vs-boundary: a privileged mean-gamma-phase-offset
+    estimator must SEPARATE N+ from common-drive — proving the blindness of
+    v1/v2 is an estimand property, not a ground-truth defect."""
+
+    def _bp(x: np.ndarray) -> np.ndarray:
+        fs = 1.0 / l1.DT
+        lo = (l1.F0 - l1.GAMMA_BAND_HALFWIDTH) / (fs / 2.0)
+        hi = (l1.F0 + l1.GAMMA_BAND_HALFWIDTH) / (fs / 2.0)
+        sos = butter(4, [lo, hi], btype="band", output="sos")
+        return np.asarray(sosfiltfilt(sos, x), dtype=np.float64)
+
+    def _offset(sig_a: np.ndarray, sig_b: np.ndarray) -> float:
+        pa = np.unwrap(np.angle(hilbert(_bp(sig_a))))
+        pb = np.unwrap(np.angle(hilbert(_bp(sig_b))))
+        return float(np.mean(pa - pb))
+
+    nplus = [_offset(s.sig_a, s.sig_b) for s in (draw_n_plus(l1.SEED + i) for i in range(5))]
+    n1 = [
+        _offset(s.sig_a, s.sig_b)
+        for s in (draw_null(l1.SEED + i, "N1_COMMON_DRIVE") for i in range(5))
+    ]
+    # The privileged estimator separates the populations even though v1/v2 do not.
+    assert abs(np.mean(nplus) - np.mean(n1)) > 0.5
+
+
+def test_config_single_source() -> None:
+    import research.ctc_falsify.l2.config_l2 as ssot
+    import research.ctc_falsify.l2.run_v2 as run_mod
+
+    for name in ("PSI_NPERSEG", "NPLUS_RESIDUAL_MIN_Z", "ESTIMATOR_VERSION"):
+        assert not hasattr(run_mod, name), f"{name} duplicated outside config_l2"
+    assert ssot is cfg


### PR DESCRIPTION
## What this is

C3 of CTC-FALSIFY-001 (L1 #748, L2 #750 merged). Replaces the L2 v1
residual estimator (phase-randomization — blind) with a **time-reversed
-surrogate directed Phase-Slope Index** (Nolte 2008; Schreiber-Schmitz).
**Same admissibility bar — no threshold tuning** (relaxing it = #199 rescue).

## Honest reference outcome

`verdict = INADMISSIBLE_NPLUS_INSITU_BLIND`. v2 self-validation: N⁺
`residual_z ≈ 0.15` (< 3.0), worst confound `≈ 2.52` (> 1.96). **v2 is also
blind by its own gate.** Reported as-is.

## Manifestation→boundary elevation (the C3 finding)

Two orthogonal standard estimators now fail identically:

| estimator | N⁺ z | worst confound z | verdict |
|---|---|---|---|
| v1 phase-randomization PLV-residual | ≈1.6 | ≈2.7 | BLIND |
| v2 time-reversed directed PSI | ≈0.15 | ≈2.52 | BLIND |

**Boundary probe** (privileged mean-gamma-phase-offset) cleanly separates
N⁺ (≈ −1.38 rad) from common-drive (≈ +0.26 rad); xcorr lag ≈ −251 samples.
⇒ the channel **is recoverable in principle**; the blindness is a
**manifestation property of the standard CTC estimands**, not a ground-truth
defect. Recorded as a *hypothesis* (in-silico, N=2), not a theory claim.

## C4 (pre-registered, pre-data)

ONE principled estimator — the mean-gamma-phase-offset *residual* the
boundary probe identified. If it clears the gate → estimator admissible
(`INADMISSIBLE_NO_PAIRED_DATA`; C5 binds data). If it too is blind → stop
estimator iteration (N≥3 convergent) and elevate to a boundary-conditions
writeup. No trial-and-error tuning.

## Provenance / gates

- SSOT `config_l2.py` (`ESTIMATOR_VERSION=v2_time_reversed_psi`); JSON schema; `repro_hash` binds verdict.
- Research line `ctc_falsify_001` continues (OPEN, same line_id).
- Diff-bound acceptor `ctc-falsify-c3`; detect-secrets baseline updated.
- Local: ruff+black+mypy --strict clean; 6 construct-validity tests (slow → heavy gate); schema validates. Isolated worktree off merged main.

## Honesty invariant

If a principled estimator recovers N⁺ and the real-data CTC residual later
survives the jointly-matched null — we report **survival**, not spin.

claim_status: hypothesized (in-silico; estimands blind by their own gates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)