### PR TITLE
fix(audit): exempt C8 false-positive on guard-efficacy test (main red→green)

### DIFF
--- a/.claude/audit/false_confidence_exemptions.yaml
+++ b/.claude/audit/false_confidence_exemptions.yaml
@@ -208,6 +208,16 @@ exemptions:
   reason: "Type-ignore concentration is a third-party typing gap (pandas, strawberry, prometheus, sqlalchemy\
     \ stubs). Each # type: ignore audited 2026-04-27 against mypy --strict; tightening requires upstream\
     \ stub fixes \u2014 out of scope."
+- finding_id: C8-TYPE-IGNORE-tests/meta/test_feedback_guards_are_live.py
+  reason: 'Detector false-positive corrected, not masked. All 10 `type: ignore`
+    occurrences are STRING LITERALS / docstring text \u2014 synthetic source the G7
+    guard-efficacy test injects into temp files to prove the anti-`# type:
+    ignore[misc]` acceptor falsifier fires; none is a real directive silencing
+    this module. Verified 2026-05-18: `mypy --strict
+    tests/meta/test_feedback_guards_are_live.py` => Success, 0 issues (the
+    apparent_claim is TRUE); zero code-level `# type: ignore` outside strings.
+    Added with #772 (capstone); same audited pattern as the other
+    C8-TYPE-IGNORE test exemptions above.'
 - finding_id: C9-NO-COVER-analytics/signals/news_sentiment.py
   reason: '# pragma: no cover concentration on platform-specific or environment-conditional branches (e.g.
     async ingestion guards, kafka transports, fallback executors). Each pragma audited 2026-04-27; replacement

--- a/.claude/commit_acceptors/fcd-c8-exempt-guard-efficacy-test.yaml
+++ b/.claude/commit_acceptors/fcd-c8-exempt-guard-efficacy-test.yaml
@@ -1,0 +1,31 @@
+id: fcd-c8-exempt-guard-efficacy-test
+status: ACTIVE
+claim_type: governance
+promise: "Corrects a C8 false-confidence detector FALSE-POSITIVE, does not mask one. tools/audit/false_confidence_detector.py counts the substring `type: ignore`; tests/meta/test_feedback_guards_are_live.py (added with #772) carries 10 such occurrences that are ALL string literals / docstring text — synthetic source the G7 guard-efficacy test injects into temp files to prove the anti-bare-`# type: ignore[misc]` acceptor falsifier fires. None is a real directive silencing this module: `mypy --strict tests/meta/test_feedback_guards_are_live.py` => Success, 0 issues, so the detector's own apparent_claim ('module passes mypy --strict') is TRUE. A documented waiver is added to false_confidence_exemptions.yaml, the same audited pattern as the pre-existing C8-TYPE-IGNORE test exemptions. No production/physics/test logic changed; Reality Validators Gate returns to green."
+diff_scope:
+  changed_files:
+    - path: ".claude/audit/false_confidence_exemptions.yaml"
+    - path: ".claude/commit_acceptors/fcd-c8-exempt-guard-efficacy-test.yaml"
+    - path: ".github/detect-secrets.baseline"
+  forbidden_paths:
+    - "trading/"
+    - "execution/"
+    - "forecast/"
+    - "policy/"
+    - "tests/meta/test_feedback_guards_are_live.py"
+    - "tools/audit/false_confidence_detector.py"
+required_python_symbols: []
+expected_signal: "false_confidence_detector returns 0 unexempted findings (exit 0) AND mypy --strict on the cited test file passes — the waiver rests on a verified true-FP, not a silenced real ignore"
+measurement_command: "python tools/audit/false_confidence_detector.py --output /tmp/fcd_acc.json --exit-on-finding && python -m mypy --strict tests/meta/test_feedback_guards_are_live.py"
+signal_artifact: "/tmp/fcd_acc.json"
+falsifier:
+  command: "python -c \"import json,subprocess,sys; subprocess.run([sys.executable,'tools/audit/false_confidence_detector.py','--output','/tmp/fcd_fal.json'],check=True); n=len(json.load(open('/tmp/fcd_fal.json')).get('findings',[])); m=subprocess.run([sys.executable,'-m','mypy','--strict','tests/meta/test_feedback_guards_are_live.py']).returncode; raise SystemExit(0 if n==0 and m==0 else 1)\""
+  description: "Exits 0 iff the detector has zero unexempted findings AND the cited file still passes mypy --strict. Exits 1 if a real type-ignore is ever introduced into that file (apparent_claim becomes false → the waiver would be masking) or any other file trips C8 — the exemption cannot launder a genuine regression."
+rollback_command: "git checkout origin/main -- .claude/audit/false_confidence_exemptions.yaml && git rm -f .claude/commit_acceptors/fcd-c8-exempt-guard-efficacy-test.yaml"
+rollback_verification_command: "git diff --quiet origin/main -- .claude/audit/false_confidence_exemptions.yaml"
+memory_update_type: none
+ledger_path: ".claude/commit_acceptors/fcd-c8-exempt-guard-efficacy-test.yaml"
+report_path: ".claude/audit/false_confidence_exemptions.yaml"
+evidence:
+  - path: ".claude/audit/false_confidence_exemptions.yaml"
+    sha256: "25feccb57a473bd4018a232308bdf74d25255570721daf68409a6577091363b8"

--- a/.github/detect-secrets.baseline
+++ b/.github/detect-secrets.baseline
@@ -158,6 +158,15 @@
         "line_number": 51
       }
     ],
+    ".claude/commit_acceptors/fcd-c8-exempt-guard-efficacy-test.yaml": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".claude/commit_acceptors/fcd-c8-exempt-guard-efficacy-test.yaml",
+        "hashed_secret": "d0e8dbcba18ee246440e00c54352a64feb1392f1",
+        "is_verified": false,
+        "line_number": 31
+      }
+    ],
     ".claude/commit_acceptors/instrument-hardening-metric-split.yaml": [
       {
         "type": "Hex High Entropy String",
@@ -5615,5 +5624,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-17T16:06:17Z"
+  "generated_at": "2026-05-18T05:52:23Z"
 }


### PR DESCRIPTION
## Problem

`Reality Validators Gate / reality-false-confidence-regression` is **RED on main HEAD** (and across the dependabot-merge window — it entered with **#772**, the guard-efficacy capstone, not the dep bumps).

Root cause: `tools/audit/false_confidence_detector.py` counts the **substring** `type: ignore`. `tests/meta/test_feedback_guards_are_live.py` has 10 occurrences (threshold 8) → C8 finding.

## Why this is a detector false-positive, not real debt

All 10 occurrences are **string literals / docstring text** — synthetic source the G7 guard-efficacy test *injects into temp files* to prove the anti-bare-`# type: ignore[misc]` acceptor falsifier fires. None is a real directive silencing the module.

Verified:
- `mypy --strict tests/meta/test_feedback_guards_are_live.py` → **Success, 0 issues** — the detector's own `apparent_claim` ("module passes mypy --strict") is **TRUE**.
- Zero code-level `# type: ignore` outside strings/docstrings.

## Fix

Documented FP waiver in `false_confidence_exemptions.yaml` — the **same audited pattern** as the pre-existing `C8-TYPE-IGNORE-tests/*` exemptions. Detector now returns **0 findings, exit 0** (verified locally). Bound by commit-acceptor `fcd-c8-exempt-guard-efficacy-test` whose falsifier exits 1 if a *real* type-ignore is ever introduced into that file (the waiver cannot launder a genuine regression) or any other file trips C8.

Not masking: the module is genuinely strict-clean; the finding is spurious.

## Verification
- detector → 0 findings / exit 0 ✓
- `mypy --strict` on cited file → clean ✓
- commit-acceptor static + diff-binding (`--require-acceptor-for-code-change`) ✓
- detect-secrets CI-form hook ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)