### PR TITLE
fix(ctc-c5): tie-correct AUC — close the metric crack under the C5 verdict

### DIFF
--- a/.claude/commit_acceptors/c5-auc-tie-correctness.yaml
+++ b/.claude/commit_acceptors/c5-auc-tie-correctness.yaml
@@ -1,0 +1,31 @@
+id: c5-auc-tie-correctness
+status: ACTIVE
+claim_type: correctness
+promise: "C5 _auc is replaced with a tie-correct Mann–Whitney (mid-ranks) equal to the definitional AUC; the prior ordinal-rank version returned a false perfect separation on tied/constant scores. Pinned by a brute-force regression suite. C5 reruns byte-identical (OOS AUC 0.9630) — verdict strengthened, not retracted; closure now unconditional."
+diff_scope:
+  changed_files:
+    - path: "research/ctc_falsify/c5/oracle.py"
+    - path: "tests/research/ctc_falsify/test_c5_auc.py"
+    - path: "research/ctc_falsify/RESULTS.md"
+    - path: ".claude/commit_acceptors/c5-auc-tie-correctness.yaml"
+  forbidden_paths:
+    - "trading/"
+    - "execution/"
+    - "forecast/"
+    - "policy/"
+    - "research/ctc_falsify/c5/config_c5.py"
+required_python_symbols:
+  - "_auc"
+  - "run_oracle"
+expected_signal: "AUC regression suite passes; C5 OOS AUC unchanged (0.9630), verdict still C5_ESTIMATOR_QUALITY_GAP"
+measurement_command: "python -m pytest tests/research/ctc_falsify/test_c5_auc.py -q"
+signal_artifact: "tmp/c5_auc_pytest.log"
+falsifier:
+  command: "python -c \"import numpy as np; from research.ctc_falsify.c5.oracle import _auc; raise SystemExit(0 if _auc(np.full(6,0.7), np.array([1.,1.,1.,0.,0.,0.]))==0.5 and abs(_auc(np.array([1.,1.,1.,1.]),np.array([1.,0.,1.,0.]))-0.5)<1e-12 else 1)\""
+  description: "Probe asserts constant scores AND all-tied subsets give chance AUC 0.5 (exits 0). It exits 1 if the buggy ordinal-rank metric (false perfect separation on ties) is ever reinstated — making the regression falsifiable."
+rollback_command: "git checkout -- research/ctc_falsify/c5/oracle.py tests/research/ctc_falsify/test_c5_auc.py research/ctc_falsify/RESULTS.md"
+rollback_verification_command: "git diff --exit-code research/ctc_falsify/c5/oracle.py"
+memory_update_type: none
+ledger_path: ".claude/commit_acceptors/c5-auc-tie-correctness.yaml"
+report_path: "research/ctc_falsify/RESULTS.md"
+evidence: []

--- a/research/ctc_falsify/RESULTS.md
+++ b/research/ctc_falsify/RESULTS.md
@@ -74,7 +74,19 @@ C4 left one question open: is the standard-estimand blindness an
 gap? C5 puts a near-oracle upper bound on it — the best out-of-sample
 linear discriminant over the **full gamma cross-spectrum**
 (magnitude + phase), train/test seed-disjoint (no leakage). Result:
-**OOS ROC-AUC ≈ 0.96** ⇒ verdict `C5_ESTIMATOR_QUALITY_GAP`.
+**OOS ROC-AUC = 0.9630** ⇒ verdict `C5_ESTIMATOR_QUALITY_GAP`.
+
+> **Metric audit (post-closure hardening).** The AUC implementation was
+> independently audited and the prior ordinal-rank version had a real
+> defect: on tied/constant scores it returned a *false* perfect
+> separation. It was replaced with a tie-correct Mann–Whitney
+> (`scipy.stats.rankdata` mid-ranks) and pinned by a brute-force
+> definitional regression suite (constant, all-tied, perfect/anti,
+> reversed-label, unbalanced, randomised-ties). On rerun the OOS AUC is
+> **byte-identical 0.9630** (the real LDA projection scores are
+> continuous — no ties — so only degenerate cases were ever affected).
+> Per the pre-stated rule "fixed AUC ≈0.96 ⇒ C5 strengthened": the
+> closure is now **unconditional**, not contingent on a suspect metric.
 
 So the channel **is** information-recoverable on this generative model: a
 sufficient statistic exists in the richer cross-spectral representation.

--- a/research/ctc_falsify/c5/oracle.py
+++ b/research/ctc_falsify/c5/oracle.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass
 
 import numpy as np
 from scipy.signal import csd
+from scipy.stats import rankdata
 
 from research.ctc_falsify import config as l1
 from research.ctc_falsify.c5 import config_c5 as c5
@@ -57,14 +58,20 @@ def _lda_direction(x: np.ndarray, y: np.ndarray) -> np.ndarray:
 
 
 def _auc(scores: np.ndarray, y: np.ndarray) -> float:
+    """Tie-correct ROC-AUC via the Mann–Whitney U with *average* ranks.
+
+    Equals the definitional AUC = P(s+ > s-) + 0.5·P(s+ == s-). Uses
+    ``scipy.stats.rankdata`` (mid-ranks for ties) — the prior ordinal-rank
+    version inflated AUC on ties and returned a *false* perfect separation
+    on constant scores (all-equal → 0.0 → orientation-fold → 1.0). With
+    mid-ranks, constant/all-tied scores correctly give 0.5.
+    """
     pos = scores[y == 1]
     neg = scores[y == 0]
     if pos.size == 0 or neg.size == 0:
         return 0.5
-    order = np.argsort(np.concatenate([pos, neg]), kind="stable")
-    ranks = np.empty(order.size, dtype=np.float64)
-    ranks[order] = np.arange(1, order.size + 1)
-    r_pos = ranks[: pos.size].sum()
+    ranks = rankdata(np.concatenate([pos, neg]))  # 'average' ties by default
+    r_pos = float(ranks[: pos.size].sum())
     u = r_pos - pos.size * (pos.size + 1) / 2.0
     return float(u / (pos.size * neg.size))
 

--- a/tests/research/ctc_falsify/test_c5_auc.py
+++ b/tests/research/ctc_falsify/test_c5_auc.py
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: MIT
+"""Regression suite for the C5 ROC-AUC metric (fast lane — not slow).
+
+The C5 verdict (`C5_ESTIMATOR_QUALITY_GAP`) rests entirely on the OOS AUC
+crossing a pre-registered band. A defective AUC would make the closure
+conditional, not factual. Every edge case here is checked against the
+*definitional* AUC = P(s+ > s-) + 0.5·P(s+ == s-) computed by brute force.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from research.ctc_falsify.c5.oracle import _auc
+
+
+def _brute_auc(scores: np.ndarray, y: np.ndarray) -> float:
+    pos = scores[y == 1]
+    neg = scores[y == 0]
+    if pos.size == 0 or neg.size == 0:
+        return 0.5
+    gt = 0.0
+    for p in pos:
+        for n in neg:
+            gt += 1.0 if p > n else (0.5 if p == n else 0.0)
+    return gt / (pos.size * neg.size)
+
+
+def _check(scores: list[float], y: list[int]) -> None:
+    s = np.asarray(scores, dtype=np.float64)
+    yy = np.asarray(y, dtype=np.float64)
+    assert abs(_auc(s, yy) - _brute_auc(s, yy)) < 1e-12
+
+
+def test_constant_scores_give_chance_auc() -> None:
+    # The old ordinal-rank bug returned 0.0 here (→ folded to a FALSE 1.0).
+    _check([0.7] * 6, [1, 1, 1, 0, 0, 0])
+    s = np.full(6, 0.7)
+    y = np.array([1, 1, 1, 0, 0, 0], dtype=np.float64)
+    assert _auc(s, y) == 0.5
+
+
+def test_all_tied_subset_is_half_credited() -> None:
+    _check([1.0, 1.0, 1.0, 1.0], [1, 0, 1, 0])
+    _check([2, 2, 1, 1, 3, 3], [1, 0, 1, 0, 1, 0])
+
+
+def test_perfect_and_anti_separation() -> None:
+    assert _auc(np.array([3.0, 4.0, 1.0, 2.0]), np.array([1, 1, 0, 0])) == 1.0
+    assert _auc(np.array([1.0, 2.0, 3.0, 4.0]), np.array([1, 1, 0, 0])) == 0.0
+
+
+def test_reversed_labels_complement() -> None:
+    s = np.array([0.1, 0.9, 0.4, 0.8, 0.2], dtype=np.float64)
+    y = np.array([1, 0, 1, 0, 1], dtype=np.float64)
+    assert abs(_auc(s, y) + _auc(s, 1.0 - y) - 1.0) < 1e-12
+
+
+def test_unbalanced_classes_match_brute() -> None:
+    rng = np.random.default_rng(7)
+    s = rng.normal(size=40)
+    y = np.array([1] * 7 + [0] * 33, dtype=np.float64)
+    _check(list(s), list(y.astype(int)))
+
+
+def test_randomised_with_injected_ties_match_brute() -> None:
+    rng = np.random.default_rng(20260517)
+    for _ in range(50):
+        n = int(rng.integers(4, 30))
+        s = np.round(rng.normal(size=n), 1)  # rounding forces many ties
+        y = rng.integers(0, 2, size=n).astype(np.float64)
+        if y.sum() == 0 or y.sum() == n:
+            continue
+        assert abs(_auc(s, y) - _brute_auc(s, y)) < 1e-12
+
+
+def test_empty_class_is_chance() -> None:
+    assert _auc(np.array([1.0, 2.0]), np.array([1.0, 1.0])) == 0.5
+    assert _auc(np.array([1.0, 2.0]), np.array([0.0, 0.0])) == 0.5


### PR DESCRIPTION
**Metric crack closed; C5 strengthened, not retracted.**

The C5 `_auc` used ordinal argsort ranks with no tie-averaging: on tied
or constant scores it inflated AUC and returned a **false perfect
separation** (constant → 0.0 → orientation-fold → 1.0). The
`C5_ESTIMATOR_QUALITY_GAP` closure rested on a potentially defective
metric.

**Fix:** tie-correct Mann–Whitney via `scipy.stats.rankdata` (mid-ranks)
= the definitional AUC `P(s+>s-)+0.5·P(s+==s-)`, pinned by a brute-force
regression suite (constant, all-tied, perfect/anti, reversed-label,
unbalanced, randomised-ties; fast lane).

**Rerun C5:** OOS AUC **byte-identical 0.9630**, verdict unchanged
(`C5_ESTIMATOR_QUALITY_GAP`) — the real LDA projection scores are
continuous, so only degenerate cases were ever affected. Per the
pre-stated rule *fixed AUC ≈0.96 ⇒ C5 strengthened*: the closure is now
**unconditional**, not contingent on a suspect metric. `RESULTS.md`
metric-audit note added. **No C6** — the C5-metric foundation is closed.

claim_status: measured

🤖 Generated with [Claude Code](https://claude.com/claude-code)