### PR TITLE
test(calib): de-flake CALIB-GRID-001 R1 determinism test (tolerant numeric compare)

### DIFF
--- a/.claude/commit_acceptors/calib-grid-r1-determinism.yaml
+++ b/.claude/commit_acceptors/calib-grid-r1-determinism.yaml
@@ -1,0 +1,28 @@
+# Diff-bound commit acceptor: CALIB-GRID-001 R1 determinism-test de-flake.
+id: calib-grid-r1-determinism
+status: ACTIVE
+claim_type: determinism
+promise: "test_r1_results_json_matches_committed_artifact compares the committed R1 artifact with numeric tolerance (rel 1e-9) instead of exact ==, removing BLAS float-order flakiness while still detecting real post-data edits; calib scientific logic and the artifact are untouched."
+diff_scope:
+  changed_files:
+    - path: "tests/research/calibration/test_grid_kuramoto.py"
+    - path: ".claude/commit_acceptors/calib-grid-r1-determinism.yaml"
+  forbidden_paths:
+    - "trading/"
+    - "execution/"
+    - "forecast/"
+    - "policy/"
+    - "research/calibration/grid_kuramoto/r1/RESULTS.json"
+required_python_symbols: []
+expected_signal: "the R1 determinism test passes deterministically across BLAS thread orders"
+measurement_command: "python -m pytest tests/research/calibration/test_grid_kuramoto.py::test_r1_results_json_matches_committed_artifact -q"
+signal_artifact: "tmp/calib_grid_r1_determinism_pytest.log"
+falsifier:
+  command: "python -c \"from tests.research.calibration.test_grid_kuramoto import _deep_close; raise SystemExit(0 if not _deep_close([{'x':1.0}],[{'x':1.05}]) else 1)\""
+  description: "Probe asserts the tolerant comparator still REJECTS a 5% edit (exits 0); it would exit 1 if the tolerance were so wide it masked real post-data edits."
+rollback_command: "git checkout -- tests/research/calibration/test_grid_kuramoto.py"
+rollback_verification_command: "git diff --exit-code tests/research/calibration/test_grid_kuramoto.py"
+memory_update_type: none
+ledger_path: ".claude/commit_acceptors/calib-grid-r1-determinism.yaml"
+report_path: ".claude/commit_acceptors/calib-grid-r1-determinism.yaml"
+evidence: []

--- a/tests/research/calibration/test_grid_kuramoto.py
+++ b/tests/research/calibration/test_grid_kuramoto.py
@@ -12,6 +12,7 @@ instrument itself is sound, and the stable NEGATIVE verdict ledger.
 from __future__ import annotations
 
 import json
+import math
 import re
 from pathlib import Path
 from typing import Any
@@ -602,6 +603,25 @@ def test_r1_ledger_is_machine_readable_and_sha_pinned() -> None:
     assert ledger["localized_refinement_targets"]
 
 
+def _deep_close(a: Any, b: Any, *, rel: float = 1e-9, abs_: float = 1e-12) -> bool:
+    """Structure-exact, numeric-tolerant equality.
+
+    Floating reductions (BLAS thread order) jitter at ~1e-13; an exact
+    ``==`` on the committed R1 artifact made the determinism test flaky.
+    Strings/bools/ints/keys/shape stay exact; floats compare within a
+    tolerance tight enough (rel 1e-9) to still catch a real post-data edit.
+    """
+    if isinstance(a, bool) or isinstance(b, bool):
+        return a is b
+    if isinstance(a, float) or isinstance(b, float):
+        return math.isclose(float(a), float(b), rel_tol=rel, abs_tol=abs_)
+    if isinstance(a, dict) and isinstance(b, dict):
+        return a.keys() == b.keys() and all(_deep_close(a[k], b[k], rel=rel, abs_=abs_) for k in a)
+    if isinstance(a, (list, tuple)) and isinstance(b, (list, tuple)):
+        return len(a) == len(b) and all(_deep_close(x, y, rel=rel, abs_=abs_) for x, y in zip(a, b))
+    return bool(a == b)
+
+
 def test_r1_results_json_matches_committed_artifact() -> None:
     """The committed r1/RESULTS.json verdict/gates match a fresh build.
 
@@ -621,5 +641,5 @@ def test_r1_results_json_matches_committed_artifact() -> None:
     committed = json.loads(art.read_text(encoding="utf-8"))
     fresh = build_r1_ledger(wscc_9_bus(), SimConfig())
     assert committed["verdict"] == fresh["verdict"] == "NEGATIVE"
-    assert committed["gates"] == fresh["gates"]
-    assert committed["metrics"] == fresh["metrics"]
+    assert _deep_close(committed["gates"], fresh["gates"])
+    assert _deep_close(committed["metrics"], fresh["metrics"])


### PR DESCRIPTION
## Problem

`tests/research/calibration/test_grid_kuramoto.py::test_r1_results_json_matches_committed_artifact`
asserted `committed == fresh` (exact) on the committed R1 JSON artifact.
BLAS thread-order float reductions jitter at ~1e-13
(`0.0665563875240445` vs `0.06655638752417228`) → **flaky red on every
PR branched off main** (blocked CTC #752 among others).

## Fix (determinism only — no science touched)

`_deep_close`: structure/keys/bools/ints **exact**; floats within
`rel 1e-9 / abs 1e-12` — tight enough to still catch a real post-data
edit (falsifier in the acceptor rejects a 5 % edit). `verdict` stays
exact. `research/calibration/grid_kuramoto/r1/RESULTS.json` is a
**forbidden_path** in the acceptor — the artifact and all calib
scientific logic are untouched.

## Out of scope — flagged honestly, not masked

A Hypothesis counterexample exists for
`test_property_swing_exact_recovery_matched_noiseless`: the swing
estimator recovers K with `k_rel ≥ 0.10` on some weakly-exciting random
`theta0`. It is **not** a CI blocker (`.hypothesis` DB is local-only;
fresh CI runs pass) and is **not** float jitter — it is a latent
**calib-instrument robustness** question (real fragility vs an
unconditional property too strong). Owned by the CALIB line; deliberately
**not** widened/`assume()`-skipped here (masking it would be the failure
class this repo exists to prevent).

## Verification

ruff + black + mypy clean; the de-flaked determinism test passes; calib
fast suite green. Diff-bound acceptor `calib-grid-r1-determinism`
(claim_type determinism).

claim_status: measured (the de-flake is verified; the property-fragility
is reported as an open calib signal, not resolved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)