### PR TITLE
harden(ctc-c5): metric↔policy split + exemplar evidence ledger (claim-neutral)

### DIFF
--- a/.claude/commit_acceptors/instrument-hardening-metric-split.yaml
+++ b/.claude/commit_acceptors/instrument-hardening-metric-split.yaml
@@ -1,0 +1,35 @@
+id: instrument-hardening-metric-split
+status: ACTIVE
+claim_type: correctness
+promise: "Cross-system hardening: the C5 orientation fold is extracted into a separate _discriminability() so the raw _auc stays direction-sensitive (anti-correlated discriminators read AUC≈0, a real failure signal). Pure refactor — C5 OOS AUC stays byte-identical 0.9629629629629629 and verdict C5_ESTIMATOR_QUALITY_GAP unchanged. This acceptor also demonstrates the populated evidence-ledger pattern (report take #3)."
+diff_scope:
+  changed_files:
+    - path: "research/ctc_falsify/c5/oracle.py"
+    - path: "tests/research/ctc_falsify/test_ctc_falsify_c5.py"
+    - path: "tests/research/ctc_falsify/test_c5_metric_policy_split.py"
+    - path: ".claude/commit_acceptors/instrument-hardening-metric-split.yaml"
+  forbidden_paths:
+    - "trading/"
+    - "execution/"
+    - "forecast/"
+    - "policy/"
+    - "research/ctc_falsify/c5/config_c5.py"
+    - "research/ctc_falsify/c5/evidence/ctc_falsify_c5_result.json"
+required_python_symbols:
+  - "_auc"
+  - "_discriminability"
+  - "run_oracle"
+expected_signal: "metric/policy split tests pass; C5 rerun byte-identical (AUC 0.9629629629629629, verdict unchanged) — claim-neutral"
+measurement_command: "python -m pytest tests/research/ctc_falsify/test_c5_metric_policy_split.py -q"
+signal_artifact: "tmp/c5_metric_split_pytest.log"
+falsifier:
+  command: "python -c \"import numpy as np; from research.ctc_falsify.c5.oracle import _auc, _discriminability; raise SystemExit(0 if _auc(np.array([1.,2.,3.,4.]), np.array([1.,1.,0.,0.]))==0.0 and _discriminability(0.0)==1.0 else 1)\""
+  description: "Asserts the raw metric is NOT sign-folded (anti-separation → 0.0) while the fold lives only in _discriminability. Exits 1 if the fold is ever collapsed back into _auc — making the hardening falsifiable."
+rollback_command: "git checkout -- research/ctc_falsify/c5/oracle.py tests/research/ctc_falsify/test_ctc_falsify_c5.py && git rm -f tests/research/ctc_falsify/test_c5_metric_policy_split.py"
+rollback_verification_command: "git diff --exit-code research/ctc_falsify/c5/oracle.py"
+memory_update_type: none
+ledger_path: ".claude/commit_acceptors/instrument-hardening-metric-split.yaml"
+report_path: "research/ctc_falsify/RESULTS.md"
+evidence:
+  - path: "research/ctc_falsify/c5/evidence/ctc_falsify_c5_result.json"
+    sha256: "419632fabd97296037bbecda892c083b056927cea178896ad8af8b98b8d39b6b"

--- a/.github/detect-secrets.baseline
+++ b/.github/detect-secrets.baseline
@@ -149,6 +149,15 @@
         "line_number": 51
       }
     ],
+    ".claude/commit_acceptors/instrument-hardening-metric-split.yaml": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".claude/commit_acceptors/instrument-hardening-metric-split.yaml",
+        "hashed_secret": "6a5406385226b864f5b823fe2f49dccd13eb8870",
+        "is_verified": false,
+        "line_number": 35
+      }
+    ],
     ".env.example": [
       {
         "type": "Basic Auth Credentials",
@@ -5565,5 +5574,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-17T11:33:50Z"
+  "generated_at": "2026-05-17T13:41:20Z"
 }

--- a/research/ctc_falsify/c5/oracle.py
+++ b/research/ctc_falsify/c5/oracle.py
@@ -76,6 +76,17 @@ def _auc(scores: np.ndarray, y: np.ndarray) -> float:
     return float(u / (pos.size * neg.size))
 
 
+def _discriminability(auc: float) -> float:
+    """Orientation-invariant separability = max(auc, 1-auc).
+
+    Deliberately a SEPARATE function, not folded into ``_auc``: the raw
+    AUC must remain a direction-sensitive metric so a discriminator that
+    is anti-correlated by construction reads as AUC≈0 (a real failure
+    signal), while the sign-blind fold is an explicit policy step.
+    """
+    return float(max(auc, 1.0 - auc))
+
+
 def run_oracle() -> OracleResult:
     tr, te = c5.train_seeds(), c5.test_seeds()
     disjoint = set(tr).isdisjoint(set(te))
@@ -85,9 +96,12 @@ def run_oracle() -> OracleResult:
     mu, sd = x_tr.mean(0), x_tr.std(0) + 1e-12
     w = _lda_direction((x_tr - mu) / sd, y_tr)
     s_te = ((x_te - mu) / sd) @ w
-    auc = _auc(s_te, y_te)
-    # AUC is symmetric about 0.5 w.r.t. orientation; report discriminability.
-    auc = max(auc, 1.0 - auc)
+    # Metric ↔ policy split: _auc stays direction-sensitive (so an
+    # anti-correlated-by-construction discriminator is detectable as AUC≈0);
+    # the orientation-invariant fold is an explicit, separately testable
+    # policy choice — never collapsed inside the metric.
+    raw_auc = _auc(s_te, y_te)
+    auc = _discriminability(raw_auc)
     return OracleResult(
         oos_auc=auc,
         n_train=len(x_tr),

--- a/tests/research/ctc_falsify/test_c5_metric_policy_split.py
+++ b/tests/research/ctc_falsify/test_c5_metric_policy_split.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: MIT
+"""Metric ↔ policy split invariant (fast lane).
+
+Cross-system hardening (report take #1): a direction-sensitive metric and
+a sign-invariant policy fold must be SEPARATE functions. Folding sign
+inside the metric hides the 'anti-correlated by construction' failure.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from research.ctc_falsify.c5.oracle import _auc, _discriminability
+
+
+def test_raw_auc_is_direction_sensitive_not_folded() -> None:
+    perfect = np.array([3.0, 4.0, 1.0, 2.0])
+    anti = np.array([1.0, 2.0, 3.0, 4.0])
+    y = np.array([1, 1, 0, 0], dtype=np.float64)
+    assert _auc(perfect, y) == 1.0
+    # The whole point: anti-separation stays 0.0, NOT folded up to 1.0.
+    assert _auc(anti, y) == 0.0
+
+
+def test_discriminability_is_the_separate_sign_invariant_policy() -> None:
+    anti = np.array([1.0, 2.0, 3.0, 4.0])
+    y = np.array([1, 1, 0, 0], dtype=np.float64)
+    assert _auc(anti, y) == 0.0
+    assert _discriminability(_auc(anti, y)) == 1.0
+    assert _discriminability(0.5) == 0.5
+    for a in (0.0, 0.27, 0.5, 0.73, 1.0):
+        assert _discriminability(a) == max(a, 1.0 - a)
+
+
+def test_constant_scores_stay_chance_through_both_layers() -> None:
+    s = np.full(6, 0.7)
+    y = np.array([1, 1, 1, 0, 0, 0], dtype=np.float64)
+    assert _auc(s, y) == 0.5
+    assert _discriminability(_auc(s, y)) == 0.5  # never a false perfect

--- a/tests/research/ctc_falsify/test_ctc_falsify_c5.py
+++ b/tests/research/ctc_falsify/test_ctc_falsify_c5.py
@@ -60,3 +60,12 @@ def test_oos_auc_in_unit_interval(result: dict[str, object]) -> None:
     o = result["oracle"]
     assert isinstance(o, dict)
     assert 0.0 <= float(o["oos_auc"]) <= 1.0  # type: ignore[arg-type]
+
+
+def test_metric_policy_split_is_claim_neutral(result: dict[str, object]) -> None:
+    """No-claim-change guarantee: extracting _discriminability from the
+    inline fold must NOT move the C5 number or verdict (pure refactor)."""
+    o = result["oracle"]
+    assert isinstance(o, dict)
+    assert abs(float(o["oos_auc"]) - 0.9629629629629629) < 1e-15  # byte-identical
+    assert result["verdict"] == c5.VERDICT_ESTIMATOR_QUALITY_GAP


### PR DESCRIPTION
Cross-system hardening salvaged from a long external audit — most of it
was stale (its P1 = `_auc` ties, already closed by #763). The **3 real
takeaways**, applied:

1. **Metric ↔ policy split.** Orientation fold extracted into
   `_discriminability()`; raw `_auc` stays direction-sensitive so an
   anti-correlated-by-construction discriminator reads AUC≈0 (a real
   failure signal) instead of being silently folded to 1.0. **Pure
   refactor — C5 OOS AUC byte-identical `0.9629629629629629`, verdict
   `C5_ESTIMATOR_QUALITY_GAP` unchanged** (a test pins claim-neutrality).
2. **Unit-of-inference = session/subject** (no pseudo-replication) —
   recorded as a cross-line contract invariant in memory; already carried
   in C-real (`MIN_SESSIONS`).
3. **Acceptor evidence-ledger pattern.** Prior acceptors shipped
   `evidence: []`; this one populates it with the protected artifact
   sha256 as the exemplar convention for all future acceptors.

No CTC-claim change, no C6. ruff+black+mypy --strict clean; metric-split
fast tests + byte-identical pin. Falsifier asserts the fold is never
re-collapsed into the metric.

claim_status: measured (claim-neutral hardening; verdict unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)