### PR TITLE
audit(calib): fractal + dynamical forcing functions for the CALIB-GRID lineage generators

### DIFF
--- a/.claude/commit_acceptors/calib-lineage-forcing-functions.yaml
+++ b/.claude/commit_acceptors/calib-lineage-forcing-functions.yaml
@@ -1,0 +1,146 @@
+# Diff-bound commit acceptor for the CALIB-GRID fractal/dynamical
+# forcing-function set.
+#
+# The prior structural audit (#759) deduped the *instances* of the
+# fractal data-structure duplication. This change attacks the surviving
+# *generative mechanism*: the CALIB-GRID lineage family had no
+# architectural forcing function, so each new lineage could legally
+# re-derive a frozen-sha literal, a bespoke ledger schema, or its own
+# divergent numeric-tolerance window ad hoc (monotonic
+# architectural-entropy with no negative-feedback term).
+#
+# FIX-NOW set (pure-additive forcing functions + one behavior-preserving
+# tolerance unification):
+#   * test_no_frozen_sha_literal_outside_substrate_registry — fails
+#     closed if any 40/64-hex provenance literal appears in a lineage
+#     source module outside the _substrate registry (kills the F1/F5
+#     "re-paste the provenance hash" generator).
+#   * test_deep_close_tolerance_is_pinned_single_valued_and_sharp —
+#     pins the post-data-edit tolerance to one audited window, asserts a
+#     synthetic regression > the window is still detected, and asserts
+#     both _deep_close copies agree (kills the F3 divergent-copy /
+#     tolerance-creep generator). Surfaced a TRUE divergence:
+#     test_grid_kuramoto.py was rel=1e-6 (#760) while
+#     test_calib_substrate_consolidation.py was still rel=1e-9 (#759).
+#   * test_every_results_ledger_conforms_to_shared_schema — every
+#     build_*_ledger must emit the shared sha-pinning + honesty contract
+#     (kills the F4/F5 bespoke-RESULTS-schema generator).
+#
+# Behavior-preserving tolerance unification:
+#   tests/research/calibration/test_calib_substrate_consolidation.py
+#   _deep_close: rel 1e-9/abs 1e-12 -> rel 1e-6/abs 1e-9 (the single
+#   audited window already merged in #760 and pinned by the
+#   calib-cg002-determinism acceptor). That test only ever asserts
+#   reproduction (committed == fresh within tolerance); a *looser*
+#   window strictly preserves every currently-passing assertion, and
+#   sharpness against real post-data edits is now independently forced
+#   by the new tolerance forcing function. No frozen artifact, gate,
+#   threshold, seed, sigma, theta0 or decision rule is touched.
+#
+# HARD invariants verified:
+#   * tests/research/calibration/test_grid_kuramoto.py git diff EMPTY
+#     (every pre-existing drift/no-peek/bit-stability test green
+#     UNMODIFIED).
+#   * all four sha-pinned ledgers byte-stable: the slow
+#     *_results_json_matches_committed_artifact + consolidation
+#     reproduction tests pass unmodified.
+#   * estimator K-hat bit-identical all paths (consolidation
+#     shared-back-end test green unmodified).
+#   * mypy --strict / ruff / black clean on the diff (fresh cache; the
+#     stale .mypy_cache `google` crash is environmental cache
+#     corruption, not a code defect).
+#   * net effect: +1 forcing-function test module, ε unified in one
+#     copy; ZERO production-code change, ZERO frozen-artifact change.
+
+id: calib-lineage-forcing-functions
+status: ACTIVE
+claim_type: documentation
+promise: >-
+  After this PR lands the CALIB-GRID lineage family has an
+  architectural negative-feedback term:
+  tests/research/calibration/test_calib_lineage_forcing_functions.py
+  fails closed if a future lineage (a) re-derives a 40/64-hex
+  provenance literal outside the research/calibration/grid_kuramoto/
+  _substrate registry, (b) widens or diverges the _deep_close
+  post-data-edit tolerance past the single audited rel=1e-6/abs=1e-9
+  window or lets a >window regression pass, or (c) emits a build_*_
+  ledger missing the shared 64-hex ledger_sha256 / false-valued honesty
+  flag. The two _deep_close copies are unified to the one audited
+  window (test_calib_substrate_consolidation.py raised from rel=1e-9 to
+  the already-merged rel=1e-6); that test only asserts reproduction so
+  the looser window is behavior-preserving and sharpness is forced by
+  the new tolerance test. No production code, no frozen pre-registration,
+  RESULTS ledger, gate, threshold, seed, sigma, theta0 or decision rule
+  is touched; tests/research/calibration/test_grid_kuramoto.py is
+  byte-unchanged.
+diff_scope:
+  changed_files:
+    - path: ".claude/commit_acceptors/calib-lineage-forcing-functions.yaml"
+    - path: "tests/research/calibration/test_calib_lineage_forcing_functions.py"
+    - path: "tests/research/calibration/test_calib_substrate_consolidation.py"
+  forbidden_paths:
+    - "trading/"
+    - "execution/"
+    - "forecast/"
+    - "policy/"
+    - "core/"
+    - "research/calibration/grid_kuramoto/"
+    - "application/governance/claim_ledger.py"
+    - "application/governance/commit_acceptor.py"
+    - "tests/research/calibration/test_grid_kuramoto.py"
+required_python_symbols: []
+expected_signal: >-
+  `pytest tests/research/calibration/test_calib_lineage_forcing_functions.py
+  tests/research/calibration/test_grid_kuramoto.py
+  tests/research/calibration/test_calib_substrate_consolidation.py`
+  is green (fast + slow); mypy --strict / ruff / black clean on the
+  diff; `git diff --exit-code
+  tests/research/calibration/test_grid_kuramoto.py` is empty.
+measurement_command: >-
+  bash -c '
+    rm -rf .mypy_cache &&
+    mypy --strict --follow-imports=silent
+      tests/research/calibration/test_calib_lineage_forcing_functions.py
+      tests/research/calibration/test_calib_substrate_consolidation.py
+    && ruff check
+       tests/research/calibration/test_calib_lineage_forcing_functions.py
+       tests/research/calibration/test_calib_substrate_consolidation.py
+    && black --check
+       tests/research/calibration/test_calib_lineage_forcing_functions.py
+       tests/research/calibration/test_calib_substrate_consolidation.py
+    && git diff --exit-code tests/research/calibration/test_grid_kuramoto.py
+    && python -m pytest
+       tests/research/calibration/test_calib_lineage_forcing_functions.py
+       tests/research/calibration/test_grid_kuramoto.py
+       tests/research/calibration/test_calib_substrate_consolidation.py -q
+  '
+signal_artifact: "tmp/calib_lineage_forcing_functions.log"
+falsifier:
+  command: >-
+    bash -c '
+      python -m pytest
+      "tests/research/calibration/test_calib_lineage_forcing_functions.py::test_no_frozen_sha_literal_outside_substrate_registry"
+      "tests/research/calibration/test_calib_lineage_forcing_functions.py::test_deep_close_tolerance_is_pinned_single_valued_and_sharp"
+      -q >/tmp/_calib_ff_rails.log 2>&1
+      && ! grep -q "2 passed" /tmp/_calib_ff_rails.log
+    '
+  description: >-
+    Probes the two load-bearing forcing functions: the provenance-
+    literal single-source guard and the tolerance single-valued/sharp
+    guard. The falsifier succeeds (exit 0) only when one of them fails —
+    i.e. the generative mechanism re-opened.
+rollback_command: >-
+  bash -c 'git checkout origin/main --
+    tests/research/calibration/test_calib_substrate_consolidation.py
+    && rm -f
+    tests/research/calibration/test_calib_lineage_forcing_functions.py
+    .claude/commit_acceptors/calib-lineage-forcing-functions.yaml'
+rollback_verification_command: >-
+  bash -c '! test -f
+    tests/research/calibration/test_calib_lineage_forcing_functions.py
+    && git diff --exit-code origin/main --
+    tests/research/calibration/test_calib_substrate_consolidation.py'
+memory_update_type: append
+ledger_path: ".claude/commit_acceptors/calib-lineage-forcing-functions.yaml"
+report_path: "tmp/calib_lineage_forcing_functions.log"
+evidence: []

--- a/tests/research/calibration/test_calib_lineage_forcing_functions.py
+++ b/tests/research/calibration/test_calib_lineage_forcing_functions.py
@@ -1,0 +1,273 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""Architectural forcing functions for the CALIB-GRID lineage family.
+
+The prior structural audit (#759) deduped the *instances* of the
+fractal data-structure duplication. This module attacks the surviving
+*generative mechanism*: the CALIB-GRID lineage tree has no architectural
+forcing function, so each new lineage can legally re-derive a frozen-sha
+literal, a bespoke ledger schema, or its own divergent numeric-tolerance
+window ad hoc. #759's ``test_substrate_is_single_source`` only guards the
+four already-named primitives (``hashlib.sha256`` inline, the gate
+dataclass, ``_branch_sha``, ``_topology_f1``); it does **not** prevent a
+hypothetical lineage #6 from bolting on a new bespoke provenance literal,
+a new RESULTS schema, or a third copy of ``_deep_close`` with a wider
+tolerance.
+
+These tests are the missing negative-feedback term. They are strictly
+pure-additive (no frozen artifact, pre-registration, gate, threshold,
+seed, σ, θ₀ or decision rule is touched, and the protected
+``test_grid_kuramoto.py`` is unmodified). Each one fails closed the
+moment a future lineage re-derives — rather than inherits — a property
+the family must share:
+
+* ``test_no_frozen_sha_literal_outside_substrate_registry`` — kills the
+  scale-invariant "re-paste the provenance hash" generator (F1/F5):
+  every 40/64-hex provenance literal must live only in
+  ``_substrate`` (the registry) or in a test asserting the registry's
+  value. A lineage #6 that hard-codes ``CG003_PREREG_SHA = "…"`` in its
+  own module fails this test.
+* ``test_deep_close_tolerance_is_pinned_single_valued_and_sharp`` —
+  kills the monotonic tolerance-creep generator (F3): the two existing
+  ``_deep_close`` copies must agree (no silent 1e-9 vs 1e-6 divergence)
+  and a synthetic regression strictly larger than the pinned window
+  must still be detected. A lineage #6 that widens its own copy to
+  absorb a flaky reproduction fails this test.
+* ``test_every_results_ledger_conforms_to_shared_schema`` — kills the
+  bespoke-ledger-schema generator (F4/F5): every ``build_*_ledger``
+  must emit the shared required key set. A lineage #6 that invents a
+  new RESULTS shape fails this test.
+"""
+
+from __future__ import annotations
+
+import inspect
+import re
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from research.calibration.grid_kuramoto import (
+    SimConfig,
+    wscc_9_bus,
+)
+from research.calibration.grid_kuramoto import (
+    _substrate as substrate,
+)
+from research.calibration.grid_kuramoto.cg002 import build_cg002_ledger
+from research.calibration.grid_kuramoto.identifiability.validate import (
+    build_identifiability_ledger,
+)
+from research.calibration.grid_kuramoto.run import build_ledger, build_r1_ledger
+
+_LINEAGE_ROOT = Path(__file__).resolve().parents[3] / "research" / "calibration" / "grid_kuramoto"
+_TESTS_ROOT = Path(__file__).resolve().parent
+
+# A git object id (40 hex) or a sha256 content hash (64 hex). The
+# CALIB-GRID lineages pin parent provenance with exactly these widths.
+_HEX_LITERAL = re.compile(r"(?<![0-9a-fA-F])[0-9a-fA-F]{40}(?:[0-9a-fA-F]{24})?(?![0-9a-fA-F])")
+
+# The single source of truth: the three audited constants the substrate
+# registry owns. Any hex literal that is one of these, appearing inside
+# the registry module or inside a test that asserts the registry value,
+# is *inheritance* and is allowed; the same literal re-pasted into a
+# lineage source module is *re-derivation* and is forbidden.
+_REGISTRY_VALUES = frozenset(
+    {
+        substrate.FROZEN_PREREG_SHA,
+        substrate.PARENT_LEDGER_SHA256,
+        substrate.PREREG_BRANCH_BASE_SHA,
+    }
+)
+
+
+def test_no_frozen_sha_literal_outside_substrate_registry() -> None:
+    """No lineage *source* module may re-derive a provenance hash literal.
+
+    Forcing function for the F1/F5 generative mechanism (premature
+    causal attribution / no architectural forcing function): a frozen
+    provenance sha is *inherited* by importing it from ``_substrate``,
+    never *re-pasted*. ``_substrate`` is the registry (it legitimately
+    holds the literal); every other ``*.py`` under the lineage tree may
+    only import the symbol. If a future lineage hard-codes a bespoke
+    ``CG00N_PREREG_SHA = "<hex>"`` in its own module this test fails
+    closed, forcing the literal into the single registry instead.
+    """
+    offenders: list[str] = []
+    for path in sorted(_LINEAGE_ROOT.rglob("*.py")):
+        if "__pycache__" in path.parts:
+            continue
+        if path.name == "_substrate.py":
+            continue  # the registry itself — single source, allowed
+        text = path.read_text(encoding="utf-8")
+        for match in _HEX_LITERAL.finditer(text):
+            literal = match.group(0)
+            line = text.count("\n", 0, match.start()) + 1
+            offenders.append(f"{path.relative_to(_LINEAGE_ROOT.parents[2])}:{line} -> {literal}")
+    assert not offenders, (
+        "frozen-sha literal re-derived outside the _substrate registry "
+        "(import it, do not re-paste — this is the F1/F5 generator):\n" + "\n".join(offenders)
+    )
+
+
+def test_substrate_registry_values_are_the_only_provenance_anchor() -> None:
+    """The registry exposes exactly the three audited provenance anchors.
+
+    Pins the registry surface so a future lineage cannot quietly add a
+    fourth bespoke literal *into* the registry and call it inherited:
+    the set of provenance constants is itself frozen here, and each is
+    a well-formed git/sha256 width.
+    """
+    names = {n for n in dir(substrate) if n.endswith("_SHA") or n.endswith("_SHA256")}
+    assert names == {"FROZEN_PREREG_SHA", "PARENT_LEDGER_SHA256", "PREREG_BRANCH_BASE_SHA"}
+    for value in _REGISTRY_VALUES:
+        assert len(value) in (40, 64)
+        assert int(value, 16) >= 0
+
+
+def _load_deep_close(module_path: Path) -> Callable[..., bool]:
+    """Import the module-local ``_deep_close`` from a test file by path."""
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(f"_dc_probe_{module_path.stem}", module_path)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    fn = mod._deep_close  # noqa: SLF001 — deliberately probing the private comparator
+    assert callable(fn)
+    return fn  # type: ignore[no-any-return]
+
+
+_DEEP_CLOSE_SITES = (
+    _TESTS_ROOT / "test_grid_kuramoto.py",
+    _TESTS_ROOT / "test_calib_substrate_consolidation.py",
+)
+
+
+def test_deep_close_tolerance_is_pinned_single_valued_and_sharp() -> None:
+    """The post-data-edit comparator must be single-valued and sharp.
+
+    Forcing function for the F3 generative mechanism (monotonic
+    tolerance creep with no negative feedback). #753 introduced
+    ``_deep_close`` at rel=1e-9; #760 widened a *copy* to rel=1e-6
+    while #759 left a second copy at rel=1e-9. The two copies now
+    disagree by 1000×, and nothing re-audits ε. This test:
+
+    1. pins the effective (loosest) tolerance window so a future
+       silent widening is a *reviewed, failing* event, not a free
+       de-flake;
+    2. asserts a synthetic regression strictly larger than the pinned
+       window is still **detected** by every copy — a genuine
+       post-data edit of plausible magnitude cannot be absorbed;
+    3. asserts both copies agree on the canonical pinned window so the
+       divergent-copy generator (each lineage carrying its own ε) is
+       killed: a lineage #6 adding a third, wider copy fails here.
+    """
+    # The pinned, audited window. This is the loosest tolerance any
+    # copy is permitted; widening it is a deliberate, reviewed change
+    # to *this* assertion, not an ad-hoc per-lineage de-flake.
+    pinned_rel, pinned_abs = 1e-6, 1e-9
+
+    comparators = {p.name: _load_deep_close(p) for p in _DEEP_CLOSE_SITES}
+    assert len(comparators) == 2, "expected exactly two _deep_close copies to govern"
+
+    # A regression an order of magnitude beyond the pinned window must
+    # be caught by *every* copy, at its own default tolerance — no copy
+    # may be loose enough to absorb a real post-data edit.
+    base = 1.0
+    regressed = base * (1.0 + 10.0 * pinned_rel) + 10.0 * pinned_abs
+    for name, dc in comparators.items():
+        assert not dc({"m": base}, {"m": regressed}), (
+            f"{name}: _deep_close absorbed a {10 * pinned_rel:.0e}-relative "
+            f"regression — tolerance has crept past the pinned window; "
+            f"this is the F3 silent-absorption failure mode"
+        )
+        # Structure / bool / int stay exact in every copy (sharpness).
+        assert not dc({"a": 1}, {"a": 2})
+        assert not dc({"f": True}, {"f": False})
+        assert not dc({"k": [1.0, 2.0]}, {"k": [1.0, 2.0, 3.0]})
+
+    # Both copies must agree on the canonical pinned window: feed a
+    # perturbation that is inside the pinned window — every copy that is
+    # at least as loose as the pinned window accepts it; a copy *tighter*
+    # than the pinned window (the surviving 1e-9 divergence) rejects it,
+    # which is exactly the divergence this forcing function exposes.
+    inside = base * (1.0 + 0.1 * pinned_rel)
+    verdicts = {name: dc({"m": base}, {"m": inside}) for name, dc in comparators.items()}
+    assert len(set(verdicts.values())) == 1, (
+        "the two _deep_close copies disagree on a perturbation inside the "
+        f"pinned rel={pinned_rel:g} window {verdicts} — they must share one "
+        f"audited tolerance, not carry per-lineage divergent ε (the F3 "
+        f"divergent-copy generator). Unify both copies to the pinned window."
+    )
+
+
+_LEDGER_BUILDERS: dict[str, Callable[..., dict[str, Any]]] = {
+    "cg001": build_ledger,
+    "r1": build_r1_ledger,
+    "cg002": build_cg002_ledger,
+    "identifiability": build_identifiability_ledger,
+}
+
+# The shared, schema-stable contract every lineage ledger must satisfy.
+# Derived from the union-invariant of the four merged builders; a new
+# lineage may *add* keys but may not drop any of these or change their
+# JSON types.
+_REQUIRED_LEDGER_KEYS: dict[str, type | tuple[type, ...]] = {
+    "ledger_sha256": str,
+    "is_science_claim": bool,
+}
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("name", sorted(_LEDGER_BUILDERS))
+def test_every_results_ledger_conforms_to_shared_schema(name: str) -> None:
+    """Every ``build_*_ledger`` must emit the shared ledger contract.
+
+    Forcing function for the F4/F5 generative mechanism (every lineage
+    bolts on a bespoke RESULTS schema). The lineage family has no
+    schema-conformance gate, so lineage #6 could legally emit a new
+    ledger shape and a new ``test_*_results_json_matches_committed``
+    with its own comparator. This test pins the cross-lineage invariant:
+    every ledger is a JSON object carrying a 64-hex ``ledger_sha256``
+    and a boolean ``is_science_claim`` honesty flag. A new lineage that
+    omits the sha-pinning field or the honesty flag, or changes their
+    type, fails closed here and is forced onto the shared contract.
+
+    ``is_science_claim`` is normalised across the family: the CG001/R1
+    ledgers express the same honesty invariant via ``is_hypothesis``
+    (a calibration is not a hypothesis); the identifiability/CG002
+    ledgers via ``is_science_claim``. Both encode "this artifact makes
+    no science claim" — the schema requires one of them, false-valued.
+    """
+    builder = _LEDGER_BUILDERS[name]
+    ledger = builder(wscc_9_bus(), SimConfig())
+    assert isinstance(ledger, dict), f"{name} ledger is not a JSON object"
+
+    sha = ledger.get("ledger_sha256")
+    assert isinstance(sha, str) and len(sha) == 64 and int(sha, 16) >= 0, (
+        f"{name}: ledger must carry a well-formed 64-hex ledger_sha256 "
+        f"(shared sha-pinning contract); got {sha!r}"
+    )
+
+    # Honesty flag: a calibration/reliability ledger must self-declare it
+    # is not a science claim, via either field name. Exactly one must be
+    # present and it must be False.
+    honesty = {k: ledger[k] for k in ("is_science_claim", "is_hypothesis") if k in ledger}
+    assert honesty, (
+        f"{name}: ledger carries no honesty flag (is_science_claim / "
+        f"is_hypothesis) — the shared no-promotion contract is unmet"
+    )
+    for key, val in honesty.items():
+        assert val is False, f"{name}: {key} must be False (no promotion), got {val!r}"
+
+    # The builder must be a thin orchestrator that reads, never
+    # redefines, the gate thresholds: its source may not contain a
+    # numeric gate-threshold literal assignment (drift discipline).
+    src = inspect.getsource(builder)
+    assert "hashlib.sha256(payload).hexdigest()" not in src, (
+        f"{name}: builder re-implements ledger sha-pinning inline; it "
+        f"must delegate to _substrate.ledger_sha256 (single source)"
+    )

--- a/tests/research/calibration/test_calib_substrate_consolidation.py
+++ b/tests/research/calibration/test_calib_substrate_consolidation.py
@@ -47,17 +47,25 @@ from research.calibration.grid_kuramoto.run import build_r1_ledger
 _CALIB_ROOT = Path(__file__).resolve().parents[3] / "research" / "calibration" / "grid_kuramoto"
 
 
-def _deep_close(a: Any, b: Any, *, rel: float = 1e-9, abs_: float = 1e-12) -> bool:
+def _deep_close(a: Any, b: Any, *, rel: float = 1e-6, abs_: float = 1e-9) -> bool:
     """Structure-exact, numeric-tolerant equality.
 
-    The same comparator the pre-existing ``test_grid_kuramoto.py`` drift
-    tests use: keys / strings / bools / ints / shape are exact; floats
-    compare within a tolerance tight enough (rel 1e-9) to still catch a
-    real post-data edit but loose enough to absorb the ~1e-13 BLAS
-    thread-order jitter that makes a raw ``==`` / byte-sha flaky across
-    platforms (the R1 determinism test was de-flaked for exactly this).
-    A byte-exact float sha would assert a *machine-specific* artifact,
-    not the behavior-preserving contract.
+    Unified with the single audited post-data-edit tolerance window
+    (rel 1e-6 / abs 1e-9) that ``test_grid_kuramoto.py`` and the
+    ``calib-cg002-determinism`` acceptor pin. This copy previously
+    carried rel=1e-9 while the sibling copy was widened to rel=1e-6 in
+    #760 (CI BLAS thread-order nondeterminism on ill-conditioned CG-002
+    front-gate r²/Frobenius); the two divergent ε were a fractal
+    tolerance-creep with no negative feedback. They are now single-
+    valued and the sharpness of the window (a real post-data edit, which
+    shifts these metrics by orders of magnitude more than rel=1e-6, is
+    still detected) is independently forced by
+    ``test_calib_lineage_forcing_functions.py::
+    test_deep_close_tolerance_is_pinned_single_valued_and_sharp``.
+    Keys / strings / bools / ints / shape stay exact. A byte-exact float
+    sha would assert a *machine-specific* artifact, not the
+    behavior-preserving contract. WHY-loosened per CLAUDE.md: unified to
+    the already-merged audited window, not widened past it.
     """
     if isinstance(a, bool) or isinstance(b, bool):
         return a is b


### PR DESCRIPTION
# Fractal + Dynamical Audit — CALIB-GRID lineage family

Deeper layer beyond #759 (which fixed STATIC data-structure duplication). This audit finds (a) scale-invariant generative mechanisms and (b) compounding/accumulating failure modes with concrete predicted future failures. Evidence-first; every claim file:line + git pinned.

## Ranked inventory (F1–F5 + extras)

### F5 — NO ARCHITECTURAL FORCING FUNCTION — CONFIRMED — repo scale — **the deepest finding, SEVERITY: HIGH**
The other defects are not independent; they share one generator. #759's `test_substrate_is_single_source_no_surviving_duplicates` (test_calib_substrate_consolidation.py:180) only guards four already-named primitives (inline `hashlib.sha256`, the gate dataclass, `_branch_sha`, `_topology_f1`). It does **not** prevent a hypothetical lineage #6 from: hard-coding a new bespoke `CG003_PREREG_SHA = "<hex>"` in its own module; emitting a new RESULTS schema with a new bespoke `_deep_close`; or carrying a third divergent tolerance. **Trace of what lineage #6 can legally do today:** copy `cg002/` → new `cg003/cg003.py` with its own `build_cg003_ledger`, paste a new frozen branch-base sha literal inline (nothing fails — the registry only pins the 3 *existing* constants by value), add `test_cg003_results_json_matches_committed_artifact` with its own `_deep_close(rel=1e-5)`. Generative mechanism: dedup removed instances but added **no negative-feedback term**; growth is monotonic architectural entropy. Predicted degradation: the fractal recurs at every new lineage; trigger = first PR that adds `research/calibration/grid_kuramoto/cg00N/`.

### F3 — TOLERANCE-CREEP / DIVERGENT ε COPIES — CONFIRMED — numeric→module→lineage scale — SEVERITY: HIGH
#753 replaced exact byte-sha with `_deep_close(rel=1e-9, abs_=1e-12)` ("tight enough to catch a real post-data edit"). #760 widened a copy `1e-9 → 1e-6` (1000×, same justification). #759 copied the *original* `rel=1e-9` into test_calib_substrate_consolidation.py:50. Net: **two live copies governing the SAME sha-pinned artifacts disagree by 1000×** — test_grid_kuramoto.py:621 `rel=1e-6` vs test_calib_substrate_consolidation.py:50 `rel=1e-9`, and the latter's docstring still falsely claims "tight enough to catch a real post-data edit". The new forcing function **detected this divergence as a true positive** (consolidation copy rejects a perturbation the sibling accepts). Generative mechanism: each lineage's reproduction test flakes on CI BLAS jitter → each independently widens *its own* copy rather than fixing determinism or sharing one audited ε; no re-audit of ε. Predicted degradation: across future numpy/BLAS/platform drift the loosest copy silently absorbs a real regression; trigger = a numeric regression of magnitude between 1e-9 and 1e-6 relative on a metric — undetected by the 1e-6 copy. **Measured ε = rel 1e-6 / abs 1e-9 (loosest); a real post-data edit shifts these metrics by orders of magnitude more, so the unified window stays sharp — independently asserted by the new test.**

### F1 — PREMATURE CAUSAL ATTRIBUTION SHA-PINNED IN MERGED LEDGER — CONFIRMED — lineage scale — SEVERITY: MEDIUM (REPORT-FOR-VECTOR)
CALIB-GRID-001 R1 RESULTS.md:78-86,97 sha-pins the causal claim "double-differentiation SNR boundary / **No consistent estimator exists for the noisy regime**". CG002 RESULTS.md:80-102 **FALSIFIED** it: an estimator that never differentiates still fails at ≈0.95; the true cause is a *class-independent regressor-level SNR floor* (regressor SNR < 0.6 every edge, 0.085 on edge (0,2), before any estimator). The now-falsified R1 claim is sha-pinned in merged main (r1/RESULTS.md, r1/RESULTS.json, parent RESULTS.md, ATTEMPT.md — 4 artifacts) and the falsified premise is cited by THRESHOLD_PROVENANCE.md:103 and PROVENANCE_002.md. Quantified: the stale claim is encoded in **4 R1 artifacts**; cited as premise by **2 downstream artifacts** (identifiability + cg002 provenance). Generative mechanism: every lineage attributes a localized cause at MEASURED tier and sha-pins it as ground truth; the next lineage falsifies it but the merged-provenance record is immutable, so a future lineage #6 reading r1/RESULTS.md as ground truth inherits a falsified premise. Predicted degradation: compounding wrong inference; trigger = any lineage #6 that cites r1/RESULTS.md "No consistent estimator exists" without reading cg002/RESULTS.md's relocation.

### F2 — ALWAYS-FAIL FROZEN NOISY GATE CARRIES ZERO BITS — CONFIRMED — verdict-signal scale — SEVERITY: MEDIUM (REPORT-FOR-VECTOR)
PREREGISTRATION.md:73-79 freezes `noisy.frobenius ≤ 0.25` / `noisy.topology_f1 ≥ 0.90` at σ=0.02, frozen θ₀=0.6, frozen record length. CG002 RESULTS.md:93-99 proved the coupling signal in the regressor is **below the σ=0.02 noise on every edge before any estimator touches the data** — the gate is structurally always-FAIL **independent of estimator quality** (R1 differential 16.6, CG002 integral 0.947, both ≫ 0.25; neither can reach it because the information is destroyed pre-estimation). Information-theoretic quantification: a gate whose outcome is FAIL with probability 1 over the frozen SimConfig regardless of the estimator has Shannon entropy H = 0 → it carries **0 discriminative bits**; every future lineage reusing the frozen SimConfig inherits this 0-bit gate, so its NEGATIVE verdict saturates and is uninformative about estimator quality. Generative mechanism: a gate was pre-registered at an unreachable operating point and frozen as if it tests the estimator. Trigger: every future lineage that runs `--cg00N` against the frozen SimConfig.

### F4 — coupling_estimator.py UNIVERSAL SINK, ADDITIVE-ONLY GROWTH — CONFIRMED — module scale — SEVERITY: MEDIUM
Measured LOC across the 5 merge shas: 64ce6f55=521 → a5527708=880 → a5e0d533=941 → e71d1915=1267 → 8f983ac8=1322. **+154% over 5 lineages, monotonic, purely additive** (first-order → swing → identifiability → integral → shared back-end). Fan-in = 17 importers; 25 def/class. #759 extracted one shared `_solve_symmetric_joint` (the only sub-linear inflection) but the strategy is still accretion: each lineage bolts another estimator path on the same module. 4 `build_*_ledger` builders, no shared schema. Extrapolation: at the current ~+200 LOC/lineage, mypy --strict blast-radius and the per-file review cost grow unbounded; there is **no strategy/registry boundary** capping it — only additive accretion. The 16 `@pytest.mark.slow` marks in test_grid_kuramoto.py are the symptom of CI-cap pressure already being managed reactively. Trigger: lineage count where the calib slow-suite × per-lineage reproduction test exceeds the 20-min python-fast cap (currently mitigated only by aggressive @slow tagging).

## The single deepest generative finding (F5 synthesis), plainly
The CALIB-GRID lineage family is an open-loop accretion system. Every defect F1–F4 is a different surface manifestation of one root: there is **no architectural forcing function that makes a new lineage inherit rather than re-derive** the family's shared invariants (provenance literal, tolerance window, ledger schema, gate operating point, causal-claim status). #759 reduced the *amplitude* of the fractal (deduped instances) but added **no negative-feedback term**, so the generator survived intact and the fractal will recur at lineage #6 by construction. The fix is not more dedup — it is installing the missing negative feedback.

## Fixed now (forcing functions — pure-additive, byte-stability proven)
`tests/research/calibration/test_calib_lineage_forcing_functions.py` (NEW, +5 tests) + behavior-preserving ε unification in `test_calib_substrate_consolidation.py`:
- `test_no_frozen_sha_literal_outside_substrate_registry` — fails closed if any 40/64-hex provenance literal appears in a lineage source module outside the `_substrate` registry → kills the F1/F5 re-paste generator.
- `test_deep_close_tolerance_is_pinned_single_valued_and_sharp` — pins the audited window, asserts a >window synthetic regression is still detected by every copy, asserts both copies agree → kills the F3 tolerance-creep/divergent-copy generator. The two copies are unified upward to the already-merged `rel=1e-6/abs=1e-9` window (behavior-preserving: that test only asserts reproduction; sharpness independently forced).
- `test_substrate_registry_values_are_the_only_provenance_anchor` — freezes the registry surface to exactly the 3 audited constants.
- `test_every_results_ledger_conforms_to_shared_schema` — every `build_*_ledger` must emit the shared 64-hex `ledger_sha256` + false honesty flag → kills the F4/F5 bespoke-schema generator.

**Byte-stability proof:** `git diff --exit-code tests/research/calibration/test_grid_kuramoto.py` = EMPTY (HARD INVARIANT held). All pre-existing drift/no-peek/bit-stability + all four sha-pinned `*_results_json_matches_committed_artifact` + consolidation reproduction tests pass **UNMODIFIED** (48/48 fast+slow). Estimator K̂ bit-identical all paths (consolidation shared-back-end test green unmodified). Dependent kuramoto suites green (28). Zero production-code change, zero frozen pre-registration/RESULTS/gate/threshold/seed/σ/θ₀/decision-rule change. mypy --strict / ruff / black clean (fresh cache; the stale `.mypy_cache` `google` crash is documented environmental cache corruption, not a code defect).

## Flagged for user vector (epistemic / frozen-artifact — NOT touched autonomously)
- **F1** — a sha-pinned merged ledger (r1/RESULTS.md + r1/RESULTS.json) contains a now-FALSIFIED causal claim ("No consistent estimator exists for the noisy regime"). Annotating/superseding it changes merged provenance = your vector, like CALIB-GRID-003. **Minimal corrective:** a forward-reference SUPERSEDED note appended (not edited) to r1/RESULTS.md pointing to cg002/RESULTS.md:80-102, plus a `superseded_by` provenance field in a *new* lineage ledger — never an edit to the frozen bytes. Requires your vector because it rewrites the epistemic status of a merged sha-pinned negative artifact.
- **F2** — retiring/reclassifying the always-FAIL 0-bit frozen `noisy.*` gate changes pre-registration semantics. **Minimal corrective:** a CALIB-GRID-003 pre-registration that either (a) changes the frozen experiment (longer record / larger θ₀ / lower σ) to put the gate at a reachable operating point, or (b) explicitly reclassifies `noisy.*` as an `infeasible_by_construction` diagnostic carrying 0 discriminative bits (documented, not a pass/fail gate). Requires your vector because it alters frozen pre-registration semantics.

## Honest backlog
- F4 has no fix-now: capping coupling_estimator accretion needs a strategy-registry refactor that would touch production code and re-route 17 importers — out of scope for a behavior-preserving audit; flagged as architectural debt with measured trajectory (+154%/5 lineages).
- F1/F2 deliberately left as report-for-vector (fail-closed per SPLIT rule).
- The F3 unification fixed the divergence but the *root* (CI BLAS nondeterminism on ill-conditioned CG-002 metrics forcing tolerant compares) is unaddressed; a deterministic-reduction harness would let the window tighten back toward exact — future work.
