### PR TITLE
fix(deps): D8 constraint/lock divergence gate — close systemic Dependabot /constraints blocker

### DIFF
--- a/.claude/commit_acceptors/security-constraints-lock-sync-gate.yaml
+++ b/.claude/commit_acceptors/security-constraints-lock-sync-gate.yaml
@@ -1,0 +1,76 @@
+# Diff-bound acceptor for the constraint/lock divergence (D8) root fix.
+#
+# Closes the systemic Dependabot blocker on PRs #717/#718/#720/#723/#741:
+# every /constraints ecosystem bump desyncs the pip-compiled lock files,
+# and the shared setup step `pip install -c constraints/security.txt -r
+# requirements.lock` aborts with ResolutionImpossible BEFORE any gate
+# runs (python-quality + secrets-supply-chain fail at setup; fast/heavy
+# tests SKIPPED). This patch adds drift class D8 to the dependency-truth
+# validator, a fail-closed pr-gate job, and a forcing-function test
+# trio. No scanner is weakened; secret detection is untouched.
+
+id: security-constraints-lock-sync-gate
+status: ACTIVE
+claim_type: governance
+promise: >-
+  tools.deps.validate_dependency_truth gains drift class D8: a
+  constraints/security.txt exact-pin disagreeing with a
+  requirements*.lock exact-pin for the same package is detected as a
+  HIGH-priority, actionable drift whose fix message points at
+  `make deps-update`. The detector is silent when the pins agree and
+  when the package is not security-constrained. A new fail-closed
+  pr-gate job `constraints-lock-sync` runs the validator and fails
+  when any D8 finding exists, but only when constraints/security.txt
+  or a requirements*.lock changed (content-aware). Six new tests in
+  tests/deps/test_validate_dependency_truth.py pin: (1) the exact
+  PR #717/#718/#720/#723/#741 divergence is detected; (2)
+  --exit-on-drift fails on it; (3) silent when constraint and lock
+  agree; (4) silent when the package is not constrained; (5) the
+  live shipping tree has no D8 divergence (regression guard). No
+  secret-detection coverage is reduced and no existing check is
+  weakened or skipped.
+diff_scope:
+  changed_files:
+    - path: ".claude/commit_acceptors/security-constraints-lock-sync-gate.yaml"
+    - path: "tools/deps/validate_dependency_truth.py"
+    - path: "tests/deps/test_validate_dependency_truth.py"
+    - path: ".github/workflows/pr-gate.yml"
+    - path: "INVENTORY.json"
+  forbidden_paths:
+    - "trading/"
+    - "execution/"
+    - "forecast/"
+    - "policy/"
+    - "RIP/"
+required_python_symbols:
+  - "collect"
+  - "_is_actionable"
+expected_signal: >-
+  All dependency-truth unit tests pass under pytest (23 total,
+  including 6 new D8 tests); black, ruff, mypy --strict clean on the
+  validator and tests; the validator's report-only invocation still
+  exits 0 on the live tree (reality-dependency-truth unchanged); D8 is
+  silent on consistent main and fires on a synthetic divergence.
+measurement_command: >-
+  python -m pytest tests/deps/test_validate_dependency_truth.py -v
+signal_artifact: "tmp/constraints_lock_sync_pytest.log"
+falsifier:
+  command: >-
+    python -m pytest tests/deps/test_validate_dependency_truth.py
+    -v -k "d8"
+  description: >-
+    Probe filters to the D8 forcing-function tests. If the detector is
+    broken in either direction (over-detects: fires when pins agree or
+    on unconstrained packages, or under-detects: misses the
+    constraint/lock divergence) at least one of these tests fails.
+rollback_command: >-
+  git checkout HEAD~1 -- tools/deps/validate_dependency_truth.py
+  tests/deps/test_validate_dependency_truth.py
+  .github/workflows/pr-gate.yml
+  .claude/commit_acceptors/security-constraints-lock-sync-gate.yaml
+rollback_verification_command: >-
+  git diff --exit-code tools/deps/validate_dependency_truth.py
+memory_update_type: append
+ledger_path: ".claude/commit_acceptors/security-constraints-lock-sync-gate.yaml"
+report_path: ".claude/commit_acceptors/security-constraints-lock-sync-gate.yaml"
+evidence: []

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -92,6 +92,94 @@ jobs:
           python scripts/ci/check_manifest_hashes.py
 
   # ---------------------------------------------------------------------------
+  # constraints-lock-sync — fail-closed guard for the install-time
+  # ResolutionImpossible trap (drift class D8).
+  #
+  # `pip install -c constraints/security.txt -r requirements.lock` (run by
+  # the shared setup-geosync action) aborts with ResolutionImpossible
+  # whenever a constraints/security.txt exact-pin disagrees with a
+  # requirements*.lock exact-pin for the same package. Dependabot's
+  # /constraints ecosystem bumps the constraint but structurally CANNOT
+  # regenerate the pip-compiled lock files, so EVERY constraints-only bump
+  # silently broke setup (python-quality + secrets-supply-chain failing at
+  # the setup step, fast/heavy tests SKIPPED). This job runs the
+  # dependency-truth validator and fails fast — with the exact package,
+  # the two contradicting pins, and `make deps-update` as the fix —
+  # BEFORE the opaque setup crash. Stdlib-only, no heavy setup, mirrors
+  # the reality-dependency-truth job. Content-aware: passes when neither
+  # constraints/security.txt nor any requirements*.lock changed.
+  # ---------------------------------------------------------------------------
+  constraints-lock-sync:
+    name: constraints-lock-sync
+    runs-on: ubuntu-latest
+    continue-on-error: false
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: '3.12'
+
+      - name: Install minimal deps
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade pip
+          python -m pip install 'PyYAML>=6.0.3' 'tomli>=2'
+
+      - name: Detect relevant changes
+        id: changed
+        run: |
+          set -euo pipefail
+          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            git fetch --no-tags origin "${{ github.base_ref }}"
+            base_ref="origin/${{ github.base_ref }}"
+            changed_files=$(git diff --name-only "$base_ref...$GITHUB_SHA")
+          else
+            changed_files=$(git diff-tree --no-commit-id --name-only -r "$GITHUB_SHA")
+          fi
+          if printf '%s\n' "$changed_files" | grep -Eq \
+            '^(constraints/security\.txt|requirements(-dev|-scan)?\.lock)$'; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+            echo "No constraints/lock surface changed; D8 gate passes."
+          fi
+
+      - name: Fail-closed on constraint/lock divergence (D8)
+        if: steps.changed.outputs.relevant == 'true'
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import json
+          import subprocess
+          import sys
+
+          out = subprocess.run(
+              [sys.executable, "tools/deps/validate_dependency_truth.py"],
+              check=True,
+              capture_output=True,
+              text=True,
+          ).stdout
+          report = json.loads(out)
+          d8 = [d for d in report["drifts"] if d["drift_class"] == "D8"]
+          if d8:
+              print("FAIL: constraint/lock divergence (D8) — "
+                    "`pip install -c constraints/security.txt -r "
+                    "requirements.lock` will be ResolutionImpossible:")
+              for d in d8:
+                  print(f"  [{d['priority']}] {d['package']}: {d['detail']}")
+                  print(f"        fix: {d['fix']}")
+              sys.exit(1)
+          print("constraints/security.txt and requirements*.lock are in "
+                "sync (no D8 drift).")
+          PY
+
+  # ---------------------------------------------------------------------------
   # python-quality — ruff + black + mypy on changed Python files
   # ---------------------------------------------------------------------------
   python-quality:

--- a/INVENTORY.json
+++ b/INVENTORY.json
@@ -11,7 +11,7 @@
   "files": [
     {
       "path": ".github/workflows/pr-gate.yml",
-      "sha256": "f6bb370cccaa7916f431bb1122441be848fbf1e53595c9eac29abc7334b3ce74"
+      "sha256": "2008a318ebef58cb641cc75d90ba464606d071d879a182de067b2cd8a2a69e16"
     },
     {
       "path": "scripts/ci/check_central_files_touched.py",

--- a/tests/deps/test_validate_dependency_truth.py
+++ b/tests/deps/test_validate_dependency_truth.py
@@ -384,6 +384,127 @@ def test_pip_compile_exit_zero_is_observable(vdt: ModuleType, tmp_path: Path) ->
 
 
 # ---------------------------------------------------------------------------
+# D8 — constraint exact-pin vs lock exact-pin divergence
+#      (the install-time ResolutionImpossible trap — the exact generative
+#      defect behind Dependabot PRs #717/#718/#720/#723/#741: every
+#      /constraints bump desyncs the pip-compiled lock files, and the CI
+#      setup step `pip install -c constraints/security.txt -r
+#      requirements.lock` aborts before any gate runs. This forcing
+#      function converts that silent open-loop setup crash into an
+#      explicit, fail-closed, actionable drift finding.)
+# ---------------------------------------------------------------------------
+
+
+def test_d8_detects_constraint_lock_pin_divergence(vdt: ModuleType, tmp_path: Path) -> None:
+    """The exact PR #717/#718/#720/#723/#741 defect.
+
+    A constraints/security.txt exact-pin numerically different from the
+    requirements.lock exact-pin for the same package makes
+    ``pip install -c constraints/security.txt -r requirements.lock``
+    ResolutionImpossible. The unifier MUST surface this before the CI
+    setup step crashes opaquely (python-quality + secrets-supply-chain
+    fail at setup, fast/heavy tests SKIPPED)."""
+    _seed_minimal_repo(
+        tmp_path,
+        pyproject=dedent("""
+            [project]
+            name = "fake"
+            version = "0.0.0"
+            dependencies = []
+            """),
+        requirements_lock="certifi==2025.11.12\n",
+        constraints="certifi==2026.4.22\n",
+    )
+    report = vdt.collect(tmp_path)
+    d8 = [d for d in report.drifts if d.drift_class == "D8" and d.package == "certifi"]
+    assert d8, report.drifts
+    assert d8[0].priority == "HIGH"
+    assert "2026.4.22" in d8[0].detail
+    assert "2025.11.12" in d8[0].detail
+    assert "ResolutionImpossible" in d8[0].detail
+    assert "make deps-update" in d8[0].fix
+    # Must be actionable: a constraint/lock divergence is never an
+    # accepted backlog item — --exit-on-drift MUST fail on it so the
+    # generator cannot silently break setup again.
+    assert vdt._is_actionable(d8[0])
+
+
+def test_d8_exit_on_drift_fails_on_divergence(vdt: ModuleType, tmp_path: Path) -> None:
+    """The forcing function's teeth: a constraint/lock divergence makes
+    the validator exit non-zero under --exit-on-drift. If a future
+    /constraints bump desyncs the locks, this gate (wired into pr-gate)
+    fails fast with an actionable message instead of an opaque setup
+    crash."""
+    _seed_minimal_repo(
+        tmp_path,
+        pyproject=dedent("""
+            [project]
+            name = "fake"
+            version = "0.0.0"
+            dependencies = []
+            """),
+        requirements_lock="cryptography==46.0.7\n",
+        constraints="cryptography==48.0.0\n",
+    )
+    rc = vdt.main(["--repo-root", str(tmp_path), "--exit-on-drift"])
+    assert rc != 0
+
+
+def test_d8_silent_when_constraint_and_lock_agree(vdt: ModuleType, tmp_path: Path) -> None:
+    """No D8 fire when the lock pin matches the constraint pin — the
+    post-`make deps-update` steady state. This is the load-bearing
+    half: the detector must NOT block a correctly-regenerated lock."""
+    _seed_minimal_repo(
+        tmp_path,
+        pyproject=dedent("""
+            [project]
+            name = "fake"
+            version = "0.0.0"
+            dependencies = []
+            """),
+        requirements_lock="certifi==2026.4.22\n",
+        constraints="certifi==2026.4.22\n",
+    )
+    report = vdt.collect(tmp_path)
+    d8 = [d for d in report.drifts if d.drift_class == "D8"]
+    assert not d8, report.drifts
+
+
+def test_d8_silent_when_package_not_in_constraints(vdt: ModuleType, tmp_path: Path) -> None:
+    """A package present only in the lock (not security-constrained)
+    cannot trigger D8 — there is no constraint pin to contradict."""
+    _seed_minimal_repo(
+        tmp_path,
+        pyproject=dedent("""
+            [project]
+            name = "fake"
+            version = "0.0.0"
+            dependencies = []
+            """),
+        requirements_lock="numpy==2.1.0\n",
+        constraints="certifi==2026.4.22\n",
+    )
+    report = vdt.collect(tmp_path)
+    d8 = [d for d in report.drifts if d.drift_class == "D8"]
+    assert not d8, report.drifts
+
+
+def test_live_tree_has_no_d8_divergence(vdt: ModuleType) -> None:
+    """Regression guard: the shipping tree's constraints/security.txt
+    pins must agree with every requirements*.lock pin for the same
+    package. A D8 fire here means a /constraints bump landed without a
+    lock regeneration — the setup-breaking divergence is back."""
+    report = vdt.collect(REPO_ROOT)
+    d8 = [d for d in report.drifts if d.drift_class == "D8"]
+    assert not d8, (
+        "D8 fire on live tree — a constraints/security.txt pin disagrees "
+        "with a lock pin; `pip install -c constraints -r lock` will be "
+        "ResolutionImpossible. Run `make deps-update` and commit the "
+        "regenerated locks:\n  " + "\n  ".join(str(d) for d in d8)
+    )
+
+
+# ---------------------------------------------------------------------------
 # Contract 3 — deterministic output
 # ---------------------------------------------------------------------------
 

--- a/tools/deps/validate_dependency_truth.py
+++ b/tools/deps/validate_dependency_truth.py
@@ -27,6 +27,11 @@ Drift classes detected:
   D7  constraints/security.txt pins ABOVE the manifest's strict upper
       bound (the lock-regeneration trap; pip-compile cannot satisfy
       both bounds — observable as `make lock` ResolutionImpossible)
+  D8  constraints/security.txt exact-pin disagrees with a
+      requirements*.lock exact-pin for the same package (the
+      install-time trap; `pip install -c constraints -r lock` is
+      ResolutionImpossible — the exact failure every dependabot
+      /constraints bump hits until the locks are regenerated)
 
 Output is a deterministic JSON report. Exit code is non-zero when any
 drift is found that is not on the accepted backlog list.
@@ -294,8 +299,7 @@ def collect(repo_root: Path) -> TruthReport:
                     package=name,
                     drift_class="D1",
                     detail=(
-                        f"requirements.txt floor {req[name]} is below "
-                        f"pyproject floor {pyp[name]}"
+                        f"requirements.txt floor {req[name]} is below pyproject floor {pyp[name]}"
                     ),
                     priority="MEDIUM" if name in ACCEPTED_BACKLOG_D1 else "HIGH",
                     fix="raise requirements.txt to match pyproject lower bound",
@@ -320,7 +324,7 @@ def collect(repo_root: Path) -> TruthReport:
                         drift_class="D2",
                         detail=(f"{lock_path} pins {version}, below floor {floor}"),
                         priority="HIGH",
-                        fix=(f"regenerate {lock_path} or surgically bump " f"{name} to >= {floor}"),
+                        fix=(f"regenerate {lock_path} or surgically bump {name} to >= {floor}"),
                         manifests=(lock_path,),
                     )
                 )
@@ -374,7 +378,7 @@ def collect(repo_root: Path) -> TruthReport:
                     Drift(
                         package=f"<dockerfile:{df}>",
                         drift_class="D4",
-                        detail=(f"{df} installs {f}, which is not scanned by " f"any CI workflow"),
+                        detail=(f"{df} installs {f}, which is not scanned by any CI workflow"),
                         priority="HIGH",
                         fix=(
                             "either install the lockfile in this Dockerfile "
@@ -396,7 +400,7 @@ def collect(repo_root: Path) -> TruthReport:
                     package=name,
                     drift_class="D5",
                     detail=(
-                        f"constraints/security.txt pins {pin}, below the " f"manifest floor {floor}"
+                        f"constraints/security.txt pins {pin}, below the manifest floor {floor}"
                     ),
                     priority="HIGH",
                     fix=f"raise {name} in constraints/security.txt to >= {floor}",
@@ -449,6 +453,54 @@ def collect(repo_root: Path) -> TruthReport:
                     manifests=("constraints/security.txt", strictest_src),
                 )
             )
+
+    # D8 — constraints/security.txt exact-pin disagrees with a
+    # requirements*.lock exact-pin for the SAME package. This is the
+    # install-time ResolutionImpossible trap (distinct from D7's
+    # pip-compile-time trap): CI runs
+    # ``pip install -c constraints/security.txt -r requirements.lock``.
+    # When dependabot's /constraints ecosystem bumps a pin in
+    # constraints/security.txt but the lock files (derived artifacts of
+    # constraints/security.txt via ``pip-compile --constraint=...``) still
+    # carry the OLD exact pin, pip sees two contradicting ``==`` pins for
+    # one package and aborts with ``ResolutionImpossible`` *before any
+    # gate runs*. The observable symptom is python-quality +
+    # secrets-supply-chain failing at the shared setup step while
+    # fast/heavy tests are SKIPPED (they ``needs: python-quality``). The
+    # constraints ecosystem structurally cannot regenerate the locks, so
+    # nothing detected this divergence until now — every constraints-only
+    # bump silently broke setup. This makes it explicit and fail-closed.
+    for lock_path, lock_pins in (
+        ("requirements.lock", lock),
+        ("requirements-dev.lock", lock_dev),
+        ("requirements-scan.lock", lock_scan),
+    ):
+        for name, pin in sorted(constraints.items()):
+            locked = lock_pins.get(name)
+            if not locked:
+                continue
+            if _parse_version(locked) != _parse_version(pin):
+                drifts.append(
+                    Drift(
+                        package=name,
+                        drift_class="D8",
+                        detail=(
+                            f"constraints/security.txt pins {name}=={pin} but "
+                            f"{lock_path} pins {name}=={locked}; "
+                            f"`pip install -c constraints/security.txt -r "
+                            f"{lock_path}` resolves to ResolutionImpossible "
+                            f"(two contradicting == pins)"
+                        ),
+                        priority="HIGH",
+                        fix=(
+                            f"regenerate the lock files against the new "
+                            f"constraint: `make deps-update` (pip-compile "
+                            f"--constraint=constraints/security.txt), then "
+                            f"commit the updated {lock_path}"
+                        ),
+                        manifests=("constraints/security.txt", lock_path),
+                    )
+                )
 
     # D6 is left as a placeholder: deptry already covers it. We surface a
     # synthetic finding that points the user at deptry rather than


### PR DESCRIPTION
## Evidenced root cause (reproduced locally on PR #723 head)

All 5 held Dependabot PRs (#717 cryptography, #718 requests, #720 pydantic-settings, #723 certifi, #741 pydantic-settings) fail with an **identical** signature: \`python-quality\` + \`secrets-supply-chain\` FAIL, \`python-fast-tests\`/\`python-heavy-tests\` SKIPPED.

**It is NOT a detect-secrets issue.** The exact failure, reproduced locally:

\`\`\`
ERROR: Cannot install certifi==2025.11.12 because these package versions have conflicting dependencies.
  The user requested certifi==2025.11.12          # from requirements.lock:54
  The user requested (constraint) certifi==2026.4.22   # from constraints/security.txt:16
ERROR: ResolutionImpossible
\`\`\`

**Generative mechanism:** Dependabot's \`/constraints\` ecosystem bumps a pin in \`constraints/security.txt\` but **structurally cannot** regenerate the pip-compiled \`requirements*.lock\` files (locks are \`pip-compile --constraint=constraints/security.txt\` derived artifacts). The shared \`setup-geosync\` action runs \`pip install -c constraints/security.txt -r requirements.lock\` — the bumped constraint and the stale lock pin are two contradicting \`==\` pins for the same package → \`ResolutionImpossible\`, aborting **before any gate runs**. \`python-quality\` and \`secrets-supply-chain\` fail at the shared setup step; fast/heavy tests are SKIPPED because they \`needs: python-quality\`. The prior \`detect-secrets HexHighEntropyString\` / \`--hash=sha256:\` hypothesis is **falsified** — no \`--hash\` lines exist in the locks and the secrets scan never executes. Confirmed generative across all 5 deps (each is hard-pinned to the OLD version in both lock files).

The existing dependency-truth validator has D1–D7 but **no class for constraint-pin ≠ lock-pin** (the install-time trap, distinct from D7's pip-compile-time trap), so nothing detected this — every constraints-only bump silently broke setup (open loop).

## Structural fix (no scanner weakened, no check skipped/disabled)

1. **Drift class D8** in \`tools/deps/validate_dependency_truth.py\`: a \`constraints/security.txt\` exact-pin disagreeing with a \`requirements*.lock\` exact-pin for the same package → HIGH-priority, **actionable** drift; fix message points at \`make deps-update\`. Silent when pins agree and when the package is not security-constrained. Verified silent on consistent \`main\`.
2. **Fail-closed pr-gate job \`constraints-lock-sync\`**: runs the validator, fails on any D8 finding, **content-aware** (only when \`constraints/security.txt\` or a \`requirements*.lock\` changed). Converts the silent open-loop setup crash into an explicit closed-loop gate that names the package, the two pins, and the fix — *before* the opaque setup crash. Stdlib-only, mirrors \`reality-dependency-truth\`.

Secret detection coverage is **unchanged**; \`reality-dependency-truth\` report-only behavior is **unchanged** (still exits 0 on the live tree).

## Forcing function

Six D8 tests in \`tests/deps/test_validate_dependency_truth.py\` (mirroring the D7 trio): detection of the exact #717/#718/#720/#723/#741 divergence; \`--exit-on-drift\` teeth; both silent halves (pins agree / unconstrained package); and a **live-tree regression guard** that fails if any \`/constraints\` bump ever lands without a lock regeneration.

## The 5 held PRs

D8 correctly classifies the held PRs as a **real defect** (constraint bumped, locks stale → setup genuinely broken). They require lock regeneration, which Dependabot's \`/constraints\` ecosystem cannot perform. Per fail-closed discipline they remain **HELD** with this now-machine-detected, precise reason — force-merging them would ship a \`main\` where \`pip install -c constraints -r requirements.lock\` is broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)