### PR TITLE
governance(calib): F1 supersession registry + F2 pre-registration amendment (append-only, forward-only, zero estimator change)

### DIFF
--- a/.claude/commit_acceptors/calib-supersession-amendment.yaml
+++ b/.claude/commit_acceptors/calib-supersession-amendment.yaml
@@ -1,0 +1,206 @@
+# Diff-bound commit acceptor for the CALIB-GRID supersession +
+# pre-registration-amendment governance correction (F1 + F2).
+#
+# Both correctives are append-only epistemic-integrity governance
+# corrections. ZERO estimator/numeric/algorithm change. The merged
+# sha-pinned artifacts of CALIB-GRID-001 / R1 / CALIB-GRID-002 (every
+# RESULTS.json, RESULTS.md, ledger_sha256, PREREGISTRATION.md/.yaml,
+# gates.py constants, THRESHOLD_PROVENANCE.md) stay BYTE-IDENTICAL and
+# are in forbidden_paths. tests/research/calibration/test_grid_kuramoto.py
+# git-diff is EMPTY (it is in forbidden_paths) and every pre-existing
+# drift / no-peek / bit-stability test passes UNMODIFIED.
+#
+# F1 — SUPERSESSION RECORD. R1's sha-pinned r1/RESULTS.md asserts a
+# causal claim ("double-differentiation second-derivative SNR boundary",
+# "No consistent estimator exists for the noisy regime") that
+# CALIB-GRID-002 (merge e71d1915, ledger d0f89e24341b0995...) FALSIFIED:
+# the true cause is a class-independent regressor-level SNR floor at the
+# frozen theta0/record-length, NOT a differentiation-operator/estimator-
+# class defect. SUPERSESSIONS.yaml + SUPERSESSIONS.md enumerate exactly
+# the 4 sha-pinned artifacts encoding the stale claim
+# (r1/RESULTS.md:74,79,97; r1/RESULTS.json:100; r1/ATTEMPT.md:77) and
+# the 2 citing it (identifiability/THRESHOLD_PROVENANCE.md:103;
+# cg002/PROVENANCE_002.md:55), with a superseded/superseding sha pair
+# (a5527708 R1 <- e71d1915 CG002, both verified commit ancestors). The
+# supersession resolves FORWARD only; no frozen artifact is edited or
+# recomputed.
+#
+# F2 — RECLASSIFY noisy.* AS infeasible_by_construction.
+# PREREGISTRATION_AMENDMENT_001.yaml/.md (append-only) supersede the
+# CLASSIFICATION (not threshold VALUES) of noisy.frobenius /
+# noisy.topology_f1: from pass/fail acceptance gates to
+# INFEASIBLE_BY_CONSTRUCTION 0-bit diagnostics, citing the CG002 proof
+# (regressor SNR < 0.6 every edge, class-independent) as the immutable
+# justification. The frozen PREREGISTRATION.md / gates.py constants are
+# NOT edited. Forward-only verdict logic: _substrate.py gains
+# INFEASIBLE_BY_CONSTRUCTION + amended_gate_names() +
+# overall_verdict_amended(); run.py gains build_amended_ledger +
+# --amended (a NEW forward-only lineage #6 artifact). The default
+# build_ledger / build_r1_ledger / build_cg002_ledger are UNTOUCHED and
+# byte-stable; the 3 historical lineages are NOT recomputed (proved by
+# test_historical_artifacts_not_recomputed_by_amendment).
+#
+# Locally verified:
+#   * pytest tests/research/calibration/test_calib_amendment_001.py
+#     tests/research/calibration/test_calib_lineage_forcing_functions.py:
+#     all green (fast + slow)
+#   * git diff --exit-code tests/research/calibration/test_grid_kuramoto.py
+#     is EMPTY; the historical reproduction tests pass UNMODIFIED
+#   * all frozen artifacts byte-untouched (git status clean on r1/,
+#     RESULTS.json, PREREGISTRATION.md, gates.py, cg002/, identifiability/)
+#   * mypy --strict / ruff / black clean on the diff (fresh cache; the
+#     stale .mypy_cache `google` crash is environmental, not a defect)
+#
+# Net effect: +2 append-only governance docs (F1) + 2 (F2), +2
+# forcing/semantics test modules, +1 forward-only opt-in builder + 1
+# verdict helper. ZERO estimator/numeric/algorithm change, ZERO
+# frozen-artifact change.
+
+id: calib-supersession-amendment
+status: ACTIVE
+claim_type: governance
+promise: >-
+  After this PR lands, research/calibration/grid_kuramoto/ carries two
+  append-only epistemic-integrity governance layers. (F1)
+  SUPERSESSIONS.yaml + SUPERSESSIONS.md record that R1's
+  double-differentiation / no-consistent-estimator noisy attribution is
+  superseded by CALIB-GRID-002's class-independent regressor-floor
+  proof, enumerating exactly the 4 encoding + 2 citing sha-pinned
+  artifacts with a verified superseded/superseding sha pair; a
+  forcing-function test (test_superseded_claims_resolve_via_registry)
+  fails closed if any NEW lineage doc inherits the falsified premise
+  without resolving the registry, and
+  test_supersession_registry_is_internally_consistent enforces every
+  enumerated path exists with its verbatim anchor and both shas are
+  real commit ancestors. (F2) PREREGISTRATION_AMENDMENT_001.yaml/.md
+  supersede the CLASSIFICATION (not threshold values) of the two frozen
+  noisy.* gates to INFEASIBLE_BY_CONSTRUCTION 0-bit diagnostics;
+  _substrate.overall_verdict_amended computes the overall verdict over
+  the remaining genuine pass/fail gates only and run.build_amended_
+  ledger / --amended emit a NEW forward-only lineage #6 artifact. The
+  default builders are byte-stable and the merged CALIB-GRID-001 / R1 /
+  CALIB-GRID-002 RESULTS.json are NOT recomputed (their historical
+  NEGATIVE + FAIL reproduce unmodified). No estimator, numeric,
+  algorithm, frozen pre-registration, gates.py constant, sha-pinned
+  RESULTS ledger, threshold value, seed, sigma, theta0 or decision rule
+  of a merged lineage is touched; tests/research/calibration/
+  test_grid_kuramoto.py is byte-unchanged.
+diff_scope:
+  changed_files:
+    - path: ".claude/commit_acceptors/calib-supersession-amendment.yaml"
+    - path: "research/calibration/grid_kuramoto/SUPERSESSIONS.yaml"
+    - path: "research/calibration/grid_kuramoto/SUPERSESSIONS.md"
+    - path: "research/calibration/grid_kuramoto/PREREGISTRATION_AMENDMENT_001.yaml"
+    - path: "research/calibration/grid_kuramoto/PREREGISTRATION_AMENDMENT_001.md"
+    - path: "research/calibration/grid_kuramoto/_substrate.py"
+    - path: "research/calibration/grid_kuramoto/run.py"
+    - path: "tests/research/calibration/test_calib_lineage_forcing_functions.py"
+    - path: "tests/research/calibration/test_calib_amendment_001.py"
+  forbidden_paths:
+    - "trading/"
+    - "execution/"
+    - "forecast/"
+    - "policy/"
+    - "core/"
+    - "research/calibration/grid_kuramoto/PREREGISTRATION.md"
+    - "research/calibration/grid_kuramoto/gates.py"
+    - "research/calibration/grid_kuramoto/calibration.py"
+    - "research/calibration/grid_kuramoto/grid_data.py"
+    - "research/calibration/grid_kuramoto/RESULTS.json"
+    - "research/calibration/grid_kuramoto/RESULTS.md"
+    - "research/calibration/grid_kuramoto/r1/"
+    - "research/calibration/grid_kuramoto/cg002/RESULTS.json"
+    - "research/calibration/grid_kuramoto/cg002/RESULTS.md"
+    - "research/calibration/grid_kuramoto/cg002/PREREGISTRATION_002.yaml"
+    - "research/calibration/grid_kuramoto/cg002/PROVENANCE_002.md"
+    - "research/calibration/grid_kuramoto/cg002/cg002.py"
+    - "research/calibration/grid_kuramoto/identifiability/"
+    - "application/governance/claim_ledger.py"
+    - "application/governance/commit_acceptor.py"
+    - "tests/research/calibration/test_grid_kuramoto.py"
+    - "tests/research/calibration/test_calib_substrate_consolidation.py"
+required_python_symbols:
+  - "research/calibration/grid_kuramoto/_substrate.py::overall_verdict_amended"
+  - "research/calibration/grid_kuramoto/_substrate.py::amended_gate_names"
+  - "research/calibration/grid_kuramoto/run.py::build_amended_ledger"
+expected_signal: >-
+  `pytest tests/research/calibration/test_calib_amendment_001.py
+  tests/research/calibration/test_calib_lineage_forcing_functions.py -q`
+  is green (fast + slow); mypy --strict / ruff / black clean on the
+  diff; `git diff --exit-code
+  tests/research/calibration/test_grid_kuramoto.py` is empty; the
+  historical reproduction tests
+  (test_r1_results_json_matches_committed_artifact,
+  test_cg002_results_json_matches_committed_artifact) pass UNMODIFIED;
+  build_amended_ledger emits per_gate_state with both noisy.* gates ==
+  INFEASIBLE_BY_CONSTRUCTION and a reduced NEGATIVE verdict resting on
+  noiseless.critical_coupling; build_ledger / build_r1_ledger carry NO
+  per_gate_state key and still emit the historical NEGATIVE.
+measurement_command: >-
+  bash -c '
+    rm -rf .mypy_cache &&
+    mypy --strict --follow-imports=silent
+      research/calibration/grid_kuramoto/_substrate.py
+      research/calibration/grid_kuramoto/run.py
+      tests/research/calibration/test_calib_amendment_001.py
+      tests/research/calibration/test_calib_lineage_forcing_functions.py
+    && ruff check
+       research/calibration/grid_kuramoto/_substrate.py
+       research/calibration/grid_kuramoto/run.py
+       tests/research/calibration/test_calib_amendment_001.py
+       tests/research/calibration/test_calib_lineage_forcing_functions.py
+    && black --check
+       research/calibration/grid_kuramoto/_substrate.py
+       research/calibration/grid_kuramoto/run.py
+       tests/research/calibration/test_calib_amendment_001.py
+       tests/research/calibration/test_calib_lineage_forcing_functions.py
+    && git diff --exit-code tests/research/calibration/test_grid_kuramoto.py
+    && python -m pytest
+       tests/research/calibration/test_calib_amendment_001.py
+       tests/research/calibration/test_calib_lineage_forcing_functions.py
+       tests/research/calibration/test_grid_kuramoto.py -q
+  '
+signal_artifact: "tmp/calib_supersession_amendment.log"
+falsifier:
+  command: >-
+    bash -c '
+      python -m pytest
+      "tests/research/calibration/test_calib_amendment_001.py::test_historical_artifacts_not_recomputed_by_amendment"
+      "tests/research/calibration/test_calib_amendment_001.py::test_fresh_amended_run_emits_infeasible_and_reduced_verdict"
+      "tests/research/calibration/test_calib_lineage_forcing_functions.py::test_supersession_registry_is_internally_consistent"
+      "tests/research/calibration/test_calib_lineage_forcing_functions.py::test_superseded_claims_resolve_via_registry"
+      -q >/tmp/_calib_sa_rails.log 2>&1
+      && ! grep -q "4 passed" /tmp/_calib_sa_rails.log
+    '
+  description: >-
+    Probes four load-bearing rails: (1) the 3 historical lineages are
+    NOT recomputed by the amendment (default builders byte-stable); (2)
+    a fresh --amended run emits INFEASIBLE_BY_CONSTRUCTION + a reduced
+    NEGATIVE resting on a genuine gate; (3) the supersession registry is
+    internally consistent (paths exist + verbatim anchors + ancestor
+    shas + audited 4/2 cardinality); (4) no new doc inherits R1's
+    falsified premise unresolved. The falsifier succeeds (exit 0) only
+    when one of these rails fails.
+rollback_command: >-
+  bash -c 'git checkout origin/main --
+    research/calibration/grid_kuramoto/_substrate.py
+    research/calibration/grid_kuramoto/run.py
+    tests/research/calibration/test_calib_lineage_forcing_functions.py
+    && rm -f
+    research/calibration/grid_kuramoto/SUPERSESSIONS.yaml
+    research/calibration/grid_kuramoto/SUPERSESSIONS.md
+    research/calibration/grid_kuramoto/PREREGISTRATION_AMENDMENT_001.yaml
+    research/calibration/grid_kuramoto/PREREGISTRATION_AMENDMENT_001.md
+    tests/research/calibration/test_calib_amendment_001.py
+    .claude/commit_acceptors/calib-supersession-amendment.yaml'
+rollback_verification_command: >-
+  bash -c '! test -f
+    research/calibration/grid_kuramoto/SUPERSESSIONS.yaml
+    && ! test -f
+    research/calibration/grid_kuramoto/PREREGISTRATION_AMENDMENT_001.yaml
+    && ! grep -q overall_verdict_amended
+    research/calibration/grid_kuramoto/_substrate.py'
+memory_update_type: append
+ledger_path: ".claude/commit_acceptors/calib-supersession-amendment.yaml"
+report_path: "tmp/calib_supersession_amendment.log"
+evidence: []

--- a/research/calibration/grid_kuramoto/PREREGISTRATION_AMENDMENT_001.md
+++ b/research/calibration/grid_kuramoto/PREREGISTRATION_AMENDMENT_001.md
@@ -1,0 +1,78 @@
+# Pre-Registration Amendment 001 — CALIB-GRID-001 (append-only)
+
+> **Status:** append-only epistemic-integrity amendment. This is a
+> **separate superseding layer**. It does **not** edit the frozen
+> `PREREGISTRATION.md`, `gates.py`, or any sha-pinned `RESULTS.json`,
+> and it changes **no threshold value**. It supersedes — **forward
+> only** (lineage #6+) — the *classification* of the two frozen
+> `noisy.*` gates: from pass/fail acceptance gates to
+> `infeasible_by_construction` zero-bit diagnostics. The single source
+> of truth for the machine contract is
+> `PREREGISTRATION_AMENDMENT_001.yaml`; this file is the rationale.
+
+## The problem (CG002-proven)
+
+The frozen `noisy.frobenius` (σ=0.02, `≤0.25`) and `noisy.topology_f1`
+(σ=0.02, `≥0.90`) gates were pre-registered as if they tested the
+estimator. CALIB-GRID-002 (sha-pinned NEGATIVE, merge `e71d1915`,
+ledger `d0f89e24341b0995…`) proved they sit at an
+**information-theoretically unreachable operating point**:
+
+* the clean `sin(θ_i−θ_j)` coupling regressor has std 0.00244–0.01611;
+* the σ=0.02 noise injects std ≈0.0287 into the *same* regressor;
+* ⇒ regressor **SNR < 0.6 on every edge** (0.085 on edge (0,2))
+  **before any estimator touches the data**.
+
+The coupling signal is below the measurement noise at the frozen
+θ₀/record-length. No estimator — differential, integral, or otherwise —
+can recover what the σ=0.02 noise has already destroyed:
+`P(FAIL) = 1 ∀ estimator`, so the gate carries **H = 0 bits** about
+estimator quality. Scored as a pass/fail acceptance gate it makes every
+future lineage's `NEGATIVE` saturate to zero information.
+
+## The amendment (classification only)
+
+| Frozen gate | Threshold (UNCHANGED) | Old class | New class |
+|---|---|---|---|
+| `noisy.frobenius` | `≤ 0.25` | pass/fail acceptance | `infeasible_by_construction` 0-bit diagnostic |
+| `noisy.topology_f1` | `≥ 0.90` | pass/fail acceptance | `infeasible_by_construction` 0-bit diagnostic |
+
+The amended gates are still **run** and still **reported** (the metric
+remains an informative regressor-floor witness), but they are
+**excluded from the overall lineage pass/fail verdict**, which is
+computed over the remaining genuine pass/fail gates only. The
+forward-only verdict state for an amended gate is
+`INFEASIBLE_BY_CONSTRUCTION` — a distinct zero-bit state, **not** PASS,
+**not** FAIL.
+
+## Forward-only — the historical record is byte-frozen
+
+This is the **only** behavioural change and it is **forward-only**:
+
+* It applies only to lineage #6+ runs that **explicitly opt into** the
+  amendment.
+* It does **not** apply to the merged CALIB-GRID-001 / R1 /
+  CALIB-GRID-002 sha-pinned `RESULTS.json` — they remain **byte-frozen**
+  with their historical `NEGATIVE` + `FAIL` and are **not** recomputed.
+* `build_ledger` / `build_r1_ledger` / `build_cg002_ledger` emit the
+  **exact historical bytes** when run *without* the amendment flag; the
+  existing `*_results_json_matches_committed_artifact` reproduction
+  tests pass **unmodified**.
+
+A regression/golden test proves the historical artifacts are **not**
+recomputed (their reproduction tests still reproduce the original FAIL
+bytes); a new test proves a fresh run *under* the amendment emits
+`INFEASIBLE_BY_CONSTRUCTION` for the amended gates and the correct
+reduced-gate overall verdict. A no-peek drift test binds the amendment
+constants to the substrate. The amendment path is frozen-after-commit
+(commit-acceptor `forbidden_paths`).
+
+## Cross-reference
+
+The causal correction this amendment rests on is recorded in
+`SUPERSESSIONS.yaml::SUPERSEDE-001` (R1's double-differentiation
+attribution falsified by CALIB-GRID-002's class-independent
+regressor-floor proof). This amendment reclassifies the *gate*; that
+record supersedes the *attribution*. Together they keep the historical
+record honest as-is while preventing lineage #6+ from inheriting either
+the falsified premise or the zero-information gate.

--- a/research/calibration/grid_kuramoto/PREREGISTRATION_AMENDMENT_001.yaml
+++ b/research/calibration/grid_kuramoto/PREREGISTRATION_AMENDMENT_001.yaml
@@ -28,7 +28,8 @@ amends:
   section: "§ 4 — Pre-registered acceptance gates (Noisy regime)"
   # The frozen pre-registration sha this amendment supersedes the
   # CLASSIFICATION (not the values) of. Verified commit ancestor.
-  frozen_preregistration_sha: d170d48afa5066c13edeb40b2c1904b3fd708516
+  # audited: frozen parent pre-registration git sha, not a credential
+  frozen_preregistration_sha: d170d48afa5066c13edeb40b2c1904b3fd708516  # pragma: allowlist secret
   # The amendment is itself committed on this branch base (sha-binding
   # is the commit that lands this file; see PROVENANCE / commit acceptor).
   amendment_branch_base_sha: e6370fe3
@@ -39,8 +40,10 @@ amends:
 # (0.085 on edge (0,2)) at the frozen sigma=0.02, class-independent.
 evidence:
   superseding_lineage: CALIB-GRID-002
-  superseding_sha: e71d1915233283452f3fb219aafabd2f19035371
-  cg002_ledger_sha256: d0f89e24341b099598e2e5cc9809772ee2c47627f77bf3354f957fab860819b1
+  # audited: CALIB-GRID-002 merge git sha, not a credential
+  superseding_sha: e71d1915233283452f3fb219aafabd2f19035371  # pragma: allowlist secret
+  # audited: CALIB-GRID-002 ledger content hash, not a credential
+  cg002_ledger_sha256: d0f89e24341b099598e2e5cc9809772ee2c47627f77bf3354f957fab860819b1  # pragma: allowlist secret
   proof: >-
     CALIB-GRID-002 cg002/RESULTS.md measures the clean
     sin(theta_i-theta_j) coupling regressor (std 0.00244-0.01611) versus

--- a/research/calibration/grid_kuramoto/PREREGISTRATION_AMENDMENT_001.yaml
+++ b/research/calibration/grid_kuramoto/PREREGISTRATION_AMENDMENT_001.yaml
@@ -1,0 +1,88 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+#
+# PRE-REGISTRATION AMENDMENT 001 — CALIB-GRID-001 (append-only).
+#
+# Status: append-only epistemic-integrity amendment. This file is a
+# SEPARATE SUPERSEDING LAYER. It does NOT edit the frozen
+# PREREGISTRATION.md / PREREGISTRATION_002.yaml, gates.py, or any
+# sha-pinned RESULTS ledger. It does NOT change any threshold VALUE.
+# It supersedes, FORWARD ONLY (lineage #6+), the CLASSIFICATION of the
+# two frozen `noisy.*` gates: from pass/fail acceptance gates to
+# `infeasible_by_construction` 0-bit DIAGNOSTICS.
+#
+# The merged CALIB-GRID-001 / R1 / CALIB-GRID-002 RESULTS.json stay
+# BYTE-FROZEN with their historical NEGATIVE + FAIL. There is NO
+# retroactive recompute and NO rewrite. A no-peek drift test
+# (test_amendment_001_matches_code) binds these constants to the
+# amended-verdict substrate. The amendment path is frozen-after-commit
+# (commit-acceptor forbidden_paths).
+
+identifier: PREREGISTRATION-AMENDMENT-001
+kind: classification-amendment
+is_hypothesis: false
+is_science_claim: false
+
+amends:
+  document: research/calibration/grid_kuramoto/PREREGISTRATION.md
+  section: "§ 4 — Pre-registered acceptance gates (Noisy regime)"
+  # The frozen pre-registration sha this amendment supersedes the
+  # CLASSIFICATION (not the values) of. Verified commit ancestor.
+  frozen_preregistration_sha: d170d48afa5066c13edeb40b2c1904b3fd708516
+  # The amendment is itself committed on this branch base (sha-binding
+  # is the commit that lands this file; see PROVENANCE / commit acceptor).
+  amendment_branch_base_sha: e6370fe3
+
+# --- Evidence anchor (the immutable justification) -----------------------
+# The CG002 sha-pinned NEGATIVE proves the reclassification. This is the
+# CITED, not re-derived, proof: regressor SNR < 0.6 on EVERY edge
+# (0.085 on edge (0,2)) at the frozen sigma=0.02, class-independent.
+evidence:
+  superseding_lineage: CALIB-GRID-002
+  superseding_sha: e71d1915233283452f3fb219aafabd2f19035371
+  cg002_ledger_sha256: d0f89e24341b099598e2e5cc9809772ee2c47627f77bf3354f957fab860819b1
+  proof: >-
+    CALIB-GRID-002 cg002/RESULTS.md measures the clean
+    sin(theta_i-theta_j) coupling regressor (std 0.00244-0.01611) versus
+    the sigma=0.02-induced perturbation in the SAME regressor (std
+    ~0.0287) on the frozen WSCC-9 over-damped transient: regressor SNR
+    < 0.6 on every edge, 0.085 on edge (0,2), BEFORE any estimator
+    touches the data. The coupling signal is information-theoretically
+    below the measurement noise at the frozen theta0/record-length. No
+    estimator (differential, integral, or otherwise) can recover what
+    the sigma=0.02 noise has already destroyed: P(FAIL)=1 for all
+    estimators, so the gate carries H=0 bits about estimator quality.
+  cross_reference: SUPERSESSIONS.yaml::SUPERSEDE-001
+
+# --- The reclassification (classification only; values unchanged) --------
+reclassification:
+  rationale: >-
+    The two frozen `noisy.*` gates were pre-registered as if they tested
+    the estimator. CALIB-GRID-002 proved they sit at an information-
+    theoretically unreachable operating point: FAIL with probability 1
+    for every estimator class, so they carry zero bits about estimator
+    quality. Scored as pass/fail acceptance gates they make every future
+    lineage's NEGATIVE saturate to zero information. Reclassified to
+    `infeasible_by_construction` 0-bit DIAGNOSTICS: still RUN and still
+    REPORTED (the metric is informative as a regressor-floor witness),
+    but EXCLUDED from the overall lineage pass/fail verdict, which is
+    computed over the remaining genuine pass/fail gates only.
+  # The threshold VALUES are NOT touched. These names mirror gates.py
+  # NOISY_GATES verbatim; the amendment changes only their CLASS.
+  amended_verdict_state: INFEASIBLE_BY_CONSTRUCTION
+  amended_gate_names:
+    - noisy.frobenius
+    - noisy.topology_f1
+
+# --- Forward-only scope (the only behavioural change) --------------------
+forward_only:
+  applies_to: "lineage #6+ runs that explicitly opt into the amendment"
+  does_not_apply_to: >-
+    the merged CALIB-GRID-001 / R1 / CALIB-GRID-002 sha-pinned
+    RESULTS.json — they are byte-frozen with their historical NEGATIVE +
+    FAIL and are NOT recomputed under this amendment.
+  default_path_unchanged: >-
+    build_ledger / build_r1_ledger / build_cg002_ledger emit the exact
+    historical bytes when run WITHOUT the amendment flag; the existing
+    *_results_json_matches_committed_artifact reproduction tests pass
+    unmodified.

--- a/research/calibration/grid_kuramoto/SUPERSESSIONS.md
+++ b/research/calibration/grid_kuramoto/SUPERSESSIONS.md
@@ -1,0 +1,88 @@
+# CALIB-GRID Supersession Record (append-only)
+
+> **Status:** append-only epistemic-integrity governance layer. This
+> document and its machine-readable twin `SUPERSESSIONS.yaml` record
+> that a sha-pinned CALIB-GRID artifact encodes a causal premise a
+> *later* sha-pinned lineage has falsified. **No frozen artifact is
+> edited, recomputed or rewritten.** The historical NEGATIVE/FAIL
+> records are immutable and stay byte-identical; the supersession
+> resolves **forward** (lineage #6+), it does not retroactively rewrite
+> the record. The single source of truth for the machine contract is
+> `SUPERSESSIONS.yaml`; this file is the rationale.
+
+## Why this layer exists
+
+R1's sha-pinned `r1/RESULTS.md` asserts a **causal** claim about *why*
+the frozen σ=0.02 noisy regime fails: a "double-differentiation
+second-derivative SNR / persistent-excitation boundary" and, verbatim,
+"**No consistent estimator exists for the noisy regime at this
+trajectory length and excitation level**". That is an estimator-class /
+differentiation-operator attribution.
+
+CALIB-GRID-002 (a *later* pre-registered lineage, merge sha
+`e71d1915`) **falsified that attribution**. An estimator that *never*
+double-differentiates the phase (the integral / weak form) still fails
+the same frozen σ=0.02 regime at ≈0.95. CALIB-GRID-002's sha-pinned
+`cg002/RESULTS.md` measures the regressor directly and shows the clean
+`sin(θ_i−θ_j)` coupling signal sits **below the σ=0.02 measurement
+noise on every edge (regressor SNR < 0.6, 0.085 on edge (0,2))
+before any estimator touches the data**. The corrected, sha-pinned
+attribution is therefore:
+
+> **a class-independent regressor-level SNR floor at the frozen
+> θ₀/record-length, NOT a differentiation-operator/estimator-class
+> defect.** The double-differentiation operator made the error *worse*
+> (16.6) but is not the cause.
+
+Without this layer, a future lineage (#6+) reading `r1/RESULTS.md` as
+ground truth inherits a **falsified premise** (it would chase an
+estimator-class fix for a regressor-floor boundary). The forcing
+function `test_superseded_claims_resolve_via_registry` fails closed if
+any artifact references the superseded R1 claim/sha without resolving
+this registry.
+
+## SUPERSEDE-001 — enumerated artifacts (grep-evidenced, file:line)
+
+### The exactly FOUR sha-pinned artifacts that ENCODE the stale claim
+
+| # | Artifact | Line | Verbatim anchor |
+|---|---|---|---|
+| 1 | `r1/RESULTS.md` | 74 | `second-derivative SNR / persistent-excitation` |
+| 1 | `r1/RESULTS.md` | 79 | `No consistent estimator exists for the noisy regime` |
+| 2 | `r1/RESULTS.md` | 97 | `double-differentiation SNR boundary in the noisy regime` |
+| 3 | `r1/RESULTS.json` | 100 | `coupling_estimator noise robustness / standardisation` (machine-readable `localized_refinement_targets` encoding the same estimator-class attribution for the noisy gates) |
+| 4 | `r1/ATTEMPT.md` | 77 | `one regime gate now passes, three still fail` (anchors the R1 noisy attribution by reference into the lineage attempt record) |
+
+(Artifact 1 = `r1/RESULTS.md` — the prose claim, two grep hits on lines
+74 and 79; artifact 2 = the `r1/RESULTS.md` summary restatement on line
+97; artifact 3 = `r1/RESULTS.json` machine-readable encoding; artifact
+4 = `r1/ATTEMPT.md` lineage record.)
+
+### The TWO downstream sha-pinned artifacts that CITE the stale claim
+
+| # | Artifact | Line | Verbatim anchor |
+|---|---|---|---|
+| 5 | `identifiability/THRESHOLD_PROVENANCE.md` | 103 | `after double differentiation, measurement noise can inflate` (inherits R1's double-differentiation attribution as a design premise) |
+| 6 | `cg002/PROVENANCE_002.md` | 55 | `CALIB-GRID-001 R1 RESULTS.md: the swept Savitzky–Golay verification` (cites R1's attribution directly) |
+
+## Supersession relation (sha-pinned)
+
+| Field | Value |
+|---|---|
+| `superseded_lineage` | `CALIB-GRID-001-R1` |
+| `superseded_sha` | `a5527708833df308e67536aaa690b4f16e88dccd` (PR #751, R1 merge — verified commit ancestor) |
+| `superseding_lineage` | `CALIB-GRID-002` |
+| `superseding_sha` | `e71d1915233283452f3fb219aafabd2f19035371` (PR #757, CG002 merge — verified commit ancestor) |
+| `superseding_artifact` | `research/calibration/grid_kuramoto/cg002/RESULTS.md` |
+| Evidence anchor | CG002 ledger `ledger_sha256 = d0f89e24341b0995…` |
+
+## What this record does *not* do
+
+It does **not** edit, recompute or rewrite any frozen artifact.
+`r1/RESULTS.md`, `r1/RESULTS.json`, `r1/ATTEMPT.md` and every other
+sha-pinned file stay **byte-identical**. R1's `NEGATIVE` verdict and
+its differential-class boundary record remain the true historical
+record. Only the *causal attribution* of the noisy failure is
+superseded **forward**: R1 stands as the differential-class boundary
+record, CALIB-GRID-002 as the class-independent regressor-floor
+boundary record. The historical record stays honest as-is.

--- a/research/calibration/grid_kuramoto/SUPERSESSIONS.yaml
+++ b/research/calibration/grid_kuramoto/SUPERSESSIONS.yaml
@@ -53,13 +53,15 @@ supersessions:
     # superseded lineage (R1). Both are real commit ancestors; the
     # forcing-function test verifies ancestry fail-closed.
     superseded_lineage: CALIB-GRID-001-R1
-    superseded_sha: a5527708833df308e67536aaa690b4f16e88dccd
+    # audited: CALIB-GRID-001 R1 merge git sha, not a credential
+    superseded_sha: a5527708833df308e67536aaa690b4f16e88dccd  # pragma: allowlist secret
     superseding_lineage: CALIB-GRID-002
-    superseding_sha: e71d1915233283452f3fb219aafabd2f19035371
+    # audited: CALIB-GRID-002 merge git sha, not a credential
+    superseding_sha: e71d1915233283452f3fb219aafabd2f19035371  # pragma: allowlist secret
     superseding_artifact: research/calibration/grid_kuramoto/cg002/RESULTS.md
-    # Evidence anchor: the superseding artifact's sha-pinned ledger.
-    superseding_ledger_sha256: >-
-      d0f89e24341b0995
+    # Evidence anchor: the superseding artifact's sha-pinned ledger
+    # (short content-hash prefix; full hash in cg002/RESULTS.json).
+    superseding_ledger_sha256: "d0f89e24341b0995"  # pragma: allowlist secret
     # The EXACTLY FOUR sha-pinned artifacts that ENCODE the stale R1
     # causal premise (found by grep; file:line + verbatim anchor).
     stale_artifacts:

--- a/research/calibration/grid_kuramoto/SUPERSESSIONS.yaml
+++ b/research/calibration/grid_kuramoto/SUPERSESSIONS.yaml
@@ -1,0 +1,113 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+#
+# CALIB-GRID supersession registry (append-only, machine-readable).
+#
+# This file is the SINGLE SOURCE OF TRUTH for "a sha-pinned CALIB-GRID
+# artifact encodes a causal premise that a LATER sha-pinned lineage has
+# FALSIFIED". It does NOT rewrite, recompute or edit any frozen artifact:
+# the historical NEGATIVE/FAIL records are immutable and stay byte-
+# identical. A supersession entry is a NEW ADDITIVE LAYER that resolves
+# FORWARD — every lineage #6+ that reads a superseded premise as ground
+# truth MUST also resolve this registry (enforced by the forcing-function
+# test test_superseded_claims_resolve_via_registry).
+#
+# Fail-closed contract: every `stale_artifacts[].path` must exist on
+# disk; every `superseded_sha` / `superseding_sha` must be a real commit
+# ancestor of the current branch. The frozen artifacts themselves are
+# NOT touched — this registry only records the supersession relation.
+
+version: 1
+registry: CALIB-GRID-SUPERSESSIONS
+
+supersessions:
+  - id: SUPERSEDE-001
+    title: >-
+      R1's "double-differentiation SNR / no-consistent-estimator" noisy
+      attribution is FALSIFIED by CALIB-GRID-002.
+    # The premise as R1 stated it (paraphrased; verbatim anchors are in
+    # stale_artifacts[].verbatim_anchor below).
+    stale_premise: >-
+      CALIB-GRID-001 R1 attributes the frozen sigma=0.02 noisy-regime
+      failure to a double-differentiation second-derivative SNR /
+      persistent-excitation boundary and asserts "no consistent
+      estimator exists for the noisy regime at this trajectory length
+      and excitation level" — i.e. an estimator-class /
+      differentiation-operator defect.
+    # The corrected attribution, verbatim-anchored to the superseding
+    # artifact (cg002/RESULTS.md) so the correction cannot drift.
+    corrected_attribution: >-
+      class-independent regressor-level SNR floor at frozen
+      theta0/record-length, NOT a differentiation-operator/estimator-
+      class defect. CALIB-GRID-002 proves by a direct regressor-level
+      SNR measurement on the SAME frozen sigma=0.02 trajectory that the
+      clean sin(theta_i-theta_j) coupling regressor sits below the
+      sigma=0.02 measurement noise on every edge (regressor SNR < 0.6
+      every edge, 0.085 on edge (0,2)) BEFORE any estimator touches the
+      data. The double-differentiation operator made the error worse
+      (16.6) but is NOT the cause; the cause is the frozen experiment's
+      signal-to-noise at this excitation and record length, and it is
+      class-independent (an estimator that never differentiates the
+      phase still fails at ~0.95).
+    # The superseding sha-pinned artifact (CALIB-GRID-002) and the
+    # superseded lineage (R1). Both are real commit ancestors; the
+    # forcing-function test verifies ancestry fail-closed.
+    superseded_lineage: CALIB-GRID-001-R1
+    superseded_sha: a5527708833df308e67536aaa690b4f16e88dccd
+    superseding_lineage: CALIB-GRID-002
+    superseding_sha: e71d1915233283452f3fb219aafabd2f19035371
+    superseding_artifact: research/calibration/grid_kuramoto/cg002/RESULTS.md
+    # Evidence anchor: the superseding artifact's sha-pinned ledger.
+    superseding_ledger_sha256: >-
+      d0f89e24341b0995
+    # The EXACTLY FOUR sha-pinned artifacts that ENCODE the stale R1
+    # causal premise (found by grep; file:line + verbatim anchor).
+    stale_artifacts:
+      - path: research/calibration/grid_kuramoto/r1/RESULTS.md
+        line: 74
+        kind: encodes
+        verbatim_anchor: >-
+          second-derivative SNR / persistent-excitation
+      - path: research/calibration/grid_kuramoto/r1/RESULTS.md
+        line: 79
+        kind: encodes
+        verbatim_anchor: >-
+          No consistent estimator exists for the noisy regime
+      - path: research/calibration/grid_kuramoto/r1/RESULTS.md
+        line: 97
+        kind: encodes
+        verbatim_anchor: >-
+          double-differentiation SNR boundary in the noisy regime
+      - path: research/calibration/grid_kuramoto/r1/RESULTS.json
+        line: 100
+        kind: encodes
+        verbatim_anchor: >-
+          coupling_estimator noise robustness / standardisation
+      - path: research/calibration/grid_kuramoto/r1/ATTEMPT.md
+        line: 77
+        kind: encodes
+        verbatim_anchor: >-
+          one regime gate now passes, three still fail
+    # The TWO downstream sha-pinned artifacts that CITE the stale R1
+    # attribution as a premise (inherit it without resolving it).
+    citing_artifacts:
+      - path: research/calibration/grid_kuramoto/identifiability/THRESHOLD_PROVENANCE.md
+        line: 103
+        kind: cites
+        verbatim_anchor: >-
+          after double differentiation, measurement noise can inflate
+      - path: research/calibration/grid_kuramoto/cg002/PROVENANCE_002.md
+        line: 55
+        kind: cites
+        verbatim_anchor: >-
+          CALIB-GRID-001 R1 RESULTS.md: the swept Savitzky
+    # What this supersession does NOT do (honesty rail).
+    not_a_recompute: >-
+      No frozen artifact is edited, recomputed or rewritten. r1/
+      RESULTS.md, r1/RESULTS.json, r1/ATTEMPT.md and every other sha-
+      pinned file stay BYTE-IDENTICAL. R1's NEGATIVE verdict and its
+      differential-class boundary record remain the true historical
+      record. Only the CAUSAL ATTRIBUTION of the noisy failure is
+      superseded forward; R1 stands as the differential-class boundary
+      record, CALIB-GRID-002 as the class-independent regressor-floor
+      boundary record.

--- a/research/calibration/grid_kuramoto/_substrate.py
+++ b/research/calibration/grid_kuramoto/_substrate.py
@@ -32,16 +32,21 @@ from pathlib import Path
 from typing import Any
 
 import numpy as np
+import yaml
 from numpy.typing import NDArray
 
 __all__ = [
+    "AMENDMENT_001_PATH",
     "FROZEN_PREREG_SHA",
+    "INFEASIBLE_BY_CONSTRUCTION",
     "PARENT_LEDGER_SHA256",
     "PREREG_BRANCH_BASE_SHA",
     "Gate",
     "GateRow",
+    "amended_gate_names",
     "branch_sha",
     "ledger_sha256",
+    "overall_verdict_amended",
     "topology_f1",
 ]
 
@@ -179,3 +184,81 @@ class GateRow:
             "passed": self.passed,
             "localises_to": self.localises_to,
         }
+
+
+# --- Pre-Registration Amendment 001 — forward-only verdict layer ---------
+#
+# This block is the ONLY behavioural change of the F2 amendment and it
+# is FORWARD-ONLY. It does NOT touch any threshold value, the frozen
+# ``PREREGISTRATION.md`` / ``gates.py``, or any sha-pinned RESULTS
+# ledger. The legacy ``gates.overall_verdict`` is left byte-identical,
+# so every historical ``build_*_ledger`` reproduces the exact frozen
+# bytes when run WITHOUT the amendment. A fresh lineage #6+ run that
+# explicitly opts into the amendment uses :func:`overall_verdict_amended`
+# instead, which reclassifies the amended ``noisy.*`` gates as
+# ``INFEASIBLE_BY_CONSTRUCTION`` (a distinct 0-bit state, not PASS, not
+# FAIL) and computes the overall verdict over the remaining genuine
+# pass/fail gates only.
+
+# A distinct, zero-bit verdict state for a gate the CG002 sha-pinned
+# NEGATIVE proved is information-theoretically unreachable (regressor
+# SNR < 0.6 ∀ edge at the frozen σ): P(FAIL)=1 ∀ estimator ⇒ H=0 bits.
+INFEASIBLE_BY_CONSTRUCTION = "INFEASIBLE_BY_CONSTRUCTION"
+
+# The append-only amendment document. The single source of truth for
+# *which* gates are reclassified is this YAML; a no-peek drift test
+# binds these names to the document fail-closed.
+AMENDMENT_001_PATH = Path(__file__).resolve().parent / "PREREGISTRATION_AMENDMENT_001.yaml"
+
+
+def amended_gate_names(amendment_path: Path | None = None) -> frozenset[str]:
+    """Gate names PRE-REGISTRATION-AMENDMENT-001 reclassifies (read-only).
+
+    Reads ``PREREGISTRATION_AMENDMENT_001.yaml`` and returns the set of
+    gate names reclassified to ``INFEASIBLE_BY_CONSTRUCTION``. This is a
+    pure read of the append-only amendment document — no threshold value
+    is read or redefined here. ``amendment_path`` defaults to the merged
+    amendment; an explicit path is accepted for the drift test.
+    """
+    path = amendment_path if amendment_path is not None else AMENDMENT_001_PATH
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"amendment {path} is not a YAML mapping")
+    if data.get("identifier") != "PREREGISTRATION-AMENDMENT-001":
+        raise ValueError(f"amendment {path} has an unexpected identifier")
+    names = data["reclassification"]["amended_gate_names"]
+    if not isinstance(names, list) or not all(isinstance(n, str) for n in names):
+        raise ValueError(f"amendment {path} amended_gate_names is malformed")
+    return frozenset(names)
+
+
+def overall_verdict_amended(
+    rows: list[GateRow],
+    *,
+    amendment_path: Path | None = None,
+) -> tuple[str, dict[str, str]]:
+    """Forward-only amended overall verdict (lineage #6+ runs only).
+
+    Returns ``(verdict, per_gate_state)`` where every gate named by
+    PRE-REGISTRATION-AMENDMENT-001 is assigned the distinct zero-bit
+    state ``INFEASIBLE_BY_CONSTRUCTION`` (neither PASS nor FAIL) and the
+    overall ``verdict`` is computed over the **remaining genuine
+    pass/fail gates only**: ``"PASS"`` iff every non-amended gate passed,
+    else ``"NEGATIVE"`` (fail-closed). If every gate is amended away the
+    verdict is ``INFEASIBLE_BY_CONSTRUCTION`` (no genuine gate remains to
+    decide). This never mutates ``rows`` and never touches a threshold;
+    it only re-partitions the verdict, forward.
+    """
+    amended = amended_gate_names(amendment_path)
+    per_gate: dict[str, str] = {}
+    genuine: list[GateRow] = []
+    for row in rows:
+        if row.name in amended:
+            per_gate[row.name] = INFEASIBLE_BY_CONSTRUCTION
+        else:
+            per_gate[row.name] = "PASS" if row.passed else "FAIL"
+            genuine.append(row)
+    if not genuine:
+        return INFEASIBLE_BY_CONSTRUCTION, per_gate
+    verdict = "PASS" if all(r.passed for r in genuine) else "NEGATIVE"
+    return verdict, per_gate

--- a/research/calibration/grid_kuramoto/run.py
+++ b/research/calibration/grid_kuramoto/run.py
@@ -21,7 +21,13 @@ import sys
 from pathlib import Path
 from typing import Any
 
-from ._substrate import FROZEN_PREREG_SHA, PARENT_LEDGER_SHA256, branch_sha, ledger_sha256
+from ._substrate import (
+    FROZEN_PREREG_SHA,
+    PARENT_LEDGER_SHA256,
+    branch_sha,
+    ledger_sha256,
+    overall_verdict_amended,
+)
 from .calibration import SimConfig, run_calibration
 from .gates import (
     NOISELESS_GATES,
@@ -31,7 +37,7 @@ from .gates import (
 )
 from .grid_data import GridSystem, ieee_39_new_england, wscc_9_bus
 
-__all__ = ["build_ledger", "build_r1_ledger", "main"]
+__all__ = ["build_amended_ledger", "build_ledger", "build_r1_ledger", "main"]
 
 _SYSTEMS: dict[str, Any] = {
     "wscc9": wscc_9_bus,
@@ -149,6 +155,80 @@ def build_r1_ledger(system: GridSystem, cfg: SimConfig) -> dict[str, Any]:
     return ledger
 
 
+def build_amended_ledger(system: GridSystem, cfg: SimConfig) -> dict[str, Any]:
+    """Forward-only lineage #6 ledger under PRE-REGISTRATION-AMENDMENT-001.
+
+    This is a **new, forward-only** lineage artifact. It runs the R1
+    swing-aware path on the frozen configuration, evaluates the *frozen*
+    gates (read, never redefined — no threshold value is touched), then
+    partitions the verdict with :func:`overall_verdict_amended`: the two
+    ``noisy.*`` gates the CALIB-GRID-002 sha-pinned NEGATIVE proved are
+    information-theoretically unreachable are emitted as the distinct
+    zero-bit state ``INFEASIBLE_BY_CONSTRUCTION`` (not PASS, not FAIL)
+    and the overall verdict is computed over the remaining genuine
+    pass/fail gates only.
+
+    It does **not** recompute, overwrite or rewrite any merged
+    CALIB-GRID-001 / R1 / CALIB-GRID-002 ``RESULTS.json`` — those stay
+    byte-frozen with their historical NEGATIVE + FAIL. ``build_ledger``
+    / ``build_r1_ledger`` are untouched and still reproduce the exact
+    historical bytes.
+    """
+    noiseless = run_calibration(system, cfg, noisy=False, estimator_path="swing")
+    noisy = run_calibration(system, cfg, noisy=True, estimator_path="swing")
+    all_gates = evaluate_gates(noiseless, NOISELESS_GATES) + evaluate_gates(noisy, NOISY_GATES)
+    amended_verdict, per_gate_state = overall_verdict_amended(all_gates)
+
+    genuine_failed = [
+        g.to_dict()
+        for g in all_gates
+        if per_gate_state[g.name] not in ("INFEASIBLE_BY_CONSTRUCTION", "PASS")
+    ]
+    ledger: dict[str, Any] = {
+        "artifact": "CALIB-GRID-001",
+        "lineage": "AMENDED-001 (forward-only, PRE-REGISTRATION-AMENDMENT-001)",
+        "kind": "external-ground-truth-calibration",
+        "is_hypothesis": False,
+        "is_science_claim": False,
+        "amends_preregistration_sha": FROZEN_PREREG_SHA,
+        "amendment": "PREREGISTRATION-AMENDMENT-001",
+        "amendment_cross_reference": "SUPERSESSIONS.yaml::SUPERSEDE-001",
+        "system": system.name,
+        "citation": system.citation,
+        "estimator": (
+            "core.kuramoto.coupling_estimator.estimate_swing_coupling "
+            "(R1 swing path; gates read not redefined)"
+        ),
+        "branch_sha": _branch_sha(),
+        "python": platform.python_version(),
+        "config": {
+            "coupling_scale": cfg.coupling_scale,
+            "dt": cfg.dt,
+            "steps": cfg.steps,
+            "keep_frac": cfg.keep_frac,
+            "theta0_perturb": cfg.theta0_perturb,
+            "seed": cfg.seed,
+            "noise_sigma": cfg.noise_sigma,
+            "lambda_reg": cfg.lambda_reg,
+            "penalty": cfg.penalty,
+            "topology_rel_threshold": cfg.topology_rel_threshold,
+        },
+        "metrics": {
+            "noiseless": noiseless.to_dict(),
+            "noisy": noisy.to_dict(),
+        },
+        "gates": [g.to_dict() for g in all_gates],
+        "per_gate_state": per_gate_state,
+        "verdict": amended_verdict,
+        "failed_gates": genuine_failed,
+        "infeasible_by_construction_gates": sorted(
+            n for n, s in per_gate_state.items() if s == "INFEASIBLE_BY_CONSTRUCTION"
+        ),
+    }
+    ledger["ledger_sha256"] = ledger_sha256(ledger)
+    return ledger
+
+
 def main(argv: list[str] | None = None) -> int:
     """CLI entry point. Returns 0 on PASS, 1 on NEGATIVE (fail-closed)."""
     parser = argparse.ArgumentParser(description="CALIB-GRID-001 runner")
@@ -167,6 +247,16 @@ def main(argv: list[str] | None = None) -> int:
             "identifier; new pre-registered lineage, own gates)"
         ),
     )
+    parser.add_argument(
+        "--amended",
+        action="store_true",
+        help=(
+            "run the forward-only lineage #6 under "
+            "PRE-REGISTRATION-AMENDMENT-001 (noisy.* gates reclassified "
+            "to INFEASIBLE_BY_CONSTRUCTION; does NOT recompute frozen "
+            "artifacts)"
+        ),
+    )
     args = parser.parse_args(argv)
 
     system = _SYSTEMS[args.system]()
@@ -175,6 +265,8 @@ def main(argv: list[str] | None = None) -> int:
         from .cg002 import build_cg002_ledger
 
         ledger = build_cg002_ledger(system, cfg)
+    elif args.amended:
+        ledger = build_amended_ledger(system, cfg)
     elif args.r1:
         ledger = build_r1_ledger(system, cfg)
     else:

--- a/tests/research/calibration/test_calib_amendment_001.py
+++ b/tests/research/calibration/test_calib_amendment_001.py
@@ -1,0 +1,274 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""PRE-REGISTRATION-AMENDMENT-001 — forward-only verdict reclassification.
+
+F2 of the supersession/amendment governance correction. CALIB-GRID-002
+proved the two frozen ``noisy.*`` gates (σ=0.02 @ frozen θ₀/record
+length) sit at an information-theoretically unreachable operating point
+— FAIL with P=1 ∀ estimator ⇒ H=0 bits. The append-only amendment
+``PREREGISTRATION_AMENDMENT_001.yaml`` reclassifies them, **forward
+only**, from pass/fail acceptance gates to ``INFEASIBLE_BY_CONSTRUCTION``
+zero-bit diagnostics; the overall verdict is then computed over the
+remaining genuine pass/fail gates only.
+
+These tests pin the two hard invariants of F2:
+
+1. **The three historical lineages are NOT recomputed.** The merged
+   CALIB-GRID-001 / R1 / CALIB-GRID-002 ledgers reproduce their exact
+   historical bytes (verdict + gate pass-flags) — the default builders
+   are byte-stable and untouched by the amendment.
+2. **A fresh run UNDER the amendment** emits the distinct
+   ``INFEASIBLE_BY_CONSTRUCTION`` state for the amended gates and the
+   correct reduced-gate overall verdict (no threshold value touched).
+
+Plus a no-peek drift test binding the amendment constants to the
+substrate (mirrors the existing amendment-binding pattern).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from research.calibration.grid_kuramoto import (
+    NOISELESS_GATES,
+    NOISY_GATES,
+    SimConfig,
+    evaluate_gates,
+    run_calibration,
+    wscc_9_bus,
+)
+from research.calibration.grid_kuramoto._substrate import (
+    INFEASIBLE_BY_CONSTRUCTION,
+    amended_gate_names,
+    overall_verdict_amended,
+)
+from research.calibration.grid_kuramoto.run import (
+    build_amended_ledger,
+    build_ledger,
+    build_r1_ledger,
+)
+
+_LINEAGE_ROOT = Path(__file__).resolve().parents[3] / "research" / "calibration" / "grid_kuramoto"
+_AMENDMENT_YAML = _LINEAGE_ROOT / "PREREGISTRATION_AMENDMENT_001.yaml"
+_AMENDMENT_MD = _LINEAGE_ROOT / "PREREGISTRATION_AMENDMENT_001.md"
+
+
+# ---------------------------------------------------------------------------
+# No-peek drift: the amendment document binds the substrate constants
+# ---------------------------------------------------------------------------
+
+
+def test_amendment_001_matches_code() -> None:
+    """No-peek: PREREGISTRATION_AMENDMENT_001.yaml binds the substrate.
+
+    Mirrors the existing amendment-binding pattern
+    (``test_cg002_preregistration_matches_code``). The set of gate names
+    the substrate reclassifies must equal the document's
+    ``amended_gate_names`` exactly; both amended gates must be real
+    frozen ``NOISY_GATES`` names; the amendment must self-declare it is
+    not a science claim; and the human ``.md`` must reference the
+    machine YAML (single source). Changing either side without the
+    other fails closed (post-data-edit detector).
+    """
+    data = yaml.safe_load(_AMENDMENT_YAML.read_text(encoding="utf-8"))
+    assert data["identifier"] == "PREREGISTRATION-AMENDMENT-001"
+    assert data["is_science_claim"] is False
+    assert data["is_hypothesis"] is False
+
+    doc_names = set(data["reclassification"]["amended_gate_names"])
+    code_names = set(amended_gate_names())
+    assert doc_names == code_names, (
+        f"amendment doc/code drift: doc {sorted(doc_names)} != substrate {sorted(code_names)}"
+    )
+
+    # Every amended name must be a real frozen NOISY_GATES name — the
+    # amendment reclassifies an existing gate, it does not invent one,
+    # and it must not name a NOISELESS gate.
+    frozen_noisy = {g.name for g in NOISY_GATES}
+    frozen_noiseless = {g.name for g in NOISELESS_GATES}
+    assert code_names == frozen_noisy, (
+        f"amended gates {sorted(code_names)} must be exactly the frozen "
+        f"noisy gates {sorted(frozen_noisy)}"
+    )
+    assert not (code_names & frozen_noiseless), "amendment must not touch a noiseless gate"
+
+    # Provenance: amends the frozen prereg sha; cites the CG002 ledger.
+    assert (
+        data["amends"]["frozen_preregistration_sha"]
+        == "d170d48afa5066c13edeb40b2c1904b3fd708516"  # pragma: allowlist secret
+    )
+    assert (  # pragma: allowlist secret
+        data["evidence"]["cg002_ledger_sha256"]
+        == "d0f89e24341b099598e2e5cc9809772ee2c47627f77bf3354f957fab860819b1"  # pragma: allowlist secret
+    )
+    assert data["evidence"]["cross_reference"] == "SUPERSESSIONS.yaml::SUPERSEDE-001"
+
+    md = _AMENDMENT_MD.read_text(encoding="utf-8")
+    assert "PREREGISTRATION_AMENDMENT_001.yaml" in md, (
+        "the amendment .md must reference the machine YAML (single source)"
+    )
+    # No threshold VALUE may appear in the amendment (classification
+    # only — values stay frozen in gates.py / PREREGISTRATION.md).
+    for g in NOISY_GATES:
+        assert f"threshold: {g.threshold}" not in _AMENDMENT_YAML.read_text(encoding="utf-8"), (
+            f"amendment must not restate a threshold value ({g.name}) — "
+            f"it reclassifies the gate CLASS only"
+        )
+
+
+# ---------------------------------------------------------------------------
+# HARD invariant 1: the three historical lineages are NOT recomputed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("lineage", ["cg001", "r1"])
+def test_historical_artifacts_not_recomputed_by_amendment(lineage: str) -> None:
+    """The default builders stay byte-stable: the amendment is opt-in.
+
+    The merged CALIB-GRID-001 / R1 ``RESULTS.json`` carry a historical
+    ``NEGATIVE`` verdict with the ``noisy.*`` gates FAILing. The
+    amendment is forward-only and opt-in: ``build_ledger`` /
+    ``build_r1_ledger`` must STILL emit the historical ``NEGATIVE`` with
+    the ``noisy.*`` gates FAILing (``passed == False``) and must NOT
+    carry the amended ``per_gate_state`` / ``INFEASIBLE_BY_CONSTRUCTION``
+    keys. This is the regression/golden proof that the historical record
+    is not recomputed.
+    """
+    builder = {"cg001": build_ledger, "r1": build_r1_ledger}[lineage]
+    art = (
+        _LINEAGE_ROOT / "RESULTS.json"
+        if lineage == "cg001"
+        else _LINEAGE_ROOT / "r1" / "RESULTS.json"
+    )
+    committed = json.loads(art.read_text(encoding="utf-8"))
+    fresh = builder(wscc_9_bus(), SimConfig())
+
+    # Historical verdict preserved (not recomputed under the amendment).
+    assert committed["verdict"] == fresh["verdict"] == "NEGATIVE"
+    # The amendment keys must be ABSENT from the default builder output.
+    assert "per_gate_state" not in fresh
+    assert "infeasible_by_construction_gates" not in fresh
+    # The noisy gates still FAIL in the historical reproduction.
+    fresh_gates = {g["name"]: g["passed"] for g in fresh["gates"]}
+    committed_gates = {g["name"]: g["passed"] for g in committed["gates"]}
+    for name in (g.name for g in NOISY_GATES):
+        assert fresh_gates[name] is False, f"{lineage}: {name} must still FAIL historically"
+        assert committed_gates[name] is False, f"{lineage}: committed {name} historical FAIL"
+
+
+# ---------------------------------------------------------------------------
+# HARD invariant 2: a fresh AMENDED run reclassifies correctly
+# ---------------------------------------------------------------------------
+
+
+def test_overall_verdict_amended_partitions_zero_bit_gates() -> None:
+    """``overall_verdict_amended`` excludes amended gates from the verdict.
+
+    Pure-logic property (no simulation): construct a gate-row set where
+    every genuine (non-amended) gate PASSes and the amended ``noisy.*``
+    gates FAIL. The amended verdict must be ``PASS`` (the zero-bit
+    gates are excluded), every amended gate carries
+    ``INFEASIBLE_BY_CONSTRUCTION``, and every genuine gate carries
+    ``PASS``/``FAIL`` — never the infeasible state.
+    """
+    from research.calibration.grid_kuramoto._substrate import GateRow
+
+    amended = amended_gate_names()
+    rows: list[GateRow] = []
+    for g in (*NOISELESS_GATES, *NOISY_GATES):
+        passed = g.name not in amended  # genuine pass, amended fail
+        rows.append(
+            GateRow(
+                name=g.name,
+                metric_key=g.metric_key,
+                observed=0.0,
+                operator=g.operator,
+                threshold=g.threshold,
+                passed=passed,
+                localises_to=g.localises_to,
+            )
+        )
+    verdict, per_gate = overall_verdict_amended(rows)
+    assert verdict == "PASS", "genuine gates all pass ⇒ reduced verdict PASS"
+    for name in amended:
+        assert per_gate[name] == INFEASIBLE_BY_CONSTRUCTION
+    for g in NOISELESS_GATES:
+        assert per_gate[g.name] in ("PASS", "FAIL")
+        assert per_gate[g.name] != INFEASIBLE_BY_CONSTRUCTION
+
+    # Now flip a genuine gate to FAIL → reduced verdict NEGATIVE,
+    # amended gates still INFEASIBLE (never absorb a genuine failure).
+    rows2 = [
+        GateRow(
+            name=r.name,
+            metric_key=r.metric_key,
+            observed=r.observed,
+            operator=r.operator,
+            threshold=r.threshold,
+            passed=False if r.name == "noiseless.frobenius" else r.passed,
+            localises_to=r.localises_to,
+        )
+        for r in rows
+    ]
+    verdict2, per_gate2 = overall_verdict_amended(rows2)
+    assert verdict2 == "NEGATIVE"
+    for name in amended:
+        assert per_gate2[name] == INFEASIBLE_BY_CONSTRUCTION
+
+
+@pytest.mark.slow
+def test_fresh_amended_run_emits_infeasible_and_reduced_verdict() -> None:
+    """A fresh lineage #6 run under the amendment reclassifies correctly.
+
+    ``build_amended_ledger`` runs the R1 swing path on the frozen
+    config, reads the frozen gates, and emits the distinct
+    ``INFEASIBLE_BY_CONSTRUCTION`` state for both ``noisy.*`` gates with
+    the overall verdict computed over the remaining genuine pass/fail
+    gates only. The R1 swing path noiseless Frobenius PASSes but the
+    noiseless critical-coupling gate still FAILs (the genuine,
+    information-bearing residual), so the reduced verdict is NEGATIVE —
+    and crucially it is NEGATIVE on a genuine gate, NOT saturated by the
+    zero-bit noisy gates. No threshold value is touched.
+    """
+    led = build_amended_ledger(wscc_9_bus(), SimConfig())
+    assert led["lineage"].startswith("AMENDED-001")
+    assert led["is_science_claim"] is False
+    assert led["amendment"] == "PREREGISTRATION-AMENDMENT-001"
+    assert led["amendment_cross_reference"] == "SUPERSESSIONS.yaml::SUPERSEDE-001"
+
+    per_gate = led["per_gate_state"]
+    for name in (g.name for g in NOISY_GATES):
+        assert per_gate[name] == INFEASIBLE_BY_CONSTRUCTION, (
+            f"{name} must be reclassified to INFEASIBLE_BY_CONSTRUCTION"
+        )
+    assert sorted(led["infeasible_by_construction_gates"]) == sorted(g.name for g in NOISY_GATES)
+
+    # The reduced verdict is decided ONLY by genuine gates. The R1
+    # swing path: noiseless.frobenius PASS, noiseless.topology_f1 PASS,
+    # noiseless.critical_coupling FAIL (the genuine residual) ⇒ NEGATIVE.
+    assert led["verdict"] == "NEGATIVE"
+    genuine_failed = {g["name"] for g in led["failed_gates"]}
+    assert "noiseless.critical_coupling" in genuine_failed, (
+        "the reduced NEGATIVE must rest on a GENUINE gate, not the zero-bit noisy gates"
+    )
+    # No noisy gate may appear in failed_gates (they are not FAIL — they
+    # are INFEASIBLE_BY_CONSTRUCTION).
+    for name in (g.name for g in NOISY_GATES):
+        assert name not in genuine_failed
+
+    # Cross-check: the same metrics under the legacy (non-amended) path
+    # still produce a noisy FAIL — proving the amendment only re-labels.
+    nl = run_calibration(wscc_9_bus(), SimConfig(), noisy=False, estimator_path="swing")
+    ny = run_calibration(wscc_9_bus(), SimConfig(), noisy=True, estimator_path="swing")
+    legacy = evaluate_gates(nl, NOISELESS_GATES) + evaluate_gates(ny, NOISY_GATES)
+    legacy_by_name = {r.name: r.passed for r in legacy}
+    for name in (g.name for g in NOISY_GATES):
+        assert legacy_by_name[name] is False, (
+            f"sanity: {name} genuinely FAILs the raw metric — the "
+            f"amendment reclassifies, it does not improve the number"
+        )

--- a/tests/research/calibration/test_calib_amendment_001.py
+++ b/tests/research/calibration/test_calib_amendment_001.py
@@ -81,9 +81,9 @@ def test_amendment_001_matches_code() -> None:
 
     doc_names = set(data["reclassification"]["amended_gate_names"])
     code_names = set(amended_gate_names())
-    assert doc_names == code_names, (
-        f"amendment doc/code drift: doc {sorted(doc_names)} != substrate {sorted(code_names)}"
-    )
+    assert (
+        doc_names == code_names
+    ), f"amendment doc/code drift: doc {sorted(doc_names)} != substrate {sorted(code_names)}"
 
     # Every amended name must be a real frozen NOISY_GATES name — the
     # amendment reclassifies an existing gate, it does not invent one,
@@ -108,9 +108,9 @@ def test_amendment_001_matches_code() -> None:
     assert data["evidence"]["cross_reference"] == "SUPERSESSIONS.yaml::SUPERSEDE-001"
 
     md = _AMENDMENT_MD.read_text(encoding="utf-8")
-    assert "PREREGISTRATION_AMENDMENT_001.yaml" in md, (
-        "the amendment .md must reference the machine YAML (single source)"
-    )
+    assert (
+        "PREREGISTRATION_AMENDMENT_001.yaml" in md
+    ), "the amendment .md must reference the machine YAML (single source)"
     # No threshold VALUE may appear in the amendment (classification
     # only — values stay frozen in gates.py / PREREGISTRATION.md).
     for g in NOISY_GATES:
@@ -243,9 +243,9 @@ def test_fresh_amended_run_emits_infeasible_and_reduced_verdict() -> None:
 
     per_gate = led["per_gate_state"]
     for name in (g.name for g in NOISY_GATES):
-        assert per_gate[name] == INFEASIBLE_BY_CONSTRUCTION, (
-            f"{name} must be reclassified to INFEASIBLE_BY_CONSTRUCTION"
-        )
+        assert (
+            per_gate[name] == INFEASIBLE_BY_CONSTRUCTION
+        ), f"{name} must be reclassified to INFEASIBLE_BY_CONSTRUCTION"
     assert sorted(led["infeasible_by_construction_gates"]) == sorted(g.name for g in NOISY_GATES)
 
     # The reduced verdict is decided ONLY by genuine gates. The R1
@@ -253,9 +253,9 @@ def test_fresh_amended_run_emits_infeasible_and_reduced_verdict() -> None:
     # noiseless.critical_coupling FAIL (the genuine residual) ⇒ NEGATIVE.
     assert led["verdict"] == "NEGATIVE"
     genuine_failed = {g["name"] for g in led["failed_gates"]}
-    assert "noiseless.critical_coupling" in genuine_failed, (
-        "the reduced NEGATIVE must rest on a GENUINE gate, not the zero-bit noisy gates"
-    )
+    assert (
+        "noiseless.critical_coupling" in genuine_failed
+    ), "the reduced NEGATIVE must rest on a GENUINE gate, not the zero-bit noisy gates"
     # No noisy gate may appear in failed_gates (they are not FAIL — they
     # are INFEASIBLE_BY_CONSTRUCTION).
     for name in (g.name for g in NOISY_GATES):

--- a/tests/research/calibration/test_calib_lineage_forcing_functions.py
+++ b/tests/research/calibration/test_calib_lineage_forcing_functions.py
@@ -37,17 +37,32 @@ the family must share:
   bespoke-ledger-schema generator (F4/F5): every ``build_*_ledger``
   must emit the shared required key set. A lineage #6 that invents a
   new RESULTS shape fails this test.
+* ``test_superseded_claims_resolve_via_registry`` /
+  ``test_supersession_registry_is_internally_consistent`` — kills the
+  stale-falsified-premise generator (F-supersession): a sha-pinned
+  artifact may encode a causal premise a *later* sha-pinned lineage has
+  falsified (R1's "double-differentiation / no-consistent-estimator"
+  noisy attribution, falsified by CALIB-GRID-002's class-independent
+  regressor-floor proof). ``SUPERSESSIONS.yaml`` is the single source
+  of truth for that relation; any *new* doc that references the
+  superseded R1 claim/sha without resolving the registry fails closed,
+  and the registry's own integrity (every stale-artifact path exists
+  and carries its verbatim anchor; the superseded sha is a real commit
+  ancestor) is enforced fail-closed. No frozen artifact is touched —
+  the registry is a pure-additive forward-only supersession layer.
 """
 
 from __future__ import annotations
 
 import inspect
 import re
+import subprocess
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
 import pytest
+import yaml
 
 from research.calibration.grid_kuramoto import (
     SimConfig,
@@ -270,4 +285,151 @@ def test_every_results_ledger_conforms_to_shared_schema(name: str) -> None:
     assert "hashlib.sha256(payload).hexdigest()" not in src, (
         f"{name}: builder re-implements ledger sha-pinning inline; it "
         f"must delegate to _substrate.ledger_sha256 (single source)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# F-supersession — the stale-falsified-premise forcing function
+# ---------------------------------------------------------------------------
+
+_SUPERSESSIONS_YAML = _LINEAGE_ROOT / "SUPERSESSIONS.yaml"
+_SUPERSESSIONS_MD = _LINEAGE_ROOT / "SUPERSESSIONS.md"
+
+# The R1 falsified-premise fingerprints. A *new* doc that contains any
+# of these (i.e. references R1's superseded noisy attribution as a
+# premise) MUST also resolve the supersession registry by naming it.
+_R1_STALE_FINGERPRINTS = (
+    "double-differentiation SNR boundary",
+    "No consistent estimator exists for the noisy regime",
+)
+# Files that legitimately *contain* the stale fingerprint: the frozen
+# R1 artifacts that ENCODE it (immutable historical record), the
+# superseding artifact that QUOTES it to falsify it, the registry
+# itself, this test, and any doc that already resolves the registry.
+_REGISTRY_RESOLUTION_TOKENS = ("SUPERSESSIONS.yaml", "SUPERSEDE-001", "SUPERSESSIONS.md")
+
+
+def _load_supersessions() -> dict[str, Any]:
+    data = yaml.safe_load(_SUPERSESSIONS_YAML.read_text(encoding="utf-8"))
+    assert isinstance(data, dict), "SUPERSESSIONS.yaml is not a mapping"
+    return data
+
+
+def test_supersession_registry_is_internally_consistent() -> None:
+    """The supersession registry is the single, fail-closed source.
+
+    Forcing function for the F-supersession generative mechanism (a
+    sha-pinned artifact encodes a premise a later sha-pinned lineage
+    falsified, with no forward-resolution layer). This pins the
+    registry's own integrity so the relation cannot silently rot:
+
+    1. every ``stale_artifacts[].path`` / ``citing_artifacts[].path``
+       exists on disk and carries its ``verbatim_anchor`` substring
+       (the enumeration cannot drift off the real artifact);
+    2. the ``superseded_sha`` and ``superseding_sha`` are real commit
+       ancestors of HEAD (the supersession points at genuine history);
+    3. the registry enumerates **exactly four** encoding artifacts and
+       **exactly two** citing artifacts (the audited cardinality —
+       a future entry that drops or pads the enumeration fails closed);
+    4. the human ``SUPERSESSIONS.md`` references the machine registry
+       (single source: the prose cannot diverge from the contract).
+    """
+    data = _load_supersessions()
+    assert data["registry"] == "CALIB-GRID-SUPERSESSIONS"
+    entries = data["supersessions"]
+    assert isinstance(entries, list) and entries, "no supersession entries"
+
+    repo_root = _LINEAGE_ROOT.parents[2]
+    for entry in entries:
+        stale = entry["stale_artifacts"]
+        citing = entry["citing_artifacts"]
+        # Audited cardinality: exactly four distinct encoding artifacts
+        # (r1/RESULTS.md, r1/RESULTS.json, r1/ATTEMPT.md — RESULTS.md
+        # contributes the prose claim + its summary restatement) and
+        # exactly two citing artifacts.
+        encoding_paths = {row["path"] for row in stale}
+        citing_paths = {row["path"] for row in citing}
+        assert encoding_paths == {
+            "research/calibration/grid_kuramoto/r1/RESULTS.md",
+            "research/calibration/grid_kuramoto/r1/RESULTS.json",
+            "research/calibration/grid_kuramoto/r1/ATTEMPT.md",
+        }, f"{entry['id']}: encoding-artifact set drifted: {sorted(encoding_paths)}"
+        assert citing_paths == {
+            "research/calibration/grid_kuramoto/identifiability/THRESHOLD_PROVENANCE.md",
+            "research/calibration/grid_kuramoto/cg002/PROVENANCE_002.md",
+        }, f"{entry['id']}: citing-artifact set drifted: {sorted(citing_paths)}"
+
+        for row in (*stale, *citing):
+            path = repo_root / row["path"]
+            assert path.is_file(), f"{entry['id']}: stale path missing: {row['path']}"
+            text = path.read_text(encoding="utf-8")
+            anchor = " ".join(row["verbatim_anchor"].split())
+            assert anchor in " ".join(text.split()), (
+                f"{entry['id']}: verbatim_anchor not found in {row['path']}: "
+                f"{anchor!r} — the enumeration drifted off the real artifact"
+            )
+
+        for sha_field in ("superseded_sha", "superseding_sha"):
+            sha = entry[sha_field]
+            assert isinstance(sha, str) and len(sha) == 40 and int(sha, 16) >= 0
+            res = subprocess.run(
+                ["git", "merge-base", "--is-ancestor", sha, "HEAD"],
+                cwd=repo_root,
+                capture_output=True,
+                check=False,
+            )
+            assert res.returncode == 0, (
+                f"{entry['id']}: {sha_field} {sha} is not a commit ancestor "
+                f"of HEAD — a supersession must point at genuine history"
+            )
+
+    md = _SUPERSESSIONS_MD.read_text(encoding="utf-8")
+    assert "SUPERSESSIONS.yaml" in md, (
+        "SUPERSESSIONS.md must reference the machine registry "
+        "(single source of truth — the prose cannot diverge)"
+    )
+
+
+def test_superseded_claims_resolve_via_registry() -> None:
+    """No *new* doc may inherit R1's falsified premise unresolved.
+
+    Forcing function: lineage #6+ reading ``r1/RESULTS.md`` as ground
+    truth would inherit a premise CALIB-GRID-002 falsified (the
+    "double-differentiation / no-consistent-estimator" noisy
+    attribution). Any markdown/yaml under the lineage tree that repeats
+    an R1 stale fingerprint must also resolve the supersession registry
+    (name ``SUPERSESSIONS.yaml`` / ``SUPERSEDE-001``). The frozen R1
+    artifacts that *encode* it (immutable historical record), the
+    superseding artifact that *quotes* it to falsify it, and the
+    registry itself are exempt — they are the enumerated supersession,
+    not an unresolved re-derivation.
+    """
+    data = _load_supersessions()
+    repo_root = _LINEAGE_ROOT.parents[2]
+    # Exempt: every enumerated stale/superseding/registry artifact.
+    exempt = {
+        _SUPERSESSIONS_YAML,
+        _SUPERSESSIONS_MD,
+        Path(__file__),
+    }
+    for entry in data["supersessions"]:
+        for row in (*entry["stale_artifacts"], *entry["citing_artifacts"]):
+            exempt.add((repo_root / row["path"]).resolve())
+        exempt.add((repo_root / entry["superseding_artifact"]).resolve())
+
+    offenders: list[str] = []
+    for path in sorted(_LINEAGE_ROOT.rglob("*")):
+        if path.suffix not in (".md", ".yaml", ".yml"):
+            continue
+        if "__pycache__" in path.parts or path.resolve() in exempt:
+            continue
+        text = path.read_text(encoding="utf-8")
+        normalised = " ".join(text.split())
+        for fp in _R1_STALE_FINGERPRINTS:
+            if fp in normalised and not any(t in text for t in _REGISTRY_RESOLUTION_TOKENS):
+                offenders.append(f"{path.relative_to(_LINEAGE_ROOT.parents[2])} -> {fp!r}")
+    assert not offenders, (
+        "doc(s) inherit R1's falsified noisy attribution without "
+        "resolving the supersession registry (reference SUPERSESSIONS.yaml "
+        "/ SUPERSEDE-001 — this is the stale-falsified-premise generator):\n" + "\n".join(offenders)
     )


### PR DESCRIPTION
## Summary

Two USER-VECTOR-APPROVED append-only epistemic-integrity governance corrections shipped as ONE PR. **ZERO estimator/numeric/algorithm change.** The merged sha-pinned artifacts of CALIB-GRID-001 / R1 / CALIB-GRID-002 stay **byte-identical**; the historical NEGATIVE/FAIL record is immutable and stays honest as-is. Corrections are NEW ADDITIVE LAYERS that supersede FORWARD (lineage #6+) only.

## F1 — Supersession record (stale falsified premise)

R1's sha-pinned `r1/RESULTS.md` asserts the causal claim *"double-differentiation second-derivative SNR / persistent-excitation boundary"* and verbatim *"No consistent estimator exists for the noisy regime"*. CALIB-GRID-002 (merge `e71d1915`, ledger `d0f89e24341b0995…`) **FALSIFIED** this: an estimator that never double-differentiates the phase still fails at ≈0.95; the true cause is a **class-independent regressor-level SNR floor at the frozen θ₀/record-length, NOT a differentiation-operator/estimator-class defect** (regressor SNR < 0.6 every edge, 0.085 on edge (0,2), before any estimator touches the data).

New append-only registry `research/calibration/grid_kuramoto/SUPERSESSIONS.yaml` + `SUPERSESSIONS.md` enumerates **exactly the 4 sha-pinned artifacts encoding the stale claim** and the **2 citing it** (grep-evidenced, file:line):

Encoding (4):
- `r1/RESULTS.md:74` — `second-derivative SNR / persistent-excitation`
- `r1/RESULTS.md:79` — `No consistent estimator exists for the noisy regime`
- `r1/RESULTS.md:97` — `double-differentiation SNR boundary in the noisy regime`
- `r1/RESULTS.json:100` — `coupling_estimator noise robustness / standardisation` (machine-readable `localized_refinement_targets`)
- `r1/ATTEMPT.md:77` — `one regime gate now passes, three still fail` (lineage record anchor)

(3 distinct files: `r1/RESULTS.md` carries the prose claim + its summary restatement; `r1/RESULTS.json`; `r1/ATTEMPT.md`.)

Citing (2):
- `identifiability/THRESHOLD_PROVENANCE.md:103` — `after double differentiation, measurement noise can inflate`
- `cg002/PROVENANCE_002.md:55` — `CALIB-GRID-001 R1 RESULTS.md: the swept Savitzky–Golay verification`

`superseded_sha`/`superseding_sha` pair: `a5527708` (R1) ← `e71d1915` (CG002), both verified commit ancestors. No frozen artifact edited or recomputed — supersession resolves FORWARD only.

**Forcing functions** added to `test_calib_lineage_forcing_functions.py`:
- `test_supersession_registry_is_internally_consistent` — every enumerated stale-artifact path exists + carries its verbatim anchor; both shas are real commit ancestors; audited 4-encoding/2-citing cardinality; MD references the machine registry.
- `test_superseded_claims_resolve_via_registry` — any NEW lineage doc repeating an R1 stale fingerprint must resolve `SUPERSESSIONS.yaml` / `SUPERSEDE-001` (fail-closed).

## F2 — Reclassify noisy.* as infeasible_by_construction

The two frozen `noisy.*` gates (σ=0.02 @ frozen θ₀/record-length) sit at an information-theoretically unreachable operating point: FAIL with P=1 ∀ estimator ⇒ H=0 bits.

New append-only `PREREGISTRATION_AMENDMENT_001.yaml` + `.md` supersede the **classification** (NOT threshold values) of `noisy.frobenius`/`noisy.topology_f1`: pass/fail acceptance gates → `INFEASIBLE_BY_CONSTRUCTION` 0-bit diagnostics, citing the CG002 ledger as the immutable justification. The frozen `PREREGISTRATION.md`/`gates.py` constants are NOT edited.

**Forward-only verdict semantics (the ONLY behavioural change):**
- `_substrate.py`: `INFEASIBLE_BY_CONSTRUCTION` state + `amended_gate_names()` + `overall_verdict_amended()` — emits the distinct 0-bit state (not PASS, not FAIL) for amended gates, computes the overall verdict over the **remaining genuine pass/fail gates only**.
- `run.py`: `build_amended_ledger` + `--amended` — a NEW forward-only lineage #6 artifact.
- The default `build_ledger` / `build_r1_ledger` / `build_cg002_ledger` are **UNTOUCHED and byte-stable**.

**Historical artifacts byte-frozen, NOT recomputed** — proved by `test_historical_artifacts_not_recomputed_by_amendment` (cg001/r1 ledgers still reproduce the historical NEGATIVE with `noisy.*` FAILing, no amendment keys) and the unmodified `*_results_json_matches_committed_artifact` reproduction tests (all green). A fresh `--amended` run emits `INFEASIBLE_BY_CONSTRUCTION` + a reduced NEGATIVE resting on the GENUINE `noiseless.critical_coupling` gate (`test_fresh_amended_run_emits_infeasible_and_reduced_verdict`). No-peek drift binding via `test_amendment_001_matches_code`.

## Byte-stability proof

- `git diff origin/main HEAD` touches **only** the 10 F1/F2 files.
- Every frozen artifact (`r1/RESULTS.json`, `r1/RESULTS.md`, `r1/ATTEMPT.md`, `RESULTS.json`, `PREREGISTRATION.md`, `gates.py`, `cg002/RESULTS.json`, `cg002/RESULTS.md`, `cg002/PREREGISTRATION_002.yaml`, `identifiability/THRESHOLD_PROVENANCE.md`) verified **BYTE-IDENTICAL** vs origin/main.
- `tests/research/calibration/test_grid_kuramoto.py` `git diff --exit-code` is **EMPTY**; every pre-existing drift / no-peek / bit-stability test passes UNMODIFIED.
- Estimator/numeric/algorithm code untouched. `.github/detect-secrets.baseline` byte-identical (audited public shas resolved via inline `# pragma: allowlist secret`, no UNION conflict).

## Local verification
- `pytest tests/research/calibration/` — 55 passed (fast + slow).
- mypy --strict / ruff / black clean on the diff; commit-acceptor validator rc=0; governance typed-models green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)