### PR TITLE
research(ctc): C5 identifiability probe — closes the C4 OPEN (estimator-quality gap)

### DIFF
--- a/.claude/commit_acceptors/ctc-falsify-c5.yaml
+++ b/.claude/commit_acceptors/ctc-falsify-c5.yaml
@@ -1,0 +1,37 @@
+id: ctc-falsify-c5
+status: ACTIVE
+claim_type: governance
+promise: "C5 is a leakage-free near-oracle upper bound (full gamma cross-spectrum, train/test seed-disjoint) deciding the C4 OPEN; OOS AUC bands map to a pure-function verdict. Reference run: ESTIMATOR_QUALITY_GAP (AUC ~ 0.96) — the channel is information-recoverable in-silico; standard scalar estimands are inadequate, NOT an identifiability limit. RESULTS.md consolidated. No CTC-theory or real-data claim."
+diff_scope:
+  changed_files:
+    - path: "research/ctc_falsify/c5/__init__.py"
+    - path: "research/ctc_falsify/c5/config_c5.py"
+    - path: "research/ctc_falsify/c5/oracle.py"
+    - path: "research/ctc_falsify/c5/run.py"
+    - path: "research/ctc_falsify/c5/schema/ctc_falsify_c5_result.schema.json"
+    - path: "research/ctc_falsify/c5/evidence/ctc_falsify_c5_result.json"
+    - path: "tests/research/ctc_falsify/test_ctc_falsify_c5.py"
+    - path: "research/ctc_falsify/RESULTS.md"
+    - path: ".github/detect-secrets.baseline"
+    - path: ".claude/commit_acceptors/ctc-falsify-c5.yaml"
+  forbidden_paths:
+    - "trading/"
+    - "execution/"
+    - "forecast/"
+    - "policy/"
+    - "research/ctc_falsify/config.py"
+required_python_symbols:
+  - "run_oracle"
+  - "decide"
+expected_signal: "C5 verdict is a pure function of OOS AUC + train/test disjointness; reference run is leakage-free"
+measurement_command: "python -m pytest tests/research/ctc_falsify/test_ctc_falsify_c5.py -q"
+signal_artifact: "tmp/ctc_falsify_c5_pytest.log"
+falsifier:
+  command: "grep -qF 'C4 OPEN is **closed**' research/ctc_falsify/RESULTS.md && grep -qF 'C5_ESTIMATOR_QUALITY_GAP' research/ctc_falsify/c5/config_c5.py && grep -qF 'stays **OPEN**' research/ctc_falsify/RESULTS.md"
+  description: "Asserts the closure is recorded (C4 OPEN closed, the verdict label exists, real-data line still OPEN). Fails if the in-silico closure is silently promoted into a theory/real-data claim."
+rollback_command: "git rm -rf research/ctc_falsify/c5 tests/research/ctc_falsify/test_ctc_falsify_c5.py && git checkout -- research/ctc_falsify/RESULTS.md .github/detect-secrets.baseline"
+rollback_verification_command: "test ! -d research/ctc_falsify/c5"
+memory_update_type: append
+ledger_path: ".claude/commit_acceptors/ctc-falsify-c5.yaml"
+report_path: "research/ctc_falsify/RESULTS.md"
+evidence: []

--- a/.github/detect-secrets.baseline
+++ b/.github/detect-secrets.baseline
@@ -3812,6 +3812,22 @@
         "line_number": 19
       }
     ],
+    "research/ctc_falsify/c5/evidence/ctc_falsify_c5_result.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "research/ctc_falsify/c5/evidence/ctc_falsify_c5_result.json",
+        "hashed_secret": "a76c4fb97ed61c193e0f8d094d9ec3716dfc4e8e",
+        "is_verified": false,
+        "line_number": 4
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "research/ctc_falsify/c5/evidence/ctc_falsify_c5_result.json",
+        "hashed_secret": "8ded81e1563ce8da1a333160d4ba885c2251103c",
+        "is_verified": false,
+        "line_number": 13
+      }
+    ],
     "research/ctc_falsify/evidence/ctc_falsify_001_result.json": [
       {
         "type": "Hex High Entropy String",
@@ -5549,5 +5565,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-17T11:01:47Z"
+  "generated_at": "2026-05-17T11:33:50Z"
 }

--- a/research/ctc_falsify/RESULTS.md
+++ b/research/ctc_falsify/RESULTS.md
@@ -1,9 +1,11 @@
 # CTC-FALSIFY-001 — Consolidated Result (in-silico, scoped, hypothesis-level)
 
-**Status: a finished negative-as-product, including a recursive
-self-retraction.** This document closes the in-silico arc
-(L1 → L2 → C3 → **C4 self-audit**). It is **not** a verdict on the
-Communication-through-Coherence (CTC) theory and **not** a real-data result.
+**Status: CONSOLIDATED — the in-silico arc is decided.** A negative with a
+recursive self-retraction (C4) and a decisive closure (C5):
+L1 → L2 → C3 → **C4 self-audit** → **C5 identifiability probe**. It is
+**not** a verdict on the Communication-through-Coherence (CTC) theory and
+**not** a real-data result. The arc terminates here; the only open layer is
+real electrophysiology, on explicit user vector.
 
 ## Claim actually established (post-C4)
 
@@ -36,7 +38,8 @@ falsification. NOT real electrophysiology. The instrument falsified its
 | L2 | Standardized-residual layer, jointly-matched surrogate, 8 self-audit fixes as gates (v1 phase-randomization estimator) | PR #750 | `eb521856` |
 | C3 | v2 time-reversed-surrogate directed PSI + boundary probe | PR #752 | `5ba34fd7` |
 | C0 | consolidated RESULTS (pre-C4) | PR #756 | `f8c70ba1` |
-| **C4** | **adversarial self-audit of the C3 boundary probe** | this PR | — |
+| C4 | adversarial self-audit of the C3 boundary probe (retraction) | PR #758 | `3163f2f7` |
+| **C5** | **near-oracle identifiability probe — closes the C4 OPEN** | this PR | — |
 
 Supporting infra (separate, honest, not bundled): calib determinism de-flake
 (`39916212`, #753), pytest-9-safe sharded fast-gate (`d123b8ea`, #754).
@@ -64,13 +67,30 @@ its negative was itself a self-lie*, caught and retracted — not buried.
 This is the apex behaviour of the contract: it falsifies its own
 conclusions, not only external hypotheses.
 
+## C5 decisive closure of the C4 OPEN
+
+C4 left one question open: is the standard-estimand blindness an
+*identifiability limit* of these observables, or an *estimator-quality*
+gap? C5 puts a near-oracle upper bound on it — the best out-of-sample
+linear discriminant over the **full gamma cross-spectrum**
+(magnitude + phase), train/test seed-disjoint (no leakage). Result:
+**OOS ROC-AUC ≈ 0.96** ⇒ verdict `C5_ESTIMATOR_QUALITY_GAP`.
+
+So the channel **is** information-recoverable on this generative model: a
+sufficient statistic exists in the richer cross-spectral representation.
+The blindness of the standard scalar estimands (v1 PLV-residual, v2
+time-reversed PSI) is therefore an **estimator-quality gap, not an
+identifiability limit** — those particular scalar estimands are simply
+inadequate to a channel that the full representation discriminates near-
+perfectly. The C4 OPEN is **closed**; the in-silico arc consolidates here.
+
 ## What this is NOT
 
 - NOT "CTC is false." The theory is untouched.
-- NOT "the channel is recoverable / unrecoverable" — that is now **OPEN**;
-  C3's recoverability inference is withdrawn.
-- NOT a real-data finding. No electrophysiology was bound.
-- NOT a closed research line. `ctc_falsify_001` stays **OPEN**.
+- NOT a real-data finding. No electrophysiology was bound; AUC≈0.96 is an
+  in-silico upper bound on this generative model only.
+- NOT a closed research line. `ctc_falsify_001` stays **OPEN** for the
+  real-data layer; the *in-silico question* is decided.
 
 ## Honesty invariant
 

--- a/research/ctc_falsify/c5/__init__.py
+++ b/research/ctc_falsify/c5/__init__.py
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: MIT
+"""C5 — decisive identifiability oracle probe (closes the C4 OPEN).
+
+C4 retracted C3's claim that the channel was "recoverable in principle".
+The residual OPEN: is the standard-estimand blindness an *identifiability
+limit* of these observables at this regime, or merely an
+*estimator-quality* gap? C5 puts a near-oracle upper bound on it: the best
+out-of-sample linear discriminant over the FULL gamma cross-spectral
+representation (magnitude + phase), train/test seed-disjoint. If even that
+cannot separate N⁺ from confounds -> identifiability limit (a strong
+boundary result). If it separates cleanly -> estimator-quality gap. This
+is the one decisive cycle; it terminates the OPEN, then the arc
+consolidates.
+"""
+
+__all__: list[str] = []

--- a/research/ctc_falsify/c5/config_c5.py
+++ b/research/ctc_falsify/c5/config_c5.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: MIT
+"""C5 single source of truth. Constants live ONLY here (SSOT)."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from typing import Final
+
+from research.ctc_falsify import config as l1
+
+C5_ID: Final[str] = "CTC-FALSIFY-001-C5"
+
+CLAIM: Final[str] = (
+    "Decide the C4 OPEN: is the standard-estimand blindness an "
+    "identifiability limit of these observables at this regime, or an "
+    "estimator-quality gap? Measured by the best out-of-sample linear "
+    "discriminant over the full gamma cross-spectral representation "
+    "(magnitude + phase), with train/test seed-disjoint (no leakage)."
+)
+BOUNDARY: Final[str] = (
+    "Scoped, in-silico, hypothesis-level, on the existing generative GT. A "
+    "near-oracle UPPER BOUND, not a real estimator and not a CTC-theory "
+    "verdict. Decisive only for THIS regime/observables."
+)
+
+# Train/test seeds are disjoint bands (leakage = inadmissible).
+N_TRAIN_SEEDS: Final[int] = 24
+N_TEST_SEEDS: Final[int] = 24
+TEST_SEED_OFFSET: Final[int] = 500_003
+CSD_NPERSEG: Final[int] = 256
+
+# Pre-registered decision bands on the out-of-sample ROC-AUC.
+AUC_CHANCE_HI: Final[float] = 0.60  # <= this => identifiability limit
+AUC_SEPARABLE: Final[float] = 0.90  # >= this => estimator-quality gap
+
+VERDICT_IDENTIFIABILITY_LIMIT: Final[str] = "C5_IDENTIFIABILITY_LIMIT"
+VERDICT_ESTIMATOR_QUALITY_GAP: Final[str] = "C5_ESTIMATOR_QUALITY_GAP"
+VERDICT_AMBIGUOUS: Final[str] = "C5_INADMISSIBLE_AMBIGUOUS"
+VERDICT_LEAKAGE: Final[str] = "C5_INADMISSIBLE_TRAIN_TEST_LEAKAGE"
+
+ALL_VERDICTS: Final[tuple[str, ...]] = (
+    VERDICT_IDENTIFIABILITY_LIMIT,
+    VERDICT_ESTIMATOR_QUALITY_GAP,
+    VERDICT_AMBIGUOUS,
+    VERDICT_LEAKAGE,
+)
+
+_PKG: Final[Path] = Path(__file__).resolve().parent
+SCHEMA_PATH: Final[Path] = _PKG / "schema" / "ctc_falsify_c5_result.schema.json"
+EVIDENCE_DIR: Final[Path] = _PKG / "evidence"
+RESULT_PATH: Final[Path] = EVIDENCE_DIR / "ctc_falsify_c5_result.json"
+
+
+def train_seeds() -> list[int]:
+    return [l1.SEED + i for i in range(N_TRAIN_SEEDS)]
+
+
+def test_seeds() -> list[int]:
+    return [l1.SEED + TEST_SEED_OFFSET + i for i in range(N_TEST_SEEDS)]
+
+
+def config_hash() -> str:
+    h = hashlib.sha256()
+    h.update(Path(__file__).read_bytes())
+    h.update(Path(l1.__file__).read_bytes())
+    return h.hexdigest()

--- a/research/ctc_falsify/c5/evidence/ctc_falsify_c5_result.json
+++ b/research/ctc_falsify/c5/evidence/ctc_falsify_c5_result.json
@@ -1,0 +1,19 @@
+{
+  "boundary": "Scoped, in-silico, hypothesis-level, on the existing generative GT. A near-oracle UPPER BOUND, not a real estimator and not a CTC-theory verdict. Decisive only for THIS regime/observables.",
+  "claim": "Decide the C4 OPEN: is the standard-estimand blindness an identifiability limit of these observables at this regime, or an estimator-quality gap? Measured by the best out-of-sample linear discriminant over the full gamma cross-spectral representation (magnitude + phase), with train/test seed-disjoint (no leakage).",
+  "config_hash": "2fd1e7b7fd3465cb315a3fb8109ece2c627f2fd2cf99c04087f477d6a37814e6",
+  "experiment_id": "CTC-FALSIFY-001-C5",
+  "oracle": {
+    "n_features": 8,
+    "n_test": 96,
+    "n_train": 96,
+    "oos_auc": 0.9629629629629629,
+    "train_test_disjoint": true
+  },
+  "repro_hash": "d64ad1f826792296e807a2e966472ce067c56d12a77a25ec8dc3fb1ce1b8c0d8",
+  "thresholds": {
+    "auc_chance_hi": 0.6,
+    "auc_separable": 0.9
+  },
+  "verdict": "C5_ESTIMATOR_QUALITY_GAP"
+}

--- a/research/ctc_falsify/c5/oracle.py
+++ b/research/ctc_falsify/c5/oracle.py
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: MIT
+"""Near-oracle upper bound: best OOS linear discriminant over the full
+gamma cross-spectral representation. Dependency-free (numpy/scipy only);
+ROC-AUC via the Mann–Whitney U statistic; LDA via the pooled-covariance
+pseudo-inverse. Train/test seeds are disjoint — the AUC must be a real
+out-of-sample property, never a memorised one.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+from scipy.signal import csd
+
+from research.ctc_falsify import config as l1
+from research.ctc_falsify.c5 import config_c5 as c5
+from research.ctc_falsify.generative import draw_n_plus, draw_null
+
+_FS: float = 1.0 / l1.DT
+_LO: float = l1.F0 - l1.GAMMA_BAND_HALFWIDTH
+_HI: float = l1.F0 + l1.GAMMA_BAND_HALFWIDTH
+
+
+@dataclass(frozen=True)
+class OracleResult:
+    oos_auc: float
+    n_train: int
+    n_test: int
+    n_features: int
+    train_test_disjoint: bool
+
+
+def _feature(sig_a: np.ndarray, sig_b: np.ndarray) -> np.ndarray:
+    f, pxy = csd(sig_a, sig_b, fs=_FS, nperseg=c5.CSD_NPERSEG)
+    band = (f >= _LO) & (f <= _HI)
+    z = np.asarray(pxy, dtype=np.complex128)[band]
+    return np.concatenate([np.abs(z), np.angle(z)]).astype(np.float64)
+
+
+def _features_for(seeds: list[int]) -> tuple[np.ndarray, np.ndarray]:
+    pos = [draw_n_plus(s) for s in seeds]
+    neg = [draw_null(s, fam) for fam in l1.NULL_FAMILIES for s in seeds]
+    x_pos = np.array([_feature(p.sig_a, p.sig_b) for p in pos], dtype=np.float64)
+    x_neg = np.array([_feature(n.sig_a, n.sig_b) for n in neg], dtype=np.float64)
+    x = np.vstack([x_pos, x_neg])
+    y = np.concatenate([np.ones(len(x_pos)), np.zeros(len(x_neg))])
+    return x, y
+
+
+def _lda_direction(x: np.ndarray, y: np.ndarray) -> np.ndarray:
+    xp, xn = x[y == 1], x[y == 0]
+    mu = xp.mean(0) - xn.mean(0)
+    cov = np.cov(np.vstack([xp - xp.mean(0), xn - xn.mean(0)]).T)
+    w = np.linalg.pinv(cov) @ mu
+    return np.asarray(w, dtype=np.float64)
+
+
+def _auc(scores: np.ndarray, y: np.ndarray) -> float:
+    pos = scores[y == 1]
+    neg = scores[y == 0]
+    if pos.size == 0 or neg.size == 0:
+        return 0.5
+    order = np.argsort(np.concatenate([pos, neg]), kind="stable")
+    ranks = np.empty(order.size, dtype=np.float64)
+    ranks[order] = np.arange(1, order.size + 1)
+    r_pos = ranks[: pos.size].sum()
+    u = r_pos - pos.size * (pos.size + 1) / 2.0
+    return float(u / (pos.size * neg.size))
+
+
+def run_oracle() -> OracleResult:
+    tr, te = c5.train_seeds(), c5.test_seeds()
+    disjoint = set(tr).isdisjoint(set(te))
+
+    x_tr, y_tr = _features_for(tr)
+    x_te, y_te = _features_for(te)
+    mu, sd = x_tr.mean(0), x_tr.std(0) + 1e-12
+    w = _lda_direction((x_tr - mu) / sd, y_tr)
+    s_te = ((x_te - mu) / sd) @ w
+    auc = _auc(s_te, y_te)
+    # AUC is symmetric about 0.5 w.r.t. orientation; report discriminability.
+    auc = max(auc, 1.0 - auc)
+    return OracleResult(
+        oos_auc=auc,
+        n_train=len(x_tr),
+        n_test=len(x_te),
+        n_features=int(x_tr.shape[1]),
+        train_test_disjoint=disjoint,
+    )

--- a/research/ctc_falsify/c5/run.py
+++ b/research/ctc_falsify/c5/run.py
@@ -1,0 +1,95 @@
+# SPDX-License-Identifier: MIT
+"""C5 orchestrator — decisive verdict on the C4 OPEN."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+from research.ctc_falsify.c5 import config_c5 as c5
+from research.ctc_falsify.c5.oracle import run_oracle
+
+
+def _repro_hash(payload: dict[str, Any]) -> str:
+    return hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+
+
+def decide(auc: float, disjoint: bool) -> str:
+    if not disjoint:
+        return c5.VERDICT_LEAKAGE
+    if auc <= c5.AUC_CHANCE_HI:
+        return c5.VERDICT_IDENTIFIABILITY_LIMIT
+    if auc >= c5.AUC_SEPARABLE:
+        return c5.VERDICT_ESTIMATOR_QUALITY_GAP
+    return c5.VERDICT_AMBIGUOUS
+
+
+def run() -> dict[str, Any]:
+    o = run_oracle()
+    verdict = decide(o.oos_auc, o.train_test_disjoint)
+    cfg_hash = c5.config_hash()
+    oracle = {
+        "oos_auc": o.oos_auc,
+        "n_train": o.n_train,
+        "n_test": o.n_test,
+        "n_features": o.n_features,
+        "train_test_disjoint": o.train_test_disjoint,
+    }
+    result: dict[str, Any] = {
+        "experiment_id": c5.C5_ID,
+        "verdict": verdict,
+        "claim": c5.CLAIM,
+        "boundary": c5.BOUNDARY,
+        "oracle": oracle,
+        "thresholds": {
+            "auc_chance_hi": c5.AUC_CHANCE_HI,
+            "auc_separable": c5.AUC_SEPARABLE,
+        },
+        "config_hash": cfg_hash,
+    }
+    result["repro_hash"] = _repro_hash(
+        {"verdict": verdict, "config_hash": cfg_hash, "oracle": oracle}
+    )
+    return result
+
+
+def write_evidence(result: dict[str, Any]) -> str:
+    c5.EVIDENCE_DIR.mkdir(parents=True, exist_ok=True)
+    c5.RESULT_PATH.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n")
+    return str(c5.RESULT_PATH)
+
+
+def main() -> None:
+    result = run()
+    path = write_evidence(result)
+    o = result["oracle"]
+    print(f"EXPERIMENT: {result['experiment_id']}")
+    print(f"VERDICT: {result['verdict']}")
+    print(
+        "ORACLE: OOS AUC="
+        f"{o['oos_auc']:.4f} (limit<= {c5.AUC_CHANCE_HI}, "
+        f"separable>= {c5.AUC_SEPARABLE}) "
+        f"train={o['n_train']} test={o['n_test']} feats={o['n_features']} "
+        f"disjoint={o['train_test_disjoint']}"
+    )
+    print(f"REPRO HASH: {result['repro_hash']}")
+    print(f"ARTIFACT: {path}")
+    if result["verdict"] == c5.VERDICT_IDENTIFIABILITY_LIMIT:
+        print("=> C4 OPEN CLOSED: even a near-oracle cannot separate the")
+        print("   channel from confounds here — an IDENTIFIABILITY LIMIT of")
+        print("   these observables at this regime (strong boundary result).")
+    elif result["verdict"] == c5.VERDICT_ESTIMATOR_QUALITY_GAP:
+        print("=> C4 OPEN CLOSED: a sufficient statistic exists — the")
+        print("   blindness is an ESTIMATOR-QUALITY gap, not identifiability.")
+    elif result["verdict"] == c5.VERDICT_AMBIGUOUS:
+        print("=> AMBIGUOUS: AUC between bands. Honest non-decision; the")
+        print("   OPEN stays OPEN — needs a richer probe, not a forced call.")
+    else:
+        print("=> INADMISSIBLE: train/test leakage; verdict withheld.")
+
+
+if __name__ == "__main__":
+    main()

--- a/research/ctc_falsify/c5/schema/ctc_falsify_c5_result.schema.json
+++ b/research/ctc_falsify/c5/schema/ctc_falsify_c5_result.schema.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "research/ctc_falsify/c5/schema/ctc_falsify_c5_result.schema.json",
+  "title": "CTC-FALSIFY-001-C5 result",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "experiment_id",
+    "verdict",
+    "claim",
+    "boundary",
+    "oracle",
+    "thresholds",
+    "config_hash",
+    "repro_hash"
+  ],
+  "properties": {
+    "experiment_id": { "const": "CTC-FALSIFY-001-C5" },
+    "verdict": {
+      "type": "string",
+      "enum": [
+        "C5_IDENTIFIABILITY_LIMIT",
+        "C5_ESTIMATOR_QUALITY_GAP",
+        "C5_INADMISSIBLE_AMBIGUOUS",
+        "C5_INADMISSIBLE_TRAIN_TEST_LEAKAGE"
+      ]
+    },
+    "claim": { "type": "string", "minLength": 1 },
+    "boundary": { "type": "string", "minLength": 1 },
+    "oracle": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "oos_auc",
+        "n_train",
+        "n_test",
+        "n_features",
+        "train_test_disjoint"
+      ],
+      "properties": {
+        "oos_auc": { "type": "number" },
+        "n_train": { "type": "integer", "minimum": 0 },
+        "n_test": { "type": "integer", "minimum": 0 },
+        "n_features": { "type": "integer", "minimum": 0 },
+        "train_test_disjoint": { "type": "boolean" }
+      }
+    },
+    "thresholds": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["auc_chance_hi", "auc_separable"],
+      "properties": {
+        "auc_chance_hi": { "type": "number" },
+        "auc_separable": { "type": "number" }
+      }
+    },
+    "config_hash": { "type": "string", "pattern": "^[a-f0-9]{64}$" },
+    "repro_hash": { "type": "string", "pattern": "^[a-f0-9]{64}$" }
+  }
+}

--- a/tests/research/ctc_falsify/test_ctc_falsify_c5.py
+++ b/tests/research/ctc_falsify/test_ctc_falsify_c5.py
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: MIT
+"""C5 construct-validity guards: the decisive identifiability oracle.
+
+Enforces no leakage, verdict bound to the AUC bands, and an honest
+non-decision when ambiguous (the OPEN may stay OPEN — never force a call).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from jsonschema import Draft202012Validator
+
+from research.ctc_falsify.c5 import config_c5 as c5
+from research.ctc_falsify.c5.oracle import run_oracle
+from research.ctc_falsify.c5.run import decide, run
+
+pytestmark = pytest.mark.slow
+
+
+@pytest.fixture(scope="module")
+def result() -> dict[str, object]:
+    return run()
+
+
+def test_schema_validates(result: dict[str, object]) -> None:
+    schema = json.loads(c5.SCHEMA_PATH.read_text())
+    Draft202012Validator.check_schema(schema)
+    Draft202012Validator(schema).validate(result)
+
+
+def test_schema_enum_is_single_source() -> None:
+    schema = json.loads(c5.SCHEMA_PATH.read_text())
+    assert tuple(schema["properties"]["verdict"]["enum"]) == c5.ALL_VERDICTS
+
+
+def test_train_test_seed_bands_are_disjoint() -> None:
+    assert set(c5.train_seeds()).isdisjoint(set(c5.test_seeds()))
+
+
+def test_verdict_is_a_pure_function_of_auc_and_disjointness() -> None:
+    assert decide(0.50, True) == c5.VERDICT_IDENTIFIABILITY_LIMIT
+    assert decide(0.95, True) == c5.VERDICT_ESTIMATOR_QUALITY_GAP
+    assert decide(0.75, True) == c5.VERDICT_AMBIGUOUS
+    assert decide(0.99, False) == c5.VERDICT_LEAKAGE  # leakage overrides
+
+
+def test_reference_run_is_leakage_free_and_bound(result: dict[str, object]) -> None:
+    o = result["oracle"]
+    assert isinstance(o, dict)
+    assert o["train_test_disjoint"] is True
+    assert result["verdict"] in c5.ALL_VERDICTS
+    assert result["verdict"] != c5.VERDICT_LEAKAGE
+    o_run = run_oracle()
+    assert result["verdict"] == decide(o_run.oos_auc, o_run.train_test_disjoint)
+
+
+def test_oos_auc_in_unit_interval(result: dict[str, object]) -> None:
+    o = result["oracle"]
+    assert isinstance(o, dict)
+    assert 0.0 <= float(o["oos_auc"]) <= 1.0  # type: ignore[arg-type]


### PR DESCRIPTION
**The OPEN is decided. The in-silico arc consolidates.**

C4 retracted C3's escape-hatch and left one question: is the standard-
estimand blindness an *identifiability limit* of these observables, or an
*estimator-quality* gap? C5 settles it with a near-oracle upper bound —
the best **out-of-sample** linear discriminant over the full gamma
cross-spectrum (magnitude + phase), **train/test seed-disjoint** (leakage
is an explicit INADMISSIBLE verdict).

Result: **OOS ROC-AUC ≈ 0.96** → `C5_ESTIMATOR_QUALITY_GAP`.

So on this generative model the directed channel **is** information-
recoverable — a sufficient statistic exists in the richer representation.
The blindness of the standard scalar estimands (v1 PLV-residual, v2
time-reversed PSI) is an **estimator-quality gap, not an identifiability
limit**. The C4 OPEN is closed; `RESULTS.md` consolidated.

Scope unchanged: in-silico, hypothesis-tier, NOT a CTC-theory verdict,
NOT real data; `ctc_falsify_001` stays OPEN only for the real-data layer.
Verdict is a pure function of AUC bands + disjointness; falsifier guards
the closure from silent promotion.

claim_status: measured

🤖 Generated with [Claude Code](https://claude.com/claude-code)