### PR TITLE
refactor(kuramoto): swing coupling-estimator strategy registry (F4 — module-scale forcing function)

### DIFF
--- a/.claude/commit_acceptors/coupling-estimator-strategy-registry.yaml
+++ b/.claude/commit_acceptors/coupling-estimator-strategy-registry.yaml
@@ -1,0 +1,187 @@
+# Diff-bound commit acceptor for the coupling-estimator strategy registry.
+#
+# Behavior-preserving, structure-only refactor of the last open
+# architectural debt from the fractal/dynamical audit (F4): the
+# symmetric-joint swing identification stack in
+# core/kuramoto/coupling_estimator.py was an open-loop universal sink —
+# every CALIB-GRID lineage bolted another estimation path
+# (estimate_swing_coupling R1, estimate_swing_coupling_integral
+# CALIB-GRID-002) onto the module with its global-design assembly
+# inlined, 521 -> 1322 LOC (+154 % over five lineages, monotonic),
+# unbounded mypy blast-radius, no strategy/boundary capping growth.
+# PR #759 extracted the shared solve tail (_solve_symmetric_joint);
+# this PR extracts the path-specific design assembly into registered
+# SwingDesignStrategy objects and turns the public functions into thin
+# dispatchers. NOT a feature, NOT a science change, NOT a gate/threshold
+# /seed/sigma/theta0 edit.
+#
+# HARD behavior-preserving invariants verified:
+#   * Every estimation path bit-identical: K-hat / omega-hat / P-hat /
+#     identifiability score / PE diagnostic / prox operators byte-for-
+#     byte equal to the parent-sha (65666072) golden vectors
+#     (test_golden_vectors_bit_identical pins all 25).
+#   * Zero importer edits: only core/kuramoto/coupling_estimator.py
+#     touched in production; public API + the private symbols
+#     dynamic_graph (_estimate_K_single) and the coupling test
+#     (_proximal_gradient_row) consume are unchanged.
+#   * Every sha-pinned calibration artifact byte-identical (RESULTS.json
+#     /.md, PREREGISTRATION*, THRESHOLD_PROVENANCE, SUPERSESSIONS,
+#     AMENDMENT_001); tests/research/calibration/test_grid_kuramoto.py
+#     git diff EMPTY; all drift/no-peek/bit-stability/reproduction tests
+#     green WITHOUT modification (calib + integral + identifiability +
+#     coupling + network_engine: full fast+slow green; no pre-existing
+#     test file touched).
+#   * mypy --strict / ruff / black clean on every touched file (fresh
+#     cache; the stale .mypy_cache `google` crash is environmental cache
+#     corruption, not a code defect).
+#
+# Forcing function (module-scale negative-feedback term, mirrors #762):
+# tests/unit/core/test_kuramoto_coupling_strategy_registry.py fails
+# closed if a new symmetric-joint estimation path is added OUTSIDE the
+# strategy registry (the set of dispatched registry keys must equal the
+# registered strategy set, and the dispatcher core must stay path-
+# independent). This structurally caps the monotonic accretion.
+#
+# Honest backlog: net LOC is +279 (1322 -> 1601). The strategy/registry
+# pattern is inherently additive (Protocol + registry + dispatcher + N
+# strategy objects; #762 itself added 436 lines). The literal LOC-flat-
+# or-down target is breached; the *crucial, emphasized* invariant —
+# bounded blast-radius, structurally enforced by the forcing function —
+# is satisfied. Documented literature-anchored physics derivations were
+# NOT gutted to hit a line count (CLAUDE.md: math notation must match
+# paper conventions; zero-tech-debt).
+
+id: coupling-estimator-strategy-registry
+status: ACTIVE
+claim_type: documentation
+promise: >-
+  After this PR lands, core.kuramoto.coupling_estimator exposes a frozen
+  SwingDesignStrategy Protocol + SwingDesign contract + a fail-closed
+  registry (swing_strategy_registry / _register_swing_strategy) and a
+  single path-independent dispatcher (_dispatch_swing). The two
+  symmetric-joint swing identifiers (differential R1 + weak/integral
+  CALIB-GRID-002) are registered strategies that encapsulate ONLY their
+  path-specific design/target assembly and delegate the shared
+  standardise -> PE -> solve -> unpack -> identifiability -> omega tail
+  to the #759 _solve_symmetric_joint. The public functions
+  estimate_swing_coupling / estimate_swing_coupling_integral are thin
+  dispatchers; the public API and all importer call sites are
+  unchanged. The change is byte-preserving: every estimation path is
+  bit-identical to the parent-sha golden vectors, every sha-pinned
+  calibration artifact is byte-identical, and every pre-existing drift /
+  no-peek / bit-stability / reproduction test stays green without
+  modification. A new symmetric-joint estimation path must register a
+  strategy — it cannot be wired by editing the dispatcher (enforced by
+  the added forcing-function test). No gate, threshold, seed, sigma,
+  theta0 or decision rule was touched; no science claim is promoted.
+diff_scope:
+  changed_files:
+    - path: ".claude/commit_acceptors/coupling-estimator-strategy-registry.yaml"
+    - path: "core/kuramoto/coupling_estimator.py"
+    - path: "tests/unit/core/test_kuramoto_coupling_strategy_registry.py"
+  forbidden_paths:
+    - "trading/"
+    - "execution/"
+    - "forecast/"
+    - "policy/"
+    - "core/physics/"
+    - "core/kuramoto/identifiability.py"
+    - "core/kuramoto/dynamic_graph.py"
+    - "core/kuramoto/network_engine.py"
+    - "core/kuramoto/__init__.py"
+    - "core/kuramoto/contracts.py"
+    - "research/calibration/grid_kuramoto/PREREGISTRATION.md"
+    - "research/calibration/grid_kuramoto/PREREGISTRATION_AMENDMENT_001.md"
+    - "research/calibration/grid_kuramoto/PREREGISTRATION_AMENDMENT_001.yaml"
+    - "research/calibration/grid_kuramoto/RESULTS.json"
+    - "research/calibration/grid_kuramoto/RESULTS.md"
+    - "research/calibration/grid_kuramoto/SUPERSESSIONS.md"
+    - "research/calibration/grid_kuramoto/SUPERSESSIONS.yaml"
+    - "research/calibration/grid_kuramoto/r1/"
+    - "research/calibration/grid_kuramoto/cg002/RESULTS.json"
+    - "research/calibration/grid_kuramoto/cg002/RESULTS.md"
+    - "research/calibration/grid_kuramoto/cg002/PREREGISTRATION_002.yaml"
+    - "research/calibration/grid_kuramoto/identifiability/RESULTS.json"
+    - "research/calibration/grid_kuramoto/identifiability/RESULTS.md"
+    - "research/calibration/grid_kuramoto/identifiability/THRESHOLD_PROVENANCE.md"
+    - "application/governance/claim_ledger.py"
+    - "application/governance/commit_acceptor.py"
+    - "tests/research/calibration/test_grid_kuramoto.py"
+    - "tests/unit/core/test_kuramoto_coupling_estimator.py"
+    - "tests/unit/core/test_kuramoto_integral_estimator.py"
+    - "tests/unit/core/test_kuramoto_identifiability.py"
+required_python_symbols:
+  - "core/kuramoto/coupling_estimator.py::SwingDesign"
+  - "core/kuramoto/coupling_estimator.py::SwingDesignStrategy"
+  - "core/kuramoto/coupling_estimator.py::swing_strategy_registry"
+  - "core/kuramoto/coupling_estimator.py::_dispatch_swing"
+  - "core/kuramoto/coupling_estimator.py::_register_swing_strategy"
+expected_signal: >-
+  `pytest tests/unit/core/test_kuramoto_coupling_strategy_registry.py
+  tests/unit/core/test_kuramoto_coupling_estimator.py
+  tests/unit/core/test_kuramoto_integral_estimator.py
+  tests/unit/core/test_kuramoto_identifiability.py
+  tests/unit/core/test_kuramoto_network_engine.py
+  tests/research/calibration/test_grid_kuramoto.py
+  tests/research/calibration/test_calib_substrate_consolidation.py
+  tests/research/calibration/test_calib_lineage_forcing_functions.py
+  -m "not slow"` is green; the @slow suite is green; mypy --strict /
+  ruff / black are clean on the diff; every estimation path reproduces
+  its parent-sha golden bytes; the sha-pinned calibration artifacts and
+  PREREGISTRATION docs are byte-unchanged; the protected
+  test_grid_kuramoto.py git diff is EMPTY.
+measurement_command: >-
+  bash -c '
+    rm -rf .mypy_cache &&
+    mypy --strict --follow-imports=silent
+      core/kuramoto/coupling_estimator.py
+      tests/unit/core/test_kuramoto_coupling_strategy_registry.py
+    && ruff check core/kuramoto/coupling_estimator.py
+       tests/unit/core/test_kuramoto_coupling_strategy_registry.py
+    && black --check core/kuramoto/coupling_estimator.py
+       tests/unit/core/test_kuramoto_coupling_strategy_registry.py
+    && python -m pytest
+       tests/unit/core/test_kuramoto_coupling_strategy_registry.py
+       tests/unit/core/test_kuramoto_coupling_estimator.py
+       tests/unit/core/test_kuramoto_integral_estimator.py
+       tests/unit/core/test_kuramoto_identifiability.py
+       tests/unit/core/test_kuramoto_network_engine.py
+       tests/research/calibration/test_grid_kuramoto.py
+       tests/research/calibration/test_calib_substrate_consolidation.py
+       tests/research/calibration/test_calib_lineage_forcing_functions.py
+       -q -m "not slow"
+  '
+signal_artifact: "tmp/coupling_estimator_strategy_registry.log"
+falsifier:
+  command: >-
+    bash -c '
+      python -m pytest
+      "tests/unit/core/test_kuramoto_coupling_strategy_registry.py::test_golden_vectors_bit_identical"
+      "tests/unit/core/test_kuramoto_coupling_strategy_registry.py::test_every_symmetric_joint_path_dispatches_through_registry"
+      "tests/unit/core/test_kuramoto_integral_estimator.py::test_differential_paths_bit_identical_after_integral_added"
+      "tests/research/calibration/test_grid_kuramoto.py::test_r1_results_json_matches_committed_artifact"
+      -q >/tmp/_cesr_rails.log 2>&1
+      && ! grep -q "4 passed" /tmp/_cesr_rails.log
+    '
+  description: >-
+    Probes the load-bearing behavior-preserving rails: every estimation
+    path is bit-identical to the parent-sha golden vectors; every
+    symmetric-joint path dispatches through the registry (the structural
+    cap); the differential path is byte-unchanged; and the pre-existing
+    R1 sha-pinned-artifact reproduction test still passes unmodified.
+    The falsifier succeeds (exit 0) only when one of these rails fails —
+    i.e. the refactor stopped being byte-preserving or a path bypassed
+    the registry.
+rollback_command: >-
+  bash -c 'git checkout origin/main --
+    core/kuramoto/coupling_estimator.py
+    && rm -f
+    tests/unit/core/test_kuramoto_coupling_strategy_registry.py
+    .claude/commit_acceptors/coupling-estimator-strategy-registry.yaml'
+rollback_verification_command: >-
+  bash -c '! grep -q _dispatch_swing core/kuramoto/coupling_estimator.py
+    && ! test -f tests/unit/core/test_kuramoto_coupling_strategy_registry.py'
+memory_update_type: append
+ledger_path: ".claude/commit_acceptors/coupling-estimator-strategy-registry.yaml"
+report_path: "tmp/coupling_estimator_strategy_registry.log"
+evidence: []

--- a/core/kuramoto/coupling_estimator.py
+++ b/core/kuramoto/coupling_estimator.py
@@ -34,7 +34,10 @@ optional per-edge ``stability_scores``.
 from __future__ import annotations
 
 import logging
+from collections.abc import Mapping
 from dataclasses import dataclass, field
+from types import MappingProxyType
+from typing import Protocol, runtime_checkable
 
 import numpy as np
 from numpy.typing import NDArray
@@ -51,6 +54,8 @@ __all__ = [
     "CouplingEstimator",
     "PersistentExcitationError",
     "SwingCouplingEstimate",
+    "SwingDesign",
+    "SwingDesignStrategy",
     "estimate_coupling",
     "estimate_swing_coupling",
     "estimate_swing_coupling_integral",
@@ -58,6 +63,7 @@ __all__ = [
     "scad_prox",
     "soft_threshold",
     "complementary_pairs_stability",
+    "swing_strategy_registry",
 ]
 
 logger = logging.getLogger(__name__)
@@ -691,6 +697,331 @@ def _singular_ratio(design: NDArray[np.float64]) -> float:
     return float(sv[-1] / s_max)
 
 
+# ---------------------------------------------------------------------------
+# Swing design-assembly strategy registry (module-scale forcing function)
+# ---------------------------------------------------------------------------
+#
+# Every symmetric-joint swing identifier ever added to this module (the
+# R1 differential path #1 and the weak/integral path CALIB-GRID-002 #2)
+# assembles a *path-specific* global design ``[n·R × (n_edge + n)]`` and
+# target and then delegates the **identical** standardise → PE-guard →
+# lstsq → unpack → identifiability → ω tail (the #759 shared
+# :func:`_solve_symmetric_joint`). Before this refactor each lineage
+# bolted another ``estimate_swing_coupling_*`` public function onto the
+# module with its design build inlined — an open-loop universal sink
+# (521 → 1322 LOC, +154 % over five lineages, monotonic). The strategy
+# registry below caps that accretion: a new symmetric-joint estimation
+# path must register a :class:`SwingDesignStrategy` (encapsulating only
+# its design/target assembly) — it cannot edit the dispatcher core.
+#
+# This is a behaviour-preserving, structure-only extraction: the design
+# / target each strategy returns is byte-for-byte the array the former
+# inline block built, and the shared tail is unchanged, so ``K̂`` / ``P̂``
+# / ``ω̂`` / the identifiability score / the PE verdict are bit-identical
+# (pinned by the existing bit-stability tests and the added golden
+# vectors).
+
+
+@dataclass(frozen=True, slots=True)
+class SwingDesign:
+    """Path-specific global design assembled by a swing strategy.
+
+    The four fields are exactly the positional arguments the shared
+    :func:`_solve_symmetric_joint` back end consumes (the ``damping``
+    and the three solver flags are supplied by the dispatcher, not the
+    strategy — they are path-independent).
+
+    Attributes
+    ----------
+    design : np.ndarray
+        Global design ``(n·R, n_edge + n)`` (``R`` = per-node rows:
+        ``t_len`` differential / ``n_windows`` weak).
+    target : np.ndarray
+        Global target ``(n·R,)``.
+    edges : list[tuple[int, int]]
+        Unordered edge list ``[(a, b) : a < b]`` indexing the first
+        ``n_edge`` design columns.
+    n_edge : int
+        Edge count (``n_param = n_edge + n``).
+    """
+
+    design: NDArray[np.float64]
+    target: NDArray[np.float64]
+    edges: list[tuple[int, int]]
+    n_edge: int
+
+
+@runtime_checkable
+class SwingDesignStrategy(Protocol):
+    """Frozen contract every symmetric-joint swing path must satisfy.
+
+    A strategy encapsulates **only** the path-specific design/target
+    assembly. It never solves, never standardises, never touches the
+    PE guard or the identifiability layer — that shared tail lives once
+    in :func:`_solve_symmetric_joint`. This is the structural boundary
+    that caps the monotonic accretion: adding a future estimation path
+    means implementing + registering a strategy, not editing the
+    dispatcher.
+
+    Implementations are stateless callables registered under a unique
+    string key in :data:`_SWING_STRATEGY_REGISTRY`.
+    """
+
+    @property
+    def key(self) -> str:
+        """Stable registry key (the estimation-path identity)."""
+        ...
+
+    def build(
+        self,
+        theta_wrapped: NDArray[np.float64],
+        inertia: NDArray[np.float64],
+        damping: NDArray[np.float64],
+        *,
+        dt: float,
+        params: Mapping[str, int],
+    ) -> SwingDesign:
+        """Assemble the path-specific global design and target.
+
+        ``params`` carries the path-specific integer hyperparameters
+        already validated by the dispatcher (the differential path uses
+        ``savgol_window`` / ``savgol_polyorder``; the weak path uses
+        ``test_support`` / ``n_windows`` / ``bump_order``). The contract
+        (shape / sign / ``dt``) has been enforced upstream so the
+        strategy only does numeric assembly.
+        """
+        ...
+
+
+_SWING_STRATEGY_REGISTRY: dict[str, SwingDesignStrategy] = {}
+
+
+def _register_swing_strategy(strategy: SwingDesignStrategy) -> SwingDesignStrategy:
+    """Register a swing design strategy under its unique key.
+
+    Fail-closed on a duplicate key — a silent overwrite would let a new
+    lineage shadow an audited path's design assembly.
+    """
+    if strategy.key in _SWING_STRATEGY_REGISTRY:
+        raise ValueError(f"swing strategy key {strategy.key!r} already registered")
+    _SWING_STRATEGY_REGISTRY[strategy.key] = strategy
+    return strategy
+
+
+def swing_strategy_registry() -> Mapping[str, SwingDesignStrategy]:
+    """Read-only view of the registered swing design strategies.
+
+    Consumed by the architectural forcing-function test, which asserts
+    every public symmetric-joint swing estimation entry point dispatches
+    through exactly the registered strategy set (no path may bypass the
+    registry).
+    """
+
+    return MappingProxyType(_SWING_STRATEGY_REGISTRY)
+
+
+def _dispatch_swing(
+    strategy_key: str,
+    theta_wrapped: NDArray[np.float64],
+    inertia: NDArray[np.float64],
+    damping: NDArray[np.float64],
+    *,
+    dt: float,
+    params: Mapping[str, int],
+    pe_guard: bool,
+    pe_min_singular_ratio: float,
+    identifiability_gate: bool,
+) -> SwingCouplingEstimate:
+    """Select a registered strategy, assemble its design, run the tail.
+
+    The single dispatcher core. It is path-*independent*: a new
+    symmetric-joint estimation path is added by registering a strategy,
+    never by editing this function (the module-scale negative-feedback
+    term — see the registry preamble).
+    """
+    strategy = _SWING_STRATEGY_REGISTRY[strategy_key]
+    sd = strategy.build(
+        theta_wrapped,
+        inertia,
+        damping,
+        dt=dt,
+        params=params,
+    )
+    n = theta_wrapped.shape[1]
+    return _solve_symmetric_joint(
+        sd.design,
+        sd.target,
+        sd.edges,
+        sd.n_edge,
+        n,
+        damping,
+        pe_guard=pe_guard,
+        pe_min_singular_ratio=pe_min_singular_ratio,
+        identifiability_gate=identifiability_gate,
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class _DifferentialSwingStrategy:
+    """R1 differential symmetric-joint design (CALIB-GRID-001 R1).
+
+    Savitzky–Golay second-derivative swing target ``m θ̈ + d θ̇`` with one
+    shared parameter per unordered edge and one injection per node.
+    Path-specific assembly only — the standardise → PE → solve → unpack
+    → identifiability → ω tail is the shared :func:`_solve_symmetric_joint`.
+    """
+
+    key: str = "differential_symmetric"
+
+    def build(
+        self,
+        theta_wrapped: NDArray[np.float64],
+        inertia: NDArray[np.float64],
+        damping: NDArray[np.float64],
+        *,
+        dt: float,
+        params: Mapping[str, int],
+    ) -> SwingDesign:
+        theta = theta_wrapped
+        m = inertia
+        d = damping
+        _, n = theta.shape
+        savgol_window = params["savgol_window"]
+        savgol_polyorder = params["savgol_polyorder"]
+        if savgol_window < 5:
+            raise ValueError("savgol_window must be ≥ 5")
+        if savgol_polyorder < 2:
+            raise ValueError("savgol_polyorder must be ≥ 2 (need a non-zero 2nd derivative)")
+        theta_dot, theta_ddot = _savgol_derivatives(
+            theta, dt, window=savgol_window, polyorder=savgol_polyorder
+        )
+        t_len = theta.shape[0]
+
+        # One shared parameter per unordered edge (a < b) + one P_i per
+        # node. Node a's equation sees +sin(θ_a−θ_b) for edge (a,b);
+        # node b's equation sees sin(θ_b−θ_a) = −sin(θ_a−θ_b). Stack all
+        # N·T scalar equations into one global least-squares problem.
+        edges = [(a, b) for a in range(n) for b in range(a + 1, n)]
+        n_edge = len(edges)
+        edge_index = {e: p for p, e in enumerate(edges)}
+        n_param = n_edge + n  # edge couplings, then per-node injections
+
+        design = np.zeros((n * t_len, n_param), dtype=np.float64)
+        target = np.zeros(n * t_len, dtype=np.float64)
+        for i in range(n):
+            r0, r1 = i * t_len, (i + 1) * t_len
+            target[r0:r1] = m[i] * theta_ddot[:, i] + d[i] * theta_dot[:, i]
+            for j in range(n):
+                if j == i:
+                    continue
+                a, b = (i, j) if i < j else (j, i)
+                # y = P_i + Σ (−K_ij) sin(θ_i − θ_j); the design column
+                # is therefore the coefficient of (−K_{ij}).
+                col = edge_index[(a, b)]
+                design[r0:r1, col] += np.sin(theta[:, i] - theta[:, j])
+            design[r0:r1, n_edge + i] = 1.0
+
+        return SwingDesign(
+            design=np.asarray(design, dtype=np.float64),
+            target=np.asarray(target, dtype=np.float64),
+            edges=edges,
+            n_edge=n_edge,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class _IntegralSwingStrategy:
+    """Weak / integral-form symmetric-joint design (CALIB-GRID-002).
+
+    The swing identity is projected onto compactly supported test
+    functions and integrated, so the phase is never differentiated.
+    Path-specific assembly only — the solve tail is the same shared
+    :func:`_solve_symmetric_joint` as the differential path.
+    """
+
+    key: str = "integral_weak_form"
+
+    def build(
+        self,
+        theta_wrapped: NDArray[np.float64],
+        inertia: NDArray[np.float64],
+        damping: NDArray[np.float64],
+        *,
+        dt: float,
+        params: Mapping[str, int],
+    ) -> SwingDesign:
+        m = inertia
+        d = damping
+        t_len, n = theta_wrapped.shape
+        test_support = params["test_support"]
+        n_windows = params["n_windows"]
+        bump_order = params["bump_order"]
+        if bump_order < 2:
+            raise ValueError("bump_order must be ≥ 2 (need a finite, C¹ test function)")
+        if n_windows < 1:
+            raise ValueError("n_windows must be ≥ 1")
+        if test_support < 5:
+            raise ValueError("test_support must be ≥ 5 samples")
+        half = min(test_support, t_len - 1) // 2
+        if half < 2:
+            raise ValueError(
+                f"test_support {test_support} too large for trajectory length {t_len} "
+                f"(need at least one full window inside the record)"
+            )
+
+        # The phase enters the integrals *unwrapped* (the wrapped jumps
+        # are not physical); φ never differentiates it — the whole point.
+        theta = np.unwrap(theta_wrapped, axis=0)
+        phi, dphi, d2phi = _test_function_stencil(half, bump_order, dt)
+
+        # Uniformly placed window centres (clipped so every window fits).
+        lo, hi = half, t_len - half - 1
+        if hi <= lo:
+            raise ValueError(f"trajectory length {t_len} too short for support {2 * half + 1}")
+        centres = np.unique(np.linspace(lo, hi, n_windows).astype(np.int64))
+        n_w = int(centres.size)
+
+        edges = [(a, b) for a in range(n) for b in range(a + 1, n)]
+        n_edge = len(edges)
+        edge_index = {e: p for p, e in enumerate(edges)}
+        n_param = n_edge + n
+
+        design = np.zeros((n * n_w, n_param), dtype=np.float64)
+        target = np.zeros(n * n_w, dtype=np.float64)
+        int_phi = float(np.trapezoid(phi, dx=dt))
+        for i in range(n):
+            for wi in range(n_w):
+                c = int(centres[wi])
+                row = i * n_w + wi
+                sl = slice(c - half, c + half + 1)
+                theta_i = theta[sl, i]
+                # Weak target: m_i ∫φ'' θ_i − d_i ∫φ' θ_i (no phase deriv).
+                target[row] = m[i] * float(np.trapezoid(d2phi * theta_i, dx=dt)) - d[i] * float(
+                    np.trapezoid(dphi * theta_i, dx=dt)
+                )
+                for j in range(n):
+                    if j == i:
+                        continue
+                    a, b = (i, j) if i < j else (j, i)
+                    col = edge_index[(a, b)]
+                    sin_ij = np.sin(theta[sl, i] - theta[sl, j])
+                    # y = P_i ∫φ + Σ(−K_ij) ∫φ sin(θ_i−θ_j); the design
+                    # column is the coefficient of (−K_{ij}).
+                    design[row, col] += float(np.trapezoid(phi * sin_ij, dx=dt))
+                design[row, n_edge + i] = int_phi
+
+        return SwingDesign(
+            design=np.asarray(design, dtype=np.float64),
+            target=np.asarray(target, dtype=np.float64),
+            edges=edges,
+            n_edge=n_edge,
+        )
+
+
+_register_swing_strategy(_DifferentialSwingStrategy())
+_register_swing_strategy(_IntegralSwingStrategy())
+
+
 def _solve_symmetric_joint(
     design: NDArray[np.float64],
     target: NDArray[np.float64],
@@ -930,6 +1261,33 @@ def estimate_swing_coupling(
     if np.any(d < 0.0):
         raise ValueError("damping must be non-negative")
 
+    if symmetric:
+        # Symmetric-joint path: a registered strategy assembles the
+        # path-specific differential design (Savitzky–Golay derivatives
+        # + one shared parameter per unordered edge + one P_i per node)
+        # and the single dispatcher runs the shared standardise → PE →
+        # solve → unpack → identifiability → ω tail. The strategy
+        # performs the *exact same operations in the exact same order*
+        # as the former inline block, so the estimate is bit-identical
+        # (algorithm-preserving extraction — pinned by the R1
+        # bit-stability tests and the added golden vectors). Adding a
+        # future symmetric-joint path means registering a strategy, not
+        # editing this dispatcher (module-scale forcing function).
+        return _dispatch_swing(
+            "differential_symmetric",
+            theta,
+            m,
+            d,
+            dt=dt,
+            params={
+                "savgol_window": savgol_window,
+                "savgol_polyorder": savgol_polyorder,
+            },
+            pe_guard=pe_guard,
+            pe_min_singular_ratio=pe_min_singular_ratio,
+            identifiability_gate=identifiability_gate,
+        )
+
     if savgol_window < 5:
         raise ValueError("savgol_window must be ≥ 5")
     if savgol_polyorder < 2:
@@ -942,46 +1300,6 @@ def estimate_swing_coupling(
     k_hat = np.zeros((n, n), dtype=np.float64)
     injection = np.zeros(n, dtype=np.float64)
     identifiability: IdentifiabilityReport | None = None
-
-    if symmetric:
-        # One shared parameter per unordered edge (a < b) + one P_i per
-        # node. Node a's equation sees +sin(θ_a−θ_b) for edge (a,b);
-        # node b's equation sees sin(θ_b−θ_a) = −sin(θ_a−θ_b). Stack all
-        # N·T scalar equations into one global least-squares problem.
-        edges = [(a, b) for a in range(n) for b in range(a + 1, n)]
-        n_edge = len(edges)
-        edge_index = {e: p for p, e in enumerate(edges)}
-        n_param = n_edge + n  # edge couplings, then per-node injections
-
-        design = np.zeros((n * t_len, n_param), dtype=np.float64)
-        target = np.zeros(n * t_len, dtype=np.float64)
-        for i in range(n):
-            r0, r1 = i * t_len, (i + 1) * t_len
-            target[r0:r1] = m[i] * theta_ddot[:, i] + d[i] * theta_dot[:, i]
-            for j in range(n):
-                if j == i:
-                    continue
-                a, b = (i, j) if i < j else (j, i)
-                # y = P_i + Σ (−K_ij) sin(θ_i − θ_j); the design column
-                # is therefore the coefficient of (−K_{ij}).
-                col = edge_index[(a, b)]
-                design[r0:r1, col] += np.sin(theta[:, i] - theta[:, j])
-            design[r0:r1, n_edge + i] = 1.0
-
-        # Identical standardise → PE → solve → unpack → identifiability
-        # → ω tail as the weak/integral path: one shared back end (no
-        # numeric change — bit-identical, structure-only extraction).
-        return _solve_symmetric_joint(
-            design,
-            target,
-            edges,
-            n_edge,
-            n,
-            d,
-            pe_guard=pe_guard,
-            pe_min_singular_ratio=pe_min_singular_ratio,
-            identifiability_gate=identifiability_gate,
-        )
 
     # Asymmetric variant: unconstrained per-row OLS (one independent fit
     # per node). Kept for diagnostic comparison; the symmetric joint
@@ -1243,7 +1561,7 @@ def estimate_swing_coupling_integral(
         raise ValueError("n_windows must be ≥ 1")
 
     theta_wrapped = np.asarray(phases.theta, dtype=np.float64)
-    t_len, n = theta_wrapped.shape
+    _, n = theta_wrapped.shape
     m = np.asarray(inertia, dtype=np.float64)
     d = np.asarray(damping, dtype=np.float64)
     if m.shape != (n,) or d.shape != (n,):
@@ -1255,67 +1573,28 @@ def estimate_swing_coupling_integral(
     if np.any(d < 0.0):
         raise ValueError("damping must be non-negative")
 
-    if test_support < 5:
-        raise ValueError("test_support must be ≥ 5 samples")
-    half = min(test_support, t_len - 1) // 2
-    if half < 2:
-        raise ValueError(
-            f"test_support {test_support} too large for trajectory length {t_len} "
-            f"(need at least one full window inside the record)"
-        )
-
-    # The phase enters the integrals *unwrapped* (the wrapped jumps are
-    # not physical); φ never differentiates it — that is the whole point.
-    theta = np.unwrap(theta_wrapped, axis=0)
-    phi, dphi, d2phi = _test_function_stencil(half, bump_order, dt)
-
-    # Uniformly placed window centres (clipped so every window fits).
-    lo, hi = half, t_len - half - 1
-    if hi <= lo:
-        raise ValueError(f"trajectory length {t_len} too short for support {2 * half + 1}")
-    centres = np.unique(np.linspace(lo, hi, n_windows).astype(np.int64))
-    n_w = int(centres.size)
-
-    edges = [(a, b) for a in range(n) for b in range(a + 1, n)]
-    n_edge = len(edges)
-    edge_index = {e: p for p, e in enumerate(edges)}
-    n_param = n_edge + n
-
-    design = np.zeros((n * n_w, n_param), dtype=np.float64)
-    target = np.zeros(n * n_w, dtype=np.float64)
-    int_phi = float(np.trapezoid(phi, dx=dt))
-    for i in range(n):
-        for wi in range(n_w):
-            c = int(centres[wi])
-            row = i * n_w + wi
-            sl = slice(c - half, c + half + 1)
-            theta_i = theta[sl, i]
-            # Weak target: m_i ∫φ'' θ_i − d_i ∫φ' θ_i  (no phase deriv).
-            target[row] = m[i] * float(np.trapezoid(d2phi * theta_i, dx=dt)) - d[i] * float(
-                np.trapezoid(dphi * theta_i, dx=dt)
-            )
-            for j in range(n):
-                if j == i:
-                    continue
-                a, b = (i, j) if i < j else (j, i)
-                col = edge_index[(a, b)]
-                sin_ij = np.sin(theta[sl, i] - theta[sl, j])
-                # y = P_i ∫φ + Σ(−K_ij) ∫φ sin(θ_i−θ_j); the design
-                # column is the coefficient of (−K_{ij}).
-                design[row, col] += float(np.trapezoid(phi * sin_ij, dx=dt))
-            design[row, n_edge + i] = int_phi
-
-    # Identical standardise → PE → solve → unpack → identifiability → ω
-    # tail as the differential symmetric path: the single shared back
-    # end. Only the weak design / target above differ — the solve is
-    # bit-identical and structure-only (no algorithm change).
-    return _solve_symmetric_joint(
-        design,
-        target,
-        edges,
-        n_edge,
-        n,
+    # Symmetric-joint weak/integral path: a registered strategy
+    # assembles the path-specific weak design (test-function projection
+    # + integration by parts; the phase is never differentiated) and the
+    # single dispatcher runs the *same* shared standardise → PE → solve
+    # → unpack → identifiability → ω tail as the differential path. The
+    # strategy performs the exact same operations in the exact same
+    # order as the former inline block (algorithm-preserving extraction
+    # — bit-identical, pinned by the CALIB-GRID-002 bit-stability tests
+    # and the added golden vectors). A future symmetric-joint estimator
+    # class is added by registering a strategy, never by editing this
+    # dispatcher (module-scale forcing function).
+    return _dispatch_swing(
+        "integral_weak_form",
+        theta_wrapped,
+        m,
         d,
+        dt=dt,
+        params={
+            "test_support": test_support,
+            "n_windows": n_windows,
+            "bump_order": bump_order,
+        },
         pe_guard=pe_guard,
         pe_min_singular_ratio=pe_min_singular_ratio,
         identifiability_gate=identifiability_gate,

--- a/tests/unit/core/test_kuramoto_coupling_strategy_registry.py
+++ b/tests/unit/core/test_kuramoto_coupling_strategy_registry.py
@@ -258,29 +258,31 @@ def _swing_pm() -> tuple[PhaseMatrix, np.ndarray, np.ndarray]:
 # every estimation path's raw-byte hash. A single ULP drift on any path
 # flips one of these and fails the test (algorithm-preserving contract).
 _GOLDEN: dict[str, object] = {
-    "first_order_mcp_K": "2ef43b77c3cb4e24b567563caddebd0a31c01155a72a283bb0b048a66266cdff",
+    # audited: numpy-array content sha256 / scalar diagnostics, NOT
+    # credentials — the bit-identical golden vectors from sha 65666072.
+    "first_order_mcp_K": "2ef43b77c3cb4e24b567563caddebd0a31c01155a72a283bb0b048a66266cdff",  # pragma: allowlist secret
     "first_order_mcp_sparsity": 0.9333333333333333,
-    "first_order_stab_K": "4a1693424442e9ef473e2f0d6a4699a885a8316d54a284412cae70e0fdcd858e",
-    "first_order_stab_scores": "f4c4a8f934857770e8649f2ee958d2af3a63a783ea4038e41108a423053d4297",
-    "cps_K_median": "bd3e05110466b148c0eae3b58928949f54207036b9a30369f66cfb2cb0c66148",
-    "cps_stability": "f4c4a8f934857770e8649f2ee958d2af3a63a783ea4038e41108a423053d4297",
-    "mcp_prox": "0509a9a0bed614b2eb21a44091006cc979db732f34076fe63af2aaa0d992226f",
-    "scad_prox": "9dff064a01a1963ac4ee4b0f71ee300deb65f81835151df3419e3043f10f935f",
-    "soft_threshold": "93f77c0d636d04dd2cd1683ec9936f95bcdeec12e3526e4c2e5b66861f3fa7c6",
-    "swing_sym_K": "f2f63bc4f07cedc6044017d641fb93e264f98e9b7959daf38b97a021a6e1ca76",
-    "swing_sym_P": "3b9e7840e3f6056bbc94e043a9ca8fbe94132a83af040168151c73c0edbc7e87",
-    "swing_sym_omega": "749e28c849ccc30f5858bd7b6f1087e24262ab450bd6f92b06bc6aeaf8800797",
+    "first_order_stab_K": "4a1693424442e9ef473e2f0d6a4699a885a8316d54a284412cae70e0fdcd858e",  # pragma: allowlist secret
+    "first_order_stab_scores": "f4c4a8f934857770e8649f2ee958d2af3a63a783ea4038e41108a423053d4297",  # pragma: allowlist secret
+    "cps_K_median": "bd3e05110466b148c0eae3b58928949f54207036b9a30369f66cfb2cb0c66148",  # pragma: allowlist secret
+    "cps_stability": "f4c4a8f934857770e8649f2ee958d2af3a63a783ea4038e41108a423053d4297",  # pragma: allowlist secret
+    "mcp_prox": "0509a9a0bed614b2eb21a44091006cc979db732f34076fe63af2aaa0d992226f",  # pragma: allowlist secret
+    "scad_prox": "9dff064a01a1963ac4ee4b0f71ee300deb65f81835151df3419e3043f10f935f",  # pragma: allowlist secret
+    "soft_threshold": "93f77c0d636d04dd2cd1683ec9936f95bcdeec12e3526e4c2e5b66861f3fa7c6",  # pragma: allowlist secret
+    "swing_sym_K": "f2f63bc4f07cedc6044017d641fb93e264f98e9b7959daf38b97a021a6e1ca76",  # pragma: allowlist secret
+    "swing_sym_P": "3b9e7840e3f6056bbc94e043a9ca8fbe94132a83af040168151c73c0edbc7e87",  # pragma: allowlist secret
+    "swing_sym_omega": "749e28c849ccc30f5858bd7b6f1087e24262ab450bd6f92b06bc6aeaf8800797",  # pragma: allowlist secret
     "swing_sym_msr": 0.04004743831202507,
-    "swing_sym_ident_K": "f2f63bc4f07cedc6044017d641fb93e264f98e9b7959daf38b97a021a6e1ca76",
+    "swing_sym_ident_K": "f2f63bc4f07cedc6044017d641fb93e264f98e9b7959daf38b97a021a6e1ca76",  # pragma: allowlist secret
     "swing_sym_ident_score": 0.9996845317668399,
     "swing_sym_ident_verdict": "ACCEPT",
-    "swing_asym_K": "cd0021bea77cada8ed6c21231b239a042783ee4d91394921d57cbca8fb765879",
-    "swing_asym_P": "92ecaf44292090862a4732bf4fa71fd8cd8d29ef9e75c7c125c8d96cf5c9e55f",
-    "swing_asym_omega": "759d69c0bd363d78abedf78b4fede1cd9bc9ca41605644822e7ff0566d853bec",
+    "swing_asym_K": "cd0021bea77cada8ed6c21231b239a042783ee4d91394921d57cbca8fb765879",  # pragma: allowlist secret
+    "swing_asym_P": "92ecaf44292090862a4732bf4fa71fd8cd8d29ef9e75c7c125c8d96cf5c9e55f",  # pragma: allowlist secret
+    "swing_asym_omega": "759d69c0bd363d78abedf78b4fede1cd9bc9ca41605644822e7ff0566d853bec",  # pragma: allowlist secret
     "swing_asym_msr": 0.03644135053721742,
-    "integral_K": "b9dc00b1f213add6039d55b1d2e25c197a9c8d6b280f315d8f693ebae80b2304",
-    "integral_P": "d22c73572803701d064edbd6678577800320fbabf1522f74c5b3bcd1bce6f30c",
-    "integral_omega": "2936f444e03019d5e58528559908ba4a60954a79a426f611c0522f38ddfb1490",
+    "integral_K": "b9dc00b1f213add6039d55b1d2e25c197a9c8d6b280f315d8f693ebae80b2304",  # pragma: allowlist secret
+    "integral_P": "d22c73572803701d064edbd6678577800320fbabf1522f74c5b3bcd1bce6f30c",  # pragma: allowlist secret
+    "integral_omega": "2936f444e03019d5e58528559908ba4a60954a79a426f611c0522f38ddfb1490",  # pragma: allowlist secret
     "integral_msr": 0.037442981977247894,
     "integral_ident_score": 0.9981478637919239,
     "integral_ident_verdict": "ACCEPT",

--- a/tests/unit/core/test_kuramoto_coupling_strategy_registry.py
+++ b/tests/unit/core/test_kuramoto_coupling_strategy_registry.py
@@ -1,0 +1,381 @@
+# Copyright (c) 2023-2026 Yaroslav Vasylenko (neuron7xLab)
+# SPDX-License-Identifier: MIT
+"""Architectural forcing function for the swing coupling-estimator stack.
+
+``core.kuramoto.coupling_estimator`` was an open-loop universal sink:
+every CALIB-GRID lineage bolted another symmetric-joint estimation path
+(``estimate_swing_coupling`` R1, then ``estimate_swing_coupling_integral``
+CALIB-GRID-002) onto the module with its global-design assembly inlined
+into the public function — 521 → 1322 LOC, +154 % over five lineages,
+monotonic, with no strategy/boundary capping growth. PR #759 extracted
+the shared solve tail (``_solve_symmetric_joint``); this refactor
+extracted the path-specific *design assembly* into registered
+:class:`SwingDesignStrategy` objects and turned the public functions
+into thin dispatchers.
+
+This module is the missing module-scale negative-feedback term (it
+mirrors the lineage-scale forcing functions added in #762). It is
+strictly pure-additive — no production formula, no frozen artifact, no
+gate/threshold/seed and no pre-existing test is touched. Each test fails
+closed the moment a future symmetric-joint estimation path is added
+*outside* the registry or perturbs a path's numerics:
+
+* ``test_every_symmetric_joint_path_dispatches_through_registry`` — the
+  set of public symmetric-joint swing entry points equals the set of
+  registered strategies routed by the single dispatcher. A lineage that
+  inlines a third ``estimate_swing_coupling_*`` symmetric-joint design
+  instead of registering a strategy fails this test (the structural cap
+  on the monotonic accretion).
+* ``test_dispatcher_core_is_path_independent`` — the one dispatcher
+  ``_dispatch_swing`` mentions no path-specific symbol; new paths cannot
+  be wired by editing it.
+* ``test_strategy_registry_is_frozen_and_fail_closed`` — strategies are
+  frozen, the registry rejects a duplicate key (no silent shadowing of
+  an audited path), and the public view is read-only.
+* ``test_golden_vectors_bit_identical`` — every estimation path's
+  ``K̂`` / ``ω̂`` / ``P̂`` / identifiability score / PE diagnostic and
+  every prox operator are byte-for-byte the values captured on the
+  parent sha (65666072), proving the extraction is algorithm-preserving.
+"""
+
+from __future__ import annotations
+
+import ast
+import hashlib
+import inspect
+from pathlib import Path
+
+import numpy as np
+
+from core.kuramoto.contracts import PhaseMatrix
+from core.kuramoto.coupling_estimator import (
+    CouplingEstimationConfig,
+    CouplingEstimator,
+    SwingDesign,
+    SwingDesignStrategy,
+    complementary_pairs_stability,
+    estimate_coupling,
+    estimate_swing_coupling,
+    estimate_swing_coupling_integral,
+    mcp_prox,
+    scad_prox,
+    soft_threshold,
+    swing_strategy_registry,
+)
+
+_MODULE = Path(__file__).resolve().parents[3] / "core" / "kuramoto" / "coupling_estimator.py"
+
+
+# ---------------------------------------------------------------------------
+# Structural cap: every symmetric-joint path goes through the registry
+# ---------------------------------------------------------------------------
+
+
+def test_every_symmetric_joint_path_dispatches_through_registry() -> None:
+    """Symmetric-joint estimation paths == registered strategies.
+
+    The two public symmetric-joint swing entry points (the differential
+    ``estimate_swing_coupling`` with ``symmetric=True`` and the
+    weak/integral ``estimate_swing_coupling_integral``) each route
+    through ``_dispatch_swing`` with a registry key, and the registry
+    holds exactly those keys. A future lineage that adds a third
+    symmetric-joint design inline — instead of registering a strategy —
+    breaks this equality and fails closed.
+    """
+    registry = swing_strategy_registry()
+    assert set(registry) == {"differential_symmetric", "integral_weak_form"}, (
+        "registered swing strategy key set drifted — a new symmetric-joint "
+        "estimation path must register a SwingDesignStrategy, not inline its "
+        "design assembly into the dispatcher/public function"
+    )
+
+    tree = ast.parse(_MODULE.read_text())
+    dispatched_keys: set[str] = set()
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "_dispatch_swing"
+            and node.args
+            and isinstance(node.args[0], ast.Constant)
+            and isinstance(node.args[0].value, str)
+        ):
+            dispatched_keys.add(node.args[0].value)
+    assert dispatched_keys == set(registry), (
+        f"dispatched keys {sorted(dispatched_keys)} != registered "
+        f"{sorted(registry)} — a symmetric-joint path bypassed the registry "
+        "or a registered strategy is unreachable (orphaned accretion)"
+    )
+
+    # Every registered strategy satisfies the frozen contract.
+    for key, strat in registry.items():
+        assert isinstance(strat, SwingDesignStrategy)
+        assert strat.key == key
+
+
+def test_dispatcher_core_is_path_independent() -> None:
+    """The single dispatcher mentions no path-specific estimator symbol.
+
+    ``_dispatch_swing`` selects a strategy by key and runs the shared
+    tail; it must not name a Savitzky–Golay / weak-form / stencil symbol
+    (that would mean a path was wired by editing the dispatcher rather
+    than by registering a strategy).
+    """
+    import core.kuramoto.coupling_estimator as ce
+
+    body = inspect.getsource(ce._dispatch_swing)
+    forbidden = ("savgol", "_test_function_stencil", "bump_order", "trapezoid", "unwrap")
+    leaked = [tok for tok in forbidden if tok in body]
+    assert not leaked, (
+        f"_dispatch_swing leaked path-specific symbols {leaked} — the "
+        "dispatcher core must stay path-independent so new paths require "
+        "strategy registration, not a dispatcher edit"
+    )
+
+
+def test_strategy_registry_is_frozen_and_fail_closed() -> None:
+    """Strategies are frozen, the view is read-only, dup keys rejected."""
+    import core.kuramoto.coupling_estimator as ce
+
+    registry = swing_strategy_registry()
+    strat = next(iter(registry.values()))
+    # Frozen dataclass: attribute assignment is blocked.
+    try:
+        strat.key = "mutated"  # type: ignore[misc]
+    except AttributeError:
+        pass
+    else:  # pragma: no cover - defensive
+        raise AssertionError("swing strategy must be frozen (no attr set)")
+    # Read-only public view.
+    try:
+        registry["x"] = strat  # type: ignore[index]
+    except TypeError:
+        pass
+    else:  # pragma: no cover - defensive
+        raise AssertionError("swing_strategy_registry() view must be read-only")
+    # Duplicate-key registration is fail-closed (no silent shadow).
+    existing = next(iter(registry.values()))
+    try:
+        ce._register_swing_strategy(existing)
+    except ValueError:
+        pass
+    else:  # pragma: no cover - defensive
+        raise AssertionError("duplicate strategy key must fail closed")
+
+    # SwingDesign is a frozen contract carrying only the assembly output.
+    sd = SwingDesign(
+        design=np.zeros((2, 2), dtype=np.float64),
+        target=np.zeros(2, dtype=np.float64),
+        edges=[(0, 1)],
+        n_edge=1,
+    )
+    try:
+        sd.n_edge = 2  # type: ignore[misc]
+    except AttributeError:
+        pass
+    else:  # pragma: no cover - defensive
+        raise AssertionError("SwingDesign must be frozen")
+
+
+# ---------------------------------------------------------------------------
+# Algorithm-preserving extraction: golden vectors pinned to parent sha
+# ---------------------------------------------------------------------------
+
+
+def _h(a: np.ndarray) -> str:
+    arr = np.ascontiguousarray(np.asarray(a, dtype=np.float64))
+    return hashlib.sha256(arr.tobytes()).hexdigest()
+
+
+def _first_order_pm() -> tuple[PhaseMatrix, np.ndarray]:
+    rng = np.random.default_rng(42)
+    n, t_len, dt = 6, 1500, 0.05
+    k_true = np.zeros((n, n))
+    k_true[0, 1] = 1.8
+    k_true[1, 0] = 1.5
+    k_true[2, 3] = -1.2
+    k_true[4, 5] = 2.0
+    omega = rng.uniform(0.3, 0.7, n)
+    theta = np.zeros((t_len, n))
+    theta[0] = rng.uniform(0.0, 2 * np.pi, n)
+    for t in range(1, t_len):
+        di = theta[t - 1, None, :] - theta[t - 1, :, None]
+        theta[t] = (
+            theta[t - 1]
+            + dt * (omega + np.sum(k_true * np.sin(di), axis=1))
+            + 0.05 * rng.standard_normal(n) * np.sqrt(dt)
+        )
+    theta = np.mod(theta, 2 * np.pi)
+    pm = PhaseMatrix(
+        theta=theta,
+        timestamps=np.arange(t_len, dtype=np.float64) * dt,
+        asset_ids=tuple(f"x{i}" for i in range(n)),
+        extraction_method="hilbert",
+        frequency_band=(0.01, 1.0),
+    )
+    return pm, theta
+
+
+def _swing_pm() -> tuple[PhaseMatrix, np.ndarray, np.ndarray]:
+    k = np.array([[0.0, 0.9, 0.5], [0.9, 0.0, 0.7], [0.5, 0.7, 0.0]])
+    p = np.array([0.6, -0.1, -0.5]) - np.mean([0.6, -0.1, -0.5])
+    m = np.array([0.4, 0.5, 0.3])
+    d = np.array([0.25, 0.3, 0.2])
+    rng = np.random.default_rng(11)
+    th0 = rng.uniform(-0.8, 0.8, 3)
+    th0 -= th0.mean()
+    nn, dt, n = 3, 0.005, 4000
+    thr = th0.astype(np.float64).copy()
+    v = np.zeros(nn)
+    traj = np.empty((n + 1, nn))
+    traj[0] = thr
+
+    def accel(x: np.ndarray, w: np.ndarray) -> np.ndarray:
+        di = x[:, None] - x[None, :]
+        return np.asarray((p - (k * np.sin(di)).sum(1) - d * w) / m, dtype=np.float64)
+
+    for t in range(n):
+        a1 = accel(thr, v)
+        a2 = accel(thr + 0.5 * dt * v, v + 0.5 * dt * a1)
+        a3 = accel(thr + 0.5 * dt * (v + 0.5 * dt * a1), v + 0.5 * dt * a2)
+        a4 = accel(thr + dt * (v + 0.5 * dt * a2), v + dt * a3)
+        thr = thr + dt * v + (dt * dt / 6.0) * (a1 + 2 * a2 + 2 * a3)
+        v = v + (dt / 6.0) * (a1 + 2 * a2 + 2 * a3 + a4)
+        traj[t + 1] = thr
+    w = np.mod(traj, 2 * np.pi)
+    w = np.clip(w, 0.0, np.nextafter(2 * np.pi, 0.0))
+    pm = PhaseMatrix(
+        theta=w,
+        timestamps=np.arange(w.shape[0], dtype=np.float64) * dt,
+        asset_ids=("a", "b", "c"),
+        extraction_method="hilbert",
+        frequency_band=(1e-6, 0.5),
+    )
+    return pm, m, d
+
+
+# Golden vectors captured on the parent sha 65666072 (pre-refactor) —
+# every estimation path's raw-byte hash. A single ULP drift on any path
+# flips one of these and fails the test (algorithm-preserving contract).
+_GOLDEN: dict[str, object] = {
+    "first_order_mcp_K": "2ef43b77c3cb4e24b567563caddebd0a31c01155a72a283bb0b048a66266cdff",
+    "first_order_mcp_sparsity": 0.9333333333333333,
+    "first_order_stab_K": "4a1693424442e9ef473e2f0d6a4699a885a8316d54a284412cae70e0fdcd858e",
+    "first_order_stab_scores": "f4c4a8f934857770e8649f2ee958d2af3a63a783ea4038e41108a423053d4297",
+    "cps_K_median": "bd3e05110466b148c0eae3b58928949f54207036b9a30369f66cfb2cb0c66148",
+    "cps_stability": "f4c4a8f934857770e8649f2ee958d2af3a63a783ea4038e41108a423053d4297",
+    "mcp_prox": "0509a9a0bed614b2eb21a44091006cc979db732f34076fe63af2aaa0d992226f",
+    "scad_prox": "9dff064a01a1963ac4ee4b0f71ee300deb65f81835151df3419e3043f10f935f",
+    "soft_threshold": "93f77c0d636d04dd2cd1683ec9936f95bcdeec12e3526e4c2e5b66861f3fa7c6",
+    "swing_sym_K": "f2f63bc4f07cedc6044017d641fb93e264f98e9b7959daf38b97a021a6e1ca76",
+    "swing_sym_P": "3b9e7840e3f6056bbc94e043a9ca8fbe94132a83af040168151c73c0edbc7e87",
+    "swing_sym_omega": "749e28c849ccc30f5858bd7b6f1087e24262ab450bd6f92b06bc6aeaf8800797",
+    "swing_sym_msr": 0.04004743831202507,
+    "swing_sym_ident_K": "f2f63bc4f07cedc6044017d641fb93e264f98e9b7959daf38b97a021a6e1ca76",
+    "swing_sym_ident_score": 0.9996845317668399,
+    "swing_sym_ident_verdict": "ACCEPT",
+    "swing_asym_K": "cd0021bea77cada8ed6c21231b239a042783ee4d91394921d57cbca8fb765879",
+    "swing_asym_P": "92ecaf44292090862a4732bf4fa71fd8cd8d29ef9e75c7c125c8d96cf5c9e55f",
+    "swing_asym_omega": "759d69c0bd363d78abedf78b4fede1cd9bc9ca41605644822e7ff0566d853bec",
+    "swing_asym_msr": 0.03644135053721742,
+    "integral_K": "b9dc00b1f213add6039d55b1d2e25c197a9c8d6b280f315d8f693ebae80b2304",
+    "integral_P": "d22c73572803701d064edbd6678577800320fbabf1522f74c5b3bcd1bce6f30c",
+    "integral_omega": "2936f444e03019d5e58528559908ba4a60954a79a426f611c0522f38ddfb1490",
+    "integral_msr": 0.037442981977247894,
+    "integral_ident_score": 0.9981478637919239,
+    "integral_ident_verdict": "ACCEPT",
+}
+
+
+def test_golden_vectors_bit_identical() -> None:
+    """Every estimation path is byte-identical to the parent sha output.
+
+    This is the bit-identical proof for the strategy-registry
+    extraction: the dispatcher + strategies reproduce the exact ``K̂`` /
+    ``ω̂`` / ``P̂`` / identifiability score / PE diagnostic / prox-operator
+    bytes captured on 65666072 before any structural change.
+    """
+    out: dict[str, object] = {}
+
+    pm, theta = _first_order_pm()
+    dt = 0.05
+    cfg = CouplingEstimationConfig(penalty="mcp", lambda_reg=0.15, dt=dt, max_iter=800, tol=1e-7)
+    r1 = estimate_coupling(pm, cfg)
+    out["first_order_mcp_K"] = _h(r1.K)
+    out["first_order_mcp_sparsity"] = float(r1.sparsity)
+
+    cfg_s = CouplingEstimationConfig(
+        penalty="mcp",
+        lambda_reg=0.02,
+        dt=dt,
+        max_iter=300,
+        tol=1e-5,
+        stability_selection=True,
+        lambda_grid=(0.01, 0.03, 0.1),
+        n_subsamples=4,
+        subsample_fraction=0.5,
+        stability_threshold=0.5,
+        random_state=0,
+    )
+    rs = CouplingEstimator(cfg_s).estimate(pm)
+    assert rs.stability_scores is not None
+    out["first_order_stab_K"] = _h(rs.K)
+    out["first_order_stab_scores"] = _h(rs.stability_scores)
+    k_med, stab = complementary_pairs_stability(theta, cfg_s)
+    out["cps_K_median"] = _h(k_med)
+    out["cps_stability"] = _h(stab)
+
+    z = np.array([-2.0, -0.3, 0.0, 0.3, 1.5, 4.0])
+    out["mcp_prox"] = _h(mcp_prox(z, 1.0, 3.0, 0.5))
+    out["scad_prox"] = _h(scad_prox(z, 1.0, 3.7, 0.5))
+    out["soft_threshold"] = _h(soft_threshold(z, 0.2))
+
+    pm2, m, d = _swing_pm()
+    dt2 = 0.005
+    sd = estimate_swing_coupling(pm2, m, d, dt=dt2, savgol_window=7, savgol_polyorder=4)
+    out["swing_sym_K"] = _h(sd.K)
+    out["swing_sym_P"] = _h(sd.injection)
+    out["swing_sym_omega"] = _h(sd.omega)
+    out["swing_sym_msr"] = float(sd.min_singular_ratio)
+    sd_i = estimate_swing_coupling(
+        pm2, m, d, dt=dt2, savgol_window=7, savgol_polyorder=4, identifiability_gate=True
+    )
+    assert sd_i.identifiability is not None
+    out["swing_sym_ident_K"] = _h(sd_i.K)
+    out["swing_sym_ident_score"] = float(sd_i.identifiability.score)
+    out["swing_sym_ident_verdict"] = sd_i.identifiability.verdict
+    sa = estimate_swing_coupling(
+        pm2, m, d, dt=dt2, symmetric=False, savgol_window=7, savgol_polyorder=4, pe_guard=False
+    )
+    out["swing_asym_K"] = _h(sa.K)
+    out["swing_asym_P"] = _h(sa.injection)
+    out["swing_asym_omega"] = _h(sa.omega)
+    out["swing_asym_msr"] = float(sa.min_singular_ratio)
+    ig = estimate_swing_coupling_integral(
+        pm2, m, d, dt=dt2, test_support=120, n_windows=120, bump_order=6
+    )
+    out["integral_K"] = _h(ig.K)
+    out["integral_P"] = _h(ig.injection)
+    out["integral_omega"] = _h(ig.omega)
+    out["integral_msr"] = float(ig.min_singular_ratio)
+    ig_i = estimate_swing_coupling_integral(
+        pm2,
+        m,
+        d,
+        dt=dt2,
+        test_support=120,
+        n_windows=120,
+        bump_order=6,
+        identifiability_gate=True,
+    )
+    assert ig_i.identifiability is not None
+    out["integral_ident_score"] = float(ig_i.identifiability.score)
+    out["integral_ident_verdict"] = ig_i.identifiability.verdict
+
+    mism = [k for k in _GOLDEN if _GOLDEN[k] != out.get(k)]
+    assert not mism, (
+        f"NON-BIT-IDENTICAL extraction — paths drifted from the parent-sha "
+        f"golden vectors: {mism}. The strategy-registry refactor is "
+        "algorithm-preserving by contract; any numeric change here is a "
+        "behavior breach, not a refactor."
+    )


### PR DESCRIPTION
## F4 — the last open architectural debt from the fractal/dynamical audit

`core/kuramoto/coupling_estimator.py` was an **open-loop universal sink**: every CALIB-GRID lineage bolted another symmetric-joint estimation path onto the module with its global-design assembly inlined. **521 → 1322 LOC, +154 % over five lineages, monotonic**, unbounded mypy blast-radius, no strategy/boundary capping growth. PR #762 installed the negative-feedback term at *lineage* scale; this installs it at *module* scale.

### Estimation-path map (evidence before code)

| Path | Public entry point | Path-specific | Shared tail |
|---|---|---|---|
| 1. First-order MCP/SCAD/Lasso row regression | `estimate_coupling`, `CouplingEstimator.estimate`, `_estimate_K_single` (private, used by `dynamic_graph`), `complementary_pairs_stability` | `_build_target_and_design` + row solver | none (not symmetric-joint) |
| 2. Swing differential **symmetric** | `estimate_swing_coupling(symmetric=True)` | Savitzky–Golay derivs + symmetric global design | `_solve_symmetric_joint` (#759) |
| 3. Swing differential **asymmetric** | `estimate_swing_coupling(symmetric=False)` | per-row OLS | none (kept inline; diagnostic-only) |
| 4. Integral / weak-form | `estimate_swing_coupling_integral` | test-function stencil + weak global design | `_solve_symmetric_joint` (#759) |

The accretion mechanism is paths 2 & 4: each lineage adds an `estimate_swing_coupling_*` public function inlining a unique symmetric-joint design build (#757 copied the *entire* integral function from the symmetric one) then delegating `_solve_symmetric_joint`.

### Strategy / registry design (public API frozen — 0 importer edits)

- Frozen `SwingDesignStrategy` Protocol + `SwingDesign` contract (`@dataclass(frozen=True, slots=True)`, matching `contracts.py` style) + fail-closed registry (`swing_strategy_registry` / `_register_swing_strategy`, duplicate key → `ValueError`).
- Single **path-independent** dispatcher `_dispatch_swing`: selects a registered strategy by key, runs the shared #759 tail.
- `_DifferentialSwingStrategy` (R1) + `_IntegralSwingStrategy` (CALIB-GRID-002) encapsulate **only** their design/target assembly — the exact same operations in the exact same order as the former inline blocks.
- Public functions `estimate_swing_coupling` / `estimate_swing_coupling_integral` are now thin dispatchers. **Only `core/kuramoto/coupling_estimator.py` changed in production** — public API + the private symbols `dynamic_graph` (`_estimate_K_single`) and the coupling test (`_proximal_gradient_row`) consume are unchanged.

### Behavior-preserving proof

- **All paths bit-identical**: K̂ / ω̂ / P̂ / identifiability score / PE diagnostic / prox operators byte-for-byte equal to the parent-sha (65666072) golden vectors — 25 hashes pinned in `test_golden_vectors_bit_identical` (added; no path lacked one now).
- **0 importer edits** (proven: `git diff --stat origin/main` = only `coupling_estimator.py` in production).
- Every sha-pinned calibration artifact **byte-identical** (RESULTS.json/.md, PREREGISTRATION*, THRESHOLD_PROVENANCE, SUPERSESSIONS, AMENDMENT_001); `test_grid_kuramoto.py` git diff **EMPTY**; all drift/no-peek/bit-stability/reproduction tests green **unmodified** (calib + integral + identifiability + coupling + network_engine, full fast+slow).
- mypy --strict / ruff / black clean (fresh cache).

### Forcing function (module-scale negative-feedback term — mandatory deliverable)

`tests/unit/core/test_kuramoto_coupling_strategy_registry.py`: the set of AST-dispatched registry keys must equal the registered strategy set, and `_dispatch_swing` must name no path-specific symbol. **A new symmetric-joint estimation path inlined outside the registry fails this test** — structurally capping the monotonic accretion.

### LOC + blast-radius before → after (honest)

| | before | after |
|---|---|---|
| LOC | 1322 | 1601 (**+279**) |
| blast-radius | unbounded (any lineage edits the module body) | **bounded** — a new path must register a strategy; the dispatcher core is path-independent and AST-guarded |

**Honest backlog**: net LOC is **+279**, breaching the literal LOC-flat-or-down target. The strategy/registry pattern is inherently additive (Protocol + registry + dispatcher + N strategy objects; #762 itself added 436 lines). The *crucial, emphasized* invariant — bounded, structurally-enforced blast-radius — is satisfied. Documented literature-anchored physics derivations (Messenger–Bortz weak-form IBP, swing identity) were **not** gutted to hit a line count (CLAUDE.md: math notation must match paper conventions; zero-tech-debt). Reported as a legitimate pattern↔metric tension, not hidden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)