### PR TITLE
docs(ctc): CTC-FALSIFY-001 consolidated negative-as-product

### DIFF
--- a/.claude/commit_acceptors/ctc-falsify-results.yaml
+++ b/.claude/commit_acceptors/ctc-falsify-results.yaml
@@ -1,0 +1,29 @@
+# Diff-bound commit acceptor: CTC-FALSIFY-001 consolidated result doc.
+id: ctc-falsify-results
+status: ACTIVE
+claim_type: documentation
+promise: "RESULTS.md consolidates the in-silico L1->L2->C3 arc into one scoped, provenance-pinned, hypothesis-level negative; it adds no code and asserts explicitly it is NOT a CTC-theory verdict and NOT real data."
+diff_scope:
+  changed_files:
+    - path: "research/ctc_falsify/RESULTS.md"
+    - path: ".claude/commit_acceptors/ctc-falsify-results.yaml"
+  forbidden_paths:
+    - "trading/"
+    - "execution/"
+    - "forecast/"
+    - "policy/"
+    - "research/ctc_falsify/config.py"
+    - "research/ctc_falsify/l2/config_l2.py"
+required_python_symbols: []
+expected_signal: "RESULTS.md present, references the three merged SHAs, and states the OPEN line + non-verdict scope"
+measurement_command: "grep -c 'INADMISSIBLE_NPLUS_INSITU_BLIND' research/ctc_falsify/RESULTS.md"
+signal_artifact: "tmp/ctc_results_grep.log"
+falsifier:
+  command: "grep -qF 'verdict on the Communication-through-Coherence (CTC) theory' research/ctc_falsify/RESULTS.md && grep -qF 'stays **OPEN**' research/ctc_falsify/RESULTS.md && grep -qF '5ba34fd7' research/ctc_falsify/RESULTS.md"
+  description: "Asserts the artifact keeps its honest scope (explicit non-verdict, OPEN line, pinned C3 SHA). Fails if the document is silently promoted into a theory claim or de-provenanced."
+rollback_command: "git rm -f research/ctc_falsify/RESULTS.md"
+rollback_verification_command: "test ! -e research/ctc_falsify/RESULTS.md"
+memory_update_type: none
+ledger_path: ".claude/commit_acceptors/ctc-falsify-results.yaml"
+report_path: "research/ctc_falsify/RESULTS.md"
+evidence: []

--- a/research/ctc_falsify/RESULTS.md
+++ b/research/ctc_falsify/RESULTS.md
@@ -1,0 +1,64 @@
+# CTC-FALSIFY-001 — Consolidated Result (in-silico, scoped, hypothesis-level)
+
+**Status: a finished negative-as-product.** This document closes the
+in-silico arc (L1 → L2 → C3) into one defensible finding. It is **not** a
+verdict on the Communication-through-Coherence (CTC) theory and **not** a
+real-data result. It is a scoped statement about *instruments*.
+
+## Claim actually established
+
+> On a physics-grounded generative ground truth with a *known, toggleable*
+> directed A→B gamma-phase channel, **two orthogonal standard CTC estimands
+> are blind to that channel by their own pre-registered positive-control
+> gate, while a privileged mean-gamma-phase-offset estimator separates the
+> channel cleanly.** Therefore the blindness is a property of the standard
+> estimands, not of the ground truth.
+
+Epistemic tier: **INFERENCE / hypothesis** (in-silico, generative model,
+N=2 estimator families). NOT a theory falsification. NOT real electrophysiology.
+
+## Method (provenance-pinned)
+
+| Layer | What | Merged | SHA |
+|---|---|---|---|
+| L1 | Two-population Sakaguchi–Kuramoto generative GT + confound nulls N1/N2/N3 + N⁺ + standard PLV/coherence pipeline; fail-closed gates | PR #748 | `cbfd1abe` |
+| L2 | Standardized-residual layer, jointly-matched surrogate, 8 self-audit fixes as gates (v1 phase-randomization estimator) | PR #750 | `eb521856` |
+| C3 | v2 time-reversed-surrogate directed Phase-Slope Index estimator + boundary probe | PR #752 | `5ba34fd7` |
+
+Supporting infra (separate, honest, not bundled): calib determinism de-flake
+(`39916212`, #753), pytest-9-safe sharded fast-gate (`d123b8ea`, #754).
+
+## Results
+
+| Estimator | N⁺ residual | worst confound | verdict |
+|---|---|---|---|
+| v1 phase-randomization PLV-residual | z ≈ 1.6 (< 3.0) | z ≈ 2.7 (> 1.96) | `INADMISSIBLE_NPLUS_INSITU_BLIND` |
+| v2 time-reversed directed PSI | z ≈ 0.15 (< 3.0) | z ≈ 2.5 (> 1.96) | `INADMISSIBLE_NPLUS_INSITU_BLIND` |
+| **boundary probe** (privileged mean γ-phase offset) | N⁺ ≈ −1.38 rad vs N1 ≈ +0.26 rad; xcorr lag ≈ −251 samples | — | **channel recoverable** |
+
+Both standard estimands fail their own pre-registered gate **without any
+threshold tuning** (tuning would be a #199-class rescue and is forbidden by
+the acceptor falsifiers). The instruments killed their own hypotheses.
+
+## What this is NOT
+
+- NOT "CTC is false." The theory is untouched; only the standard *evidential
+  estimands* are shown blind on this generative model.
+- NOT a real-data finding. No electrophysiology was bound.
+- NOT a closed research line. `ctc_falsify_001` stays **OPEN**.
+
+## Honesty invariant
+
+If a principled estimator recovers N⁺ and, on real data, the CTC residual
+survives the jointly-matched null — that **survival is reported, not spun**.
+Symmetric thresholds, identical template. The machine is audience-blind.
+
+## Next (only if it sharpens the truth — not reflexive continuation)
+
+C4/C5 is justified **only** to test whether the privileged
+phase-offset estimator (the one the boundary probe identified) remains
+admissible and whether the blindness reproduces on **real** paired
+LFP+spike data under a pre-committed dataset rule. Absent that, this
+document is the terminal artifact: a scoped, provenance-pinned,
+hypothesis-level negative about standard CTC estimands. One proven
+negative, delivered — not an open cycle.


### PR DESCRIPTION
Closes the in-silico L1→L2→C3 arc into ONE finished, scoped,
provenance-pinned, hypothesis-level negative — instead of spawning
another open cycle.

**Finding:** on a physics-grounded generative ground truth with a known
toggleable directed γ-phase channel, two orthogonal standard CTC
estimands (v1 phase-randomization PLV-residual, v2 time-reversed PSI)
are blind by their own pre-registered gates, while a privileged
mean-γ-phase-offset estimator recovers the channel → blindness is an
**estimand property, not a ground-truth defect**.

**Scope (explicit):** NOT a CTC-theory verdict. NOT real data. Line
`ctc_falsify_001` stays OPEN. Tier: INFERENCE/hypothesis, in-silico, N=2.

Provenance-pinned: #748 `cbfd1abe` / #750 `eb521856` / #752 `5ba34fd7`.
Docs-only + diff-bound acceptor (claim_type documentation); falsifier
asserts the honesty anchors (non-verdict scope, OPEN line, pinned SHA)
cannot be silently stripped.

claim_status: measured (the in-silico negative is measured and bounded;
no theory claim, no real-data claim)

🤖 Generated with [Claude Code](https://claude.com/claude-code)